### PR TITLE
Assert non-null texture in setTextureData

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2283,6 +2283,7 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
         PixelBufferDescriptor&& p) {
     auto& gl = mContext;
 
+    assert_invariant(t != nullptr);
     assert_invariant(xoffset + width <= std::max(1u, t->width >> level));
     assert_invariant(yoffset + height <= std::max(1u, t->height >> level));
     assert_invariant(t->samples <= 1);


### PR DESCRIPTION
I hit a seg fault here when (incorrectly) trying to use feature level 0 without #defining FILAMENT_ENABLE_FEATURE_LEVEL_0, which could have been caught by an assert here rather than a seg fault.