### PR TITLE
vk: workaround swiftshader spirv no-op issue

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -37,7 +37,7 @@ class VulkanTimestamps;
 
 struct VulkanProgram : public HwProgram, VulkanResource {
 
-    VulkanProgram(VkDevice device, Program& builder) noexcept;
+    VulkanProgram(VkDevice device, Program const& builder) noexcept;
 
     struct CustomSamplerInfo {
         uint8_t groupIndex;

--- a/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
+++ b/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
@@ -16,22 +16,22 @@
 
 #include "VulkanSpirvUtils.h"
 
-#include <utils/Log.h>
+#include <utils/compiler.h>   // UTILS_UNUSED_IN_RELEASE, UTILS_FALLTHROUGH
+#include <utils/debug.h>      // assert_invariant
+#include <utils/FixedCapacityVector.h>
 
-#include <bluevk/BlueVK.h>
 #include <spirv/unified1/spirv.hpp>
 
 #include <unordered_map>
+#include <variant>
 
 namespace filament::backend {
-
-using namespace bluevk;
 
 namespace {
 
 // This function transforms an OpSpecConstant instruction into just a OpConstant instruction.
 // Additionally, it will adjust the value of the constant as given by the program.
-void getTransformedConstantInst(SpecConstantValue const& value, uint32_t* inst) {
+void getTransformedConstantInst(SpecConstantValue* value, uint32_t* inst) {
 
     // The first word is the size of the instruction and the instruction type.
     // The second word is the type of the instruction.
@@ -41,15 +41,25 @@ void getTransformedConstantInst(SpecConstantValue const& value, uint32_t* inst) 
     constexpr size_t const OP = 0;
     constexpr size_t const VALUE = 3;
 
-    if (std::holds_alternative<bool>(value)) {
+    if (!value) {
+        // If a specialization wasn't provided, just switch the opcode.
+        uint32_t const op = inst[OP] & 0x0000FFFF;
+        if (op == spv::Op::OpSpecConstantFalse) {
+            inst[OP] = (3 << 16) | spv::Op::OpConstantFalse;
+        } else if (op == spv::Op::OpSpecConstantTrue) {
+            inst[OP] = (3 << 16) | spv::Op::OpConstantTrue;
+        } else if (op == spv::Op::OpSpecConstant) {
+            inst[OP] = (4 << 16) | spv::Op::OpConstant;
+        }
+    } else if (std::holds_alternative<bool>(*value)) {
         inst[OP] = (3 << 16)
-                   | (std::get<bool>(value) ? spv::Op::OpConstantTrue : spv::Op::OpConstantFalse);
-    } else if (std::holds_alternative<float>(value)) {
-        float const fval = std::get<float>(value);
+                   | (std::get<bool>(*value) ? spv::Op::OpConstantTrue : spv::Op::OpConstantFalse);
+    } else if (std::holds_alternative<float>(*value)) {
+        float const fval = std::get<float>(*value);
         inst[OP] = (4 << 16) | spv::Op::OpConstant;
         inst[VALUE] = *reinterpret_cast<uint32_t const*>(&fval);
     } else {
-        int const ival = std::get<int>(value);
+        int const ival = std::get<int>(*value);
         inst[OP] = (4 << 16) | spv::Op::OpConstant;
         inst[VALUE] = *reinterpret_cast<uint32_t const*>(&ival);
     }
@@ -57,10 +67,12 @@ void getTransformedConstantInst(SpecConstantValue const& value, uint32_t* inst) 
 
 } // anonymous namespace
 
-void workaroundSpecConstant(Program::ShaderBlob& blob,
-        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants) {
+void workaroundSpecConstant(Program::ShaderBlob const& blob,
+        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants,
+        std::vector<uint32_t>& output) {
     using WordMap = std::unordered_map<uint32_t, uint32_t>;
     using SpecValueMap = std::unordered_map<uint32_t, SpecConstantValue>;
+    constexpr size_t const HEADER_SIZE = 5;
 
     WordMap varToIdMap;
     SpecValueMap idToValue;
@@ -79,47 +91,58 @@ void workaroundSpecConstant(Program::ShaderBlob& blob,
     // %1 as the result, we want to change that instruction to just an OpConsant where the constant
     // value is adjusted by the spec values provided in the program.
     // Additionally, we will turn the SpecId decorations to no-ops.
-    uint32_t* outputData = (uint32_t*) blob.data();
+    size_t const dataSize = blob.size() / 4;
 
-    for (uint32_t cursor = 5, cursorEnd = blob.size() / 4; cursor < cursorEnd;) {
-        uint32_t const firstWord = outputData[cursor];
+    output.resize(dataSize);
+    uint32_t const* data = (uint32_t*) blob.data();
+    uint32_t* outputData = output.data();
+
+    std::memcpy(&outputData[0], &data[0], HEADER_SIZE * 4);
+    size_t outputCursor = HEADER_SIZE;
+
+    for (uint32_t cursor = HEADER_SIZE, cursorEnd = dataSize; cursor < cursorEnd;) {
+        uint32_t const firstWord = data[cursor];
         uint32_t const wordCount = firstWord >> 16;
         uint32_t const op = firstWord & 0x0000FFFF;
 
         switch(op) {
-            case spv::Op::OpDecorate: {
-                if (outputData[cursor + 2] == spv::Decoration::DecorationSpecId) {
-                    uint32_t const targetVar = outputData[cursor + 1];
-                    uint32_t const specId = outputData[cursor + 3];
-                    varToIdMap[targetVar] = specId;
-                    // Now we write noops over the decoration since its no longer needed.
-                    for (size_t i = cursor, n = cursor + wordCount; i < n; ++i) {
-                        outputData[i] = (1 << 16) | spv::Op::OpNop;
-                    }
-                }
-                break;
-            }
             case spv::Op::OpSpecConstant:
             case spv::Op::OpSpecConstantTrue:
             case spv::Op::OpSpecConstantFalse: {
-                uint32_t const targetVar = outputData[cursor + 2];
+                uint32_t const targetVar = data[cursor + 2];
 
                 UTILS_UNUSED_IN_RELEASE WordMap::const_iterator idItr = varToIdMap.find(targetVar);
                 assert_invariant(idItr != varToIdMap.end() &&
                         "Cannot find variable previously decorated with SpecId");
 
-                assert_invariant(idToValue.find(idItr->second) != idToValue.end() &&
-                        "Spec constant value not provided");
+                auto valItr = idToValue.find(idItr->second);
 
-                auto const& val = idToValue[varToIdMap[targetVar]];
-                getTransformedConstantInst(val, &outputData[cursor]);
+                SpecConstantValue* val = (valItr != idToValue.end()) ? &valItr->second : nullptr;
+                std::memcpy(&outputData[outputCursor], &data[cursor], wordCount * 4);
+                getTransformedConstantInst(val, &outputData[outputCursor]);
+                outputCursor += wordCount;
                 break;
             }
+            case spv::Op::OpDecorate: {
+                if (data[cursor + 2] == spv::Decoration::DecorationSpecId) {
+                    uint32_t const targetVar = data[cursor + 1];
+                    uint32_t const specId = data[cursor + 3];
+                    varToIdMap[targetVar] = specId;
+
+                    // Note these decorations do not need to be written to the output.
+                    break;
+                }
+                // else fallthrough and copy like all other instructions
+                UTILS_FALLTHROUGH;
+            }
             default:
+                std::memcpy(&outputData[outputCursor], &data[cursor], wordCount * 4);
+                outputCursor += wordCount;
                 break;
         }
         cursor += wordCount;
     }
+    output.resize(outputCursor);
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.h
+++ b/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.h
@@ -28,15 +28,19 @@ namespace filament::backend {
 using SpecConstantValue = Program::SpecializationConstant::Type;
 
 // For certain drivers, using spec constant can lead to compile errors [1] or undesirable behaviors
-// [2]. In those instances, we simply change the spirv and set them to constants. This function will
-// modify the blob (but it's safe to do so since blobs are "moved" to the backend).
+// [2]. In those instances, we simply change the spirv and set them to constants.
+//
+// (Implemenation note: we cannot write to the blob because spirv-validator does not properly handle
+//  the Nop (no-op) instruction, and swiftshader validates the shader before compilation. So we need
+//  to skip those instructions instead).
 //
 // [1]: QC driver cannot use spec constant to size fields
 //      (https://github.com/google/filament/issues/6444).
 // [2]: An internal driver does not DCE a block guarded by a spec-const boolean set to false
 //      (b/310603393).
-void workaroundSpecConstant(Program::ShaderBlob& blob,
-        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants);
+void workaroundSpecConstant(Program::ShaderBlob const& blob,
+        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants,
+        std::vector<uint32_t>& output);
 
 } // namespace filament::backend
 


### PR DESCRIPTION
Swiftshader runs spirv validation before compilation. However, the validation does not like having Nop (no-op) in the input. So we skip instructions instead of writing no-op for the output of `workaroundSpecConstant`.

Also, fix issue to keep the value in the original shader if a specialization wasn't provided.