### PR TITLE
Metal: disable fast math

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- Metal: fix some shader artifacts by disabling fast math optimizations.

--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -103,10 +103,19 @@ void MetalShaderCompiler::terminate() noexcept {
         NSString* objcSource = [[NSString alloc] initWithBytes:source.data()
                                                         length:source.size() - 1
                                                       encoding:NSUTF8StringEncoding];
+
+        // By default, Metal uses the most recent language version.
+        MTLCompileOptions* options = [MTLCompileOptions new];
+
+        // Disable Fast Math optimizations.
+        // This ensures that operations adhere to IEEE standards for floating-point arithmetic,
+        // which is crucial for half precision floats in scenarios where fast math optimizations
+        // lead to inaccuracies, such as in handling special values like NaN or Infinity.
+        options.fastMathEnabled = NO;
+
         NSError* error = nil;
-        // When options is nil, Metal uses the most recent language version available.
         id<MTLLibrary> library = [device newLibraryWithSource:objcSource
-                                                      options:nil
+                                                      options:options
                                                         error:&error];
         if (library == nil) {
             if (error) {


### PR DESCRIPTION
This PR disables 'fast math' optimizations for Metal, which makes assumptions that Filament's GLSL code does not adhere to. One example is as follows.

Inside our GLSL fragment code, we use the `saturateMediump` define to clamp floating-point values to a maximum of `65504.0` (the largest finite half-precision value). The purpose is to manage values that could potentially reach Infinity during computation.

```glsl
precision mediump float;

#define MEDIUMP_FLT_MAX    65504.0
#define saturateMediump(x) min(x, MEDIUMP_FLT_MAX)

// ...

float d = // computation that could be Infinity
return saturateMediump(d);
```

However, when this code is cross-compiled to MSL with optimizations enabled, it translates to:

```c++
half d = // ...
return min(d, half(65504.0));
```

The issue here is that Metal's default compiler setting uses 'fast math', which among other optimizations, assumes that Infinities are impossible in fp16 calculations. As a result, the `saturateMediump` statement in our code effectively gets ignored, and the computation defaults to simply returning `d`. This leads to shading artifacts in scenarios where `d` exceeds the half-precision floating-point range.



Fixes #7393