### PR TITLE
Add picking queries to gltf-viewer iOS sample

### DIFF
--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
@@ -16,6 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
+#include <utils/Entity.h>
+
 namespace filament {
 class Engine;
 class Scene;
@@ -75,6 +77,17 @@ typedef NSData* _Nonnull (^ResourceCallback)(NSString* _Nonnull);
 - (void)loadModelGltf:(NSData*)buffer callback:(ResourceCallback)callback;
 
 - (void)destroyModel;
+
+/**
+ * Issues a pick query at the given view coordinates.
+ * The coordinates should be in UIKit's coordinate system, with the origin at
+ * the top-left.
+ * The callback is triggered with entity of the picked object.
+ */
+typedef void (^PickCallback)(utils::Entity);
+- (void)issuePickQuery:(CGPoint)point callback:(PickCallback)callback;
+
+- (NSString* _Nullable)getEntityName:(utils::Entity)entity;
 
 /**
  * Sets up a root transform on the current model to make it fit into a unit cube.

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -127,13 +127,12 @@ const float kSensitivity = 100.0f;
 
     _swapChain = _engine->createSwapChain((__bridge void*)self.layer);
 
-    _materialProvider = createUbershaderProvider(_engine,
-            UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
+    _materialProvider =
+            createUbershaderProvider(_engine, UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
     EntityManager& em = EntityManager::get();
     NameComponentManager* ncm = new NameComponentManager(em);
     _assetLoader = AssetLoader::create({_engine, _materialProvider, ncm, &em});
-    _resourceLoader = new ResourceLoader(
-            {.engine = _engine, .normalizeSkinningWeights = true});
+    _resourceLoader = new ResourceLoader({.engine = _engine, .normalizeSkinningWeights = true});
     _stbDecoder = createStbProvider(_engine);
     _ktxDecoder = createKtx2Provider(_engine);
     _resourceLoader->addTextureProvider("image/png", _stbDecoder);
@@ -180,6 +179,26 @@ const float kSensitivity = 100.0f;
     _assetLoader->destroyAsset(_asset);
     _asset = nullptr;
     _animator = nullptr;
+}
+
+- (void)issuePickQuery:(CGPoint)point callback:(PickCallback)callback {
+    CGPoint pointOriginBottomLeft = CGPointMake(point.x, self.bounds.size.height - point.y);
+    CGPoint pointScaled = CGPointMake(pointOriginBottomLeft.x * self.contentScaleFactor,
+            pointOriginBottomLeft.y * self.contentScaleFactor);
+    _view->pick(pointScaled.x, pointScaled.y,
+            [callback](View::PickingQueryResult const& result) { callback(result.renderable); });
+}
+
+- (NSString* _Nullable)getEntityName:(utils::Entity)entity {
+    if (!_asset) {
+        return nil;
+    }
+    NameComponentManager* ncm = _assetLoader->getNames();
+    NameComponentManager::Instance instance = ncm->getInstance(entity);
+    if (instance) {
+        return [NSString stringWithUTF8String:ncm->getName(ncm->getInstance(entity))];
+    }
+    return nil;
 }
 
 - (void)transformToUnitCube {

--- a/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
@@ -15,6 +15,7 @@
  */
 
 #import "FILViewController.h"
+#include <UIKit/UIKit.h>
 
 #import "FILModelView.h"
 
@@ -35,6 +36,9 @@ using namespace filament;
 using namespace utils;
 using namespace ktxreader;
 
+const float kToastAnimationDuration = 0.25f;
+const float kToastDelayDuration = 2.0f;
+
 @interface FILViewController ()
 
 - (void)startDisplayLink;
@@ -50,6 +54,7 @@ using namespace ktxreader;
     CFTimeInterval _startTime;
     viewer::RemoteServer* _server;
     viewer::AutomationEngine* _automation;
+    UILabel* _toastLabel;
 
     Texture* _skyboxTexture;
     Skybox* _skybox;
@@ -57,6 +62,7 @@ using namespace ktxreader;
     IndirectLight* _indirectLight;
     Entity _sun;
 
+    UITapGestureRecognizer* _singleTapRecognizer;
     UITapGestureRecognizer* _doubleTapRecognizer;
 }
 
@@ -94,9 +100,29 @@ using namespace ktxreader;
     _server = new viewer::RemoteServer();
     _automation = viewer::AutomationEngine::createDefault();
 
-    _doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(reloadModel)];
+    _doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                   action:@selector(reloadModel)];
     _doubleTapRecognizer.numberOfTapsRequired = 2;
     [self.modelView addGestureRecognizer:_doubleTapRecognizer];
+    _singleTapRecognizer =
+            [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                    action:@selector(issuePickingQuery)];
+    _singleTapRecognizer.numberOfTapsRequired = 1;
+    [self.modelView addGestureRecognizer:_singleTapRecognizer];
+
+    // Create a label at the top of the screen to toast messages to the user.
+    CGRect labelRect = self.view.bounds;
+    labelRect.size.height = 50;
+    _toastLabel = [[UILabel alloc] initWithFrame:labelRect];
+    _toastLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    _toastLabel.textAlignment = NSTextAlignmentCenter;
+    _toastLabel.textColor = [UIColor whiteColor];
+    _toastLabel.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.5f];
+    _toastLabel.numberOfLines = 0;
+    _toastLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    _toastLabel.text = @"";
+    _toastLabel.alpha = 0.0f;
+    [self.view addSubview:_toastLabel];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -223,7 +249,8 @@ using namespace ktxreader;
         .indirectLight = _indirectLight,
         .sunlight = _sun,
     };
-    _automation->applySettings(self.modelView.engine, message->buffer, message->bufferByteCount, content);
+    _automation->applySettings(
+            self.modelView.engine, message->buffer, message->bufferByteCount, content);
     ColorGrading* const colorGrading = _automation->getColorGrading(self.modelView.engine);
     self.modelView.view->setColorGrading(colorGrading);
     self.modelView.cameraFocalLength = _automation->getViewerOptions().cameraFocalLength;
@@ -266,6 +293,40 @@ using namespace ktxreader;
 - (void)reloadModel {
     [self.modelView destroyModel];
     [self createDefaultRenderables];
+}
+
+- (void)issuePickingQuery {
+    CGPoint tapLocation = [_singleTapRecognizer locationInView:self.modelView];
+    __weak typeof(self) weakSelf = self;
+    [self.modelView issuePickQuery:tapLocation
+                          callback:^(utils::Entity entity) {
+                              NSString* name = [self.modelView getEntityName:entity];
+                              if (!name) {
+                                  name = @"<unnamed>";
+                              }
+                              NSString* message = [NSString
+                                      stringWithFormat:@"Picked entity %d (%@) at (%d,%d)",
+                                      entity.getId(), name, int(tapLocation.x), int(tapLocation.y)];
+                              [weakSelf toastMessage:message];
+                          }];
+}
+
+- (void)toastMessage:(NSString*)message {
+    _toastLabel.text = message;
+    _toastLabel.alpha = 0.0f;
+    [UIView animateWithDuration:kToastAnimationDuration
+            animations:^{
+                _toastLabel.alpha = 1.0f;
+            }
+            completion:^(BOOL finished) {
+                [UIView animateWithDuration:kToastAnimationDuration
+                                      delay:kToastDelayDuration
+                                    options:UIViewAnimationOptionCurveEaseInOut
+                                 animations:^{
+                                     _toastLabel.alpha = 0.0f;
+                                 }
+                                 completion:nil];
+            }];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
This is an example implementation of how a client might utilize Filament's picking queries in an iOS app.


![picking](https://github-production-user-asset-6210df.s3.amazonaws.com/5298046/293287829-fba6febe-9725-4259-abe3-bc41560e268e.png)
