### PR TITLE
Add stereoscopic type to Engine::Config

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -484,7 +484,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
 extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBuilderConfig(JNIEnv*,
         jclass, jlong nativeBuilder, jlong commandBufferSizeMB, jlong perRenderPassArenaSizeMB,
         jlong driverHandleArenaSizeMB, jlong minCommandBufferSizeMB, jlong perFrameCommandsSizeMB,
-        jlong jobSystemThreadCount, jlong stereoscopicEyeCount,
+        jlong jobSystemThreadCount, jint stereoscopicType, jlong stereoscopicEyeCount,
         jlong resourceAllocatorCacheSizeMB, jlong resourceAllocatorCacheMaxAge) {
     Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
     Engine::Config config = {
@@ -494,6 +494,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
             .minCommandBufferSizeMB = (uint32_t) minCommandBufferSizeMB,
             .perFrameCommandsSizeMB = (uint32_t) perFrameCommandsSizeMB,
             .jobSystemThreadCount = (uint32_t) jobSystemThreadCount,
+            .stereoscopicType = (Engine::StereoscopicType) stereoscopicType,
             .stereoscopicEyeCount = (uint8_t) stereoscopicEyeCount,
             .resourceAllocatorCacheSizeMB = (uint32_t) resourceAllocatorCacheSizeMB,
             .resourceAllocatorCacheMaxAge = (uint8_t) resourceAllocatorCacheMaxAge,

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -364,7 +364,7 @@ public class Engine {
          * The type of technique for stereoscopic rendering.
          *
          * This setting determines the algorithm used when stereoscopic rendering is enabled. This
-         * decision applies the entire Engine during the lifetime of the Engine. E.g., multiple
+         * decision applies to the entire Engine for the lifetime of the Engine. E.g., multiple
          * Views created from the Engine must use the same stereoscopic type.
          *
          * Each view can enable stereoscopic rendering via the StereoscopicOptions::enable flag.

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -364,8 +364,10 @@ public class Engine {
          * The type of technique for stereoscopic rendering.
          *
          * This setting determines the algorithm used when stereoscopic rendering is enabled. This
-         * decision applies the entire Engine during the lifetime of the Engine.
-         * E.g., multiple Views must use the same stereoscopic type.
+         * decision applies the entire Engine during the lifetime of the Engine. E.g., multiple
+         * Views created from the Engine must use the same stereoscopic type.
+         *
+         * Each view can enable stereoscopic rendering via the StereoscopicOptions::enable flag.
          *
          * @see View#setStereoscopicOptions
          */

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -159,6 +159,16 @@ public class Engine {
     };
 
     /**
+     * The type of technique for stereoscopic rendering
+     */
+    public enum StereoscopicType {
+        /** Stereoscopic rendering is performed using instanced rendering technique. */
+        INSTANCED,
+        /** Stereoscopic rendering is performed using the multiview feature from the graphics backend. */
+        MULTIVIEW,
+    };
+
+    /**
      * Constructs <code>Engine</code> objects using a builder pattern.
      */
     public static class Builder {
@@ -211,7 +221,8 @@ public class Engine {
             nSetBuilderConfig(mNativeBuilder, config.commandBufferSizeMB,
                     config.perRenderPassArenaSizeMB, config.driverHandleArenaSizeMB,
                     config.minCommandBufferSizeMB, config.perFrameCommandsSizeMB,
-                    config.jobSystemThreadCount, config.stereoscopicEyeCount,
+                    config.jobSystemThreadCount,
+                    config.stereoscopicType.ordinal(), config.stereoscopicEyeCount,
                     config.resourceAllocatorCacheSizeMB, config.resourceAllocatorCacheMaxAge);
             return this;
         }
@@ -348,6 +359,17 @@ public class Engine {
          * the number of threads to use.
          */
         public long jobSystemThreadCount = 0;
+
+        /**
+         * The type of technique for stereoscopic rendering.
+         *
+         * This setting determines the algorithm used when stereoscopic rendering is enabled. This
+         * decision applies the entire Engine during the lifetime of the Engine.
+         * E.g., multiple Views must use the same stereoscopic type.
+         *
+         * @see View#setStereoscopicOptions
+         */
+        public StereoscopicType stereoscopicType = StereoscopicType.INSTANCED;
 
         /**
          * The number of eyes to render when stereoscopic rendering is enabled. Supported values are
@@ -1240,7 +1262,7 @@ public class Engine {
     private static native void nSetBuilderConfig(long nativeBuilder, long commandBufferSizeMB,
             long perRenderPassArenaSizeMB, long driverHandleArenaSizeMB,
             long minCommandBufferSizeMB, long perFrameCommandsSizeMB, long jobSystemThreadCount,
-            long stereoscopicEyeCount,
+            int stereoscopicType, long stereoscopicEyeCount,
             long resourceAllocatorCacheSizeMB, long resourceAllocatorCacheMaxAge);
     private static native void nSetBuilderFeatureLevel(long nativeBuilder, int ordinal);
     private static native void nSetBuilderSharedContext(long nativeBuilder, long sharedContext);

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1212,6 +1212,14 @@ enum class Workaround : uint16_t {
     DISABLE_THREAD_AFFINITY
 };
 
+//! The type of technique for stereoscopic rendering
+enum class StereoscopicType : uint8_t {
+    // Stereoscopic rendering is performed using instanced rendering technique.
+    INSTANCED,
+    // Stereoscopic rendering is performed using the multiview feature from the graphics backend.
+    MULTIVIEW,
+};
+
 } // namespace filament::backend
 
 template<> struct utils::EnableBitMaskOperators<filament::backend::ShaderStageFlags>

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -302,8 +302,10 @@ public:
          * The type of technique for stereoscopic rendering.
          *
          * This setting determines the algorithm used when stereoscopic rendering is enabled. This
-         * decision applies the entire Engine during the lifetime of the Engine.
-         * E.g., multiple Views must use the same stereoscopic type.
+         * decision applies the entire Engine during the lifetime of the Engine. E.g., multiple
+         * Views created from the Engine must use the same stereoscopic type.
+         *
+         * Each view can enable stereoscopic rendering via the StereoscopicOptions::enable flag.
          *
          * @see View::setStereoscopicOptions
          */

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -178,6 +178,7 @@ public:
     using Backend = backend::Backend;
     using DriverConfig = backend::Platform::DriverConfig;
     using FeatureLevel = backend::FeatureLevel;
+    using StereoscopicType = backend::StereoscopicType;
 
     /**
      * Config is used to define the memory footprint used by the engine, such as the
@@ -296,6 +297,17 @@ public:
          * Currently only respected by the Metal backend.
          */
         size_t textureUseAfterFreePoolSize = 0;
+
+        /*
+         * The type of technique for stereoscopic rendering.
+         *
+         * This setting determines the algorithm used when stereoscopic rendering is enabled. This
+         * decision applies the entire Engine during the lifetime of the Engine.
+         * E.g., multiple Views must use the same stereoscopic type.
+         *
+         * @see View::setStereoscopicOptions
+         */
+        StereoscopicType stereoscopicType = StereoscopicType::INSTANCED;
 
         /*
          * The number of eyes to render when stereoscopic rendering is enabled. Supported values are

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -302,7 +302,7 @@ public:
          * The type of technique for stereoscopic rendering.
          *
          * This setting determines the algorithm used when stereoscopic rendering is enabled. This
-         * decision applies the entire Engine during the lifetime of the Engine. E.g., multiple
+         * decision applies to the entire Engine for the lifetime of the Engine. E.g., multiple
          * Views created from the Engine must use the same stereoscopic type.
          *
          * Each view can enable stereoscopic rendering via the StereoscopicOptions::enable flag.


### PR DESCRIPTION
This new type value will determine the algorithm used when stereoscopic rendering is enabled.