### PR TITLE
Fix a couple race conditions in Metal backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ option(FILAMENT_LINUX_IS_MOBILE "Treat Linux as Mobile" OFF)
 
 option(FILAMENT_ENABLE_ASAN_UBSAN "Enable Address and Undefined Behavior Sanitizers" OFF)
 
+option(FILAMENT_ENABLE_TSAN "Enable Thread Sanitizer" OFF)
+
 option(FILAMENT_ENABLE_FEATURE_LEVEL_0 "Enable Feature Level 0" ON)
 
 set(FILAMENT_NDK_VERSION "" CACHE STRING
@@ -425,6 +427,9 @@ endif()
 # ==================================================================================================
 if (FILAMENT_ENABLE_ASAN_UBSAN)
    set(EXTRA_SANITIZE_OPTIONS "-fsanitize=address -fsanitize=undefined")
+endif()
+if (FILAMENT_ENABLE_TSAN)
+   set(EXTRA_SANITIZE_OPTIONS "-fsanitize=thread")
 endif()
 if (ANDROID)
     # keep STL debug infos (mimics what the NDK does)

--- a/filament/backend/src/metal/MetalBufferPool.h
+++ b/filament/backend/src/metal/MetalBufferPool.h
@@ -73,6 +73,9 @@ private:
     std::unordered_set<MetalBufferPoolEntry const*> mUsedStages;
 
     // Store the current "time" (really just a frame count) and LRU eviction parameters.
+    // An atomic is necessary as mCurrentFrame is incremented in gc() (called on
+    // the driver thread) and read from acquireBuffer() and releaseBuffer(),
+    // which may be called on non-driver threads.
     std::atomic<uint64_t> mCurrentFrame = 0;
     static constexpr uint32_t TIME_BEFORE_EVICTION = 10;
 };

--- a/filament/backend/src/metal/MetalBufferPool.h
+++ b/filament/backend/src/metal/MetalBufferPool.h
@@ -73,7 +73,7 @@ private:
     std::unordered_set<MetalBufferPoolEntry const*> mUsedStages;
 
     // Store the current "time" (really just a frame count) and LRU eviction parameters.
-    uint64_t mCurrentFrame = 0;
+    std::atomic<uint64_t> mCurrentFrame = 0;
     static constexpr uint32_t TIME_BEFORE_EVICTION = 10;
 };
 

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -142,6 +142,9 @@ struct MetalContext {
     // Fences, only supported on macOS 10.14 and iOS 12 and above.
     API_AVAILABLE(macos(10.14), ios(12.0))
     MTLSharedEventListener* eventListener = nil;
+    // signalId is incremented in the MetalFence constructor, which is called on
+    // both the driver (MetalTimerQueryFence::beginTimeElapsedQuery) and main
+    // threads (in createFenceS), so an atomic is necessary.
     std::atomic<uint64_t> signalId = 1;
 
     MetalTimerQueryInterface* timerQueryImpl;

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -142,7 +142,7 @@ struct MetalContext {
     // Fences, only supported on macOS 10.14 and iOS 12 and above.
     API_AVAILABLE(macos(10.14), ios(12.0))
     MTLSharedEventListener* eventListener = nil;
-    uint64_t signalId = 1;
+    std::atomic<uint64_t> signalId = 1;
 
     MetalTimerQueryInterface* timerQueryImpl;
 


### PR DESCRIPTION
1. MetalFence is constructed from two threads:
- the main thread, from `MetalDriver::createFenceS`
- the driver thread, from `MetalTimerQueryFence::beginTimeElapsedQuery`

Because the `MetalFence` constructor reads and writes to `context.signalId`, it needs to be made atomic.

2. `MetalBufferPool::mCurrentframe` needs to be made atomic, as it is accessed by two threads:
- the driver thread, from `MetalBufferPool::gc`, read/writes to `mCurrentFrame`
- a completion handler thread, from `MetalBufferPool::releaseBuffer`, reads `mCurrentFrame`

This also adds support for a new CMake flag to enable TSAN.

b/314267870
b/314265331