### PR TITLE
gltfio: use tangent space mesh

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+ - gltfio: support for fallback flat-shading and mikktspace tangents

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -81,9 +81,17 @@ set(GLTFIO_SRCS
         ${GLTFIO_DIR}/src/TangentsJob.cpp
         ${GLTFIO_DIR}/src/TangentsJob.h
         ${GLTFIO_DIR}/src/UbershaderProvider.cpp
+        ${GLTFIO_DIR}/src/Utility.cpp
+        ${GLTFIO_DIR}/src/Utility.h
         ${GLTFIO_DIR}/src/Wireframe.cpp
         ${GLTFIO_DIR}/src/Wireframe.h
         ${GLTFIO_DIR}/src/downcast.h
+        ${GLTFIO_DIR}/src/extended/AssetLoaderExtended.cpp
+        ${GLTFIO_DIR}/src/extended/AssetLoaderExtended.h
+        ${GLTFIO_DIR}/src/extended/ResourceLoaderExtended.cpp
+        ${GLTFIO_DIR}/src/extended/ResourceLoaderExtended.h
+        ${GLTFIO_DIR}/src/extended/TangentsJobExtended.cpp
+        ${GLTFIO_DIR}/src/extended/TangentsJobExtended.h
 
         src/main/cpp/Animator.cpp
         src/main/cpp/AssetLoader.cpp

--- a/libs/geometry/include/geometry/TangentSpaceMesh.h
+++ b/libs/geometry/include/geometry/TangentSpaceMesh.h
@@ -242,7 +242,7 @@ public:
      * Destroy the mesh object
      * @param mesh A pointer to a TangentSpaceMesh ready to be destroyed
      */
-     static void destroy(TangentSpaceMesh* mesh) noexcept;
+    static void destroy(TangentSpaceMesh* mesh) noexcept;
 
     /**
      * Move constructor

--- a/libs/geometry/src/MikktspaceImpl.h
+++ b/libs/geometry/src/MikktspaceImpl.h
@@ -48,7 +48,14 @@ public:
 
 private:
     // sizeof(float3 + float2 + quatf) (pos, uv, tangent)
-    static constexpr size_t const BASE_OUTPUT_SIZE = 36;
+    static constexpr size_t const FLOAT3_SIZE = sizeof(float3);
+    static constexpr size_t const FLOAT2_SIZE = sizeof(float2);
+    static constexpr size_t const QUATF_SIZE = sizeof(quatf);
+
+    static constexpr size_t const POS_OFFSET = 0;
+    static constexpr size_t const UV_OFFSET = FLOAT3_SIZE;
+    static constexpr size_t const TBN_OFFSET = FLOAT3_SIZE + FLOAT2_SIZE;
+    static constexpr size_t const BASE_OUTPUT_SIZE = FLOAT3_SIZE + FLOAT2_SIZE + QUATF_SIZE;
 
     static int getNumFaces(SMikkTSpaceContext const* context) noexcept;
     static int getNumVerticesOfFace(SMikkTSpaceContext const* context, int const iFace) noexcept;
@@ -74,7 +81,14 @@ private:
     size_t const mUVStride;
     uint8_t const* mTriangles;
     bool mIsTriangle16;
-    std::vector<std::tuple<uint8_t const*, size_t, size_t>> mInputAttribArrays;
+
+    struct InputAttribute {
+        AttributeImpl attrib;
+        uint8_t const* data;
+        size_t stride;
+        size_t size;
+    };
+    std::vector<InputAttribute> mInputAttribArrays;
 
     size_t mOutputElementSize;
     std::vector<uint8_t> mOutputData;

--- a/libs/geometry/src/TangentSpaceMesh.cpp
+++ b/libs/geometry/src/TangentSpaceMesh.cpp
@@ -503,6 +503,14 @@ void lengyelMethod(TangentSpaceMeshInput const* input, TangentSpaceMeshOutput* o
     output->triangles16.borrow(triangles16);
 }
 
+void auxImpl(TangentSpaceMeshInput::AttributeMap& attributeData, AttributeImpl attribute,
+        InData data, size_t stride) noexcept {
+    attributeData[attribute] = {
+            data,
+            stride ? stride : TangentSpaceMeshInput::attributeSize(attribute),
+    };
+}
+
 } // anonymous namespace
 
 Builder::Builder() noexcept
@@ -527,27 +535,27 @@ Builder& Builder::vertexCount(size_t vertexCount) noexcept {
 }
 
 Builder& Builder::normals(float3 const* normals, size_t stride) noexcept {
-    mMesh->mInput->attributeData[AttributeImpl::NORMALS] = { normals, stride };
+    auxImpl(mMesh->mInput->attributeData, AttributeImpl::NORMALS, normals, stride);
     return *this;
 }
 
 Builder& Builder::uvs(float2 const* uvs, size_t stride) noexcept {
-    mMesh->mInput->attributeData[AttributeImpl::UV0] = { uvs, stride };
+    auxImpl(mMesh->mInput->attributeData, AttributeImpl::UV0, uvs, stride);
     return *this;
 }
 
 Builder& Builder::positions(float3 const* positions, size_t stride) noexcept {
-    mMesh->mInput->attributeData[AttributeImpl::POSITIONS] = { positions, stride };
+    auxImpl(mMesh->mInput->attributeData, AttributeImpl::POSITIONS, positions, stride);
     return *this;
 }
 
 Builder& Builder::tangents(float4 const* tangents, size_t stride) noexcept {
-    mMesh->mInput->attributeData[AttributeImpl::TANGENTS] = { tangents, stride };
+    auxImpl(mMesh->mInput->attributeData, AttributeImpl::TANGENTS, tangents, stride);
     return *this;
 }
 
 Builder& Builder::aux(AuxAttribute attribute, InData data, size_t stride) noexcept {
-    mMesh->mInput->attributeData[static_cast<AttributeImpl>(attribute)] = { data, stride };
+    auxImpl(mMesh->mInput->attributeData, static_cast<AttributeImpl>(attribute), data, stride);
     return *this;
 }
 
@@ -646,7 +654,6 @@ size_t TangentSpaceMesh::getVertexCount() const noexcept {
 
 void TangentSpaceMesh::getPositions(float3* positions, size_t stride) const {
     auto inPositions = mInput->positions();
-
     ASSERT_PRECONDITION(inPositions, "Must provide input positions");
     stride = stride ? stride : sizeof(decltype(*positions));
     auto const& outPositions = mOutput->positions();

--- a/libs/geometry/src/TangentSpaceMeshInternal.h
+++ b/libs/geometry/src/TangentSpaceMeshInternal.h
@@ -150,8 +150,6 @@ private:
 using ArrayType = std::variant<InternalArray<float2>, InternalArray<float3>, InternalArray<float4>,
         InternalArray<ushort3>, InternalArray<ushort4>, InternalArray<quatf>>;
 
-using AttributeMap = std::unordered_map<AttributeImpl, AttributeDataStride>;
-
 ArrayType toArray(AttributeImpl attribute) {
     switch (attribute) {
         case AttributeImpl::UV1:
@@ -178,6 +176,8 @@ ArrayType toArray(AttributeImpl attribute) {
 } // namespace
 
 struct TangentSpaceMeshInput {
+    using AttributeMap = std::unordered_map<AttributeImpl, AttributeDataStride>;
+
     size_t vertexCount = 0;
     ushort3 const* triangles16 = nullptr;
     uint3 const* triangles32 = nullptr;
@@ -357,7 +357,7 @@ struct TangentSpaceMeshOutput {
         return std::get<InternalArray<DataType>>(attributeData[attrib]);
     }
 
-    void passthrough(AttributeMap const& inAttributeMap,
+    void passthrough(TangentSpaceMeshInput::AttributeMap const& inAttributeMap,
             std::vector<AttributeImpl> const& attributes) {
         auto const borrow = [&inAttributeMap, this](AttributeImpl attrib) {
             auto ref = inAttributeMap.find(attrib);

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -47,9 +47,17 @@ set(SRCS
         src/TangentsJob.cpp
         src/TangentsJob.h
         src/UbershaderProvider.cpp
+        src/Utility.cpp
+        src/Utility.h        
         src/Wireframe.cpp
         src/Wireframe.h
         src/downcast.h
+        src/extended/AssetLoaderExtended.cpp
+        src/extended/AssetLoaderExtended.h
+        src/extended/ResourceLoaderExtended.cpp
+        src/extended/ResourceLoaderExtended.h
+        src/extended/TangentsJobExtended.cpp
+        src/extended/TangentsJobExtended.h
 )
 
 # ==================================================================================================

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -38,6 +38,18 @@ namespace filament::gltfio {
 
 class NodeManager;
 
+// Use this struct to enable mikktspace-based tangent-space computation.
+/**
+ * \struct AssetConfigurationExtended AssetLoader.h gltfio/AssetLoader.h
+ * \brief extends struct AssetConfiguration
+ * Useful if client needs mikktspace tangents.
+ */
+struct AssetConfigurationExtended {
+    //! Optional The same parameter as provided to \struct ResourceConfiguration ResourceLoader.h
+    //! gltfio/ResourceLoader.h
+    char const* gltfPath;
+};
+
 /**
  * \struct AssetConfiguration AssetLoader.h gltfio/AssetLoader.h
  * \brief Construction parameters for AssetLoader.
@@ -62,6 +74,9 @@ struct AssetConfiguration {
 
     //! Optional default node name for anonymous nodes
     char* defaultNodeName = nullptr;
+
+    //! Optional to enable mikktspace tangents.
+    AssetConfigurationExtended* ext = nullptr;
 };
 
 /**

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -156,7 +156,6 @@ public:
 
 private:
     bool loadResources(FFilamentAsset* asset, bool async);
-    void normalizeSkinningWeights(FFilamentAsset* asset) const;
     struct Impl;
     Impl* pImpl;
 };

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -45,9 +45,11 @@
 #include "DependencyGraph.h"
 #include "DracoCache.h"
 #include "FFilamentInstance.h"
+#include "Utility.h"
 
 #include <tsl/htrie_map.h>
 
+#include <variant>
 #include <vector>
 
 #ifdef NDEBUG
@@ -72,16 +74,6 @@ namespace utils {
 namespace filament::gltfio {
 
 struct Wireframe;
-
-// Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
-struct BufferSlot {
-    const cgltf_accessor* accessor;
-    cgltf_attribute_type attribute;
-    int bufferIndex; // for vertex buffer and morph target buffer only
-    VertexBuffer* vertexBuffer;
-    IndexBuffer* indexBuffer;
-    MorphTargetBuffer* morphTargetBuffer;
-};
 
 // Stores a connection between Texture and MaterialInstance; consumed by resource loader so that it
 // can call "setParameter" on the given MaterialInstance after the Texture has been created.
@@ -109,14 +101,24 @@ struct Primitive {
 using MeshCache = utils::FixedCapacityVector<utils::FixedCapacityVector<Primitive>>;
 
 struct FFilamentAsset : public FilamentAsset {
+    struct ResourceInfo;
+    struct ResourceInfoExtended;
+
     FFilamentAsset(Engine* engine, utils::NameComponentManager* names,
             utils::EntityManager* entityManager, NodeManager* nodeManager,
-            TrsTransformManager* trsTransformManager, const cgltf_data* srcAsset) :
+            TrsTransformManager* trsTransformManager, const cgltf_data* srcAsset,
+            bool useExtendedAlgo) :
             mEngine(engine), mNameManager(names), mEntityManager(entityManager),
             mNodeManager(nodeManager), mTrsTransformManager(trsTransformManager),
             mSourceAsset(new SourceAsset {(cgltf_data*)srcAsset}),
             mTextures(srcAsset->textures_count),
-            mMeshCache(srcAsset->meshes_count) {}
+            mMeshCache(srcAsset->meshes_count) {
+        if (!useExtendedAlgo) {
+            mResourceInfo = ResourceInfo{};
+        } else {
+            mResourceInfo = ResourceInfoExtended {};
+        }
+    }
 
     ~FFilamentAsset();
 
@@ -227,6 +229,10 @@ struct FFilamentAsset : public FilamentAsset {
         mDetachedFilamentComponents = true;
     }
 
+    bool isUsingExtendedAlgorithm() {
+        return std::holds_alternative<ResourceInfoExtended>(mResourceInfo);
+    }
+
     // end public API
 
     // If a Filament Texture for the given args already exists, calls setParameter() and returns
@@ -314,8 +320,50 @@ struct FFilamentAsset : public FilamentAsset {
     MeshCache mMeshCache;
 
     // Asset information that is produced by AssetLoader and consumed by ResourceLoader:
-    std::vector<BufferSlot> mBufferSlots;
-    std::vector<std::pair<const cgltf_primitive*, VertexBuffer*> > mPrimitives;
+    struct ResourceInfo {
+        // Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
+        struct BufferSlot {
+            const cgltf_accessor* accessor;
+            cgltf_attribute_type attribute;
+            int bufferIndex;// for vertex buffer and morph target buffer only
+            VertexBuffer* vertexBuffer;
+            IndexBuffer* indexBuffer;
+            MorphTargetBuffer* morphTargetBuffer;
+        };
+
+        std::vector<BufferSlot> mBufferSlots;
+        std::vector<std::pair<const cgltf_primitive*, VertexBuffer*>> mPrimitives;
+    };
+    struct ResourceInfoExtended {
+        // Used to denote a generated buffer. Set as `index in `CgltfAttribute`.
+        static constexpr int const GENERATED_0_INDEX = -1;
+        static constexpr int const GENERATED_1_INDEX = -2;
+
+        struct BufferSlot {
+            VertexBuffer* vertices = nullptr;
+            IndexBuffer* indices = nullptr;
+            MorphTargetBuffer* target = nullptr;
+            int slot = -1;
+            size_t sizeInBytes = 0;
+
+            void* data = nullptr;
+
+            // MorphTarget-only data;
+            struct {
+                short4* tbn = nullptr;
+                float3* positions = nullptr;
+            } targetData;
+        };
+
+        std::vector<BufferSlot> slots;
+
+        // This is to workaround the fact that the original ResourceLoader owns the UriDataCache. In
+        // the extended implementation, we create it in AssetLoader. We pass it along to
+        // ResourceLoader here.
+        UriDataCacheHandle uriDataCache;
+    };
+
+    std::variant<ResourceInfo, ResourceInfoExtended> mResourceInfo;
 };
 
 FILAMENT_DOWNCAST(FilamentAsset)

--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Utility.h"
+
+#include "DracoCache.h"
+#include "FFilamentAsset.h"
+#include "GltfEnums.h"
+
+#include <utils/Log.h>
+#include <utils/Systrace.h>
+
+#define CGLTF_IMPLEMENTATION
+#include <cgltf.h>
+#include <meshoptimizer.h>
+
+namespace filament::gltfio::utility {
+
+using namespace utils;
+
+void decodeDracoMeshes(cgltf_data const* gltf, cgltf_primitive const* prim,
+        DracoCache* dracoCache) {
+    if (!prim->has_draco_mesh_compression) {
+        return;
+    }
+
+    // For a given primitive and attribute, find the corresponding accessor.
+    auto findAccessor = [](const cgltf_primitive* prim, cgltf_attribute_type type, cgltf_int idx) {
+        for (cgltf_size i = 0; i < prim->attributes_count; i++) {
+            const cgltf_attribute& attr = prim->attributes[i];
+            if (attr.type == type && attr.index == idx) {
+                return attr.data;
+            }
+        }
+        return (cgltf_accessor*) nullptr;
+    };
+    const cgltf_draco_mesh_compression& draco = prim->draco_mesh_compression;
+
+    // Check if we have already decoded this mesh.
+    DracoMesh* mesh = dracoCache->findOrCreateMesh(draco.buffer_view);
+    if (!mesh) {
+        slog.e << "Cannot decompress mesh, Draco decoding error." << io::endl;
+        return;
+    }
+
+    // Copy over the decompressed data, converting the data type if necessary.
+    if (prim->indices && !mesh->getFaceIndices(prim->indices)) {
+        return;
+    }
+
+    // Go through each attribute in the decompressed mesh.
+    for (cgltf_size i = 0; i < draco.attributes_count; i++) {
+
+        // In cgltf, each Draco attribute's data pointer is an attribute id, not an accessor.
+        const uint32_t id = draco.attributes[i].data - gltf->accessors;
+
+        // Find the destination accessor; this contains the desired component type, etc.
+        const cgltf_attribute_type type = draco.attributes[i].type;
+        const cgltf_int index = draco.attributes[i].index;
+        cgltf_accessor* accessor = findAccessor(prim, type, index);
+        if (!accessor) {
+            slog.w << "Cannot find matching accessor for Draco id " << id << io::endl;
+            continue;
+        }
+
+        // Copy over the decompressed data, converting the data type if necessary.
+        if (!mesh->getVertexAttributes(id, accessor)) {
+            break;
+        }
+    }
+}
+
+void decodeMeshoptCompression(cgltf_data* data) {
+    for (size_t i = 0; i < data->buffer_views_count; ++i) {
+        if (!data->buffer_views[i].has_meshopt_compression) {
+            continue;
+        }
+        cgltf_meshopt_compression* compression = &data->buffer_views[i].meshopt_compression;
+        const uint8_t* source = (const uint8_t*) compression->buffer->data;
+        assert_invariant(source);
+        source += compression->offset;
+
+        // This memory is freed by cgltf.
+        void* destination = malloc(compression->count * compression->stride);
+        assert_invariant(destination);
+
+        UTILS_UNUSED_IN_RELEASE int error = 0;
+        switch (compression->mode) {
+            case cgltf_meshopt_compression_mode_invalid:
+                break;
+            case cgltf_meshopt_compression_mode_attributes:
+                error = meshopt_decodeVertexBuffer(destination, compression->count,
+                        compression->stride, source, compression->size);
+                break;
+            case cgltf_meshopt_compression_mode_triangles:
+                error = meshopt_decodeIndexBuffer(destination, compression->count,
+                        compression->stride, source, compression->size);
+                break;
+            case cgltf_meshopt_compression_mode_indices:
+                error = meshopt_decodeIndexSequence(destination, compression->count,
+                        compression->stride, source, compression->size);
+                break;
+            default:
+                assert_invariant(false);
+                break;
+        }
+        assert_invariant(!error);
+
+        switch (compression->filter) {
+            case cgltf_meshopt_compression_filter_none:
+                break;
+            case cgltf_meshopt_compression_filter_octahedral:
+                meshopt_decodeFilterOct(destination, compression->count, compression->stride);
+                break;
+            case cgltf_meshopt_compression_filter_quaternion:
+                meshopt_decodeFilterQuat(destination, compression->count, compression->stride);
+                break;
+            case cgltf_meshopt_compression_filter_exponential:
+                meshopt_decodeFilterExp(destination, compression->count, compression->stride);
+                break;
+            default:
+                assert_invariant(false);
+                break;
+        }
+
+        data->buffer_views[i].data = destination;
+    }
+}
+
+bool primitiveHasVertexColor(cgltf_primitive* inPrim) {
+    for (int slot = 0; slot < inPrim->attributes_count; slot++) {
+        const cgltf_attribute& inputAttribute = inPrim->attributes[slot];
+        if (inputAttribute.type == cgltf_attribute_type_color) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Sometimes a glTF bufferview includes unused data at the end (e.g. in skinning.gltf) so we need to
+// compute the correct size of the vertex buffer. Filament automatically infers the size of
+// driver-level vertex buffers from the attribute data (stride, count, offset) and clients are
+// expected to avoid uploading data blobs that exceed this size. Since this information doesn't
+// exist in the glTF we need to compute it manually. This is a bit of a cheat, cgltf_calc_size is
+// private but its implementation file is available in this cpp file.
+uint32_t computeBindingSize(cgltf_accessor const* accessor) {
+    cgltf_size element_size = cgltf_calc_size(accessor->type, accessor->component_type);
+    return uint32_t(accessor->stride * (accessor->count - 1) + element_size);
+}
+
+void convertBytesToShorts(uint16_t* dst, uint8_t const* src, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        dst[i] = src[i];
+    }
+}
+
+uint32_t computeBindingOffset(cgltf_accessor const* accessor) {
+    return uint32_t(accessor->offset + accessor->buffer_view->offset);
+}
+
+bool requiresConversion(cgltf_accessor const* accessor) {
+    if (UTILS_UNLIKELY(accessor->is_sparse)) {
+        return true;
+    }
+    const cgltf_type type = accessor->type;
+    const cgltf_component_type ctype = accessor->component_type;
+    filament::VertexBuffer::AttributeType permitted;
+    filament::VertexBuffer::AttributeType actual;
+    UTILS_UNUSED_IN_RELEASE bool supported = getElementType(type, ctype, &permitted, &actual);
+    assert_invariant(supported && "Unsupported types");
+    return permitted != actual;
+}
+
+bool requiresPacking(cgltf_accessor const* accessor) {
+    if (requiresConversion(accessor)) {
+        return true;
+    }
+    const size_t dim = cgltf_num_components(accessor->type);
+    switch (accessor->component_type) {
+        case cgltf_component_type_r_8:
+        case cgltf_component_type_r_8u:
+            return accessor->stride != dim;
+        case cgltf_component_type_r_16:
+        case cgltf_component_type_r_16u:
+            return accessor->stride != dim * 2;
+        case cgltf_component_type_r_32u:
+        case cgltf_component_type_r_32f:
+            return accessor->stride != dim * 4;
+        default:
+            assert_invariant(false);
+            return true;
+    }
+}
+
+bool loadCgltfBuffers(cgltf_data const* gltf, char const* gltfPath,
+        UriDataCacheHandle uriDataCacheHandle) {
+    SYSTRACE_CONTEXT();
+    SYSTRACE_NAME_BEGIN("Load buffers");
+    cgltf_options options{};
+
+    // For emscripten and Android builds we supply a custom file reader callback that looks inside a
+    // cache of externally-supplied data blobs, rather than loading from the filesystem.
+
+#if !GLTFIO_USE_FILESYSTEM
+    struct Closure {
+        UriDataCacheHandle uriDataCache;
+        const cgltf_data* gltf;
+    };
+
+    Closure closure = { uriDataCacheHandle, gltf };
+
+    options.file.user_data = &closure;
+
+    options.file.read = [](const cgltf_memory_options* memoryOpts,
+                                const cgltf_file_options* fileOpts, const char* path,
+                                cgltf_size* size, void** data) {
+        Closure* closure = (Closure*) fileOpts->user_data;
+        auto& uriDataCache = closure->uriDataCache;
+
+        if (auto iter = uriDataCache->find(path); iter != uriDataCache->end()) {
+            *size = iter->second.size;
+            *data = iter->second.buffer;
+        } else {
+            // Even if we don't find the given resource in the cache, we still return a successful
+            // error code, because we allow downloads to finish after the decoding work starts.
+            *size = 0;
+            *data = 0;
+        }
+
+        return cgltf_result_success;
+    };
+#endif
+
+    // Read data from the file system and base64 URIs.
+    cgltf_result result = cgltf_load_buffers(&options, (cgltf_data*) gltf, gltfPath);
+    if (result != cgltf_result_success) {
+        slog.e << "Unable to load resources." << io::endl;
+        return false;
+    }
+
+    SYSTRACE_NAME_END();
+
+#ifndef NDEBUG
+    if (cgltf_validate((cgltf_data*) gltf) != cgltf_result_success) {
+        slog.e << "Failed cgltf validation." << io::endl;
+        return false;
+    }
+#endif
+    return true;
+}
+
+} // namespace filament::gltfio::utility

--- a/libs/gltfio/src/Utility.h
+++ b/libs/gltfio/src/Utility.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_UTILITY_H
+#define GLTFIO_UTILITY_H
+
+#include <backend/BufferDescriptor.h>
+
+#include <tsl/robin_map.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+struct FFilamentAsset;
+struct cgltf_primitive;
+struct cgltf_data;
+class DracoCache;
+
+struct cgltf_accessor;
+
+namespace filament::gltfio {
+
+// Referenced in ResourceLoader and AssetLoaderExtended
+using BufferDescriptor = filament::backend::BufferDescriptor;
+using UriDataCache = tsl::robin_map<std::string, BufferDescriptor>;
+using UriDataCacheHandle = std::shared_ptr<UriDataCache>;
+    
+} // namespace filament::gltfio::utility
+
+namespace filament::gltfio::utility {    
+
+// Functions that are shared between the original implementation and the extended implementation.
+void decodeDracoMeshes(cgltf_data const* gltf, cgltf_primitive const* prim, DracoCache* dracoCache);
+void decodeMeshoptCompression(cgltf_data* data);
+bool primitiveHasVertexColor(cgltf_primitive* inPrim);
+uint32_t computeBindingSize(cgltf_accessor const* accessor);
+void convertBytesToShorts(uint16_t* dst, uint8_t const* src, size_t count);
+uint32_t computeBindingOffset(cgltf_accessor const* accessor);
+bool requiresConversion(cgltf_accessor const* accessor);
+bool requiresPacking(cgltf_accessor const* accessor);
+bool loadCgltfBuffers(cgltf_data const* gltf, char const* gltfPath,
+        UriDataCacheHandle uriDataCacheHandle);
+
+} // namespace filament::gltfio::utility
+
+#endif

--- a/libs/gltfio/src/extended/AssetLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.cpp
@@ -1,0 +1,545 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AssetLoaderExtended.h"
+
+#include "../DracoCache.h"
+#include "../FFilamentAsset.h"
+#include "../GltfEnums.h"
+#include "../Utility.h"
+#include "TangentsJobExtended.h"
+
+#include <filament/BufferObject.h>
+
+#include <utils/JobSystem.h>
+#include <utils/Log.h>
+#include <utils/Panic.h>
+
+#include <cgltf.h>
+
+namespace filament::gltfio {
+
+namespace {
+
+constexpr uint8_t const VERTEX_JOB = 0x1;
+constexpr uint8_t const INDEX_JOB = 0x2;
+constexpr uint8_t const MORPH_TARGET_JOB = 0x4;
+
+constexpr int const GENERATED_0 = FFilamentAsset::ResourceInfoExtended::GENERATED_0_INDEX;
+constexpr int const GENERATED_1 = FFilamentAsset::ResourceInfoExtended::GENERATED_1_INDEX;
+
+using BufferSlot = AssetLoaderExtended::BufferSlot;
+using BufferType = std::variant<short4*, ushort4*, float2*, float3*, float4*>;
+
+struct AttributeHash {
+    size_t operator()(Attribute const& key) const {
+        size_t h1 = std::hash<uint64_t>{}((uint64_t) key.type);
+        size_t h2 = std::hash<uint64_t>{}((uint64_t) key.index);
+        return h1 ^ (h2 << 1);
+    }
+};
+
+struct AttributeEqual {
+    bool operator()(Attribute const& lhs, Attribute const& rhs) const {
+        return lhs.type == rhs.type && lhs.index == rhs.index;
+    }
+};
+
+using AttributesMap =
+        std::unordered_map<Attribute, FilamentAttribute, AttributeHash, AttributeEqual>;
+
+inline std::tuple<VertexBuffer::AttributeType, size_t, void*> getVertexBundle(
+        VertexAttribute attrib, TangentsJobExtended::OutputParams& out) {
+    VertexBuffer::AttributeType type;
+    size_t byteCount = 0;
+    void* data = nullptr;
+    switch (attrib) {
+        case VertexAttribute::POSITION:
+            type = VertexBuffer::AttributeType::FLOAT3;
+            byteCount = sizeof(float3);
+            data = out.positions;
+            out.positions = nullptr;
+            break;
+        case VertexAttribute::TANGENTS:
+            type = VertexBuffer::AttributeType::SHORT4;
+            byteCount = sizeof(short4);
+            data = out.tbn;
+            out.tbn = nullptr;
+            break;
+        case VertexAttribute::COLOR:
+            type = VertexBuffer::AttributeType::FLOAT4;
+            byteCount = sizeof(float4);
+            data = out.colors;
+            out.colors = nullptr;
+            break;
+        case VertexAttribute::UV0:
+            type = VertexBuffer::AttributeType::FLOAT2;
+            byteCount = sizeof(float2);
+            data = out.uv0;
+            out.uv0 = nullptr;
+            break;
+        case VertexAttribute::UV1:
+            type = VertexBuffer::AttributeType::FLOAT2;
+            byteCount = sizeof(float2);
+            data = out.uv1;
+            out.uv1 = nullptr;
+            break;
+        case VertexAttribute::BONE_INDICES:
+            type = VertexBuffer::AttributeType::USHORT4;
+            byteCount = sizeof(ushort4);
+            data = out.joints;
+            out.joints = nullptr;
+            break;
+        case VertexAttribute::BONE_WEIGHTS:
+            type = VertexBuffer::AttributeType::FLOAT4;
+            byteCount = sizeof(float4);
+            data = out.weights;
+            out.weights = nullptr;
+            break;
+        default:
+            PANIC_POSTCONDITION("Unexpected vertex attribute %d", static_cast<int>(attrib));
+    }
+    return {type, byteCount, data};
+}
+
+// This will run the jobs to create tangent spaces if necessary, or simply forward the data if the
+// input does not require processing. The output is a list of buffers that will be uploaded in the
+// ResourceLoader.
+std::vector<BufferSlot> computeGeometries(cgltf_primitive const* prim, uint8_t const jobType,
+        AttributesMap const& attributesMap, std::vector<int> const& morphTargets, UvMap const& uvmap,
+        filament::Engine* engine) {
+
+    bool const isUnlit = prim->material ? prim->material->unlit : false;
+
+    using Params = TangentsJobExtended::Params;
+
+    std::unordered_map<int, Params> jobs;
+    auto getJob = [&jobs](int key) -> Params& {
+        auto result = jobs.find(key);
+        if (result == jobs.end()) {
+            return (jobs.emplace(key, Params{}).first)->second;
+        }
+        return result->second;
+    };
+
+    // Create a job description for each triangle-based primitive.
+    // Collect all TANGENT vertex attribute slots that need to be populated.
+    if ((jobType & VERTEX_JOB) != 0) {
+        auto& job = getJob(TangentsJobExtended::kMorphTargetUnused);
+        job.in = {
+                .prim = prim,
+                .uvmap = uvmap,
+        };
+        job.jobType |= VERTEX_JOB;
+    }
+    if ((jobType & INDEX_JOB) != 0) {
+        auto& job = getJob(TangentsJobExtended::kMorphTargetUnused);
+        job.in = {
+                .prim = prim,
+                .uvmap = uvmap,
+        };
+        job.jobType |= INDEX_JOB;
+    }
+    for (auto const target: morphTargets) {
+        auto& job = getJob(target);
+        job.jobType = MORPH_TARGET_JOB;
+        job.in = {
+                .prim = prim,
+                .morphTargetIndex = target,
+        };
+    }
+
+    utils::JobSystem& js = engine->getJobSystem();
+    utils::JobSystem::Job* parent = js.createJob();
+    for (auto& [key, params]: jobs) {
+        js.run(utils::jobs::createJob(js, parent,
+                [pptr = &params] { TangentsJobExtended::run(pptr); }));
+    }
+    js.runAndWait(parent);
+
+    std::vector<BufferSlot> slots;
+
+    struct MorphTargetOut {
+        int morphTarget;
+        float3* positions;
+        short4* tbn;
+        size_t vertexCount;
+    };
+    std::vector<MorphTargetOut> morphTargetOuts;
+
+    for (auto& [key, params]: jobs) {
+        uint8_t const jobType = params.jobType;
+        TangentsJobExtended::OutputParams& out = params.out;
+        size_t const vertexCount = out.vertexCount;
+
+        if ((jobType & VERTEX_JOB) != 0) {
+            auto vertexBufferBuilder =
+                    VertexBuffer::Builder().enableBufferObjects().vertexCount(vertexCount);
+
+            std::vector<BufferSlot> vslots;
+            bool slottedTangent = false;
+            int maxSlot = 0;
+            for (auto [cgltfAttr, filamentAttr]: attributesMap) {
+                auto const [cattr, expectedIndex] = cgltfAttr;
+                auto const [vattr, slot] = filamentAttr;
+                auto const [type, byteCount, data] = getVertexBundle(vattr, out);
+
+                vertexBufferBuilder.attribute(vattr, slot, type);
+
+                // Here we generate data if needed.
+                if (expectedIndex == GENERATED_0 || expectedIndex == GENERATED_1) {
+                    // We should free `data` here because it's not being passed on to ResourceLoader.
+                    if (data) {
+                        free(data);
+                    }
+
+                    size_t const requiredSize = byteCount * vertexCount;
+                    auto gendata = (uint8_t*) malloc(requiredSize);
+                    memset(gendata, 0xff, requiredSize);
+                    vslots.push_back({
+                        .slot = slot,
+                        .sizeInBytes = requiredSize,
+                        .data = gendata,
+                    });
+                } else {
+                    // Note that normalization is not necessary because we always convert the input.
+                    if (vattr == filament::VertexAttribute::TANGENTS) {
+                        vertexBufferBuilder.normalized(vattr);
+                        slottedTangent = true;
+                    }
+                    vslots.push_back({
+                        .slot = slot,
+                        .sizeInBytes = byteCount * vertexCount,
+                        .data = data,
+                    });
+                }
+                maxSlot = std::max(maxSlot, slot);
+            }
+
+            // Tangent is always computed for lit.
+            if (!slottedTangent && !isUnlit) {
+                auto const slot = maxSlot + 1;
+                auto const vattr = filament::VertexAttribute::TANGENTS;
+                auto const [type, byteCount, data] = getVertexBundle(vattr, out);
+                vertexBufferBuilder.attribute(vattr, slot, type);
+                vertexBufferBuilder.normalized(vattr);
+                vslots.push_back({
+                        .slot = slot,
+                        .sizeInBytes = byteCount * vertexCount,
+                        .data = data,
+                });
+            }
+
+            assert_invariant(!vslots.empty());
+            vertexBufferBuilder.bufferCount(vslots.size());
+            auto vertexBuffer = vertexBufferBuilder.build(*engine);
+            std::for_each(vslots.begin(), vslots.end(),
+                    [vertexBuffer](BufferSlot& slot) { slot.vertices = vertexBuffer; });
+            slots.insert(slots.end(), vslots.begin(), vslots.end());
+        }
+        if ((jobType & INDEX_JOB) != 0) {
+            auto indexBuffer = IndexBuffer::Builder()
+                                       .indexCount(out.triangleCount * 3)
+                                       .bufferType(IndexBuffer::IndexType::UINT)
+                                       .build(*engine);
+
+            slots.push_back({
+                    .indices = indexBuffer,
+                    .sizeInBytes = out.triangleCount * 3 * 4,
+                    .data = out.triangles,
+            });
+            out.triangles = nullptr;
+        }
+        if ((jobType & MORPH_TARGET_JOB) != 0) {
+            morphTargetOuts.push_back({
+                    .morphTarget = params.in.morphTargetIndex,
+                    .positions = out.positions,
+                    .tbn = out.tbn,
+                    .vertexCount = vertexCount,
+            });
+            out.positions = nullptr;
+            out.tbn = nullptr;
+        }
+
+        // We should have passed ownership of all allocation to other parties.
+        assert_invariant(out.isEmpty());
+    }
+
+    if (!morphTargets.empty()) {
+        auto const vertexCount = morphTargetOuts[0].vertexCount;
+        MorphTargetBuffer* buffer = MorphTargetBuffer::Builder()
+                                            .count(morphTargets.size())
+                                            .vertexCount(vertexCount)
+                                            .build(*engine);
+        for (auto target: morphTargetOuts) {
+            assert_invariant(target.vertexCount == vertexCount);
+            slots.push_back({.target = buffer,
+                    .slot = target.morphTarget,
+                    .targetData = {
+                            .tbn = target.tbn,
+                            .positions = target.positions,
+                    }});
+        }
+    }
+    return slots;
+}
+
+} // anonymous namespace
+
+bool AssetLoaderExtended::createPrimitive(Input* input, Output* out,
+        std::vector<BufferSlot>& outSlots) {
+    auto gltf = input->gltf;
+    auto prim = input->prim;
+    auto name = input->name;
+
+    bool const isUnlit = prim->material ? prim->material->unlit : false;
+    uint8_t jobType = 0;
+
+    // In glTF, each primitive may or may not have an index buffer.
+    const cgltf_accessor* indexAccessor = prim->indices;
+    if (indexAccessor || prim->attributes_count > 0) {
+        IndexBuffer::IndexType indexType;
+        if (indexAccessor && !getIndexType(indexAccessor->component_type, &indexType)) {
+            utils::slog.e << "Unrecognized index type in " << name << utils::io::endl;
+            return false;
+        }
+        jobType |= INDEX_JOB;
+    }
+
+    jobType |= VERTEX_JOB;
+
+    AttributesMap attributesMap;
+    bool hasUv0 = false, hasUv1 = false, hasVertexColor = false, hasNormals = false;
+    int slotCount = 0;
+
+    for (cgltf_size aindex = 0; aindex < prim->attributes_count; aindex++) {
+        cgltf_attribute const attribute = prim->attributes[aindex];
+        int const index = attribute.index;
+        cgltf_attribute_type const atype = attribute.type;
+        cgltf_accessor const* accessor = attribute.data;
+
+        Attribute const cattr{atype, index};
+
+        // At a minimum, surface orientation requires normals to be present in the source data.
+        // Here we re-purpose the normals slot to point to the quats that get computed later.
+        if (atype == cgltf_attribute_type_normal) {
+            if (isUnlit) continue;
+            if (!hasNormals) {
+                FilamentAttribute const fattr { VertexAttribute::TANGENTS, slotCount++ };
+                hasNormals = true;
+                attributesMap[cattr] = fattr;
+            }
+            continue;
+        }
+
+        if (atype == cgltf_attribute_type_tangent) {
+            if (isUnlit) continue;
+            if (!hasNormals) {
+                FilamentAttribute const fattr { VertexAttribute::TANGENTS, slotCount++ };
+                hasNormals = true;
+                attributesMap[cattr] = fattr;
+            }
+            continue;
+        }
+
+        // Translate the cgltf attribute enum into a Filament enum.
+        VertexAttribute semantic;
+        if (!getVertexAttrType(atype, &semantic)) {
+            utils::slog.e << "Unrecognized vertex semantic in " << name << utils::io::endl;
+            return false;
+        }
+        if (atype == cgltf_attribute_type_weights && index > 0) {
+            utils::slog.e << "Too many bone weights in " << name << utils::io::endl;
+            continue;
+        }
+        if (atype == cgltf_attribute_type_joints && index > 0) {
+            utils::slog.e << "Too many joints in " << name << utils::io::endl;
+            continue;
+        }
+        if (atype == cgltf_attribute_type_texcoord) {
+            if (index >= UvMapSize) {
+                utils::slog.e << "Too many texture coordinate sets in " << name << utils::io::endl;
+                continue;
+            }
+            UvSet uvset = out->uvmap[index];
+            switch (uvset) {
+                case UV0:
+                    semantic = VertexAttribute::UV0;
+                    hasUv0 = true;
+                    break;
+                case UV1:
+                    semantic = VertexAttribute::UV1;
+                    hasUv1 = true;
+                    break;
+                case UNUSED:
+                    // If we have a free slot, then include this unused UV set in the VertexBuffer.
+                    // This allows clients to swap the glTF material with a custom material.
+                    if (!hasUv0 && getNumUvSets(out->uvmap) == 0) {
+                        semantic = VertexAttribute::UV0;
+                        hasUv0 = true;
+                        break;
+                    }
+
+                    // If there are no free slots then drop this unused texture coordinate set.
+                    // This should not print an error or warning because the glTF spec stipulates an
+                    // order of degradation for gracefully dropping UV sets. We implement this in
+                    // constrainMaterial in MaterialProvider.
+                    continue;
+            }
+        }
+
+        if (atype == cgltf_attribute_type_color) {
+            hasVertexColor = true;
+        }
+
+        // The positions accessor is required to have min/max properties, use them to expand
+        // the bounding box for this primitive.
+        if (atype == cgltf_attribute_type_position) {
+            const float* minp = &accessor->min[0];
+            const float* maxp = &accessor->max[0];
+            out->aabb.min = min(out->aabb.min, float3(minp[0], minp[1], minp[2]));
+            out->aabb.max = max(out->aabb.max, float3(maxp[0], maxp[1], maxp[2]));
+        }
+
+        if (VertexBuffer::AttributeType fatype, actualType;
+                !getElementType(accessor->type, accessor->component_type, &fatype, &actualType)) {
+            utils::slog.e << "Unsupported accessor type in " << name << utils::io::endl;
+            return false;
+        }
+
+        attributesMap[cattr] = { semantic, slotCount++ };
+
+        if (accessor->count == 0) {
+            utils::slog.e << "Empty vertex buffer in " << name << utils::io::endl;
+            return false;
+        }
+    }
+
+    cgltf_size targetsCount = prim->targets_count;
+    if (targetsCount > MAX_MORPH_TARGETS) {
+        utils::slog.w << "WARNING: Exceeded max morph target count of " << MAX_MORPH_TARGETS
+                      << utils::io::endl;
+        targetsCount = MAX_MORPH_TARGETS;
+    }
+
+    // A set of morph targets to generate tangents for.
+    std::vector<int> morphTargets;
+
+    Aabb const baseAabb(out->aabb);
+    for (cgltf_size targetIndex = 0; targetIndex < targetsCount; targetIndex++) {
+        bool morphTargetHasNormals = false;
+        cgltf_morph_target const& target = prim->targets[targetIndex];
+        for (cgltf_size aindex = 0; aindex < target.attributes_count; aindex++) {
+            cgltf_attribute const& attribute = target.attributes[aindex];
+            cgltf_accessor const* accessor = attribute.data;
+            cgltf_attribute_type const atype = attribute.type;
+
+            if (atype != cgltf_attribute_type_position && atype != cgltf_attribute_type_normal &&
+                    atype != cgltf_attribute_type_tangent) {
+                utils::slog.e << "Only positions, normals, and tangents can be morphed."
+                              << " type=" << static_cast<int>(atype) << utils::io::endl;
+                return false;
+            }
+
+            if (VertexBuffer::AttributeType fatype, actualType; !getElementType(accessor->type,
+                        accessor->component_type, &fatype, &actualType)) {
+                utils::slog.e << "Unsupported accessor type in " << name << utils::io::endl;
+                return false;
+            }
+
+            if (atype == cgltf_attribute_type_position && accessor->has_min && accessor->has_max) {
+                Aabb targetAabb(baseAabb);
+                float const* minp = &accessor->min[0];
+                float const* maxp = &accessor->max[0];
+
+                // We assume that the range of morph target weight is [0, 1].
+                targetAabb.min += float3(minp[0], minp[1], minp[2]);
+                targetAabb.max += float3(maxp[0], maxp[1], maxp[2]);
+
+                out->aabb.min = min(out->aabb.min, targetAabb.min);
+                out->aabb.max = max(out->aabb.max, targetAabb.max);
+            }
+
+            if (atype == cgltf_attribute_type_tangent) {
+                morphTargetHasNormals = true;
+                morphTargets.push_back(targetIndex);
+            }
+        }
+        // Generate flat normals if necessary.
+        if (!morphTargetHasNormals && prim->material && !prim->material->unlit) {
+            morphTargets.push_back(targetIndex);
+        }
+    }
+
+    // We provide a single dummy buffer (filled with 0xff) for all unfulfilled vertex requirements.
+    // The color data should be a sequence of normalized UBYTE4, so dummy UVs are USHORT2 to make
+    // the sizes match.
+    if (mMaterials.needsDummyData(VertexAttribute::UV0) && !hasUv0) {
+        attributesMap[{cgltf_attribute_type_texcoord, GENERATED_0}] = {VertexAttribute::UV0,
+                slotCount++};
+    }
+
+    if (mMaterials.needsDummyData(VertexAttribute::UV1) && !hasUv1) {
+        attributesMap[{cgltf_attribute_type_texcoord, GENERATED_1}] = {VertexAttribute::UV1,
+                slotCount++};
+    }
+
+    if (mMaterials.needsDummyData(VertexAttribute::COLOR) && !hasVertexColor) {
+        attributesMap[{cgltf_attribute_type_color, GENERATED_0}] = {VertexAttribute::COLOR,
+                slotCount++};
+    }
+
+    int numUvSets = getNumUvSets(out->uvmap);
+    if (!hasUv0 && numUvSets > 0) {
+        attributesMap[{cgltf_attribute_type_texcoord, GENERATED_0}] = {VertexAttribute::UV0,
+                slotCount++};
+    }
+
+    if (!hasUv1 && numUvSets > 1) {
+        utils::slog.w << "Missing UV1 data in " << name << utils::io::endl;
+        attributesMap[{cgltf_attribute_type_texcoord, GENERATED_1}] = {VertexAttribute::UV1,
+                slotCount++};
+    }
+
+    if (!utility::loadCgltfBuffers(gltf, mGltfPath.c_str(), mUriDataCache)) {
+        return false;
+    }
+
+    utility::decodeDracoMeshes(gltf, prim, input->dracoCache);
+    utility::decodeMeshoptCompression(gltf);
+
+    auto slots = computeGeometries(prim, jobType, attributesMap, morphTargets, out->uvmap, mEngine);
+
+    for (auto slot: slots) {
+        if (slot.vertices) {
+            assert_invariant(!out->vertices || out->vertices == slot.vertices);
+            out->vertices = slot.vertices;
+        }
+        if (slot.indices) {
+            assert_invariant(!out->indices || out->indices == slot.indices);
+            out->indices = slot.indices;
+        }
+        if (slot.target) {
+            assert_invariant(!out->targets || out->targets == slot.target);
+            out->targets = slot.target;
+        }
+    }
+
+    outSlots.insert(outSlots.end(), slots.begin(), slots.end());
+    return true;
+}
+
+}// namespace filament::gltfio

--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_ASSETLOADEREXTENDED_H
+#define GLTFIO_ASSETLOADEREXTENDED_H
+
+#include "../FFilamentAsset.h"
+#include "../Utility.h"
+
+#include <backend/BufferDescriptor.h>
+#include <gltfio/AssetLoader.h>
+
+#include <cgltf.h>
+
+#include <future>
+#include <string>
+
+
+namespace filament::gltfio {
+
+struct Primitive;
+struct FFilamentAsset;
+class DracoCache;
+
+using BufferDescriptor = filament::backend::BufferDescriptor;
+
+// The cgltf attribute is a type and the attribute index
+struct Attribute {
+    cgltf_attribute_type type; // positions, tangents
+    int index;
+};
+
+// The Filament Attribute is defined as a type and a slot.
+struct FilamentAttribute {
+    VertexAttribute attribute;
+    int slot;
+};
+
+struct AssetLoaderExtended {
+    using BufferSlot = FFilamentAsset::ResourceInfoExtended::BufferSlot;
+    using Output = Primitive;
+
+    struct Input {
+        cgltf_data* gltf;
+        cgltf_primitive* prim;
+        char const* name;
+        DracoCache* dracoCache;
+        Material* material;
+    };
+
+    AssetLoaderExtended(AssetConfigurationExtended const& config, Engine* engine,
+            MaterialProvider& materials)
+        : mEngine(engine), mGltfPath(config.gltfPath), mMaterials(materials),
+          mUriDataCache(std::make_shared<UriDataCache>()) {}
+
+    ~AssetLoaderExtended() = default;
+
+    bool createPrimitive(Input* input, Output* out, std::vector<BufferSlot>& outSlots);
+
+    UriDataCacheHandle getUriDataCache() const noexcept {
+        return mUriDataCache;
+    }
+
+private:
+    filament::Engine* mEngine;
+    std::string mGltfPath;
+    MaterialProvider& mMaterials;
+    UriDataCacheHandle mUriDataCache;
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_ASSETLOADEREXTENDED_H

--- a/libs/gltfio/src/extended/ResourceLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/ResourceLoaderExtended.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ResourceLoaderExtended.h"
+
+#include "../FFilamentAsset.h"
+
+#include <backend/BufferDescriptor.h>
+#include <filament/BufferObject.h>
+
+#include <cgltf.h>
+
+#include <vector>
+
+static const auto FREE_CALLBACK = [](void* mem, size_t, void*) {
+    free(mem);
+ };
+
+namespace filament::gltfio {
+
+using filament::backend::BufferDescriptor;
+
+void ResourceLoaderExtended::loadResources(std::vector<BufferSlot> const& slots,
+        filament::Engine* engine, std::vector<BufferObject*>& bufferObjects) {
+    for (auto& slot: slots) {
+        size_t const byteCount = slot.sizeInBytes;
+        if (slot.vertices) {
+            BufferObject* bo = BufferObject::Builder().size(byteCount).build(*engine);
+            bo->setBuffer(*engine, BufferDescriptor(slot.data, byteCount, FREE_CALLBACK));
+            slot.vertices->setBufferObjectAt(*engine, slot.slot, bo);
+            bufferObjects.push_back(bo);
+        }
+        if (slot.indices) {
+            slot.indices->setBuffer(*engine, BufferDescriptor(slot.data, byteCount, FREE_CALLBACK));
+        }
+        if (slot.target) {
+            assert_invariant(slot.targetData.positions && slot.targetData.tbn);
+            slot.target->setPositionsAt(*engine, slot.slot,
+                    (float3 const*) slot.targetData.positions, slot.target->getVertexCount());
+            slot.target->setTangentsAt(*engine, slot.slot, (short4 const*) slot.targetData.tbn,
+                    slot.target->getVertexCount());
+
+            free(slot.targetData.positions);
+            free(slot.targetData.tbn);
+        }
+    }
+}
+
+} // namespace filament::gltfio

--- a/libs/gltfio/src/extended/ResourceLoaderExtended.h
+++ b/libs/gltfio/src/extended/ResourceLoaderExtended.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_RESOURCELOADEREXTENDED_H
+#define GLTFIO_RESOURCELOADEREXTENDED_H
+
+#include "../FFilamentAsset.h"
+
+#include <vector>
+
+namespace filament::gltfio {
+
+struct ResourceLoaderExtended {
+    using BufferSlot = FFilamentAsset::ResourceInfoExtended::BufferSlot;
+    static void loadResources(
+        std::vector<BufferSlot> const& slots, filament::Engine* engine,
+        std::vector<BufferObject*>& bufferObjects);
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_RESOURCELOADEREXTENDED_H

--- a/libs/gltfio/src/extended/TangentsJobExtended.cpp
+++ b/libs/gltfio/src/extended/TangentsJobExtended.cpp
@@ -1,0 +1,759 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TangentsJobExtended.h"
+
+#include "AssetLoaderExtended.h"
+#include "../GltfEnums.h"
+#include "../FFilamentAsset.h"
+#include "../Utility.h"
+
+#include <geometry/TangentSpaceMesh.h>
+#include <utils/Log.h>
+#include <utils/StructureOfArrays.h>
+
+#include <memory>
+#include <unordered_map>
+
+using namespace filament;
+using namespace filament::gltfio;
+using namespace filament::math;
+
+namespace {
+
+constexpr uint8_t POSITIONS_ID = 0;
+constexpr uint8_t TANGENTS_ID = 1;
+constexpr uint8_t COLORS_ID = 3;
+constexpr uint8_t NORMALS_ID = 4;
+constexpr uint8_t UV0_ID = 5;
+constexpr uint8_t UV1_ID = 6;
+constexpr uint8_t WEIGHTS_ID = 7;
+constexpr uint8_t JOINTS_ID = 8;
+constexpr uint8_t INVALID_ID = 0xFF;
+
+using POSITIONS_TYPE = float3*;
+using TANGENTS_TYPE = float4*;
+using COLORS_TYPE = float4*;
+using NORMALS_TYPE = float3*;
+using UV0_TYPE = float2*;
+using UV1_TYPE = float2*;
+using WEIGHTS_TYPE = float4*;
+using JOINTS_TYPE = ushort4*;
+
+// Used in template specifier.
+#define POSITIONS_T POSITIONS_TYPE, POSITIONS_ID
+#define TANGENTS_T TANGENTS_TYPE, TANGENTS_ID
+#define COLORS_T COLORS_TYPE, COLORS_ID
+#define NORMALS_T NORMALS_TYPE, NORMALS_ID
+#define UV0_T UV0_TYPE, UV0_ID
+#define UV1_T UV1_TYPE, UV1_ID
+#define WEIGHTS_T WEIGHTS_TYPE, WEIGHTS_ID
+#define JOINTS_T JOINTS_TYPE, JOINTS_ID
+
+using DataType = std::variant<float2*, float3*, float4*, ubyte4*, ushort4*>;
+using AttributeDataMap = std::unordered_map<uint8_t, DataType>;
+
+inline uint8_t toCode(Attribute attr, UvMap const& uvmap, bool hasUv0) {
+    if (attr.type == cgltf_attribute_type_normal) {
+        assert_invariant(attr.index == 0);
+        return NORMALS_ID;
+    }
+    if (attr.type == cgltf_attribute_type_tangent) {
+        assert_invariant(attr.index == 0);
+        return TANGENTS_ID;
+    }
+    if (attr.type == cgltf_attribute_type_color) {
+        assert_invariant(attr.index == 0);
+        return COLORS_ID;
+        PANIC_POSTCONDITION("Unexpected number of components in color attribute");
+    }
+    if (attr.type == cgltf_attribute_type_position) {
+        assert_invariant(attr.index == 0);
+        return POSITIONS_ID;
+    }
+
+    // This logic is replicating slot assignment in AssetLoaderExtended.cpp
+    if (attr.type == cgltf_attribute_type_texcoord) {
+        assert_invariant(attr.index < UvMapSize);
+        UvSet uvset = uvmap[attr.index];
+        switch (uvset) {
+            case gltfio::UV0:
+                return UV0_ID;
+            case gltfio::UV1:
+                return UV1_ID;
+            case gltfio::UNUSED:
+                // If we have a free slot, then include this unused UV set in the VertexBuffer.
+                // This allows clients to swap the glTF material with a custom material.
+                if (!hasUv0 && getNumUvSets(uvmap) == 0) {
+                    return UV0_ID;
+                }
+        }
+        utils::slog.w <<"Only two sets of UVs are available" << utils::io::endl;
+        return INVALID_ID;
+    }
+    if (attr.type == cgltf_attribute_type_weights) {
+        assert_invariant(attr.index == 0);
+        return WEIGHTS_ID;
+    }
+    if (attr.type == cgltf_attribute_type_joints) {
+        assert_invariant(attr.index == 0);
+        return JOINTS_ID;
+    }
+    // Otherwise, this is not an attribute supported by Filament.
+    return INVALID_ID;
+}
+
+// Wrapper around TangentSpaceMesh to allow for passthrough if unlit.
+struct Mesh {
+    using AuxType = geometry::TangentSpaceMesh::AuxAttribute;
+
+    struct Passthrough {
+        static constexpr int POSITION = 256;
+        static constexpr int UV0 = 257;
+        static constexpr int NORMALS = 258;
+        static constexpr int TANGENTS = 259;
+        static constexpr int TRIANGLES = 260;
+
+        std::unordered_map<int, void const*> data;
+        size_t vertexCount = 0;
+        size_t triangleCount = 0;
+    };
+
+    struct Builder {
+        Builder(bool isUnlit)
+            : isUnlit(isUnlit) {}
+
+        Builder& vertexCount(size_t count) noexcept {
+            if (isUnlit) {
+                passthrough.vertexCount = count;
+            } else {
+                tob.vertexCount(count);
+            }
+            return *this;
+        }
+
+        Builder& normals(float3 const* normals) noexcept {
+            if (isUnlit) {
+                passthrough.data[Passthrough::NORMALS] = normals;
+            } else {
+                tob.normals(normals);
+            }
+            return *this;
+        }
+
+        Builder& tangents(float4 const* tangents) noexcept {
+            if (isUnlit) {
+                passthrough.data[Passthrough::TANGENTS] = tangents;
+            } else {
+                tob.tangents(tangents);
+            }
+            return *this;
+
+        }
+
+        Builder& uvs(float2 const* uvs) noexcept {
+            if (isUnlit) {
+                passthrough.data[Passthrough::UV0] = uvs;
+            } else {
+                tob.uvs(uvs);
+            }
+            return *this;
+        }
+
+        Builder& positions(float3 const* positions) noexcept{
+            if (isUnlit) {
+                passthrough.data[Passthrough::POSITION] = positions;
+            } else {
+                tob.positions(positions);
+            }
+            return *this;
+        }
+
+        Builder& triangleCount(size_t triangleCount) noexcept {
+            if (isUnlit) {
+                passthrough.triangleCount = triangleCount;
+            } else {
+                tob.triangleCount(triangleCount);
+            }
+            return *this;
+        }
+
+        Builder& triangles(uint3 const* triangles) noexcept {
+            if (isUnlit) {
+                passthrough.data[Passthrough::TRIANGLES] = triangles;
+            } else {
+                tob.triangles(triangles);
+            }
+            return *this;
+        }
+
+        template<typename T>
+        Builder& aux(AuxType type, T data) {
+            if (isUnlit) {
+                passthrough.data[static_cast<int>(type)] = (void*) data;
+            } else {
+                tob.aux(type, data);
+            }
+            return *this;
+        }
+
+        Mesh* build() {
+            if (isUnlit) {
+                return new Mesh(passthrough);
+            } else {
+                return new Mesh(tob.build());
+            }
+        }
+
+    private:
+        bool const isUnlit;
+        Passthrough passthrough;
+        geometry::TangentSpaceMesh::Builder tob;
+    };
+
+private:
+    Mesh(geometry::TangentSpaceMesh* tsMesh)
+        : tsMesh(tsMesh),
+          vertexCount(tsMesh->getVertexCount()),
+          triangleCount(tsMesh->getTriangleCount()) {}
+
+    Mesh(Passthrough& passthrough)
+        : passthrough(passthrough),
+          vertexCount(passthrough.vertexCount),
+          triangleCount(passthrough.triangleCount) {}
+
+public:
+    static void destroy(Mesh* mesh) {
+        if (mesh->tsMesh) {
+            geometry::TangentSpaceMesh::destroy(mesh->tsMesh);
+        }
+        // For the unlit case, the arrays are owned by another map, which will be cleaned up separately.
+    }
+
+    size_t getVertexCount() const noexcept {
+        return vertexCount;
+    }
+
+    float3* getPositions() noexcept {
+        size_t const nbytes = vertexCount * sizeof(float3);
+        auto data = (float3*) malloc(nbytes);
+        if (tsMesh) {
+            tsMesh->getPositions(data);
+            return data;
+        }
+        std::memcpy(data, passthrough.data[Passthrough::POSITION], nbytes);
+        return data;
+    }
+
+    float2* getUVs() noexcept {
+        size_t const nbytes = vertexCount * sizeof(float2);
+        auto data = (float2*) malloc(nbytes);
+        if (tsMesh) {
+            tsMesh->getUVs(data);
+            return data;
+        }
+        std::memcpy(data, passthrough.data[Passthrough::UV0], nbytes);
+        return data;
+    }
+
+    short4* getQuats() noexcept {
+        size_t const nbytes = vertexCount * sizeof(short4);
+        auto data = (short4*) malloc(nbytes);
+        if (tsMesh) {
+            tsMesh->getQuats(data);
+            return data;
+        }
+        std::memcpy(data, passthrough.data[Passthrough::TANGENTS], nbytes);
+        return data;
+    }
+
+    uint3* getTriangles() {
+        size_t const nbytes = triangleCount * sizeof(uint3);
+        auto data = (uint3*) malloc(nbytes);
+        if (tsMesh) {
+            tsMesh->getTriangles(data);
+            return data;
+        }
+        std::memcpy(data, passthrough.data[Passthrough::TRIANGLES], nbytes);
+        return data;
+    }
+
+    template<typename T>
+    using is_supported_aux_t =
+            typename std::enable_if<std::is_same<float2*, T>::value ||
+                                    std::is_same<float3*, T>::value ||
+                                    std::is_same<float4*, T>::value ||
+                                    std::is_same<ushort3*, T>::value ||
+                                    std::is_same<ushort4*, T>::value>::type;
+    template<typename T, typename = is_supported_aux_t<T>>
+    T getAux(AuxType attribute) noexcept {
+        size_t const nbytes = vertexCount * sizeof(std::remove_pointer_t<T>);
+        auto data = (T) malloc(nbytes);
+        if (tsMesh) {
+            tsMesh->getAux(attribute, data);
+            return data;
+        }
+        std::memcpy(data, (T) passthrough.data[static_cast<int>(attribute)], nbytes);
+        return data;
+    }
+
+    size_t getTriangleCount() const noexcept {
+        if (tsMesh) {
+            return tsMesh->getTriangleCount();
+        }
+        return passthrough.triangleCount;
+    }
+
+private:
+    geometry::TangentSpaceMesh* tsMesh = nullptr;
+    Passthrough passthrough;
+    size_t const vertexCount;
+    size_t const triangleCount;
+};
+
+namespace data {
+
+template<typename T, uint8_t attrib>
+inline T get(AttributeDataMap const& data) {
+    auto iter = data.find(attrib);
+    if (iter != data.end()) {
+        return std::get<T>(iter->second);
+    }
+    return nullptr;
+}
+
+template<typename T, uint8_t attrib>
+void allocate(AttributeDataMap& data, size_t count) {
+    assert_invariant(data.find(attrib) == data.end());
+    data[attrib]  = (T) malloc(sizeof(std::remove_pointer_t<T>) * count);
+}
+
+template<typename T, uint8_t attrib>
+void free(AttributeDataMap& data) {
+    if (data.find(attrib) == data.end()) {
+        return;
+    }
+    std::free(std::get<T>(data[attrib]));
+    data.erase(attrib);
+}
+
+constexpr uint8_t const UBYTE_TYPE = 1;
+constexpr uint8_t const USHORT_TYPE = 2;
+constexpr uint8_t const FLOAT_TYPE = 3;
+
+template<typename T>
+constexpr uint8_t componentType() {
+    if constexpr (std::is_same_v<T, float2*> ||
+            std::is_same_v<T, float3*> ||
+            std::is_same_v<T, float4*>) {
+        return FLOAT_TYPE;
+    } else if constexpr (std::is_same_v<T, ubyte2*> ||
+            std::is_same_v<T, ubyte3*> ||
+            std::is_same_v<T, ubyte4*>) {
+        return UBYTE_TYPE;
+    } else if constexpr (std::is_same_v<T, ushort2*> ||
+            std::is_same_v<T, ushort3*> ||
+            std::is_same_v<T, ushort4*>) {
+        return USHORT_TYPE;
+    }
+    return 0;
+}
+
+template<typename T>
+constexpr size_t byteCount() {
+    return sizeof(std::remove_pointer_t<T>);
+}
+
+template<typename T>
+constexpr size_t componentCount() {
+    if constexpr (std::is_same_v<T, float2*> || std::is_same_v<T, ubyte2*> ||
+                  std::is_same_v<T, ushort2*>) {
+        return 2;
+    } else if constexpr (std::is_same_v<T, float3*> || std::is_same_v<T, ubyte3*> ||
+                         std::is_same_v<T, ushort3*>) {
+        return 3;
+    } else if constexpr (std::is_same_v<T, float4*> || std::is_same_v<T, ubyte4*> ||
+                         std::is_same_v<T, ushort4*>) {
+        return 4;
+    }
+    return 0;
+}
+
+template<typename InDataType, typename OutDataType>
+void copy(InDataType in, size_t inStride, OutDataType out, size_t outStride, size_t count) {
+    uint8_t* inBytes = (uint8_t*) in;
+    uint8_t* outBytes = (uint8_t*) out;
+
+    if constexpr (componentType<InDataType>() == componentType<OutDataType>()) {
+        if constexpr (componentCount<InDataType>() == 3 && componentCount<OutDataType>() == 4) {
+            for (size_t i = 0; i < count; ++i) {
+                *((OutDataType) (outBytes + (i * outStride))) = std::remove_pointer_t<OutDataType>(
+                        *((InDataType) (inBytes + (i * inStride))), 1);
+            }
+            return;
+        } else if constexpr (componentCount<InDataType>() == componentCount<OutDataType>()) {
+            if (inStride == outStride) {
+                std::memcpy(out, in, data::byteCount<InDataType>() * count);
+            } else {
+                for (size_t i = 0; i < count; ++i) {
+                    *((OutDataType) (outBytes + (i * outStride))) =
+                            std::remove_pointer_t<OutDataType>(
+                                    *((InDataType) (inBytes + (i * inStride))));
+                }
+            }
+            return;
+        }
+
+        PANIC_POSTCONDITION("Invalid component count in conversion");
+    } else if constexpr (componentCount<InDataType>() == componentCount<OutDataType>()) {
+        // byte to float conversion
+        constexpr size_t const compCount = componentCount<InDataType>();
+        if constexpr (componentType<InDataType>() == UBYTE_TYPE &&
+                      componentType<OutDataType>() == FLOAT_TYPE) {
+            for (size_t i = 0; i < count; ++i) {
+                for (size_t j = 0; j < compCount; ++j) {
+                    *(((float*) (outBytes + (i * outStride))) + j) =
+                            *(((uint8_t*) (inBytes + (i * inStride))) + j) / 255.0f;
+                }
+            }
+            return;
+        } else if constexpr (componentType<InDataType>() == UBYTE_TYPE &&
+                             componentType<OutDataType>() == USHORT_TYPE) {
+            for (size_t i = 0; i < count; ++i) {
+                for (size_t j = 0; j < compCount; ++j) {
+                    *(((uint16_t*) (outBytes + (i * outStride))) + j) =
+                            *(((uint8_t*) (inBytes + (i * inStride))) + j);
+                }
+            }
+            return;
+        }
+    }
+    PANIC_POSTCONDITION("Invalid conversion");
+}
+
+template<typename T>
+void unpack(cgltf_accessor const* accessor, size_t const vertexCount, T out,
+        bool isMorphTarget = false) {
+    assert_invariant(accessor->count == vertexCount);
+    uint8_t const* data = nullptr;
+    if (accessor->buffer_view->has_meshopt_compression) {
+        data = (uint8_t const*) accessor->buffer_view->data + accessor->offset;
+    } else {
+        data = (uint8_t const*) accessor->buffer_view->buffer->data +
+               utility::computeBindingOffset(accessor);
+    }
+    auto componentType = accessor->component_type;
+    size_t const inDim = cgltf_num_components(accessor->type);
+    size_t const outDim = componentCount<T>();
+
+    if (componentType == cgltf_component_type_r_32f) {
+        assert_invariant(accessor->buffer_view);
+        assert_invariant(data::componentType<T>() == FLOAT_TYPE);
+        size_t const elementCount = outDim * vertexCount;
+
+        if ((isMorphTarget && utility::requiresPacking(accessor)) ||
+                utility::requiresConversion(accessor)) {
+            cgltf_accessor_unpack_floats(accessor, (float*) out, elementCount);
+            return;
+        } else {
+            if (inDim == 3 && outDim == 4) {
+                data::copy<float3*, T>((float3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else {
+                assert_invariant(inDim == outDim);
+                data::copy<T, T>((T) data, accessor->stride, (T) out, data::byteCount<T>(),
+                        vertexCount);
+                return;
+            }
+        }
+    } else {
+        assert_invariant(outDim == inDim);
+        if (componentType == cgltf_component_type_r_8u) {
+            if (inDim == 2) {
+                data::copy<ubyte2*, T>((ubyte2*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 3) {
+                data::copy<ubyte3*, T>((ubyte3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 4) {
+                data::copy<ubyte4*, T>((ubyte4*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            }
+        } else if (componentType == cgltf_component_type_r_16u) {
+            if (inDim == 2) {
+                data::copy<ushort2*, T>((ushort2*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 3) {
+                data::copy<ushort3*, T>((ushort3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 4) {
+                data::copy<ushort4*, T>((ushort4*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            }
+        }
+
+        PANIC_POSTCONDITION("Only ubyte or ushort accepted as input");
+    }
+}
+
+template<typename T, uint8_t attrib>
+void unpack(cgltf_accessor const* accessor, AttributeDataMap& data, size_t const vertexCount,
+        bool isMorphTarget = false) {
+    assert_invariant(accessor->count == vertexCount);
+    assert_invariant(data.find(attrib) != data.end());
+
+    unpack(accessor, vertexCount, data::get<T, attrib>(data), isMorphTarget);
+}
+
+template<typename T, uint8_t attrib>
+void add(AttributeDataMap& data, size_t const vertexCount, float3* addition) {
+    assert_invariant(data.find(attrib) != data.end());
+
+    T datav = std::get<T>(data[attrib]);
+    for (size_t i = 0; i < vertexCount; ++i) {
+        if constexpr(std::is_same_v<T, float2*>) {
+            datav[i] += addition[i].xy;
+        } else if constexpr(std::is_same_v<T, float3*>) {
+            datav[i] += addition[i];
+        } else if constexpr(std::is_same_v<T, float4*>) {
+            datav[i].xyz += addition[i];
+        }
+    }
+}
+
+} // namespace data
+
+void destroy(AttributeDataMap& data) {
+    data::free<POSITIONS_T>(data);
+    data::free<TANGENTS_T>(data);
+    data::free<COLORS_T>(data);
+    data::free<NORMALS_T>(data);
+    data::free<UV0_T>(data);
+    data::free<UV1_T>(data);
+    data::free<WEIGHTS_T>(data);
+    data::free<JOINTS_T>(data);
+}
+
+} // anonymous namespace
+
+namespace filament::gltfio {
+
+void TangentsJobExtended::run(Params* params) {
+    cgltf_primitive const& prim = *params->in.prim;
+    int const morphTargetIndex = params->in.morphTargetIndex;
+    bool const isMorphTarget = morphTargetIndex != kMorphTargetUnused;
+
+    bool const isUnlit = prim.material ? prim.material->unlit : false;
+
+    // Extract the vertex count from the first attribute. All attributes must have the same count.
+    assert_invariant(prim.attributes_count > 0);
+    auto const vertexCount = prim.attributes[0].data->count;
+    assert_invariant(vertexCount > 0);
+
+    std::unordered_map<uint8_t, cgltf_accessor const*> accessors;
+    std::unordered_map<uint8_t, cgltf_accessor const*> morphAccessors;
+    AttributeDataMap attributes;
+
+    std::unique_ptr<uint3[]> unpackedTriangles;
+    bool hasUV0 = false;
+    for (cgltf_size aindex = 0; aindex < prim.attributes_count; aindex++) {
+        cgltf_attribute const& attr = prim.attributes[aindex];
+        cgltf_accessor* accessor = attr.data;
+        assert_invariant(accessor);
+        if (auto const attrCode = toCode({attr.type, attr.index}, params->in.uvmap, hasUV0);
+                attrCode != INVALID_ID) {
+            hasUV0 = hasUV0 || attrCode == UV0_ID;
+            accessors[attrCode] = accessor;
+        }
+    }
+
+    std::vector<float3> morphDelta;
+    if (isMorphTarget) {
+        auto const& morphTarget = prim.targets[morphTargetIndex];
+        decltype(params->in.uvmap) tmpUvmap; // just a placeholder since we don't consider morph target uvs.
+        for (cgltf_size aindex = 0; aindex < morphTarget.attributes_count; aindex++) {
+            cgltf_attribute const& attr = morphTarget.attributes[aindex];
+            if (auto const attrCode = toCode({attr.type, attr.index}, tmpUvmap, false);
+                    attrCode != INVALID_ID) {
+                assert_invariant(accessors.find(attrCode) != accessors.end() &&
+                                 "Morph target data has no corresponding base vertex data.");
+                morphAccessors[attrCode] = attr.data;
+            }
+        }
+        morphDelta.resize(vertexCount);
+    }
+    using AuxType = Mesh::AuxType;
+    Mesh::Builder tob(isUnlit);
+    tob.vertexCount(vertexCount);
+
+    for (auto [attr, accessor]: accessors) {
+        switch (attr) {
+            case POSITIONS_ID:
+                data::allocate<POSITIONS_T>(attributes, vertexCount);
+                data::unpack<POSITIONS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data(),
+                            isMorphTarget);
+                    data::add<POSITIONS_T>(attributes, vertexCount, morphDelta.data());
+
+                    // We stash the positions as colors so that they can be retrieved without change
+                    // after the TBN algo, which might have remeshed the input.
+                    data::allocate<COLORS_T>(attributes, vertexCount);
+                    float4* storage = data::get<COLORS_T>(attributes);
+                    for (size_t i = 0; i < vertexCount; i++) {
+                        storage[i] = float4{morphDelta[i], 0.0};
+                    }
+                    tob.aux(AuxType::COLORS, storage);
+                }
+                tob.positions(data::get<POSITIONS_T>(attributes));
+                break;
+            case TANGENTS_ID:
+                data::allocate<TANGENTS_T>(attributes, vertexCount);
+                data::unpack<TANGENTS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data());
+                    data::add<TANGENTS_T>(attributes, vertexCount, morphDelta.data());
+                }
+                tob.tangents(data::get<TANGENTS_T>(attributes));
+                break;
+            case NORMALS_ID:
+                data::allocate<NORMALS_T>(attributes, vertexCount);
+                data::unpack<NORMALS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data());
+                    data::add<NORMALS_T>(attributes, vertexCount, morphDelta.data());
+                }
+                tob.normals(data::get<NORMALS_T>(attributes));
+                break;
+            case COLORS_ID:
+                data::allocate<COLORS_T>(attributes, vertexCount);
+                data::unpack<COLORS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::COLORS, data::get<COLORS_T>(attributes));
+                break;
+            case UV0_ID:
+                data::allocate<UV0_T>(attributes, vertexCount);
+                data::unpack<UV0_T>(accessor, attributes, vertexCount);
+                tob.uvs(data::get<UV0_T>(attributes));
+                break;
+            case UV1_ID:
+                data::allocate<UV1_T>(attributes, vertexCount);
+                data::unpack<UV1_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::UV1, data::get<UV1_T>(attributes));
+                break;
+            case WEIGHTS_ID:
+                data::allocate<WEIGHTS_T>(attributes, vertexCount);
+                data::unpack<WEIGHTS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::WEIGHTS, data::get<WEIGHTS_T>(attributes));
+                break;
+            case JOINTS_ID:
+                data::allocate<JOINTS_T>(attributes, vertexCount);
+                data::unpack<JOINTS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::JOINTS, data::get<JOINTS_T>(attributes));
+                break;
+            default:
+                break;
+        }
+    }
+
+    size_t const triangleCount = prim.indices ? (prim.indices->count / 3) : (vertexCount / 3);
+    unpackedTriangles.reset(new uint3[triangleCount]);
+
+    // TODO, this is slow. We might be able to skip the manual read if the indices are already in
+    // the right format.
+    if (prim.indices) {
+        for (size_t tri = 0, j = 0; tri < triangleCount; ++tri) {
+            auto& triangle = unpackedTriangles[tri];
+            triangle.x = cgltf_accessor_read_index(prim.indices, j++);
+            triangle.y = cgltf_accessor_read_index(prim.indices, j++);
+            triangle.z = cgltf_accessor_read_index(prim.indices, j++);
+        }
+    } else {
+        for (size_t tri = 0, j = 0; tri < triangleCount; ++tri) {
+            auto& triangle = unpackedTriangles[tri];
+            triangle.x = j++;
+            triangle.y = j++;
+            triangle.z = j++;
+        }
+    }
+
+    tob.triangleCount(triangleCount);
+    tob.triangles(unpackedTriangles.get());
+    auto const mesh = tob.build();
+
+    auto& out = params->out;
+    out.vertexCount = mesh->getVertexCount();
+
+    auto const cleanup = [&]() {
+        destroy(attributes);
+        Mesh::destroy(mesh);
+    };
+
+    out.triangleCount = mesh->getTriangleCount();
+    out.triangles = mesh->getTriangles();
+
+    if (!isUnlit) {
+        out.tbn = mesh->getQuats();
+    }
+
+    if (isMorphTarget) {
+        // For morph targets, we need to retrieve the positions, but note that the unadjusted
+        // positions are stored as colors.
+        // For morph targets, we use COLORS as a way to store the original positions.
+        auto data = mesh->getAux<COLORS_TYPE>(AuxType::COLORS);
+        out.positions = (float3*) malloc(sizeof(float3) * out.vertexCount);
+        for (size_t i = 0; i < out.vertexCount; ++i) {
+            out.positions[i] = data[i].xyz;
+        }
+        free(data);
+    } else {
+        for (auto [attr, data]: attributes) {
+            switch (attr) {
+                case POSITIONS_ID:
+                    out.positions = mesh->getPositions();
+                    break;
+                case COLORS_ID:
+                    out.colors = mesh->getAux<COLORS_TYPE>(AuxType::COLORS);
+                    break;
+                case UV0_ID:
+                    out.uv0 = mesh->getUVs();
+                    break;
+                case UV1_ID:
+                    out.uv1 = mesh->getAux<UV1_TYPE>(AuxType::UV1);
+                    break;
+                case WEIGHTS_ID:
+                    out.weights = mesh->getAux<WEIGHTS_TYPE>(AuxType::WEIGHTS);
+                    break;
+                case JOINTS_ID:
+                    out.joints = mesh->getAux<JOINTS_TYPE>(AuxType::JOINTS);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+
+    cleanup();
+}
+
+} // namespace filament::gltfio

--- a/libs/gltfio/src/extended/TangentsJobExtended.h
+++ b/libs/gltfio/src/extended/TangentsJobExtended.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_TANGENTS_JOB_EXTENDED_H
+#define GLTFIO_TANGENTS_JOB_EXTENDED_H
+
+#include "AssetLoaderExtended.h"
+
+#include <cgltf.h>
+
+#include <math/vec4.h>
+
+#include <memory>
+#include <unordered_map>
+
+namespace filament::gltfio {
+
+struct VertexBufferProducer;
+struct MorphTargetBufferProducer;
+struct IndexBufferProducer;
+
+struct TangentsJobExtended {
+    static constexpr int kMorphTargetUnused = -1;
+
+    // The inputs to the procedure. The prim is owned by the client, which should ensure that it
+    // stays alive for the duration of the procedure.
+    struct InputParams {
+        cgltf_primitive const* prim;
+        int morphTargetIndex = kMorphTargetUnused;
+        UvMap uvmap;
+    };
+
+    // The outputs of the procedure. The results array gets malloc'd by the procedure, so clients
+    // should remember to free it.
+    struct OutputParams {
+        size_t triangleCount = 0;
+        math::uint3* triangles = nullptr;
+
+        size_t vertexCount = 0;
+        math::short4* tbn = nullptr;
+        math::float2* uv0 = nullptr;
+        math::float2* uv1 = nullptr;
+        math::float3* positions = nullptr;
+        math::ushort4* joints = nullptr;
+        math::float4* weights = nullptr;
+        math::float4* colors = nullptr;
+
+        bool isEmpty() const {
+            return !tbn && !uv0 && !uv1 && !positions && !joints && !weights && !colors;
+        }
+    };
+
+    // Clients might want to track the jobs in an array, so the arguments are bundled into a struct.
+    struct Params {
+        InputParams in;
+        OutputParams out;
+        uint8_t jobType = 0;        
+    };
+
+    // Performs tangents generation synchronously. This can be invoked from inside a job if desired.
+    // The parameters structure is owned by the client.
+    static void run(Params* params);
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_TANGENTS_JOB_EXTENDED_H

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -747,14 +747,25 @@ int main(int argc, char** argv) {
                 createJitShaderProvider(engine, OPTIMIZE_MATERIALS) :
                 createUbershaderProvider(engine, UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
 
-        app.assetLoader = AssetLoader::create({engine, app.materials, app.names });
+        AssetConfiguration assetLoaderConfig {
+            .engine= engine,
+            .materials = app.materials,
+            .names = app.names,
+        };
         app.mainCamera = &view->getCamera();
         if (filename.isEmpty()) {
+            app.assetLoader = AssetLoader::create(assetLoaderConfig);
             app.asset = app.assetLoader->createAsset(
                     GLTF_DEMO_DAMAGEDHELMET_DATA,
                     GLTF_DEMO_DAMAGEDHELMET_SIZE);
             app.instance = app.asset->getInstance();
         } else {
+            std::string gltfPath = filename.getAbsolutePath();
+            AssetConfigurationExtended extendedConfig = {
+                    .gltfPath = gltfPath.c_str(),                    
+            };
+            assetLoaderConfig.ext = &extendedConfig;
+            app.assetLoader = AssetLoader::create(assetLoaderConfig);
             loadAsset(filename);
         }
 


### PR DESCRIPTION
     - Fix missing attributes in TangentSpaceMesh
     - Fix missing reference in MikktspaceImpl.cpp
     - Add gltfio/src/extended to implement an alternate loader for
       primitives. This is largely based on the implementation in
       AssetLoader/ResourceLoader
     - Pull common methods between the two implementations into a
       utility namespace.
     - Switch gltf_viewer to use new gltf loader (extended loader).
     - Able to correctly produce flat shading from gltf that only have
       vertex positions and indices.
     - Able to run mikktspace to generate tangent spaces as per gltf
       spec
     - Note that java/webgl samples have not been ported to this
       framework due to difficulty in maintaining interaction between
       AssetLoader/ResourceLoader
    
    Fixes #7444; Fixes #6358
