### PR TITLE
fix IBLPrefilterContext::EquirectangularToCubemap

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - Metal: fix some shader artifacts by disabling fast math optimizations.
+- backend: remove `atan2` overload which had a typo and wasn't useful. Fixes b/320856413.

--- a/libs/iblprefilter/src/materials/equirectToCube.mat
+++ b/libs/iblprefilter/src/materials/equirectToCube.mat
@@ -48,7 +48,7 @@ fragment {
 void dummy() {}
 
 highp vec2 toEquirect(const highp vec3 s) {
-    highp float xf = atan2(s.x, s.z) * (1.0 / PI);  // range [-1.0, 1.0]
+    highp float xf = atan(s.x, s.z) * (1.0 / PI);   // range [-1.0, 1.0]
     highp float yf = asin(s.y) * (2.0 / PI);        // range [-1.0, 1.0]
     xf = (xf + 1.0) * 0.5;                          // range [0, 1.0]
     yf = (1.0 - yf) * 0.5;                          // range [0, 1.0]
@@ -62,17 +62,22 @@ mediump vec3 sampleEquirect(mediump sampler2D equirect, const highp vec3 r) {
 
 void postProcess(inout PostProcessInputs postProcess) {
     highp vec2 uv = variable_vertex.xy; // interpolated at pixel's center
-    highp vec2 p = uv * 2.0 - 1.0;
+    highp vec2 p = vec2(
+        uv.x * 2.0 - 1.0,
+        1.0 - uv.y * 2.0);
+
     float side = materialParams.side;
+    highp float l = inversesqrt(p.x * p.x + p.y * p.y + 1.0);
 
     // compute the view (and normal, since v = n) direction for each face
-    highp vec3 rx = normalize(vec3(      side,  -p.y, side * -p.x));
-    highp vec3 ry = normalize(vec3(       p.x,  side, side *  p.y));
-    highp vec3 rz = normalize(vec3(side * p.x,  -p.y, side));
+    highp vec3 rx = vec3(      side,  p.y,  side * -p.x);
+    highp vec3 ry = vec3(       p.x,  side, side * -p.y);
+    highp vec3 rz = vec3(side * p.x,  p.y,  side);
 
-    postProcess.outx = sampleEquirect(materialParams_equirect, rx);
-    postProcess.outy = sampleEquirect(materialParams_equirect, ry);
-    postProcess.outz = sampleEquirect(materialParams_equirect, rz);
+
+    postProcess.outx = sampleEquirect(materialParams_equirect, rx * l);
+    postProcess.outy = sampleEquirect(materialParams_equirect, ry * l);
+    postProcess.outz = sampleEquirect(materialParams_equirect, rz * l);
 }
 
 }

--- a/shaders/src/common_math.glsl
+++ b/shaders/src/common_math.glsl
@@ -19,7 +19,6 @@
 #endif
 
 #define saturate(x)        clamp(x, 0.0, 1.0)
-#define atan2(x, y)        atan(y, x)
 
 //------------------------------------------------------------------------------
 // Scalar operations


### PR DESCRIPTION
it was incorrectly mapping the equirect image to a cubemap due to a typo in our overload of atan2 which was swapping its parameters.

atan2 is now removed, and we use atan(y,x) instead. Also modified the code slightly so it matches almost exactly cmgen's.

FIXES=[320856413]