### PR TITLE
fix framegraph clear flags for imported targets

### DIFF
--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -455,7 +455,7 @@ io::ostream& operator<<(io::ostream& out, filament::backend::Viewport const& vie
 
 io::ostream& operator<<(io::ostream& out, TargetBufferFlags flags) {
     // TODO: implement decoding of enum
-    out << uint8_t(flags);
+    out << uint32_t(flags);
     return out;
 }
 

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -229,6 +229,11 @@ void RenderPassNode::resolve() noexcept {
             rt.descriptor.samples    = pImportedRenderTarget->importedDesc.samples;
             rt.backend.target        = pImportedRenderTarget->target;
 
+            // We could end-up here more than once, for instance if the rendertarget is used
+            // by multiple passes (this would imply a read-back, btw). In this case, we don't want
+            // to clear it the 2nd time, so we clear the imported pass's clear flags.
+            pImportedRenderTarget->importedDesc.clearFlags = TargetBufferFlags::NONE;
+
             // but don't discard attachments the imported target tells us to keep
             rt.backend.params.flags.discardStart &= ~pImportedRenderTarget->importedDesc.keepOverrideStart;
             rt.backend.params.flags.discardEnd   &= ~pImportedRenderTarget->importedDesc.keepOverrideEnd;


### PR DESCRIPTION
Imported targets always use the imported flags, not the flags that where specified when the target was created. The clear flags should be cleared after they've been used once in case that rendertarget is reused by multiple passes.

For e.g. if the clear flag is set, the target will be cleared the first time it is used, but if it's used again, we don't want to clear again,  in that case we'll use the "local" flags used when the target was created (as opposed to the imported flags).