### PR TITLE
matdbg: Load codicon font

### DIFF
--- a/libs/matdbg/web/index.html
+++ b/libs/matdbg/web/index.html
@@ -12,6 +12,11 @@
           margin: 0;
           font-family: "Open Sans";
       }
+
+      @font-face {
+        font-family: codicon;
+        src: url(https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.25.2/min/vs/base/browser/ui/codicons/codicon/codicon.ttf);
+      }
     </style>
     <script src="api.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.25.2/min/vs/loader.js"></script>


### PR DESCRIPTION
This font is used to render some of the icons in the matdbg editor. For some reason, monaco-editor wasn't loading this font automatically.

![Screenshot 2024-01-03 at 10 30 39 AM](https://github.com/google/filament/assets/5298046/e979707e-2f2b-41c9-8b0e-3e1cac115f41)
