### PR TITLE
Bokeh aspect ratio

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1882,7 +1882,7 @@ public class View {
      * Options for Temporal Anti-aliasing (TAA)
      * Most TAA parameters are extremely costly to change, as they will trigger the TAA post-process
      * shaders to be recompiled. These options should be changed or set during initialization.
-     * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed an any time.
+     * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed at any time.
      *
      * `feedback` of 0.1 effectively accumulates a maximum of 19 samples in steady state.
      * see "A Survey of Temporal Antialiasing Techniques" by Lei Yang and all for more information.

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1638,6 +1638,10 @@ public class View {
          */
         public float cocScale = 1.0f;
         /**
+         * width/height aspect ratio of the circle of confusion (simulate anamorphic lenses)
+         */
+        public float cocAspectRatio = 1.0f;
+        /**
          * maximum aperture diameter in meters (zero to disable rotation)
          */
         public float maxApertureDiameter = 0.01f;
@@ -1878,7 +1882,7 @@ public class View {
      * Options for Temporal Anti-aliasing (TAA)
      * Most TAA parameters are extremely costly to change, as they will trigger the TAA post-process
      * shaders to be recompiled. These options should be changed or set during initialization.
-     * `filterWidth`, `feedback` and `jitterPattern`, however, can be changed at any time.
+     * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed an any time.
      *
      * `feedback` of 0.1 effectively accumulates a maximum of 19 samples in steady state.
      * see "A Survey of Temporal Antialiasing Techniques" by Lei Yang and all for more information.

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -293,6 +293,7 @@ struct DepthOfFieldOptions {
         MEDIAN
     };
     float cocScale = 1.0f;              //!< circle of confusion scale factor (amount of blur)
+    float cocAspectRatio = 1.0f;        //!< width/height aspect ratio of the circle of confusion (simulate anamorphic lenses)
     float maxApertureDiameter = 0.01f;  //!< maximum aperture diameter in meters (zero to disable rotation)
     bool enabled = false;               //!< enable or disable depth of field effect
     Filter filter = Filter::MEDIAN;     //!< filter to use for filling gaps in the kernel

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1428,7 +1428,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> depth,
         const CameraInfo& cameraInfo,
         bool translucent,
-        float bokehAspectRatio,
+        float2 bokehScale,
         const DepthOfFieldOptions& dofOptions) noexcept {
 
     assert_invariant(depth);
@@ -1818,8 +1818,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 mi->setParameter("tiles", tilesCocMinMax,
                         { .filterMin = SamplerMinFilter::NEAREST });
                 mi->setParameter("cocToTexelScale", float2{
-                        bokehAspectRatio / (inputDesc.width  * dofResolution),
-                                     1.0 / (inputDesc.height * dofResolution)
+                        bokehScale.x / (inputDesc.width * dofResolution),
+                        bokehScale.y / (inputDesc.height * dofResolution)
                 });
                 mi->setParameter("cocToPixelScale", (1.0f / float(dofResolution)));
                 mi->setParameter("ringCounts", float4{

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -162,7 +162,7 @@ public:
             FrameGraphId<FrameGraphTexture> depth,
             const CameraInfo& cameraInfo,
             bool translucent,
-            float bokehAspectRatio,
+            math::float2 bokehScale,
             const DepthOfFieldOptions& dofOptions) noexcept;
 
     // Bloom

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1026,9 +1026,13 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             // The bokeh height is always correct regardless of the dynamic resolution scaling.
             // (because the CoC is calculated w.r.t. the height), so we only need to adjust
             // the width.
-            float const bokehAspectRatio = scale.x / scale.y;
+            float const aspect = (scale.x / scale.y) * dofOptions.cocAspectRatio;
+            float2 const bokehScale{
+                aspect < 1.0f ? aspect : 1.0f,
+                aspect > 1.0f ? 1.0f / aspect : 1.0f
+            };
             input = ppm.dof(fg, input, depth, cameraInfo, needsAlphaChannel,
-                    bokehAspectRatio, dofOptions);
+                    bokehScale, dofOptions);
         }
 
         FrameGraphId<FrameGraphTexture> bloom, flare;

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -391,6 +391,8 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, DepthOfFieldOpt
         CHECK_KEY(tok);
         if (compare(tok, jsonChunk, "cocScale") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->cocScale);
+        } else if (compare(tok, jsonChunk, "cocAspectRatio") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->cocAspectRatio);
         } else if (compare(tok, jsonChunk, "maxApertureDiameter") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->maxApertureDiameter);
         } else if (compare(tok, jsonChunk, "enabled") == 0) {
@@ -424,6 +426,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, DepthOfFieldOpt
 std::ostream& operator<<(std::ostream& out, const DepthOfFieldOptions& in) {
     return out << "{\n"
         << "\"cocScale\": " << (in.cocScale) << ",\n"
+        << "\"cocAspectRatio\": " << (in.cocAspectRatio) << ",\n"
         << "\"maxApertureDiameter\": " << (in.maxApertureDiameter) << ",\n"
         << "\"enabled\": " << to_string(in.enabled) << ",\n"
         << "\"filter\": " << (in.filter) << ",\n"

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1034,6 +1034,7 @@ void ViewerGui::updateUserInterface() {
             ImGui::Checkbox("Enabled##dofEnabled", &mSettings.view.dof.enabled);
             ImGui::SliderFloat("Focus distance", &mSettings.viewer.cameraFocusDistance, 0.0f, 30.0f);
             ImGui::SliderFloat("Blur scale", &mSettings.view.dof.cocScale, 0.1f, 10.0f);
+            ImGui::SliderFloat("CoC aspect-ratio", &mSettings.view.dof.cocAspectRatio, 0.25f, 4.0f);
             ImGui::SliderInt("Ring count", &dofRingCount, 1, 17);
             ImGui::SliderInt("Max CoC", &dofMaxCoC, 1, 32);
             ImGui::Checkbox("Native Resolution", &mSettings.view.dof.nativeResolution);

--- a/web/filament-js/extensions_generated.js
+++ b/web/filament-js/extensions_generated.js
@@ -60,6 +60,7 @@ Filament.loadGeneratedExtensions = function() {
     Filament.View.prototype.setDepthOfFieldOptionsDefaults = function(overrides) {
         const options = {
             cocScale: 1.0,
+            cocAspectRatio: 1.0,
             maxApertureDiameter: 0.01,
             enabled: false,
             filter: Filament.View$DepthOfFieldOptions$Filter.MEDIAN,

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1663,7 +1663,7 @@ export enum View$TemporalAntiAliasingOptions$JitterPattern {
  * Options for Temporal Anti-aliasing (TAA)
  * Most TAA parameters are extremely costly to change, as they will trigger the TAA post-process
  * shaders to be recompiled. These options should be changed or set during initialization.
- * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed an any time.
+ * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed at any time.
  *
  * `feedback` of 0.1 effectively accumulates a maximum of 19 samples in steady state.
  * see "A Survey of Temporal Antialiasing Techniques" by Lei Yang and all for more information.

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1410,6 +1410,10 @@ export interface View$DepthOfFieldOptions {
      */
     cocScale?: number;
     /**
+     * width/height aspect ratio of the circle of confusion (simulate anamorphic lenses)
+     */
+    cocAspectRatio?: number;
+    /**
      * maximum aperture diameter in meters (zero to disable rotation)
      */
     maxApertureDiameter?: number;
@@ -1659,7 +1663,7 @@ export enum View$TemporalAntiAliasingOptions$JitterPattern {
  * Options for Temporal Anti-aliasing (TAA)
  * Most TAA parameters are extremely costly to change, as they will trigger the TAA post-process
  * shaders to be recompiled. These options should be changed or set during initialization.
- * `filterWidth`, `feedback` and `jitterPattern`, however, can be changed at any time.
+ * `filterWidth`, `feedback` and `jitterPattern`, however, could be changed an any time.
  *
  * `feedback` of 0.1 effectively accumulates a maximum of 19 samples in steady state.
  * see "A Survey of Temporal Antialiasing Techniques" by Lei Yang and all for more information.

--- a/web/filament-js/jsbindings_generated.cpp
+++ b/web/filament-js/jsbindings_generated.cpp
@@ -58,6 +58,7 @@ value_object<View::FogOptions>("View$FogOptions")
 
 value_object<View::DepthOfFieldOptions>("View$DepthOfFieldOptions")
     .field("cocScale", &View::DepthOfFieldOptions::cocScale)
+    .field("cocAspectRatio", &View::DepthOfFieldOptions::cocAspectRatio)
     .field("maxApertureDiameter", &View::DepthOfFieldOptions::maxApertureDiameter)
     .field("enabled", &View::DepthOfFieldOptions::enabled)
     .field("filter", &View::DepthOfFieldOptions::filter)


### PR DESCRIPTION
new DoF option to set the bokeh aspect ratio, this can be used to 
simulate anamorphic lenses
![bokeh](https://github.com/google/filament/assets/1240896/06027b49-f078-443c-98ae-af795e12e9ee)
