### PR TITLE
Fix a json parsing bug

### DIFF
--- a/tools/matc/src/matc/JsonishLexer.cpp
+++ b/tools/matc/src/matc/JsonishLexer.cpp
@@ -27,9 +27,7 @@ JsonType JsonishLexer::readIdentifier() noexcept {
         consume();
     }
 
-    const char* lexemeEnd = mCursor - 1;
-
-    size_t lexemeSize = lexemeEnd - lexemeStart;
+    size_t lexemeSize = mCursor - lexemeStart;
 
     // Check what kind of keyword we got here.
     if (strncmp("true", lexemeStart, lexemeSize) == 0) {


### PR DESCRIPTION
When parsing a lexeme, we use one less byte than it's intended to be for comparing the current string.

This results in a success in cases like:
- true and truX
- false and falsX
- null and nulX
where X means an arbitrary character.

Fix this by using the full intended length.