### PR TITLE
Shadowmap texture vizualizer

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -238,6 +238,7 @@ set(MATERIAL_SRCS
         src/materials/resolveDepth.mat
         src/materials/separableGaussianBlur.mat
         src/materials/skybox.mat
+        src/materials/shadowmap.mat
         src/materials/ssao/bilateralBlur.mat
         src/materials/ssao/bilateralBlurBentNormals.mat
         src/materials/ssao/mipmapDepth.mat

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -307,6 +307,7 @@ static const PostProcessManager::MaterialInfo sMaterialList[] = {
         { "fsr_rcas",                   MATERIAL(FSR_RCAS) },
         { "debugShadowCascades",        MATERIAL(DEBUGSHADOWCASCADES) },
         { "resolveDepth",               MATERIAL(RESOLVEDEPTH) },
+        { "shadowmap",                  MATERIAL(SHADOWMAP) },
 };
 
 void PostProcessManager::init() noexcept {
@@ -3272,5 +3273,52 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::debugShadowCascades(FrameGra
 
     return debugShadowCascadePass->output;
 }
+
+FrameGraphId<FrameGraphTexture> PostProcessManager::debugDisplayShadowTexture(
+        FrameGraph& fg,
+        FrameGraphId<FrameGraphTexture> input,
+        FrameGraphId<FrameGraphTexture> shadowmap, float scale,
+        uint8_t layer, uint8_t level, uint8_t channel, float power) noexcept {
+    if (shadowmap) {
+        struct ShadowMapData {
+            FrameGraphId<FrameGraphTexture> color;
+            FrameGraphId<FrameGraphTexture> depth;
+        };
+
+        auto const& desc = fg.getDescriptor(input);
+        float const ratio = float(desc.height) / float(desc.width);
+        float const screenScale = float(fg.getDescriptor(shadowmap).height) / float(desc.height);
+        float2 const s = { screenScale * scale * ratio, screenScale * scale };
+
+        auto& shadomapDebugPass = fg.addPass<ShadowMapData>("shadowmap debug pass",
+                [&](FrameGraph::Builder& builder, auto& data) {
+                    data.color = builder.read(input,
+                            FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                    data.color = builder.write(data.color,
+                            FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                    data.depth = builder.sample(shadowmap);
+                    builder.declareRenderPass("color target", {
+                            .attachments = { .color = { data.color }}
+                    });
+                },
+                [=](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
+                    auto out = resources.getRenderPassInfo();
+                    auto in = resources.getTexture(data.depth);
+                    auto const& material = getPostProcessMaterial("shadowmap");
+                    FMaterialInstance* const mi = material.getMaterialInstance(mEngine);
+                    mi->setParameter("shadowmap", in, {
+                        .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST });
+                    mi->setParameter("scale", s);
+                    mi->setParameter("layer", (uint32_t)layer);
+                    mi->setParameter("level", (uint32_t)level);
+                    mi->setParameter("channel", (uint32_t)channel);
+                    mi->setParameter("power", power);
+                    commitAndRender(out, material, driver);
+                });
+        input = shadomapDebugPass->color;
+    }
+    return input;
+}
+
 
 } // namespace filament

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -282,6 +282,11 @@ public:
             FrameGraphId<FrameGraphTexture> input,
             FrameGraphId<FrameGraphTexture> depth) noexcept;
 
+    FrameGraphId<FrameGraphTexture> debugDisplayShadowTexture(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> shadowmap, float scale,
+            uint8_t layer, uint8_t level, uint8_t channel, float power) noexcept;
+
     backend::Handle<backend::HwTexture> getOneTexture() const;
     backend::Handle<backend::HwTexture> getZeroTexture() const;
     backend::Handle<backend::HwTexture> getOneTextureArray() const;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -294,6 +294,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
     // Shadow Passes
     // -------------------------------------------------------------------------------------------
 
+    fg.getBlackboard()["shadowmap"] = prepareShadowPass->shadows;
+
     struct ShadowPassData {
         FrameGraphId<FrameGraphTexture> tempBlurSrc{};  // temporary shadowmap when blurring
         FrameGraphId<FrameGraphTexture> output;
@@ -942,6 +944,10 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
         int const lowMipmapLevel = 7;    // log2(256) - 1
         mipLevels = std::max(1, FTexture::maxLevelCount(maxDimension) - lowMipmapLevel);
     }
+
+    // publish the debugging data
+    engine.debug.shadowmap.display_shadow_texture_layer_count = layersNeeded;
+    engine.debug.shadowmap.display_shadow_texture_level_count = mipLevels;
 
     mTextureAtlasRequirements = {
             (uint16_t)maxDimension,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -548,12 +548,20 @@ public:
     struct {
         struct {
             bool debug_directional_shadowmap = false;
+            bool display_shadow_texture = false;
             bool far_uses_shadowcasters = true;
             bool focus_shadowcasters = true;
             bool visualize_cascades = false;
             bool tightly_bound_scene = true;
             float dzn = -1.0f;
             float dzf =  1.0f;
+            float display_shadow_texture_scale = 0.25f;
+            int display_shadow_texture_layer = 0;
+            int display_shadow_texture_level = 0;
+            int display_shadow_texture_channel = 0;
+            int display_shadow_texture_layer_count = 0;
+            int display_shadow_texture_level_count = 0;
+            float display_shadow_texture_power = 1;
         } shadowmap;
         struct {
             bool camera_at_origin = true;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -70,6 +70,22 @@ FRenderer::FRenderer(FEngine& engine) :
             &engine.debug.renderer.doFrameCapture);
     debugRegistry.registerProperty("d.renderer.disable_buffer_padding",
             &engine.debug.renderer.disable_buffer_padding);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture",
+            &engine.debug.shadowmap.display_shadow_texture);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_scale",
+            &engine.debug.shadowmap.display_shadow_texture_scale);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_layer",
+            &engine.debug.shadowmap.display_shadow_texture_layer);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_level",
+            &engine.debug.shadowmap.display_shadow_texture_level);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_channel",
+            &engine.debug.shadowmap.display_shadow_texture_channel);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_layer_count",
+            &engine.debug.shadowmap.display_shadow_texture_layer_count);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_level_count",
+            &engine.debug.shadowmap.display_shadow_texture_level_count);
+    debugRegistry.registerProperty("d.shadowmap.display_shadow_texture_power",
+            &engine.debug.shadowmap.display_shadow_texture_power);
 
     DriverApi& driver = engine.getDriverApi();
 
@@ -1131,6 +1147,16 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         ASSERT_PRECONDITION(mSwapChain->hasStencilBuffer(),
                 "View has stencil buffer enabled, but SwapChain does not have "
                 "SwapChain::CONFIG_HAS_STENCIL_BUFFER flag set.");
+    }
+
+    if (UTILS_UNLIKELY(engine.debug.shadowmap.display_shadow_texture)) {
+        auto shadowmap = blackboard.get<FrameGraphTexture>("shadowmap");
+        input = ppm.debugDisplayShadowTexture(fg, input, shadowmap,
+                engine.debug.shadowmap.display_shadow_texture_scale,
+                engine.debug.shadowmap.display_shadow_texture_layer,
+                engine.debug.shadowmap.display_shadow_texture_level,
+                engine.debug.shadowmap.display_shadow_texture_channel,
+                engine.debug.shadowmap.display_shadow_texture_power);
     }
 
 //    auto debug = structure

--- a/filament/src/materials/shadowmap.mat
+++ b/filament/src/materials/shadowmap.mat
@@ -1,0 +1,59 @@
+material {
+    name : shadowmap,
+    parameters : [
+        {
+           type : sampler2dArray,
+           name : shadowmap,
+           precision : high
+        },
+        {
+           type : float,
+           name : power,
+           precision : high
+        },
+        {
+           type : float2,
+           name : scale,
+        },
+        {
+            type : int,
+            name : layer
+        },
+        {
+            type : int,
+            name : level
+        },
+        {
+            type : int,
+            name : channel
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    vertexDomain : device,
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.position.xy = 1.0 + (postProcess.position.xy - 1.0) * materialParams.scale;
+    }
+}
+
+fragment {
+    void dummy(){}
+
+    void postProcess(inout PostProcessInputs postProcess) {
+        highp vec2 uv = uvToRenderTargetUV(variable_vertex.xy);
+        highp vec3 p = vec3(uv, float(materialParams.layer));
+        float m = float(materialParams.level);
+        highp float c = textureLod(materialParams_shadowmap, p, m)[materialParams.channel];
+        c = pow(abs(c), materialParams.power);
+        postProcess.color.rgb = vec3(c);
+        postProcess.color.a = 1.0;
+    }
+}

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -872,6 +872,27 @@ int main(int argc, char** argv) {
                             debugDirectionalShadowmap);
                 }
 
+                ImGui::Checkbox("Display Shadow Texture",
+                        debug.getPropertyAddress<bool>("d.shadowmap.display_shadow_texture"));
+                if (*debug.getPropertyAddress<bool>("d.shadowmap.display_shadow_texture")) {
+                    int layerCount;
+                    int levelCount;
+                    debug.getProperty("d.shadowmap.display_shadow_texture_layer_count", &layerCount);
+                    debug.getProperty("d.shadowmap.display_shadow_texture_level_count", &levelCount);
+                    ImGui::Indent();
+                    ImGui::SliderFloat("scale", debug.getPropertyAddress<float>(
+                                    "d.shadowmap.display_shadow_texture_scale"), 0.0f, 8.0f);
+                    ImGui::SliderFloat("contrast", debug.getPropertyAddress<float>(
+                                    "d.shadowmap.display_shadow_texture_power"), 0.0f, 2.0f);
+                    ImGui::SliderInt("layer", debug.getPropertyAddress<int>(
+                                    "d.shadowmap.display_shadow_texture_layer"), 0, layerCount - 1);
+                    ImGui::SliderInt("level", debug.getPropertyAddress<int>(
+                                    "d.shadowmap.display_shadow_texture_level"), 0, levelCount - 1);
+                    ImGui::SliderInt("channel", debug.getPropertyAddress<int>(
+                                    "d.shadowmap.display_shadow_texture_channel"), 0, 3);
+                    ImGui::Unindent();
+                }
+
                 bool debugFroxelVisualization;
                 if (debug.getProperty("d.lighting.debug_froxel_visualization",
                         &debugFroxelVisualization)) {


### PR DESCRIPTION
The vizualizer is implemented inside filament itself and activated using the debug registry. This intended for filament development use.
![shadow-debug](https://github.com/google/filament/assets/1240896/55f9d051-8356-4fae-9213-3db54a5a5bc5)
