### PR TITLE
Metal: Always report material name in use-after-free detector

### DIFF
--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -117,7 +117,7 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
     if (!material->getSamplerInterfaceBlock().isEmpty()) {
         mSamplers = SamplerGroup(material->getSamplerInterfaceBlock().getSize());
         mSbHandle = driver.createSamplerGroup(
-                mSamplers.getSize(), utils::FixedSizeString<32>("Default material"));
+                mSamplers.getSize(), utils::FixedSizeString<32>(mMaterial->getName().c_str_safe()));
     }
 
     const RasterState& rasterState = material->getRasterState();


### PR DESCRIPTION
There's no reason we can't report the material name here, even if the client is using the default material instance.