### PR TITLE
fix per-light shadow "caster" flag update

### DIFF
--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -844,7 +844,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
         FScene::LightSoa const& lightData) noexcept {
 
     // The const_cast here is a little ugly, but conceptually lightData should be const,
-    // it's just that we're using it to store some temporary data. with SoA we can't have
+    // it's just that we're using it to store some temporary data. With SoA we can't have
     // a `mutable` element, so that's a workaround.
     FScene::ShadowInfo* const shadowInfo = const_cast<FScene::ShadowInfo*>(
             lightData.data<FScene::SHADOW_INFO>());
@@ -855,7 +855,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
         shadowTechnique |= ShadowTechnique::SHADOW_MAP;
         for (ShadowMap const& shadowMap : spotShadowMaps) {
             const size_t lightIndex = shadowMap.getLightIndex();
-            // gather the per-light (not per shadow map) information. For point lights we will
+            // Gather the per-light (not per shadow map) information. For point lights we will
             // "see" 6 shadowmaps (one per face), we must use the first face one, the shader
             // knows how to find the entry for other faces (they're guaranteed to be sequential).
             if (shadowMap.getFace() == 0) {

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -313,6 +313,10 @@ void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableD
         }
 
         if (UTILS_LIKELY(!lcm.isShadowCaster(li))) {
+            // Because we early exit here, we need to make sure we mark the light as non-casting.
+            // See `ShadowMapManager::updateSpotShadowMaps` for const_cast<> justification.
+            const_cast<FScene::ShadowInfo&>(
+                    lightData.elementAt<FScene::SHADOW_INFO>(l)).castsShadows = false;
             continue; // doesn't cast shadows
         }
 


### PR DESCRIPTION
The per-light shadow caster flag wasn't updated when a light was toggled from casting to non-casting. This resulted in an out of date or incorrect shadowmap to be used.

FIXES=[315859790]