### PR TITLE
Remove spirv-opt size optimizations for MSL

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -702,9 +702,12 @@ void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer, Config const& c
         optimizer.RegisterPass(std::move(pass));
     };
 
+    if (config.targetApi == MaterialBuilder::TargetApi::METAL) {
+        return;
+    }
+
     RegisterPass(CreateWrapOpKillPass());
     RegisterPass(CreateDeadBranchElimPass());
-    RegisterPass(CreateMergeReturnPass(), MaterialBuilder::TargetApi::METAL);
     RegisterPass(CreateInlineExhaustivePass());
     RegisterPass(CreateEliminateDeadFunctionsPass());
     RegisterPass(CreatePrivateToLocalPass());
@@ -713,11 +716,9 @@ void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer, Config const& c
     RegisterPass(CreateCCPPass());
     RegisterPass(CreateLoopUnrollPass(true));
     RegisterPass(CreateDeadBranchElimPass());
-    RegisterPass(CreateSimplificationPass(), MaterialBuilder::TargetApi::METAL);
     RegisterPass(CreateScalarReplacementPass(0));
     RegisterPass(CreateLocalSingleStoreElimPass());
     RegisterPass(CreateIfConversionPass());
-    RegisterPass(CreateSimplificationPass(), MaterialBuilder::TargetApi::METAL);
     RegisterPass(CreateAggressiveDCEPass());
     RegisterPass(CreateDeadBranchElimPass());
     RegisterPass(CreateBlockMergePass());
@@ -733,7 +734,6 @@ void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer, Config const& c
     RegisterPass(CreateBlockMergePass());
     RegisterPass(CreateLocalMultiStoreElimPass());
     RegisterPass(CreateRedundancyEliminationPass());
-    RegisterPass(CreateSimplificationPass(), MaterialBuilder::TargetApi::METAL);
     RegisterPass(CreateAggressiveDCEPass());
     RegisterPass(CreateCFGCleanupPass());
 }


### PR DESCRIPTION
For generating MSL, turning off `--optimize-size` optimization passes (still keeping the ones necessary for fp16), reduces sizes of lit materials by nearly 400 KiB:
- sandboxLit.mat: 376.6 KiB savings
- gltfio lit_opaque.mat: 395.7 KiB savings
- bakedColor.mat: 1.799 KiB increase

Note there is a slight increase with unlit materials, as seen above with bakedColor.mat.

Removing these optimizations helps the line dictionary compress better. It's likely the Metal compiler itself does a lot of these optimizations.

An added benefit is this makes MSL shaders much easier to debug.