### PR TITLE
on ANGLE we now use a thread pool for parallel shader compilation

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -476,7 +476,6 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
             // (that should be regardless of ANGLE, but we should double-check)
             bugs->split_easu = true;
         }
-        // TODO: see if we could use `bugs.allow_read_only_ancillary_feedback_loop = true`
     }
 
 #ifdef BACKEND_OPENGL_VERSION_GLES


### PR DESCRIPTION
in general we now prefer using a thread pool instead of the KHR extension, because we have less control over how the queue is managed by the driver.

ANGLE supports many threads very well, so we use cpu_threads/2 for the pool size, at background priority.