### PR TITLE
better handle invalid programs in release builds

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3547,7 +3547,7 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph, uint
         return;
     }
 
-    GLRenderPrimitive* const rp = handle_cast<GLRenderPrimitive *>(rph);
+    GLRenderPrimitive* const rp = handle_cast<GLRenderPrimitive*>(rph);
 
     // Gracefully do nothing if the render primitive has not been set up.
     VertexBufferHandle vb = rp->gl.vertexBufferWithObjects;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -318,7 +318,7 @@ private:
 
            void bindTexture(GLuint unit, GLTexture const* t) noexcept;
            void bindSampler(GLuint unit, GLuint sampler) noexcept;
-    inline void useProgram(OpenGLProgram* p) noexcept;
+    inline bool useProgram(OpenGLProgram* p) noexcept;
 
     enum class ResolveAction { LOAD, STORE };
     void resolvePass(ResolveAction action, GLRenderTarget const* rt,

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -129,7 +129,7 @@ void OpenGLProgram::initializeProgramState(OpenGLContext& context, GLuint progra
 #endif
     {
         // ES2 initialization of (fake) UBOs
-        UniformsRecord* const uniformsRecords = new UniformsRecord[Program::UNIFORM_BINDING_COUNT];
+        UniformsRecord* const uniformsRecords = new(std::nothrow) UniformsRecord[Program::UNIFORM_BINDING_COUNT];
         UTILS_NOUNROLL
         for (GLuint binding = 0, n = Program::UNIFORM_BINDING_COUNT; binding < n; binding++) {
             Program::UniformInfo& uniforms = lazyInitializationData.bindingUniformInfo[binding];

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -59,7 +59,7 @@ public:
             // - the content of any bound sampler buffer has changed
             // ... since last time we used this program
 
-            // turns out the former might be relatively cheap to check, the later requires
+            // Turns out the former might be relatively cheap to check, the latter requires
             // a bit less. Compared to what updateSamplers() actually does, which is
             // pretty little, I'm not sure if we'll get ahead.
 

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -22,7 +22,6 @@
 
 #include <private/backend/BackendUtils.h>
 
-#include <backend/platforms/OpenGLPlatform.h>
 #include <backend/Program.h>
 
 #include <utils/compiler.h>
@@ -254,8 +253,6 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
                     glGetProgramiv(glProgram, GL_LINK_STATUS, &status);
                     programData.program = glProgram;
 
-                    token->gl.program = programData.program;
-
                     // we don't need to check for success here, it'll be done on the
                     // main thread side.
                     token->set(programData);
@@ -337,12 +334,12 @@ GLuint ShaderCompilerService::getProgram(ShaderCompilerService::program_token_t&
     return program;
 }
 
-/* static*/ void ShaderCompilerService::terminate(program_token_t& token) {
+void ShaderCompilerService::terminate(program_token_t& token) {
     assert_invariant(token);
 
     token->canceled = true;
 
-    bool canceled = token->compiler.cancelTickOp(token);
+    bool const canceled = token->compiler.cancelTickOp(token);
 
     if (token->compiler.mShaderCompilerThreadCount) {
         auto job = token->compiler.mCompilerThreadPool.dequeue(token);


### PR DESCRIPTION
Until now invalid program would basically be undefined behavior, which in practice was a crash via a null pointer dereference. With this change, invalid programs cause drawing ops to become no-ops.

Additionally fixed an unsynchronized access of a the variable containing the program id. I don't think it would have caused issues though.

FIXES=[311775564]