### PR TITLE
fix a typo that broke the resourceallocator cache

### DIFF
--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -109,7 +109,7 @@ size_t ResourceAllocator::TextureKey::getSize() const noexcept {
 }
 
 ResourceAllocator::ResourceAllocator(Engine::Config const& config, DriverApi& driverApi) noexcept
-        : mCacheCapacity(config.resourceAllocatorCacheSizeMB),
+        : mCacheCapacity(config.resourceAllocatorCacheSizeMB << 20),
           mCacheMaxAge(config.resourceAllocatorCacheMaxAge),
           mBackend(driverApi) {
 }


### PR DESCRIPTION
the cache size is given in MiB not bytes, so we needed to convert it to bytes.