### PR TITLE
fix jni Scene.getEntities

### DIFF
--- a/android/filament-android/src/main/cpp/EntityManager.cpp
+++ b/android/filament-android/src/main/cpp/EntityManager.cpp
@@ -38,7 +38,7 @@ Java_com_google_android_filament_EntityManager_nCreateArray(JNIEnv* env, jclass,
     // (which it is), but still.
     em->create((size_t) n, reinterpret_cast<Entity *>(entities));
 
-    env->ReleaseIntArrayElements(entities_, entities, 0);
+    env->ReleaseIntArrayElements(entities_, entities, JNI_ABORT);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/filament-android/src/main/cpp/MaterialInstance.cpp
+++ b/android/filament-android/src/main/cpp/MaterialInstance.cpp
@@ -205,7 +205,7 @@ Java_com_google_android_filament_MaterialInstance_nSetIntParameterArray(JNIEnv *
             break;
     }
 
-    env->ReleaseIntArrayElements(v_, v, 0);
+    env->ReleaseIntArrayElements(v_, v, JNI_ABORT);
 
     env->ReleaseStringUTFChars(name_, name);
 }

--- a/android/filament-android/src/main/cpp/Scene.cpp
+++ b/android/filament-android/src/main/cpp/Scene.cpp
@@ -114,6 +114,6 @@ Java_com_google_android_filament_Scene_nGetEntities(JNIEnv *env, jclass ,
             out[i++] = (jint) entity.getId();
         }
     });
-    env->ReleaseIntArrayElements(outArray, (jint*) out, JNI_ABORT);
+    env->ReleaseIntArrayElements(outArray, (jint*) out, 0);
     return JNI_TRUE;
 }


### PR DESCRIPTION
we were using the version of ReleaseIntArrayElements that doesn't always keep changes to the array.