### PR TITLE
bloom: disable fireflies reduction when using TAA

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -171,7 +171,9 @@ public:
         FrameGraphId<FrameGraphTexture> flare;
     };
     BloomPassOutput bloom(FrameGraph& fg, FrameGraphId<FrameGraphTexture> input,
-            BloomOptions& inoutBloomOptions, backend::TextureFormat outFormat,
+            backend::TextureFormat outFormat,
+            BloomOptions& inoutBloomOptions,
+            TemporalAntiAliasingOptions const& taaOptions,
             math::float2 scale) noexcept;
 
     FrameGraphId<FrameGraphTexture> flarePass(FrameGraph& fg,
@@ -341,10 +343,6 @@ private:
             FrameGraphId<FrameGraphTexture> input, FrameGraphId<FrameGraphTexture> depth,
             math::int2 axis, float zf, backend::TextureFormat format,
             BilateralPassConfig const& config) noexcept;
-
-    BloomPassOutput bloomPass(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
-            BloomOptions& inoutBloomOptions, math::float2 scale) noexcept;
 
     FrameGraphId<FrameGraphTexture> downscalePass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1035,7 +1035,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (bloomOptions.enabled) {
             // Generate the bloom buffer, which is stored in the blackboard as "bloom". This is
             // consumed by the colorGrading pass and will be culled if colorGrading is disabled.
-            auto [bloom_, flare_] = ppm.bloom(fg, input, bloomOptions, TextureFormat::R11F_G11F_B10F, scale);
+            auto [bloom_, flare_] = ppm.bloom(fg, input, TextureFormat::R11F_G11F_B10F,
+                    bloomOptions, taaOptions, scale);
             bloom = bloom_;
             flare = flare_;
         }


### PR DESCRIPTION
TAA already does a fireflies reduction pass, so it's not needed when applying bloom.
