### PR TITLE
Make`applyMaterialVariant` Method Public in FilamentInstance Class

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
@@ -144,7 +144,7 @@ public class FilamentInstance {
      *
      * Ignored if variantIndex is out of bounds.
      */
-    void applyMaterialVariant(@IntRange(from = 0) int variantIndex) {
+    public void applyMaterialVariant(@IntRange(from = 0) int variantIndex) {
         nApplyMaterialVariant(mNativeObject, variantIndex);
     }
 


### PR DESCRIPTION
The current implementation restricts access to this method, and making it public will enable external classes or components to utilise this functionality