### PR TITLE
Fix ostream linking error when compiling Linux DSO

### DIFF
--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -111,7 +111,7 @@ private:
     friend ostream& hex(ostream& s) noexcept;
     friend ostream& dec(ostream& s) noexcept;
     friend ostream& endl(ostream& s) noexcept;
-    friend ostream& flush(ostream& s) noexcept;
+    UTILS_PUBLIC friend ostream& flush(ostream& s) noexcept;
 
     enum type {
         SHORT, USHORT, CHAR, UCHAR, INT, UINT, LONG, ULONG, LONG_LONG, ULONG_LONG, FLOAT, DOUBLE,


### PR DESCRIPTION
Because `utils::io::flush(utils::io::ostream&)` is now implemented in a cpp file (introduced in https://github.com/google/filament/commit/d6b2ec49b0a9c7c166a5a39aa924808c73e28c25), its needs to be marked with public visibility to work correctly with dynamic libraries. Otherwise we get the following error:

```
ld: error: non-exported symbol 'utils::io::flush(utils::io::ostream&)' in 'blaze-out/k8-opt/bin/third_party/filament/libs/_objs/utils/ostream.pic.o' is referenced by DSO 'blaze-out/k8-opt/bin/_solib_k8/libthird_Uparty_Sfilament_Slibs_Slibimageio.ifso'
```