### PR TITLE
fix TAA on mobile devices.

### DIFF
--- a/filament/src/materials/antiAliasing/taa.mat
+++ b/filament/src/materials/antiAliasing/taa.mat
@@ -287,16 +287,17 @@ void postProcess(inout PostProcessInputs postProcess) {
     if (materialConstants_boxType == BOX_TYPE_VARIANCE ||
             materialConstants_boxType == BOX_TYPE_AABB_VARIANCE) {
         // "An Excursion in Temporal Supersampling" by Marco Salvi
-        vec3 m0 = s[4];
-        vec3 m1 = s[4] * s[4];
+        highp vec3 m0 = s[4];  // conversion to highp
+        highp vec3 m1 = m0 * m0;
         // we use only 5 samples instead of all 9
         for (int i = 1; i < 9; i+=2) {
-            m0 += s[i];
-            m1 += s[i] * s[i];
+            highp vec3 c = s[i]; // conversion to highp
+            m0 += c;
+            m1 += c * c;
         }
-        vec3 a0 = m0 * (1.0 / 5.0);
-        vec3 a1 = m1 * (1.0 / 5.0);
-        vec3 sigma = sqrt(a1 - a0 * a0);
+        highp vec3 a0 = m0 * (1.0 / 5.0);
+        highp vec3 a1 = m1 * (1.0 / 5.0);
+        highp vec3 sigma = sqrt(a1 - a0 * a0);
         if (materialConstants_boxType == BOX_TYPE_VARIANCE) {
             boxmin = a0 - VARIANCE_GAMMA * sigma;
             boxmax = a0 + VARIANCE_GAMMA * sigma;


### PR DESCRIPTION
The history neighborhood variance needed to be computed in highp.

fixes #6504