### PR TITLE
Modernize HwRenderPrimitive and draw() APIs

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -224,11 +224,7 @@ DECL_DRIVER_API_R_N(backend::SamplerGroupHandle, createSamplerGroup,
 DECL_DRIVER_API_R_N(backend::RenderPrimitiveHandle, createRenderPrimitive,
         backend::VertexBufferHandle, vbh,
         backend::IndexBufferHandle, ibh,
-        backend::PrimitiveType, pt,
-        uint32_t, offset,
-        uint32_t, minIndex,
-        uint32_t, maxIndex,
-        uint32_t, count)
+        backend::PrimitiveType, pt)
 
 DECL_DRIVER_API_R_N(backend::ProgramHandle, createProgram,
         backend::Program&&, program)
@@ -494,6 +490,8 @@ DECL_DRIVER_API_N(blit,
 DECL_DRIVER_API_N(draw,
         backend::PipelineState, state,
         backend::RenderPrimitiveHandle, rph,
+        uint32_t, indexOffset,
+        uint32_t, indexCount,
         uint32_t, instanceCount)
 
 DECL_DRIVER_API_N(dispatchCompute,

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -88,11 +88,6 @@ struct HwIndexBuffer : public HwBase {
 };
 
 struct HwRenderPrimitive : public HwBase {
-    uint32_t offset{};
-    uint32_t minIndex{};
-    uint32_t maxIndex{};
-    uint32_t count{};
-    uint32_t maxVertexCount{};
     PrimitiveType type = PrimitiveType::TRIANGLES;
 };
 

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -133,11 +133,8 @@ private:
         mHandleAllocator.deallocate(handle, p);
     }
 
-    inline void setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
+    inline void setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
             Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh);
-
-    inline void setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
-            uint32_t offset, uint32_t minIndex, uint32_t maxIndex, uint32_t count);
 
     void finalizeSamplerGroup(MetalSamplerGroup* sg);
     void enumerateBoundBuffers(BufferObjectBinding bindingType,

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -340,7 +340,7 @@ void NoopDriver::blit(
 }
 
 void NoopDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph,
-        uint32_t instanceCount) {
+        uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
 }
 
 void NoopDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGroupCount) {

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -77,11 +77,9 @@ private:
     VulkanDriver& operator=(VulkanDriver const&) = delete;
 
 private:
-    inline void setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph, Handle<HwVertexBuffer> vbh,
+    inline void setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
+            Handle<HwVertexBuffer> vbh,
             Handle<HwIndexBuffer> ibh);
-
-    inline void setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
-            uint32_t offset, uint32_t minIndex, uint32_t maxIndex, uint32_t count);
 
     void collectGarbage();
 

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -143,7 +143,7 @@ void BackendTest::renderTriangle(Handle<HwRenderTarget> renderTarget,
     state.rasterState.depthFunc = RasterState::DepthFunc::A;
     state.rasterState.culling = CullingMode::NONE;
 
-    api.draw(state, triangle.getRenderPrimitive(), 1);
+    api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
 
     api.endRenderPass();
 }

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -60,7 +60,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 
     mRenderPrimitive = mDriverApi.createRenderPrimitive(
-            mVertexBuffer, mIndexBuffer, PrimitiveType::TRIANGLES, 0, 0, 2, 3);
+            mVertexBuffer, mIndexBuffer, PrimitiveType::TRIANGLES);
 }
 
 void TrianglePrimitive::updateVertices(const filament::math::float2 vertices[3]) noexcept {

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -405,7 +405,7 @@ TEST_F(BackendTest, ColorResolve) {
     api.beginFrame(0, 0);
         api.beginRenderPass(srcRenderTarget, params);
             api.bindUniformBuffer(0, ubuffer);
-            api.draw(state, triangle.getRenderPrimitive(), 1);
+            api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
     api.endFrame(0);
 

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -172,7 +172,7 @@ TEST_F(BackendTest, VertexBufferUpdate) {
             }
 
             getDriverApi().beginRenderPass(defaultRenderTarget, params);
-            getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+            getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
             getDriverApi().endRenderPass();
 
             triangleIndex++;

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -218,7 +218,7 @@ TEST_F(BackendTest, FeedbackLoops) {
                     .sourceLevel = float(sourceLevel),
                 });
                 api.beginRenderPass(renderTargets[targetLevel], params);
-                api.draw(state, triangle.getRenderPrimitive(), 1);
+                api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
                 api.endRenderPass();
             }
 
@@ -237,7 +237,7 @@ TEST_F(BackendTest, FeedbackLoops) {
                     .sourceLevel = float(sourceLevel),
                 });
                 api.beginRenderPass(renderTargets[targetLevel], params);
-                api.draw(state, triangle.getRenderPrimitive(), 1);
+                api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
                 api.endRenderPass();
             }
 

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -130,7 +130,7 @@ TEST_F(BackendTest, MRT) {
 
         // Draw a triangle.
         getDriverApi().beginRenderPass(renderTarget, params);
-        getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+        getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         getDriverApi().endRenderPass();
 
         getDriverApi().flush();

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -168,7 +168,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
             ps.rasterState.colorWrite = true;
             ps.rasterState.depthWrite = false;
             api.beginRenderPass(renderTarget, params);
-            api.draw(ps, triangle.getRenderPrimitive(), 1);
+            api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
             api.endRenderPass();
         }
 
@@ -203,7 +203,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         // Because the min level is 1, the result color should be the white triangle drawn in the
         // previous pass.
         api.beginRenderPass(defaultRenderTarget, params);
-        api.draw(state, triangle.getRenderPrimitive(), 1);
+        api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         // Adjust the base mip to 2.
@@ -221,7 +221,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         params.flags.clear = TargetBufferFlags::NONE;
         params.flags.discardStart = TargetBufferFlags::NONE;
         api.beginRenderPass(defaultRenderTarget, params);
-        api.draw(state, triangle.getRenderPrimitive(), 1);
+        api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         api.commit(swapChain);

--- a/filament/backend/test/test_MissingRequiredAttributes.cpp
+++ b/filament/backend/test/test_MissingRequiredAttributes.cpp
@@ -104,7 +104,7 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
 
         // Render a triangle.
         getDriverApi().beginRenderPass(defaultRenderTarget, params);
-        getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+        getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         getDriverApi().endRenderPass();
 
         getDriverApi().flush();

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -309,7 +309,7 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         state.rasterState.depthWrite = false;
         state.rasterState.depthFunc = RasterState::DepthFunc::A;
         state.rasterState.culling = CullingMode::NONE;
-        getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+        getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
 
         getDriverApi().endRenderPass();
 
@@ -438,7 +438,7 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
 
         // Render some content, just so we don't read back uninitialized data.
         getDriverApi().beginRenderPass(renderTarget, params);
-        getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+        getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         getDriverApi().endRenderPass();
 
         PixelBufferDescriptor descriptor(buffer, renderTargetSize * renderTargetSize * 4,

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -120,7 +120,7 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
 
     // Render a triangle.
     getDriverApi().beginRenderPass(defaultRenderTarget, params);
-    getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+    getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
     getDriverApi().endRenderPass();
 
     getDriverApi().flush();
@@ -242,7 +242,7 @@ TEST_F(BackendTest, RenderExternalImage) {
 
     // Render a triangle.
     getDriverApi().beginRenderPass(defaultRenderTarget, params);
-    getDriverApi().draw(state, triangle.getRenderPrimitive(), 1);
+    getDriverApi().draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
     getDriverApi().endRenderPass();
 
     getDriverApi().flush();

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -140,7 +140,7 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         api.beginFrame(0, 0);
 
         api.beginRenderPass(srcRenderTarget, params);
-        api.draw(ps, triangle.getRenderPrimitive(), 1);
+        api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         readPixelsAndAssertHash("scissor", kSrcTexWidth >> 1, kSrcTexHeight >> 1, fullRenderTarget,
@@ -231,14 +231,14 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         api.beginFrame(0, 0);
 
         api.beginRenderPass(renderTarget, params);
-        api.draw(ps, triangle.getRenderPrimitive(), 1);
+        api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         params.viewport = topLeftViewport;
         params.flags.clear = TargetBufferFlags::NONE;
         params.flags.discardStart = TargetBufferFlags::NONE;
         api.beginRenderPass(renderTarget, params);
-        api.draw(ps, triangle.getRenderPrimitive(), 1);
+        api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         readPixelsAndAssertHash(

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -113,7 +113,7 @@ public:
         api.beginFrame(0, 0);
 
         api.beginRenderPass(renderTarget, params);
-        api.draw(ps, smallTriangle.getRenderPrimitive(), 1);
+        api.draw(ps, smallTriangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         // Step 2: Render a larger triangle with the stencil test enabled.
@@ -126,7 +126,7 @@ public:
         ps.stencilState.front.ref = 0u;
 
         api.beginRenderPass(renderTarget, params);
-        api.draw(ps, triangle.getRenderPrimitive(), 1);
+        api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
         api.commit(swapChain);
@@ -240,7 +240,7 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     api.beginFrame(0, 0);
 
     api.beginRenderPass(renderTarget0, params);
-    api.draw(ps, smallTriangle.getRenderPrimitive(), 1);
+    api.draw(ps, smallTriangle.getRenderPrimitive(), 0, 3, 1);
     api.endRenderPass();
 
     // Step 2: Render a larger triangle with the stencil test enabled.
@@ -255,7 +255,7 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     ps.stencilState.front.ref = 0u;
 
     api.beginRenderPass(renderTarget1, params);
-    api.draw(ps, triangle.getRenderPrimitive(), 1);
+    api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
     api.endRenderPass();
 
     api.commit(swapChain);

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -583,8 +583,6 @@ public:
             VertexBuffer* UTILS_NULLABLE vertices = nullptr;
             IndexBuffer* UTILS_NULLABLE indices = nullptr;
             size_t offset = 0;
-            size_t minIndex = 0;
-            size_t maxIndex = 0;
             size_t count = 0;
             MaterialInstance const* UTILS_NULLABLE materialInstance = nullptr;
             PrimitiveType type = PrimitiveType::TRIANGLES;

--- a/filament/src/HwRenderPrimitiveFactory.cpp
+++ b/filament/src/HwRenderPrimitiveFactory.cpp
@@ -27,15 +27,7 @@ bool operator<(HwRenderPrimitiveFactory::Key const& lhs,
         HwRenderPrimitiveFactory::Key const& rhs) noexcept {
     if (lhs.vbh == rhs.vbh) {
         if (lhs.ibh == rhs.ibh) {
-            if (lhs.offset == rhs.offset) {
-                if (lhs.count == rhs.count) {
-                    return lhs.type < rhs.type;
-                } else {
-                    return lhs.count < rhs.count;
-                }
-            } else {
-                return lhs.offset < rhs.offset;
-            }
+            return lhs.type < rhs.type;
         } else {
             return lhs.ibh < rhs.ibh;
         }
@@ -69,17 +61,16 @@ HwRenderPrimitiveFactory::HwRenderPrimitiveFactory()
 
 HwRenderPrimitiveFactory::~HwRenderPrimitiveFactory() noexcept = default;
 
-void HwRenderPrimitiveFactory::terminate(DriverApi& driver) noexcept {
+void HwRenderPrimitiveFactory::terminate(DriverApi&) noexcept {
     assert_invariant(mMap.empty());
     assert_invariant(mSet.empty());
 }
 
 RenderPrimitiveHandle HwRenderPrimitiveFactory::create(DriverApi& driver,
         VertexBufferHandle vbh, IndexBufferHandle ibh,
-        PrimitiveType type, uint32_t offset, uint32_t minIndex, uint32_t maxIndex,
-        uint32_t count) noexcept {
+        PrimitiveType type) noexcept {
 
-    const Key key = { vbh, ibh, offset, count, type };
+    const Key key = { vbh, ibh, type };
 
     // see if we already have seen this RenderPrimitive
     auto pos = mSet.find(key);
@@ -87,8 +78,7 @@ RenderPrimitiveHandle HwRenderPrimitiveFactory::create(DriverApi& driver,
     // the common case is that we've never seen it (i.e.: no reuse)
     if (UTILS_LIKELY(pos == mSet.end())) {
         // create the backend object
-        auto handle = driver.createRenderPrimitive(vbh, ibh,
-                type, offset, minIndex, maxIndex, count);
+        auto handle = driver.createRenderPrimitive(vbh, ibh, type);
         // insert key/handle in our set with a refcount of 1
         // IMPORTANT: std::set<> doesn't invalidate iterators in insert/erase
         auto [ipos, _] = mSet.insert({ key, handle, 1 });

--- a/filament/src/HwRenderPrimitiveFactory.h
+++ b/filament/src/HwRenderPrimitiveFactory.h
@@ -26,8 +26,10 @@
 
 #include <tsl/robin_map.h>
 
+#include <functional>
 #include <set>
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace filament {
@@ -50,11 +52,7 @@ public:
     backend::RenderPrimitiveHandle create(backend::DriverApi& driver,
             backend::VertexBufferHandle vbh,
             backend::IndexBufferHandle ibh,
-            backend::PrimitiveType type,
-            uint32_t offset,
-            uint32_t minIndex,
-            uint32_t maxIndex,
-            uint32_t count) noexcept;
+            backend::PrimitiveType type) noexcept;
 
     void destroy(backend::DriverApi& driver,
             backend::RenderPrimitiveHandle rph) noexcept;
@@ -63,8 +61,6 @@ private:
     struct Key { // 20 bytes
         backend::VertexBufferHandle vbh;            // 4
         backend::IndexBufferHandle ibh;             // 4
-        uint32_t offset;                            // 4
-        uint32_t count;                             // 4
         backend::PrimitiveType type;                // 4
     };
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -392,7 +392,7 @@ void PostProcessManager::render(FrameGraphResources::RenderPassInfo const& out,
     FEngine const& engine = mEngine;
     Handle<HwRenderPrimitive> const fullScreenQuad = engine.getFullScreenRenderPrimitive();
     driver.beginRenderPass(out.target, out.params);
-    driver.draw(pipeline, fullScreenQuad, 1);
+    driver.draw(pipeline, fullScreenQuad, 0, 3, 1);
     driver.endRenderPass();
 }
 
@@ -2300,7 +2300,7 @@ void PostProcessManager::colorGradingSubpass(DriverApi& driver,
             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
     driver.nextSubpass();
-    driver.draw(material.getPipelineState(mEngine, variant), fullScreenRenderPrimitive, 1);
+    driver.draw(material.getPipelineState(mEngine, variant), fullScreenRenderPrimitive, 0, 3, 1);
 }
 
 void PostProcessManager::customResolvePrepareSubpass(DriverApi& driver, CustomResolveOp op) noexcept {
@@ -2319,7 +2319,7 @@ void PostProcessManager::customResolveSubpass(DriverApi& driver) noexcept {
     FMaterialInstance* mi = material.getMaterialInstance(mEngine);
     mi->use(driver);
     driver.nextSubpass();
-    driver.draw(material.getPipelineState(mEngine), fullScreenRenderPrimitive, 1);
+    driver.draw(material.getPipelineState(mEngine), fullScreenRenderPrimitive, 0, 3, 1);
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::customResolveUncompressPass(FrameGraph& fg,
@@ -2764,7 +2764,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
                 }
                 PipelineState const pipeline(material.getPipelineState(mEngine, variant));
                 driver.beginRenderPass(out.target, out.params);
-                driver.draw(pipeline, mEngine.getFullScreenRenderPrimitive(), 1);
+                driver.draw(pipeline, mEngine.getFullScreenRenderPrimitive(), 0, 3, 1);
                 if (colorGradingConfig.asSubpass) {
                     colorGradingSubpass(driver, colorGradingConfig);
                 }
@@ -2988,8 +2988,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::upscale(FrameGraph& fg, bool
                         enableTranslucentBlending(pipeline1);
                     }
                     driver.beginRenderPass(out.target, out.params);
-                    driver.draw(pipeline0, fullScreenRenderPrimitive, 1);
-                    driver.draw(pipeline1, fullScreenRenderPrimitive, 1);
+                    driver.draw(pipeline0, fullScreenRenderPrimitive, 0, 3, 1);
+                    driver.draw(pipeline1, fullScreenRenderPrimitive, 0, 3, 1);
                     driver.endRenderPass();
                 } else {
                     PipelineState pipeline(easuMaterial->getPipelineState(mEngine));
@@ -2997,7 +2997,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::upscale(FrameGraph& fg, bool
                         enableTranslucentBlending(pipeline);
                     }
                     driver.beginRenderPass(out.target, out.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive, 1);
+                    driver.draw(pipeline, fullScreenRenderPrimitive, 0, 3, 1);
                     driver.endRenderPass();
                 }
             });

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -292,6 +292,8 @@ void RenderPass::instanceify(FEngine& engine, Arena& arena) noexcept {
             // skinning/morphing.
             return  lhs.primitive.mi                == rhs.primitive.mi                 &&
                     lhs.primitive.primitiveHandle   == rhs.primitive.primitiveHandle    &&
+                    lhs.primitive.indexOffset       == rhs.primitive.indexOffset        &&
+                    lhs.primitive.indexCount        == rhs.primitive.indexCount         &&
                     lhs.primitive.rasterState       == rhs.primitive.rasterState        &&
                     lhs.primitive.skinningHandle    == rhs.primitive.skinningHandle     &&
                     lhs.primitive.skinningOffset    == rhs.primitive.skinningOffset     &&
@@ -640,6 +642,8 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
 
             if constexpr (isColorPass) {
                 cmdColor.primitive.primitiveHandle = primitive.getHwHandle();
+                cmdColor.primitive.indexOffset = primitive.getIndexOffset();
+                cmdColor.primitive.indexCount = primitive.getIndexCount();
                 RenderPass::setupColorCommand(cmdColor, renderableVariant, mi, inverseFrontFaces);
 
                 cmdColor.primitive.skinningHandle = skinning.handle;
@@ -745,6 +749,8 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
 
                 // unconditionally write the command
                 cmdDepth.primitive.primitiveHandle = primitive.getHwHandle();
+                cmdDepth.primitive.indexOffset = primitive.getIndexOffset();
+                cmdDepth.primitive.indexCount = primitive.getIndexCount();
                 cmdDepth.primitive.mi = mi;
                 cmdDepth.primitive.rasterState.culling = mi->getCullingMode();
 
@@ -988,7 +994,8 @@ void RenderPass::Executor::execute(FEngine& engine,
                             info.skinningTexture);
                 }
 
-                driver.draw(pipeline, info.primitiveHandle, instanceCount);
+                driver.draw(pipeline, info.primitiveHandle,
+                        info.indexOffset, info.indexCount, instanceCount);
             }
         }
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -249,18 +249,19 @@ public:
         backend::Handle<backend::HwBufferObject> instanceBufferHandle;  // 4 bytes
         uint32_t index = 0;                                             // 4 bytes
         uint32_t skinningOffset = 0;                                    // 4 bytes
+        uint32_t indexOffset;                                           // 4 bytes
+        uint32_t indexCount;                                            // 4 bytes
         uint16_t instanceCount;                                         // 2 bytes [MSb: user]
         Variant materialVariant;                                        // 1 byte
 
         static const uint16_t USER_INSTANCE_MASK = 0x8000u;
         static const uint16_t INSTANCE_COUNT_MASK = 0x7fffu;
     };
-    static_assert(sizeof(PrimitiveInfo) == 48);
+    static_assert(sizeof(PrimitiveInfo) == 56);
 
     struct alignas(8) Command {     // 64 bytes
         CommandKey key = 0;         //  8 bytes
         PrimitiveInfo primitive;    // 48 bytes
-        uint64_t reserved[1] = {};  //  8 bytes
         bool operator < (Command const& rhs) const noexcept { return key < rhs.key; }
         // placement new declared as "throw" to avoid the compiler's null-check
         inline void* operator new (size_t, void* ptr) {

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -17,13 +17,16 @@
 #ifndef TNT_FILAMENT_DETAILS_RENDERPRIMITIVE_H
 #define TNT_FILAMENT_DETAILS_RENDERPRIMITIVE_H
 
+#include <filament/RenderableManager.h>
+
 #include "components/RenderableManager.h"
 
 #include "details/MaterialInstance.h"
 
+#include <backend/DriverEnums.h>
 #include <backend/Handle.h>
 
-#include <utils/compiler.h>
+#include <stdint.h>
 
 namespace filament {
 
@@ -43,13 +46,15 @@ public:
     void set(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
             RenderableManager::PrimitiveType type,
             FVertexBuffer* vertices, FIndexBuffer* indices, size_t offset,
-            size_t minIndex, size_t maxIndex, size_t count) noexcept;
+            size_t count) noexcept;
 
     // frees driver resources, object becomes invalid
     void terminate(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver);
 
     const FMaterialInstance* getMaterialInstance() const noexcept { return mMaterialInstance; }
     backend::Handle<backend::HwRenderPrimitive> getHwHandle() const noexcept { return mHandle; }
+    uint32_t getIndexOffset() const noexcept { return mIndexOffset; }
+    uint32_t getIndexCount() const noexcept { return mIndexCount; }
     backend::PrimitiveType getPrimitiveType() const noexcept { return mPrimitiveType; }
     AttributeBitset getEnabledAttributes() const noexcept { return mEnabledAttributes; }
     uint16_t getBlendOrder() const noexcept { return mBlendOrder; }
@@ -72,7 +77,8 @@ private:
     uint16_t mBlendOrder = 0;
     bool mGlobalBlendOrderEnabled = false;
     backend::PrimitiveType mPrimitiveType = backend::PrimitiveType::TRIANGLES;
-    UTILS_UNUSED uint8_t reserved[4] = {};
+    uint32_t mIndexOffset = 0;
+    uint32_t mIndexCount = 0;
 };
 
 } // namespace filament

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -109,14 +109,12 @@ RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
 
 RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
         PrimitiveType type, VertexBuffer* vertices, IndexBuffer* indices,
-        size_t offset, size_t minIndex, size_t maxIndex, size_t count) noexcept {
+        size_t offset, UTILS_UNUSED size_t minIndex, UTILS_UNUSED size_t maxIndex, size_t count) noexcept {
     std::vector<Entry>& entries = mImpl->mEntries;
     if (index < entries.size()) {
         entries[index].vertices = vertices;
         entries[index].indices = indices;
         entries[index].offset = offset;
-        entries[index].minIndex = minIndex;
-        entries[index].maxIndex = maxIndex;
         entries[index].count = count;
         entries[index].type = type;
     }
@@ -435,11 +433,6 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
                 "[entity=%u, primitive @ %u] offset (%u) + count (%u) > indexCount (%u)",
                 entity.getId(), i,
                 entry.offset, entry.count, entry.indices->getIndexCount());
-
-        ASSERT_PRECONDITION(entry.minIndex <= entry.maxIndex,
-                "[entity=%u, primitive @ %u] minIndex (%u) > maxIndex (%u)",
-                entity.getId(), i,
-                entry.minIndex, entry.maxIndex);
 
         // this can't be an error because (1) those values are not immutable, so the caller
         // could fix later, and (2) the material's shader will work (i.e. compile), and
@@ -816,7 +809,7 @@ void FRenderableManager::setGeometryAt(Instance instance, uint8_t level, size_t 
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].set(mHwRenderPrimitiveFactory, mEngine.getDriverApi(),
-                    type, vertices, indices, offset, 0, vertices->getVertexCount() - 1, count);
+                    type, vertices, indices, offset, count);
         }
     }
 }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -273,7 +273,7 @@ void FEngine::init() {
 
     mFullScreenTriangleRph = driverApi.createRenderPrimitive(
             mFullScreenTriangleVb->getHwHandle(), mFullScreenTriangleIb->getHwHandle(),
-            PrimitiveType::TRIANGLES, 0, 0, 2, (uint32_t)mFullScreenTriangleIb->getIndexCount());
+            PrimitiveType::TRIANGLES);
 
     // Compute a clip-space [-1 to 1] to texture space [0 to 1] matrix, taking into account
     // backend differences.


### PR DESCRIPTION
HwRenderPrimitive doesn't need to know about the index offset and index count, these parameters are only needed when drawing. draw() is updated consequently.

This is a first step towards being able to lower the overhead of draw similar draw calls. 

A side effect of this is that the HwRenderPrimitiveFactory now will cache buffers regardless of their index count & offset.