### PR TITLE
Allow post-process materials to update the vertex position

### DIFF
--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -5,21 +5,26 @@ void main() {
 
     inputs.normalizedUV = position.xy * 0.5 + 0.5;
 
-    vec4 position = getPosition();
+    inputs.position = getPosition();
 
-    // GL convention to inverted DX convention
-    position.z = position.z * -0.5 + 0.5;
+    // Invoke user code
+    postProcessVertex(inputs);
+
+    // (vertex domain) GL convention to inverted DX convention
+    inputs.position.z = inputs.position.z * -0.5 + 0.5;
+
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
+    inputs.position.y = -inputs.position.y;
+#endif
 
     // Adjust clip-space
 #if !defined(TARGET_VULKAN_ENVIRONMENT) && !defined(TARGET_METAL_ENVIRONMENT)
     // This is not needed in Vulkan or Metal because clipControl is always (1, 0)
-    // (We don't use a dot() here because it workaround a spirv-opt optimization that in turn
+    // (We don't use a dot() here because it works around a spirv-opt optimization that in turn
     //  causes a crash on PowerVR, see #5118)
-    position.z = position.z * frameUniforms.clipControl.x + position.w * frameUniforms.clipControl.y;
+    inputs.position.z = inputs.position.z * frameUniforms.clipControl.x + inputs.position.w * frameUniforms.clipControl.y;
 #endif
-
-    // Invoke user code
-    postProcessVertex(inputs);
 
     // Handle user-defined interpolated attributes
 #if defined(VARIABLE_CUSTOM0)
@@ -36,5 +41,5 @@ void main() {
 #endif
 
     // some PowerVR drivers crash when gl_Position is written more than once
-    gl_Position = position;
+    gl_Position = inputs.position;
 }

--- a/shaders/src/post_process_getters.vs
+++ b/shaders/src/post_process_getters.vs
@@ -1,11 +1,4 @@
 /** @public-api */
 vec4 getPosition() {
-    vec4 pos = position;
-
-// In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
-#if defined(TARGET_VULKAN_ENVIRONMENT)
-    pos.y = -pos.y;
-#endif
-
-    return pos;
+    return position;
 }

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -5,6 +5,9 @@ struct PostProcessVertexInputs {
     // We provide normalized texture coordinates to custom vertex shaders.
     vec2 normalizedUV;
 
+    // vertex position, can be modified by the user code
+    vec4 position;
+
 #ifdef VARIABLE_CUSTOM0
     vec4 VARIABLE_CUSTOM0;
 #endif


### PR DESCRIPTION
we add a `position` field to PostProcessVertexInputs which the user code can modify if needed.