### PR TITLE
Generate dummy skinning variants for FL0 mats

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- matc: Generate skinning variants for FL0 materials [⚠️ **Recompile materials**]

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1163,7 +1163,6 @@ error:
         mVariantFilter |= uint32_t(UserVariantFilterBit::DIRECTIONAL_LIGHTING);
         mVariantFilter |= uint32_t(UserVariantFilterBit::DYNAMIC_LIGHTING);
         mVariantFilter |= uint32_t(UserVariantFilterBit::SHADOW_RECEIVER);
-        mVariantFilter |= uint32_t(UserVariantFilterBit::SKINNING);
         mVariantFilter |= uint32_t(UserVariantFilterBit::VSM);
         mVariantFilter |= uint32_t(UserVariantFilterBit::SSR);
         mVariantFilter |= uint32_t(UserVariantFilterBit::STE);

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -111,6 +111,10 @@ private:
     static void appendShader(utils::io::sstream& ss,
             const utils::CString& shader, size_t lineOffset) noexcept;
 
+    static bool hasSkinningOrMorphing(
+            filament::Variant variant,
+            MaterialBuilder::FeatureLevel featureLevel) noexcept;
+
     MaterialBuilder::PropertyList mProperties;
     MaterialBuilder::VariableList mVariables;
     MaterialBuilder::OutputList mOutputs;


### PR DESCRIPTION
Even if skinning is not fully implemented on FL0, we have clients which depend on materials with skinning variants that otherwise could easily be converted to FL0 materials. There are two proper ways to deal with this:

1. Support skinning/morphing in Feature Level 0.

2. Allow ESSL 1.0 code and ESSL 3.0 code to support different sets of variants.

However, the simplest solution is to just include skinning/morphing variants, but disable codegen for ESSL 1.0 code, making them identical to the base variants. This shouldn't increase the file size much due to the dictionary deflation. Of course, skinning will not work correctly on FL0, but this has always been the case. Future work here would be to properly implement one of the two solutions described above.