### PR TITLE
vk: add debug names to shader modules

### DIFF
--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -39,7 +39,12 @@
 // not required for validation.
 
 // FVK is short for Filament Vulkan
+
+// Enables Android systrace
 #define FVK_DEBUG_SYSTRACE                0x00000001
+
+// Group markers are used to denote collection of GPU commands.  It is typically at the granualarity
+// of a renderpass.
 #define FVK_DEBUG_GROUP_MARKERS           0x00000002
 #define FVK_DEBUG_TEXTURE                 0x00000004
 #define FVK_DEBUG_LAYOUT_TRANSITION       0x00000008
@@ -54,6 +59,9 @@
 #define FVK_DEBUG_READ_PIXELS             0x00001000
 #define FVK_DEBUG_PIPELINE_CACHE          0x00002000
 #define FVK_DEBUG_ALLOCATION              0x00004000
+
+// Enable the debug utils extension if it is available.
+#define FVK_DEBUG_DEBUG_UTILS             0x00008000
 
 // Usefaul default combinations
 #define FVK_DEBUG_EVERYTHING              0xFFFFFFFF
@@ -72,7 +80,7 @@
     FVK_DEBUG_PRINT_GROUP_MARKERS
 
 #ifndef NDEBUG
-#define FVK_DEBUG_FLAGS FVK_DEBUG_PERFORMANCE
+#define FVK_DEBUG_FLAGS (FVK_DEBUG_PERFORMANCE | FVK_DEBUG_DEBUG_UTILS | FVK_DEBUG_VALIDATION)
 #else
 #define FVK_DEBUG_FLAGS 0
 #endif
@@ -80,9 +88,21 @@
 #define FVK_ENABLED(flags) ((FVK_DEBUG_FLAGS) & (flags))
 #define FVK_ENABLED_BOOL(flags) ((bool) FVK_ENABLED(flags))
 
+
+// Group marker only works only if validation or debug utils is enabled since it uses
+// vkCmd(Begin/End)DebugUtilsLabelEXT or vkCmdDebugMarker(Begin/End)EXT
+#if FVK_ENABLED(FVK_DEBUG_PRINT_GROUP_MARKERS)
+static_assert(FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS) || FVK_ENABLED(FVK_DEBUG_VALIDATION));
+#endif
+
 // Ensure dependencies are met between debug options
 #if FVK_ENABLED(FVK_DEBUG_PRINT_GROUP_MARKERS)
 static_assert(FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS));
+#endif
+
+// Only enable debug utils if validation is enabled.
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
+static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 #endif
 
 // end dependcy checks

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -45,6 +45,30 @@ public:
     static Driver* create(VulkanPlatform* platform, VulkanContext const& context,
             Platform::DriverConfig const& driverConfig) noexcept;
 
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
+    // Encapsulates the VK_EXT_debug_utils extension.  In particular, we use
+    // vkSetDebugUtilsObjectNameEXT and vkCreateDebugUtilsMessengerEXT
+    class DebugUtils {
+    public:
+        static void setName(VkObjectType type, uint64_t handle, char const* name);
+
+    private:
+        static DebugUtils* get();
+
+        DebugUtils(VkInstance instance, VkDevice device, VulkanContext const* context);
+        ~DebugUtils();
+
+        VkInstance const mInstance;
+        VkDevice const mDevice;
+        bool const mEnabled;
+        VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;
+
+        static DebugUtils* mSingleton;
+
+        friend class VulkanDriver;
+    };
+#endif // FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
+
 private:
     void debugCommandBegin(CommandStream* cmds, bool synchronous,
             const char* methodName) noexcept override;
@@ -93,7 +117,6 @@ private:
     VulkanRenderPass mCurrentRenderPass = {};
     VmaAllocator mAllocator = VK_NULL_HANDLE;
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
-    VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;
 
     VulkanContext mContext = {};
     VulkanResourceAllocator mResourceAllocator;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -17,6 +17,7 @@
 #include "VulkanHandles.h"
 
 #include "VulkanConstants.h"
+#include "VulkanDriver.h"
 #include "VulkanMemory.h"
 #include "spirv/VulkanSpirvUtils.h"
 
@@ -78,6 +79,23 @@ VulkanProgram::VulkanProgram(VkDevice device, Program const& builder) noexcept
         };
         VkResult result = vkCreateShaderModule(mDevice, &moduleInfo, VKALLOC, &module);
         ASSERT_POSTCONDITION(result == VK_SUCCESS, "Unable to create shader module.");
+
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
+        std::string name{ builder.getName().c_str(), builder.getName().size() };
+        switch (static_cast<ShaderStage>(i)) {
+            case ShaderStage::VERTEX:
+                name += "_vs";
+                break;
+            case ShaderStage::FRAGMENT:
+                name += "_fs";
+                break;
+            default:
+                PANIC_POSTCONDITION("Unexpected stage");
+                break;
+        }
+        VulkanDriver::DebugUtils::setName(VK_OBJECT_TYPE_SHADER_MODULE,
+                reinterpret_cast<uint64_t>(module), name.c_str());
+#endif
     }
 
     auto& groupInfo = builder.getSamplerGroupInfo();
@@ -93,10 +111,10 @@ VulkanProgram::VulkanProgram(VkDevice device, Program const& builder) noexcept
         }
     }
 
-    #if FVK_ENABLED(FVK_DEBUG_SHADER_MODULE)
-        utils::slog.d << "Created VulkanProgram " << builder << ", shaders = (" << bundle.vertex
-                      << ", " << bundle.fragment << ")" << utils::io::endl;
-    #endif
+#if FVK_ENABLED(FVK_DEBUG_SHADER_MODULE)
+    utils::slog.d << "Created VulkanProgram " << builder << ", shaders = (" << bundle.vertex
+                  << ", " << bundle.fragment << ")" << utils::io::endl;
+#endif
 }
 
 VulkanProgram::VulkanProgram(VkDevice device, VkShaderModule vs, VkShaderModule fs,


### PR DESCRIPTION
 - Also removed debugUtils workaround for Mesa since it's been addressed properly from the vk backend.