### PR TITLE
fix getUserWorldFromWorldMatrix() during the shadow passes

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -50,7 +50,7 @@ PerViewUniforms::PerViewUniforms(FEngine& engine) noexcept
             BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     if (engine.getDFG().isValid()) {
-        TextureSampler sampler(TextureSampler::MagFilter::LINEAR);
+        TextureSampler const sampler(TextureSampler::MagFilter::LINEAR);
         mSamplers.setSampler(PerViewSib::IBL_DFG_LUT,
                 { engine.getDFG().getTexture(), sampler.getSamplerParams() });
     }

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -247,7 +247,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
 
 
                         // cameraInfo only valid after calling update
-                        const CameraInfo cameraInfo{ shadowMap.getCamera() };
+                        const CameraInfo cameraInfo{ shadowMap.getCamera(), mainCameraInfo };
 
                         auto transaction = ShadowMap::open(driver);
                         ShadowMap::prepareCamera(transaction, engine, cameraInfo);

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -265,24 +265,22 @@ uint8_t FCamera::getStereoscopicEyeCount() const noexcept {
 
 // ------------------------------------------------------------------------------------------------
 
-CameraInfo::CameraInfo(FCamera const& camera) noexcept {
-    for (int i = 0; i < camera.getStereoscopicEyeCount(); i++) {
-        eyeProjection[i]   = mat4f{ camera.getProjectionMatrix(i) };
-    }
-    cullingProjection  = mat4f{ camera.getCullingProjectionMatrix() };
-    model              = mat4f{ camera.getModelMatrix() };
-    view               = mat4f{ camera.getViewMatrix() };
-    zn                 = (float)camera.getNear();
-    zf                 = (float)camera.getCullingFar();
-    ev100              = Exposure::ev100(camera);
-    f                  = (float)camera.getFocalLength();
-    A                  = f / camera.getAperture();
-    d                  = std::max(zn, camera.getFocusDistance());
+CameraInfo::CameraInfo(FCamera const& camera) noexcept
+        : CameraInfo(camera, {}, camera.getModelMatrix()) {
 }
 
-CameraInfo::CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept {
-    const mat4 modelMatrix{ inWorldTransform * camera.getModelMatrix() };
-    for (int i = 0; i < camera.getStereoscopicEyeCount(); i++) {
+CameraInfo::CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept
+        : CameraInfo(camera, inWorldTransform, inWorldTransform * camera.getModelMatrix()) {
+}
+
+CameraInfo::CameraInfo(FCamera const& camera, CameraInfo const& mainCameraInfo) noexcept
+        : CameraInfo(camera, mainCameraInfo.worldTransform, camera.getModelMatrix()) {
+}
+
+CameraInfo::CameraInfo(FCamera const& camera,
+        math::mat4 const& inWorldTransform,
+        math::mat4 const& modelMatrix) noexcept {
+    for (size_t i = 0; i < camera.getStereoscopicEyeCount(); i++) {
         eyeProjection[i]   = mat4f{ camera.getProjectionMatrix(i) };
         eyeFromView[i]     = mat4f{ camera.getEyeFromViewMatrix(i) };
     }

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -220,8 +220,18 @@ private:
 
 struct CameraInfo {
     CameraInfo() noexcept {}
-    explicit CameraInfo(FCamera const& camera) noexcept;
+
+    // Creates a CameraInfo relative to inWorldTransform (i.e. it's model matrix is
+    // transformed by inWorldTransform and inWorldTransform is recorded).
+    // This is typically used for the color pass camera.
     CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept;
+
+    // Creates a CameraInfo from a camera that is relative to mainCameraInfo.
+    // This is typically used for the shadow pass cameras.
+    CameraInfo(FCamera const& camera, CameraInfo const& mainCameraInfo) noexcept;
+
+    // Creates a CameraInfo from the FCamera
+    explicit CameraInfo(FCamera const& camera) noexcept;
 
     union {
         // projection matrix for drawing (infinite zfar)
@@ -249,6 +259,11 @@ struct CameraInfo {
     math::float3 const& getPosition() const noexcept { return model[3].xyz; }
     math::float3 getForwardVector() const noexcept { return normalize(-model[2].xyz); }
     math::mat4 getUserViewMatrix() const noexcept { return view * worldTransform; }
+
+private:
+    CameraInfo(FCamera const& camera,
+            math::mat4 const& inWorldTransform,
+            math::mat4 const& modelMatrix) noexcept;
 };
 
 FILAMENT_DOWNCAST(Camera)


### PR DESCRIPTION
getUserWorldFromWorldMatrix() was always set to identity during the shadow pass. It needs to be set the the same value as the main camera.

FIXES=[315504607]