### PR TITLE
Fix ESSL 1.0 external samplers

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- matc: Fix ESSL 1.0 codegen when using external samplers [⚠️ **Recompile materials**]

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -912,7 +912,8 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 
                 if (targetApi == TargetApi::OPENGL) {
                     if (targetLanguage == TargetLanguage::SPIRV) {
-                        ShaderGenerator::fixupExternalSamplers(shaderModel, shader, info);
+                        ShaderGenerator::fixupExternalSamplers(shaderModel, shader, featureLevel,
+                                info);
                     }
                 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -778,7 +778,7 @@ io::sstream& CodeGenerator::generateSubpass(io::sstream& out, SubpassInfo subpas
 }
 
 void CodeGenerator::fixupExternalSamplers(
-        std::string& shader, SamplerInterfaceBlock const& sib) noexcept {
+        std::string& shader, SamplerInterfaceBlock const& sib, FeatureLevel featureLevel) noexcept {
     auto const& infos = sib.getSamplerInfoList();
     if (infos.empty()) {
         return;
@@ -813,7 +813,10 @@ void CodeGenerator::fixupExternalSamplers(
         while (shader[index] != '\n') index++;
         index++;
 
-        shader.insert(index, "#extension GL_OES_EGL_image_external_essl3 : require\n");
+        const char *extensionLine = (featureLevel >= FeatureLevel::FEATURE_LEVEL_1)
+                ? "#extension GL_OES_EGL_image_external_essl3 : require\n\n"
+                : "#extension GL_OES_EGL_image_external : require\n\n";
+        shader.insert(index, extensionLine);
     }
 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -161,7 +161,8 @@ public:
     static utils::io::sstream& generateParameters(utils::io::sstream& out, ShaderStage type);
 
     static void fixupExternalSamplers(
-            std::string& shader, filament::SamplerInterfaceBlock const& sib) noexcept;
+            std::string& shader, filament::SamplerInterfaceBlock const& sib,
+            FeatureLevel featureLevel) noexcept;
 
     // These constants must match the equivalent in MetalState.h.
     // These values represent the starting index for uniform, ssbo, and sampler group [[buffer(n)]]

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -342,12 +342,13 @@ ShaderGenerator::ShaderGenerator(
     }
 }
 
-void ShaderGenerator::fixupExternalSamplers(ShaderModel sm,
-        std::string& shader, MaterialInfo const& material) noexcept {
+void ShaderGenerator::fixupExternalSamplers(ShaderModel sm, std::string& shader,
+        MaterialBuilder::FeatureLevel featureLevel,
+        MaterialInfo const& material) noexcept {
     // External samplers are only supported on GL ES at the moment, we must
     // skip the fixup on desktop targets
     if (material.hasExternalSamplers && sm == ShaderModel::MOBILE) {
-        CodeGenerator::fixupExternalSamplers(shader, material.sib);
+        CodeGenerator::fixupExternalSamplers(shader, material.sib, featureLevel);
     }
 }
 

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -75,6 +75,7 @@ public:
      * the optimizations have been applied.
      */
     static void fixupExternalSamplers(filament::backend::ShaderModel sm, std::string& shader,
+            MaterialBuilder::FeatureLevel featureLevel,
             MaterialInfo const& material) noexcept;
 
 private:


### PR DESCRIPTION
matc was re-introducing the incorrect extension for external samplers in ESSL 1.0 code after spirv optimizations.