### PR TITLE
Generate dummy stereo variants for FL0 mats

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Instead, if you are authoring a PR for the main branch, add your release note to
 
 ## v1.49.3
 
+- matc: Generate stereo variants for FL0 materials [⚠️ **Recompile materials**]
 
 ## v1.49.2
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1168,7 +1168,6 @@ error:
         mVariantFilter |= uint32_t(UserVariantFilterBit::SHADOW_RECEIVER);
         mVariantFilter |= uint32_t(UserVariantFilterBit::VSM);
         mVariantFilter |= uint32_t(UserVariantFilterBit::SSR);
-        mVariantFilter |= uint32_t(UserVariantFilterBit::STE);
     }
 
     // Create chunk tree.

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -52,7 +52,7 @@ void ShaderGenerator::generateSurfaceMaterialVariantDefines(utils::io::sstream& 
     CodeGenerator::generateDefine(out, "VARIANT_HAS_VSM",
             filament::Variant::isVSMVariant(variant));
     CodeGenerator::generateDefine(out, "VARIANT_HAS_INSTANCED_STEREO",
-            filament::Variant::isStereoVariant(variant));
+            hasInstancedStereo(variant, featureLevel));
 
     switch (stage) {
         case ShaderStage::VERTEX:
@@ -755,6 +755,14 @@ bool ShaderGenerator::hasSkinningOrMorphing(
             // HACK(exv): Ignore skinning/morphing variant when targeting ESSL 1.0. We should
             // either properly support skinning on FL0 or build a system in matc which allows
             // the set of included variants to differ per-feature level.
+            && featureLevel > MaterialBuilder::FeatureLevel::FEATURE_LEVEL_0;
+}
+
+bool ShaderGenerator::hasInstancedStereo(
+        filament::Variant variant, MaterialBuilder::FeatureLevel featureLevel) noexcept {
+    return variant.hasInstancedStereo()
+            // HACK(exv): Ignore stereo variant when targeting ESSL 1.0. We should properly build a
+            // system in matc which allows the set of included variants to differ per-feature level.
             && featureLevel > MaterialBuilder::FeatureLevel::FEATURE_LEVEL_0;
 }
 

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -115,6 +115,10 @@ private:
             filament::Variant variant,
             MaterialBuilder::FeatureLevel featureLevel) noexcept;
 
+    static bool hasInstancedStereo(
+            filament::Variant variant,
+            MaterialBuilder::FeatureLevel featureLevel) noexcept;
+
     MaterialBuilder::PropertyList mProperties;
     MaterialBuilder::VariableList mVariables;
     MaterialBuilder::OutputList mOutputs;


### PR DESCRIPTION
See #7415 for a more detailed description of why this change is necessary.

The remaining variants which are filtered from FL0 materials are all related to lighting, so further hacks like this won't be necessary.

Future work involves properly supporting differing sets of variants based on shader language.