### PR TITLE
Refactor the mesh reader

### DIFF
--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -90,9 +90,9 @@ public:
      * used instead. The default material can be overridden by adding a material
      * named "DefaultMaterial" to the registry.
      */
-    static Mesh loadMeshFromFile(filament::Engine* engine,
+    static Mesh loadMeshFromFile(filament::Engine *const engine,
             const utils::Path& path,
-            MaterialRegistry& materials);
+            MaterialRegistry& materialRegistry);
 
     /**
      * Loads a filamesh renderable from an in-memory buffer. The material registry
@@ -103,7 +103,7 @@ public:
      */
     static Mesh loadMeshFromBuffer(filament::Engine* engine,
             void const* data, Callback destructor, void* user,
-            MaterialRegistry& materials);
+            MaterialRegistry& materialRegistry);
 
     /**
      * Loads a filamesh renderable from an in-memory buffer. The material registry


### PR DESCRIPTION
- Check if an error occurred when opening the mesh file.
- Use the `const` type qualifier.
- Convert to void expression when not using the function return.
- Remove unused variable.
- Fix pointer dereferencing for material count.
- Use array instead of `std::vector`.