### PR TITLE
A set of CLs to introduce HwVertexBufferInfo

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -137,6 +137,7 @@ set(SRCS
 
 set(PRIVATE_HDRS
         src/Allocators.h
+        src/Bimap.h
         src/BufferPoolAllocator.h
         src/ColorSpaceUtils.h
         src/Culler.h

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRCS
         src/Froxelizer.cpp
         src/Frustum.cpp
         src/HwRenderPrimitiveFactory.cpp
+        src/HwVertexBufferInfoFactory.cpp
         src/IndexBuffer.cpp
         src/IndirectLight.cpp
         src/InstanceBuffer.cpp
@@ -148,6 +149,7 @@ set(PRIVATE_HDRS
         src/FrameSkipper.h
         src/Froxelizer.h
         src/HwRenderPrimitiveFactory.h
+        src/HwVertexBufferInfoFactory.h
         src/Intersections.h
         src/MaterialParser.h
         src/PerViewUniforms.h

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -39,6 +39,7 @@ struct HwStream;
 struct HwSwapChain;
 struct HwTexture;
 struct HwTimerQuery;
+struct HwVertexBufferInfo;
 struct HwVertexBuffer;
 
 /*
@@ -114,18 +115,19 @@ private:
 
 // Types used by the command stream
 // (we use this renaming because the macro-system doesn't deal well with "<" and ">")
-using BufferObjectHandle    = Handle<HwBufferObject>;
-using FenceHandle           = Handle<HwFence>;
-using IndexBufferHandle     = Handle<HwIndexBuffer>;
-using ProgramHandle         = Handle<HwProgram>;
-using RenderPrimitiveHandle = Handle<HwRenderPrimitive>;
-using RenderTargetHandle    = Handle<HwRenderTarget>;
-using SamplerGroupHandle    = Handle<HwSamplerGroup>;
-using StreamHandle          = Handle<HwStream>;
-using SwapChainHandle       = Handle<HwSwapChain>;
-using TextureHandle         = Handle<HwTexture>;
-using TimerQueryHandle      = Handle<HwTimerQuery>;
-using VertexBufferHandle    = Handle<HwVertexBuffer>;
+using BufferObjectHandle     = Handle<HwBufferObject>;
+using FenceHandle            = Handle<HwFence>;
+using IndexBufferHandle      = Handle<HwIndexBuffer>;
+using ProgramHandle          = Handle<HwProgram>;
+using RenderPrimitiveHandle  = Handle<HwRenderPrimitive>;
+using RenderTargetHandle     = Handle<HwRenderTarget>;
+using SamplerGroupHandle     = Handle<HwSamplerGroup>;
+using StreamHandle           = Handle<HwStream>;
+using SwapChainHandle        = Handle<HwSwapChain>;
+using TextureHandle          = Handle<HwTexture>;
+using TimerQueryHandle       = Handle<HwTimerQuery>;
+using VertexBufferHandle     = Handle<HwVertexBuffer>;
+using VertexBufferInfoHandle = Handle<HwVertexBufferInfo>;
 
 } // namespace filament::backend
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -167,11 +167,14 @@ DECL_DRIVER_API_0(resetState)
  * -----------------------
  */
 
-DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
+DECL_DRIVER_API_R_N(backend::VertexBufferInfoHandle, createVertexBufferInfo,
         uint8_t, bufferCount,
         uint8_t, attributeCount,
-        uint32_t, vertexCount,
         backend::AttributeArray, attributes)
+
+DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
+        uint32_t, vertexCount,
+        backend::VertexBufferInfoHandle, vbih)
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
@@ -260,6 +263,7 @@ DECL_DRIVER_API_R_0(backend::TimerQueryHandle, createTimerQuery)
  */
 
 DECL_DRIVER_API_N(destroyVertexBuffer,    backend::VertexBufferHandle, vbh)
+DECL_DRIVER_API_N(destroyVertexBufferInfo,backend::VertexBufferInfoHandle, vbih)
 DECL_DRIVER_API_N(destroyIndexBuffer,     backend::IndexBufferHandle, ibh)
 DECL_DRIVER_API_N(destroyBufferObject,    backend::BufferObjectHandle, ibh)
 DECL_DRIVER_API_N(destroyRenderPrimitive, backend::RenderPrimitiveHandle, rph)

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -37,7 +37,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define HandleAllocatorGL  HandleAllocator<16,  64, 208>    // ~3640 / pool / MiB
+#define HandleAllocatorGL  HandleAllocator<24,  64, 136>    // ~3640 / pool / MiB
 #define HandleAllocatorVK  HandleAllocator<80, 176, 320>    // ~1820 / pool / MiB
 #define HandleAllocatorMTL HandleAllocator<48, 160, 592>    // ~1310 / pool / MiB
 

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -49,21 +49,25 @@ struct AcquiredImage;
 struct HwBase {
 };
 
-struct HwVertexBuffer : public HwBase {
-    AttributeArray attributes{};          // 8 * MAX_VERTEX_ATTRIBUTE_COUNT
-    uint32_t vertexCount{};               //   4
+
+struct HwVertexBufferInfo : public HwBase {
     uint8_t bufferCount{};                //   1
     uint8_t attributeCount{};             //   1
-    bool padding{};                       //   1
-    uint8_t bufferObjectsVersion{};       //   1 -> total struct is 136 bytes
-
-    HwVertexBuffer() noexcept = default;
-    HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            AttributeArray const& attributes) noexcept
-            : attributes(attributes),
-              vertexCount(elementCount),
-              bufferCount(bufferCount),
+    bool padding[2]{};                    //   2
+    HwVertexBufferInfo() noexcept = default;
+    HwVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount) noexcept
+            : bufferCount(bufferCount),
               attributeCount(attributeCount) {
+    }
+};
+
+struct HwVertexBuffer : public HwBase {
+    uint32_t vertexCount{};               //   4
+    uint8_t bufferObjectsVersion{};       //   1
+    bool padding[3]{};                    //   2
+    HwVertexBuffer() noexcept = default;
+    explicit HwVertexBuffer(uint32_t vertextCount) noexcept
+            : vertexCount(vertextCount) {
     }
 };
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -145,10 +145,18 @@ private:
     MetalBuffer buffer;
 };
 
-struct MetalVertexBuffer : public HwVertexBuffer {
-    MetalVertexBuffer(MetalContext& context, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t vertexCount, AttributeArray const& attributes);
+struct MetalVertexBufferInfo : public HwVertexBufferInfo {
+    MetalVertexBufferInfo(MetalContext& context,
+            uint8_t bufferCount, uint8_t attributeCount, AttributeArray const& attributes);
 
+    AttributeArray attributes;
+};
+
+struct MetalVertexBuffer : public HwVertexBuffer {
+    MetalVertexBuffer(MetalContext& context,
+            uint32_t vertexCount, uint32_t bufferCount, Handle<HwVertexBufferInfo> vbih);
+
+    Handle<HwVertexBufferInfo> vbih;
     utils::FixedCapacityVector<MetalBuffer*> buffers;
 };
 
@@ -161,7 +169,8 @@ struct MetalIndexBuffer : public HwIndexBuffer {
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {
     MetalRenderPrimitive();
-    void setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer* indexBuffer);
+    void setBuffers(MetalVertexBufferInfo const* const vbi,
+            MetalVertexBuffer* vertexBuffer, MetalIndexBuffer* indexBuffer);
     // The pointers to MetalVertexBuffer and MetalIndexBuffer are "weak".
     // The MetalVertexBuffer and MetalIndexBuffer must outlive the MetalRenderPrimitive.
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -77,6 +77,9 @@ void NoopDriver::finish(int) {
 void NoopDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 }
 
+void NoopDriver::destroyVertexBufferInfo(Handle<HwVertexBufferInfo> vbih) {
+}
+
 void NoopDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -94,8 +94,22 @@ public:
         uint16_t age = 0;
     };
 
+    struct GLVertexBufferInfo : public HwVertexBufferInfo {
+        GLVertexBufferInfo() noexcept = default;
+        GLVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount,
+                AttributeArray const& attributes)
+                : HwVertexBufferInfo(bufferCount, attributeCount),
+                  attributes(attributes) {
+        }
+        AttributeArray attributes;
+    };
+
     struct GLVertexBuffer : public HwVertexBuffer {
-        using HwVertexBuffer::HwVertexBuffer;
+        GLVertexBuffer() noexcept = default;
+        GLVertexBuffer(uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih)
+                : HwVertexBuffer(vertexCount), vbih(vbih) {
+        }
+        Handle<HwVertexBufferInfo> vbih;
         struct {
             // 4 * MAX_VERTEX_ATTRIBUTE_COUNT bytes
             std::array<GLuint, MAX_VERTEX_ATTRIBUTE_COUNT> buffers{};

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -373,10 +373,26 @@ void VulkanDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     mResourceManager.release(rp);
 }
 
-void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
-        uint8_t attributeCount, uint32_t elementCount, AttributeArray attributes) {
-    auto vertexBuffer = mResourceAllocator.construct<VulkanVertexBuffer>(vbh, mContext, mStagePool,
-            &mResourceAllocator, bufferCount, attributeCount, elementCount, attributes);
+void VulkanDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vbih, uint8_t bufferCount,
+        uint8_t attributeCount, AttributeArray attributes) {
+    auto vbi = mResourceAllocator.construct<VulkanVertexBufferInfo>(vbih,
+            bufferCount, attributeCount, attributes);
+    mResourceManager.acquire(vbi);
+}
+
+void VulkanDriver::destroyVertexBufferInfo(Handle<HwVertexBufferInfo> vbih) {
+    if (!vbih) {
+        return;
+    }
+    auto vbi = mResourceAllocator.handle_cast<VulkanVertexBufferInfo*>(vbih);
+    mResourceManager.release(vbi);
+}
+
+
+void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh,
+        uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih) {
+    auto vertexBuffer = mResourceAllocator.construct<VulkanVertexBuffer>(vbh,
+            mContext, mStagePool, &mResourceAllocator, vertexCount, vbih);
     mResourceManager.acquire(vertexBuffer);
 }
 
@@ -581,6 +597,10 @@ void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t wi
 
 void VulkanDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, int) {
     // nothing to do, timer query was constructed in createTimerQueryS
+}
+
+Handle<HwVertexBufferInfo> VulkanDriver::createVertexBufferInfoS() noexcept {
+    return mResourceAllocator.allocHandle<VulkanVertexBufferInfo>();
 }
 
 Handle<HwVertexBuffer> VulkanDriver::createVertexBufferS() noexcept {
@@ -903,7 +923,7 @@ void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t in
     auto bo = mResourceAllocator.handle_cast<VulkanBufferObject*>(boh);
     assert_invariant(bo->bindingType == BufferObjectBinding::VERTEX);
 
-    vb->setBuffer(bo, index);
+    vb->setBuffer(mResourceAllocator, bo, index);
 }
 
 void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
@@ -1692,7 +1712,9 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     };
 
     // Declare fixed-size arrays that get passed to the pipeCache and to vkCmdBindVertexBuffers.
-    uint32_t const bufferCount = prim.vertexBuffer->attributes.size();
+    VulkanVertexBufferInfo const* const vbi =
+            mResourceAllocator.handle_cast<VulkanVertexBufferInfo*>(prim.vertexBuffer->vbih);
+    uint32_t const bufferCount = vbi->attributes.size();
     VkVertexInputAttributeDescription const* attribDesc = prim.vertexBuffer->getAttribDescriptions();
     VkVertexInputBindingDescription const* bufferDesc =  prim.vertexBuffer->getBufferDescriptions();
     VkBuffer const* buffers = prim.vertexBuffer->getVkBuffers();

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -16,6 +16,7 @@
 
 #include "VulkanHandles.h"
 
+#include "VulkanDriver.h"
 #include "VulkanConstants.h"
 #include "VulkanMemory.h"
 #include "spirv/VulkanSpirvUtils.h"
@@ -262,13 +263,23 @@ uint8_t VulkanRenderTarget::getColorTargetCount(const VulkanRenderPass& pass) co
     return count;
 }
 
+VulkanVertexBufferInfo::VulkanVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount,
+        AttributeArray const& attributes)
+        : HwVertexBufferInfo(bufferCount, attributeCount),
+          VulkanResource(VulkanResourceType::VERTEX_BUFFER_INFO),
+          attributes(attributes) {
+}
+
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
-        VulkanResourceAllocator* allocator, uint8_t bufferCount, uint8_t attributeCount,
-        uint32_t elementCount, AttributeArray const& attribs)
-    : HwVertexBuffer(bufferCount, attributeCount, elementCount, attribs),
+        VulkanResourceAllocator* allocator, uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih)
+    : HwVertexBuffer(vertexCount),
       VulkanResource(VulkanResourceType::VERTEX_BUFFER),
-      mInfo(new PipelineInfo(attribs.size())),
+      vbih(vbih),
       mResources(allocator) {
+
+    VulkanVertexBufferInfo const* const vbi = allocator->handle_cast<VulkanVertexBufferInfo*>(vbih);
+    mInfo = new PipelineInfo(vbi->attributes.size());
+
     auto attribDesc = mInfo->mSoa.data<PipelineInfo::ATTRIBUTE_DESCRIPTION>();
     auto bufferDesc = mInfo->mSoa.data<PipelineInfo::BUFFER_DESCRIPTION>();
     auto offsets = mInfo->mSoa.data<PipelineInfo::OFFSETS>();
@@ -276,8 +287,8 @@ VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& 
     std::fill(mInfo->mSoa.begin<PipelineInfo::ATTRIBUTE_TO_BUFFER_INDEX>(),
             mInfo->mSoa.end<PipelineInfo::ATTRIBUTE_TO_BUFFER_INDEX>(), -1);
 
-    for (uint32_t attribIndex = 0; attribIndex < attribs.size(); attribIndex++) {
-        Attribute attrib = attribs[attribIndex];
+    for (uint32_t attribIndex = 0; attribIndex < vbi->attributes.size(); attribIndex++) {
+        Attribute attrib = vbi->attributes[attribIndex];
         bool const isInteger = attrib.flags & Attribute::FLAG_INTEGER_TARGET;
         bool const isNormalized = attrib.flags & Attribute::FLAG_NORMALIZED;
         VkFormat vkformat = getVkFormat(attrib.type, isNormalized, isInteger);
@@ -289,7 +300,7 @@ VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& 
         // expects to receive floats or ints.
         if (attrib.buffer == Attribute::BUFFER_UNUSED) {
             vkformat = isInteger ? VK_FORMAT_R8G8B8A8_UINT : VK_FORMAT_R8G8B8A8_SNORM;
-            attrib = attribs[0];
+            attrib = vbi->attributes[0];
         }
         offsets[attribIndex] = attrib.offset;
         attribDesc[attribIndex] = {
@@ -309,8 +320,12 @@ VulkanVertexBuffer::~VulkanVertexBuffer() {
     delete mInfo;
 }
 
-void VulkanVertexBuffer::setBuffer(VulkanBufferObject* bufferObject, uint32_t index) {
-    size_t count = attributes.size();
+void VulkanVertexBuffer::setBuffer(VulkanResourceAllocator const& allocator,
+        VulkanBufferObject* bufferObject, uint32_t index) {
+
+    VulkanVertexBufferInfo const* const vbi =
+            const_cast<VulkanResourceAllocator&>(allocator).handle_cast<VulkanVertexBufferInfo*>(vbih);
+    size_t count = vbi->attributes.size();
     auto vkbuffers = mInfo->mSoa.data<PipelineInfo::VK_BUFFER>();
     auto attribToBuffer = mInfo->mSoa.data<PipelineInfo::ATTRIBUTE_TO_BUFFER_INDEX>();
     for (uint8_t attribIndex = 0; attribIndex < count; attribIndex++) {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -129,14 +129,21 @@ private:
 
 struct VulkanBufferObject;
 
+struct VulkanVertexBufferInfo : public HwVertexBufferInfo, VulkanResource {
+    VulkanVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount,
+            AttributeArray const& attributes);
+    AttributeArray attributes;
+};
+
 struct VulkanVertexBuffer : public HwVertexBuffer, VulkanResource {
     VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
-            VulkanResourceAllocator* allocator, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t elementCount, AttributeArray const& attributes);
+            VulkanResourceAllocator* allocator,
+            uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih);
 
     ~VulkanVertexBuffer();
 
-    void setBuffer(VulkanBufferObject* bufferObject, uint32_t index);
+    void setBuffer(VulkanResourceAllocator const& allocator,
+            VulkanBufferObject* bufferObject, uint32_t index);
 
     inline VkVertexInputAttributeDescription const* getAttribDescriptions() {
         return mInfo->mSoa.data<PipelineInfo::ATTRIBUTE_DESCRIPTION>();
@@ -154,6 +161,8 @@ struct VulkanVertexBuffer : public HwVertexBuffer, VulkanResource {
         return mInfo->mSoa.data<PipelineInfo::OFFSETS>();
     }
 
+    Handle<HwVertexBufferInfo> vbih;
+
 private:
     struct PipelineInfo {
         PipelineInfo(size_t size)
@@ -161,7 +170,7 @@ private:
             mSoa.resize(size);
         }
 
-        // These corresponds to the index of the element in the SoA
+        // These correspond to the index of the element in the SoA
         static constexpr uint8_t ATTRIBUTE_DESCRIPTION = 0;
         static constexpr uint8_t BUFFER_DESCRIPTION = 1;
         static constexpr uint8_t VK_BUFFER = 2;

--- a/filament/backend/src/vulkan/VulkanResources.cpp
+++ b/filament/backend/src/vulkan/VulkanResources.cpp
@@ -53,6 +53,9 @@ void deallocateResource(VulkanResourceAllocator* allocator, VulkanResourceType t
         case VulkanResourceType::TIMER_QUERY:
             allocator->destruct<VulkanTimerQuery>(Handle<HwTimerQuery>(id));
             break;
+        case VulkanResourceType::VERTEX_BUFFER_INFO:
+            allocator->destruct<VulkanVertexBufferInfo>(Handle<HwVertexBufferInfo>(id));
+            break;
         case VulkanResourceType::VERTEX_BUFFER:
             allocator->destruct<VulkanVertexBuffer>(Handle<HwVertexBuffer>(id));
             break;

--- a/filament/backend/src/vulkan/VulkanResources.h
+++ b/filament/backend/src/vulkan/VulkanResources.h
@@ -43,6 +43,7 @@ enum class VulkanResourceType : uint8_t {
     TEXTURE,
     TIMER_QUERY,
     VERTEX_BUFFER,
+    VERTEX_BUFFER_INFO,
 
     // Below are resources that are managed manually (i.e. not ref counted).
     FENCE,

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -48,7 +48,9 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
 
     const size_t size = sizeof(math::float2) * 3;
     mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, BufferUsage::STATIC);
-    mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes);
+    mVertexBufferInfo = mDriverApi.createVertexBufferInfo(1, 1, attributes);
+    mVertexBuffer = mDriverApi.createVertexBuffer(mVertexCount, mVertexBufferInfo);
+
     mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
     BufferDescriptor vertexBufferDesc(gVertices, size);
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
@@ -102,6 +104,7 @@ void TrianglePrimitive::updateIndices(const index_type* indices, int count, int 
 TrianglePrimitive::~TrianglePrimitive() {
     mDriverApi.destroyBufferObject(mBufferObject);
     mDriverApi.destroyVertexBuffer(mVertexBuffer);
+    mDriverApi.destroyVertexBufferInfo(mVertexBufferInfo);
     mDriverApi.destroyIndexBuffer(mIndexBuffer);
     mDriverApi.destroyRenderPrimitive(mRenderPrimitive);
 }

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -40,6 +40,7 @@ public:
 
     using PrimitiveHandle = filament::backend::Handle<filament::backend::HwRenderPrimitive>;
     using BufferObjectHandle = filament::backend::Handle<filament::backend::HwBufferObject>;
+    using VertexInfoHandle = filament::backend::Handle<filament::backend::HwVertexBufferInfo>;
     using VertexHandle = filament::backend::Handle<filament::backend::HwVertexBuffer>;
     using IndexHandle = filament::backend::Handle<filament::backend::HwIndexBuffer>;
 
@@ -63,6 +64,7 @@ private:
 
     PrimitiveHandle mRenderPrimitive;
     BufferObjectHandle mBufferObject;
+    VertexInfoHandle mVertexBufferInfo;
     VertexHandle mVertexBuffer;
     IndexHandle mIndexBuffer;
 

--- a/filament/src/Bimap.h
+++ b/filament/src/Bimap.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BIMAP_H
+#define TNT_FILAMENT_BIMAP_H
+
+#include <utils/debug.h>
+
+#include <tsl/robin_map.h>
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include <stddef.h>
+
+namespace filament {
+
+/*
+ * A semi-generic custom bimap. This bimap stores a key/value pair and can retrieve
+ * the value from the key and the key from the value.
+ * It is optimized for large keys and small values.  The keys are stored out-of-line and are
+ * never moved.
+ */
+template<typename Key, typename Value,
+        typename KeyHash = std::hash<Key>,
+        typename ValueHash = std::hash<Value>,
+        typename Allocator = std::allocator<Key>>
+class Bimap {
+
+    struct KeyDelegate {
+        Key const* pKey = nullptr;
+        bool operator==(KeyDelegate const& rhs) const noexcept {
+            return *pKey == *rhs.pKey;
+        }
+    };
+
+    // KeyWrapperHash delegates the hash computation to KeyHash
+    struct KeyHasherDelegate {
+        size_t operator()(KeyDelegate const& p) const noexcept {
+            KeyHash const h;
+            return h(*p.pKey);
+        }
+    };
+
+    using ForwardMap = tsl::robin_map<KeyDelegate, Value, KeyHasherDelegate>;
+    using BackwardMap = tsl::robin_map<Value, KeyDelegate, ValueHash>;
+
+    Allocator mAllocator;
+    ForwardMap mForwardMap;
+    BackwardMap mBackwardMap;
+
+public:
+    Bimap() = default;
+    explicit Bimap(Allocator&& allocator)
+            : mAllocator(std::forward<Allocator>(allocator)) {
+    }
+
+    void reserve(size_t capacity) {
+        mForwardMap.reserve(capacity);
+        mBackwardMap.reserve(capacity);
+    }
+
+    bool empty() const noexcept {
+        return mForwardMap.empty() && mBackwardMap.empty();
+    }
+
+    // insert a new key/value pair
+    void insert(Key const& key, Value const& value) noexcept {
+        Key* pKey = mAllocator.allocate(1); // allocate storage for the key
+        new((void*)pKey) Key{ key }; // copy-construct the key
+        mForwardMap.insert({{ pKey }, value });
+        mBackwardMap.insert({ value, { pKey }});
+    }
+
+    typename ForwardMap::iterator end() { return mForwardMap.end(); }
+
+    // Find the value iterator from the key in O(1)
+    typename ForwardMap::const_iterator find(Key const& key) const {
+        return mForwardMap.find(KeyDelegate{ .pKey = &key });
+    }
+    typename ForwardMap::iterator find(Key const& key) {
+        return mForwardMap.find(KeyDelegate{ .pKey = &key });
+    }
+
+    // Find the key iterator from the value in O(1). precondition, the value must exist.
+    typename BackwardMap::const_iterator find(Value const& value) const {
+        auto pos = mBackwardMap.find(value);
+        assert_invariant( pos != mBackwardMap.end() );
+        return pos;
+    }
+    typename BackwardMap::iterator find(Value& value) const {
+        return mBackwardMap.find(value);
+    }
+
+    // erase a key/value pair using an iterator to the value
+    void erase(typename BackwardMap::const_iterator it) {
+        // find the key
+        Key const& key = *(it->second.pKey);
+        // and its iterator
+        auto pos = find(key);
+        // destroy the key
+        it->second.pKey->~Key();
+        // free its memory
+        mAllocator.deallocate(const_cast<Key *>(it->second.pKey), 1);
+        // remove the entries from both maps
+        mForwardMap.erase(pos);
+        mBackwardMap.erase(it);
+    }
+};
+
+} // namespace filament
+
+
+#endif // TNT_FILAMENT_BIMAP_H

--- a/filament/src/HwRenderPrimitiveFactory.cpp
+++ b/filament/src/HwRenderPrimitiveFactory.cpp
@@ -16,6 +16,16 @@
 
 #include "HwRenderPrimitiveFactory.h"
 
+#include <backend/DriverApiForward.h>
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <private/backend/DriverApi.h>
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Hash.h>
+
 #include <stdlib.h>
 
 namespace filament {
@@ -23,86 +33,60 @@ namespace filament {
 using namespace utils;
 using namespace backend;
 
-bool operator<(HwRenderPrimitiveFactory::Key const& lhs,
+size_t HwRenderPrimitiveFactory::KeyHash::operator()(
+        HwRenderPrimitiveFactory::Key const& p) const noexcept {
+    return utils::hash::combine(
+            p.params.vbh.getId(),
+            utils::hash::combine(p.params.ibh.getId(), (size_t)p.params.type));
+}
+
+bool operator==(HwRenderPrimitiveFactory::Key const& lhs,
         HwRenderPrimitiveFactory::Key const& rhs) noexcept {
-    if (lhs.vbh == rhs.vbh) {
-        if (lhs.ibh == rhs.ibh) {
-            return lhs.type < rhs.type;
-        } else {
-            return lhs.ibh < rhs.ibh;
-        }
-    } else {
-        return lhs.vbh < rhs.vbh;
-    }
-}
-
-inline bool operator<(HwRenderPrimitiveFactory::Entry const& lhs,
-        HwRenderPrimitiveFactory::Entry const& rhs) noexcept {
-    return lhs.key < rhs.key;
-}
-
-inline bool operator<(HwRenderPrimitiveFactory::Key const& lhs,
-        HwRenderPrimitiveFactory::Entry const& rhs) noexcept {
-    return lhs < rhs.key;
-}
-
-inline bool operator<(HwRenderPrimitiveFactory::Entry const& lhs,
-        HwRenderPrimitiveFactory::Key const& rhs) noexcept {
-    return lhs.key < rhs;
+    return lhs.params.vbh == rhs.params.vbh &&
+           lhs.params.ibh == rhs.params.ibh &&
+           lhs.params.type == rhs.params.type;
 }
 
 // ------------------------------------------------------------------------------------------------
 
 HwRenderPrimitiveFactory::HwRenderPrimitiveFactory()
         : mArena("HwRenderPrimitiveFactory::mArena", SET_ARENA_SIZE),
-          mSet(mArena) {
-    mMap.reserve(256);
+          mBimap(mArena) {
+    mBimap.reserve(256);
 }
 
 HwRenderPrimitiveFactory::~HwRenderPrimitiveFactory() noexcept = default;
 
 void HwRenderPrimitiveFactory::terminate(DriverApi&) noexcept {
-    assert_invariant(mMap.empty());
-    assert_invariant(mSet.empty());
+    assert_invariant(mBimap.empty());
 }
 
-RenderPrimitiveHandle HwRenderPrimitiveFactory::create(DriverApi& driver,
-        VertexBufferHandle vbh, IndexBufferHandle ibh,
-        PrimitiveType type) noexcept {
-
-    const Key key = { vbh, ibh, type };
+auto HwRenderPrimitiveFactory::create(DriverApi& driver,
+        backend::VertexBufferHandle vbh,
+        backend::IndexBufferHandle ibh,
+        backend::PrimitiveType type) noexcept -> Handle {
 
     // see if we already have seen this RenderPrimitive
-    auto pos = mSet.find(key);
+    Key const key{{ vbh, ibh, type }, 1 };
+    auto pos = mBimap.find(key);
 
     // the common case is that we've never seen it (i.e.: no reuse)
-    if (UTILS_LIKELY(pos == mSet.end())) {
-        // create the backend object
+    if (UTILS_LIKELY(pos == mBimap.end())) {
         auto handle = driver.createRenderPrimitive(vbh, ibh, type);
-        // insert key/handle in our set with a refcount of 1
-        // IMPORTANT: std::set<> doesn't invalidate iterators in insert/erase
-        auto [ipos, _] = mSet.insert({ key, handle, 1 });
-        // map the handle back to the key/payload
-        mMap.insert({ handle.getId(), ipos });
+        mBimap.insert(key, { handle });
         return handle;
     }
-    pos->refs++;
-    return pos->handle;
+
+    pos->first.pKey->refs++;
+    return pos->second.handle;
 }
 
-void HwRenderPrimitiveFactory::destroy(DriverApi& driver, RenderPrimitiveHandle rph) noexcept {
+void HwRenderPrimitiveFactory::destroy(DriverApi& driver, Handle handle) noexcept {
     // look for this handle in our map
-    auto pos = mMap.find(rph.getId());
-
-    // it must be there
-    assert_invariant(pos != mMap.end());
-
-    // check the refcount and destroy if needed
-    auto ipos = pos->second;
-    if (--ipos->refs == 0) {
-        mSet.erase(ipos);
-        mMap.erase(pos);
-        driver.destroyRenderPrimitive(rph);
+    auto pos = mBimap.find(Value{ handle });
+    if (--pos->second.pKey->refs == 0) {
+        mBimap.erase(pos);
+        driver.destroyRenderPrimitive(handle);
     }
 }
 

--- a/filament/src/HwVertexBufferInfoFactory.cpp
+++ b/filament/src/HwVertexBufferInfoFactory.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HwVertexBufferInfoFactory.h"
+
+#include <backend/DriverApiForward.h>
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <private/backend/DriverApi.h>
+
+#include <utils/Log.h>
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Hash.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace filament {
+
+using namespace utils;
+using namespace backend;
+
+size_t HwVertexBufferInfoFactory::Parameters::hash() const noexcept {
+    static_assert((sizeof(*this) % sizeof(uint32_t)) == 0);
+    return utils::hash::murmur3(
+            reinterpret_cast<uint32_t const*>(this), sizeof(Parameters) / sizeof(uint32_t), 0);
+}
+
+bool operator==(HwVertexBufferInfoFactory::Parameters const& lhs,
+        HwVertexBufferInfoFactory::Parameters const& rhs) noexcept {
+    return !memcmp(&lhs, &rhs, sizeof(HwVertexBufferInfoFactory::Parameters));
+}
+
+// ------------------------------------------------------------------------------------------------
+
+HwVertexBufferInfoFactory::HwVertexBufferInfoFactory()
+        : mArena("HwVertexBufferInfoFactory::mArena", SET_ARENA_SIZE),
+          mBimap(mArena) {
+    mBimap.reserve(256);
+}
+
+HwVertexBufferInfoFactory::~HwVertexBufferInfoFactory() noexcept = default;
+
+void HwVertexBufferInfoFactory::terminate(DriverApi&) noexcept {
+    assert_invariant(mBimap.empty());
+}
+
+auto HwVertexBufferInfoFactory::create(DriverApi& driver,
+        uint8_t bufferCount,
+        uint8_t attributeCount,
+        backend::AttributeArray attributes) noexcept -> Handle {
+
+    Key const key{{ bufferCount, attributeCount, {}, attributes }, 1 };
+    auto pos = mBimap.find(key);
+
+    // the common case is that we've never seen it (i.e.: no reuse)
+    if (UTILS_LIKELY(pos == mBimap.end())) {
+        auto handle = driver.createVertexBufferInfo(
+                bufferCount, attributeCount,
+                attributes);
+        mBimap.insert(key, { handle });
+        return handle;
+    }
+
+    ++(pos->first.pKey->refs);
+    return pos->second.handle;
+}
+
+void HwVertexBufferInfoFactory::destroy(DriverApi& driver, Handle handle) noexcept {
+    // look for this handle in our map
+    auto pos = mBimap.find(Value{ handle });
+    if (--(pos->second.pKey->refs) == 0) {
+        mBimap.erase(pos);
+        driver.destroyVertexBufferInfo(handle);
+    }
+}
+
+} // namespace filament

--- a/filament/src/HwVertexBufferInfoFactory.h
+++ b/filament/src/HwVertexBufferInfoFactory.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_HWVERTEXBUFFERINFOFACTORY_H
+#define TNT_FILAMENT_HWVERTEXBUFFERINFOFACTORY_H
+
+#include "Bimap.h"
+
+#include <backend/DriverApiForward.h>
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <utils/Allocator.h>
+
+#include <functional>
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace filament {
+
+class FEngine;
+
+class HwVertexBufferInfoFactory {
+public:
+    using Handle = backend::VertexBufferInfoHandle;
+
+    HwVertexBufferInfoFactory();
+    ~HwVertexBufferInfoFactory() noexcept;
+
+    HwVertexBufferInfoFactory(HwVertexBufferInfoFactory const& rhs) = delete;
+    HwVertexBufferInfoFactory(HwVertexBufferInfoFactory&& rhs) noexcept = delete;
+    HwVertexBufferInfoFactory& operator=(HwVertexBufferInfoFactory const& rhs) = delete;
+    HwVertexBufferInfoFactory& operator=(HwVertexBufferInfoFactory&& rhs) noexcept = delete;
+
+    void terminate(backend::DriverApi& driver) noexcept;
+
+    struct Parameters { // 136 bytes
+        uint8_t bufferCount;
+        uint8_t attributeCount;
+        uint8_t padding[2] = {};
+        backend::AttributeArray attributes;
+        size_t hash() const noexcept;
+    };
+
+    friend bool operator==(Parameters const& lhs, Parameters const& rhs) noexcept;
+
+    Handle create(backend::DriverApi& driver,
+            uint8_t bufferCount,
+            uint8_t attributeCount,
+            backend::AttributeArray attributes) noexcept;
+
+    void destroy(backend::DriverApi& driver, Handle handle) noexcept;
+
+private:
+    struct Key { // 140 bytes
+        Parameters params;
+        mutable uint32_t refs;  // 4 bytes
+        bool operator==(Key const& rhs) const noexcept {
+            return params == rhs.params;
+        }
+    };
+
+    struct KeyHasher {
+        size_t operator()(Key const& p) const noexcept {
+            return p.params.hash();
+        }
+    };
+
+    struct Value {
+        Handle handle;
+    };
+
+    struct ValueHasher {
+        size_t operator()(Value v) const noexcept {
+            std::hash<Handle::HandleId> const hasher;
+            return hasher(v.handle.getId());
+        }
+    };
+
+    friend bool operator==(Value const& lhs, Value const& rhs) noexcept {
+        return lhs.handle == rhs.handle;
+    }
+
+    // Size of the arena used for the "set" part of the bimap
+    static constexpr size_t SET_ARENA_SIZE = 4 * 1024 * 1024;
+
+    // Arena for the set<>, using a pool allocator inside a heap area.
+    using PoolAllocatorArena = utils::Arena<
+            utils::PoolAllocatorWithFallback<sizeof(Key)>,
+            utils::LockingPolicy::NoLock,
+            utils::TrackingPolicy::Untracked,
+            utils::AreaPolicy::HeapArea>;
+
+
+    // Arena where the set memory is allocated
+    PoolAllocatorArena mArena;
+
+    // The special Bimap
+    Bimap<Key, Value, KeyHasher, ValueHasher,
+            utils::STLAllocator<Key, PoolAllocatorArena>> mBimap;
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_HWVERTEXBUFFERINFOFACTORY_H

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -208,7 +208,7 @@ void RenderPass::appendCommands(FEngine& engine,
     // This must be done from the main thread.
     for (Command const* first = curr, *last = curr + commandCount ; first != last ; ++first) {
         if (UTILS_LIKELY((first->key & CUSTOM_MASK) == uint64_t(CustomCommand::PASS))) {
-            auto ma = first->primitive.mi->getMaterial();
+            auto ma = first->primitive.primitive->getMaterialInstance()->getMaterial();
             ma->prepareProgram(first->primitive.materialVariant);
         }
     }
@@ -290,10 +290,7 @@ void RenderPass::instanceify(FEngine& engine, Arena& arena) noexcept {
                 [lhs = *curr](Command const& rhs) {
             // primitives must be identical to be instanced. Currently, instancing doesn't support
             // skinning/morphing.
-            return  lhs.primitive.mi                == rhs.primitive.mi                 &&
-                    lhs.primitive.primitiveHandle   == rhs.primitive.primitiveHandle    &&
-                    lhs.primitive.indexOffset       == rhs.primitive.indexOffset        &&
-                    lhs.primitive.indexCount        == rhs.primitive.indexCount         &&
+            return  lhs.primitive.primitive         == rhs.primitive.primitive          &&
                     lhs.primitive.rasterState       == rhs.primitive.rasterState        &&
                     lhs.primitive.skinningHandle    == rhs.primitive.skinningHandle     &&
                     lhs.primitive.skinningOffset    == rhs.primitive.skinningOffset     &&
@@ -422,7 +419,6 @@ void RenderPass::setupColorCommand(Command& cmdDraw, Variant variant,
     cmdDraw.primitive.rasterState.colorWrite = mi->isColorWriteEnabled();
     cmdDraw.primitive.rasterState.depthWrite = mi->isDepthWriteEnabled();
     cmdDraw.primitive.rasterState.depthFunc = mi->getDepthFunc();
-    cmdDraw.primitive.mi = mi;
     cmdDraw.primitive.materialVariant = variant;
     // we keep "RasterState::colorWrite" to the value set by material (could be disabled)
 }
@@ -579,7 +575,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
 
         cmdColor.key = makeField(soaVisibility[i].priority, PRIORITY_MASK, PRIORITY_SHIFT);
         cmdColor.key |= makeField(soaVisibility[i].channel, CHANNEL_MASK, CHANNEL_SHIFT);
-        cmdColor.primitive.index = (uint16_t)i;
+        cmdColor.primitive.index = i;
         cmdColor.primitive.instanceCount =
                 soaInstanceInfo[i].count | PrimitiveInfo::USER_INSTANCE_MASK;
         cmdColor.primitive.instanceBufferHandle = soaInstanceInfo[i].handle;
@@ -606,7 +602,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
             cmdDepth.key |= makeField(soaVisibility[i].priority, PRIORITY_MASK, PRIORITY_SHIFT);
             cmdDepth.key |= makeField(soaVisibility[i].channel, CHANNEL_MASK, CHANNEL_SHIFT);
             cmdDepth.key |= makeField(distanceBits >> 22u, Z_BUCKET_MASK, Z_BUCKET_SHIFT);
-            cmdDepth.primitive.index = (uint16_t)i;
+            cmdDepth.primitive.index = i;
             cmdDepth.primitive.instanceCount =
                     soaInstanceInfo[i].count | PrimitiveInfo::USER_INSTANCE_MASK;
             cmdDepth.primitive.instanceBufferHandle = soaInstanceInfo[i].handle;
@@ -641,9 +637,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
             FMaterial const* const ma = mi->getMaterial();
 
             if constexpr (isColorPass) {
-                cmdColor.primitive.primitiveHandle = primitive.getHwHandle();
-                cmdColor.primitive.indexOffset = primitive.getIndexOffset();
-                cmdColor.primitive.indexCount = primitive.getIndexCount();
+                cmdColor.primitive.primitive = &primitive;
                 RenderPass::setupColorCommand(cmdColor, renderableVariant, mi, inverseFrontFaces);
 
                 cmdColor.primitive.skinningHandle = skinning.handle;
@@ -748,10 +742,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
                 cmdDepth.key |= mi->getSortingKey(); // already all set-up for direct or'ing
 
                 // unconditionally write the command
-                cmdDepth.primitive.primitiveHandle = primitive.getHwHandle();
-                cmdDepth.primitive.indexOffset = primitive.getIndexOffset();
-                cmdDepth.primitive.indexCount = primitive.getIndexCount();
-                cmdDepth.primitive.mi = mi;
+                cmdDepth.primitive.primitive = &primitive;
                 cmdDepth.primitive.rasterState.culling = mi->getCullingMode();
 
                 cmdDepth.primitive.skinningHandle = skinning.handle;
@@ -886,17 +877,18 @@ void RenderPass::Executor::execute(FEngine& engine,
                 }
 
                 // primitiveHandle may be invalid if no geometry was set on the renderable.
-                if (UTILS_UNLIKELY(!first->primitive.primitiveHandle)) {
+                if (UTILS_UNLIKELY(!first->primitive.primitive->getHwHandle())) {
                     continue;
                 }
 
                 // per-renderable uniform
                 const PrimitiveInfo info = first->primitive;
                 pipeline.rasterState = info.rasterState;
+                //pipeline.vertexBufferInfo = info.vertexBufferInfo;
 
-                if (UTILS_UNLIKELY(mi != info.mi)) {
+                if (UTILS_UNLIKELY(mi != info.primitive->getMaterialInstance())) {
                     // this is always taken the first time
-                    mi = info.mi;
+                    mi = info.primitive->getMaterialInstance();
                     assert_invariant(mi);
 
                     ma = mi->getMaterial();
@@ -994,8 +986,9 @@ void RenderPass::Executor::execute(FEngine& engine,
                             info.skinningTexture);
                 }
 
-                driver.draw(pipeline, info.primitiveHandle,
-                        info.indexOffset, info.indexCount, instanceCount);
+                driver.draw(pipeline, info.primitive->getHwHandle(),
+                        info.primitive->getIndexOffset(), info.primitive->getIndexCount(),
+                        instanceCount);
             }
         }
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -53,6 +53,7 @@ class CommandBufferQueue;
 }
 
 class FMaterialInstance;
+class FRenderPrimitive;
 class RenderPassBuilder;
 
 class RenderPass {
@@ -235,13 +236,13 @@ public:
         return boolish ? value : uint64_t(0);
     }
 
-    struct PrimitiveInfo { // 48 bytes
+    struct PrimitiveInfo { // 56 bytes
         union {
-            FMaterialInstance const* mi;
-            uint64_t padding = {}; // ensures mi is 8 bytes on all archs
+            FRenderPrimitive const* primitive;                          // 8 bytes;
+            uint64_t padding = {}; // ensures primitive is 8 bytes on all archs
         };                                                              // 8 bytes
+        uint64_t rfu0;                                                  // 8 bytes
         backend::RasterState rasterState;                               // 4 bytes
-        backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
         backend::Handle<backend::HwBufferObject> skinningHandle;        // 4 bytes
         backend::Handle<backend::HwSamplerGroup> skinningTexture;       // 4 bytes
         backend::Handle<backend::HwBufferObject> morphWeightBuffer;     // 4 bytes
@@ -249,10 +250,9 @@ public:
         backend::Handle<backend::HwBufferObject> instanceBufferHandle;  // 4 bytes
         uint32_t index = 0;                                             // 4 bytes
         uint32_t skinningOffset = 0;                                    // 4 bytes
-        uint32_t indexOffset;                                           // 4 bytes
-        uint32_t indexCount;                                            // 4 bytes
         uint16_t instanceCount;                                         // 2 bytes [MSb: user]
         Variant materialVariant;                                        // 1 byte
+        uint8_t rfu1;                                                   // 1 byte
 
         static const uint16_t USER_INSTANCE_MASK = 0x8000u;
         static const uint16_t INSTANCE_COUNT_MASK = 0x7fffu;

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -55,6 +55,7 @@ public:
     backend::Handle<backend::HwRenderPrimitive> getHwHandle() const noexcept { return mHandle; }
     uint32_t getIndexOffset() const noexcept { return mIndexOffset; }
     uint32_t getIndexCount() const noexcept { return mIndexCount; }
+
     backend::PrimitiveType getPrimitiveType() const noexcept { return mPrimitiveType; }
     AttributeBitset getEnabledAttributes() const noexcept { return mEnabledAttributes; }
     uint16_t getBlendOrder() const noexcept { return mBlendOrder; }
@@ -71,14 +72,19 @@ public:
     }
 
 private:
-    FMaterialInstance const* mMaterialInstance = nullptr;
-    backend::Handle<backend::HwRenderPrimitive> mHandle = {};
+    // These first fields are dereferences from PrimitiveInfo, keep them together
+    struct {
+        FMaterialInstance const* mMaterialInstance = nullptr;
+        backend::Handle<backend::HwRenderPrimitive> mHandle = {};
+        UTILS_UNUSED uint8_t padding[4]= {};
+        uint32_t mIndexOffset = 0;
+        uint32_t mIndexCount = 0;
+    };
+
     AttributeBitset mEnabledAttributes = {};
     uint16_t mBlendOrder = 0;
     bool mGlobalBlendOrderEnabled = false;
     backend::PrimitiveType mPrimitiveType = backend::PrimitiveType::TRIANGLES;
-    uint32_t mIndexOffset = 0;
-    uint32_t mIndexCount = 0;
 };
 
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -23,6 +23,7 @@
 #include "DFG.h"
 #include "PostProcessManager.h"
 #include "ResourceList.h"
+#include "HwVertexBufferInfoFactory.h"
 
 #include "components/CameraManager.h"
 #include "components/LightManager.h"
@@ -405,6 +406,10 @@ public:
         return mAutomaticInstancingEnabled;
     }
 
+    HwVertexBufferInfoFactory& getVertexBufferInfoFactory() noexcept {
+        return mHwVertexBufferInfoFactory;
+    }
+
     backend::Handle<backend::HwTexture> getOneTexture() const { return mDummyOneTexture; }
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
     backend::Handle<backend::HwTexture> getOneTextureArray() const { return mDummyOneTextureArray; }
@@ -473,6 +478,7 @@ private:
     FLightManager mLightManager;
     FCameraManager mCameraManager;
     ResourceAllocator* mResourceAllocator = nullptr;
+    HwVertexBufferInfoFactory mHwVertexBufferInfoFactory;
 
     ResourceList<FBufferObject> mBufferObjects{ "BufferObject" };
     ResourceList<FRenderer> mRenderers{ "Renderer" };

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -153,7 +153,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
     mDeclaredAttributes = builder->mDeclaredAttributes;
     uint8_t const attributeCount = (uint8_t)mDeclaredAttributes.count();
 
-    AttributeArray attributeArray;
+    AttributeArray attributeArray{};
 
     static_assert(attributeArray.size() == MAX_VERTEX_ATTRIBUTE_COUNT,
             "Attribute and Builder::Attribute arrays must match");
@@ -213,8 +213,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    // TODO: this should use a cache
-    mVertexBufferInfoHandle = driver.createVertexBufferInfo(
+    mVertexBufferInfoHandle = engine.getVertexBufferInfoFactory().create(driver,
             mBufferCount, attributeCount, attributeArray);
 
     mHandle = driver.createVertexBuffer(mVertexCount, mVertexBufferInfoHandle);
@@ -251,7 +250,7 @@ void FVertexBuffer::terminate(FEngine& engine) {
         }
     }
     driver.destroyVertexBuffer(mHandle);
-    driver.destroyVertexBufferInfo(mVertexBufferInfoHandle);
+    engine.getVertexBufferInfoFactory().destroy(driver, mVertexBufferInfoHandle);
 }
 
 size_t FVertexBuffer::getVertexCount() const noexcept {

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -213,8 +213,11 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    mHandle = driver.createVertexBuffer(
-            mBufferCount, attributeCount, mVertexCount, attributeArray);
+    // TODO: this should use a cache
+    mVertexBufferInfoHandle = driver.createVertexBufferInfo(
+            mBufferCount, attributeCount, attributeArray);
+
+    mHandle = driver.createVertexBuffer(mVertexCount, mVertexBufferInfoHandle);
 
     // If buffer objects are not enabled at the API level, then we create them internally.
     if (!mBufferObjectsEnabled) {
@@ -238,7 +241,6 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
             }
         }
     }
-
 }
 
 void FVertexBuffer::terminate(FEngine& engine) {
@@ -249,6 +251,7 @@ void FVertexBuffer::terminate(FEngine& engine) {
         }
     }
     driver.destroyVertexBuffer(mHandle);
+    driver.destroyVertexBufferInfo(mVertexBufferInfoHandle);
 }
 
 size_t FVertexBuffer::getVertexCount() const noexcept {

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -40,6 +40,7 @@ class FEngine;
 
 class FVertexBuffer : public VertexBuffer {
 public:
+    using VertexBufferInfoHandle = backend::VertexBufferInfoHandle;
     using VertexBufferHandle = backend::VertexBufferHandle;
     using BufferObjectHandle = backend::BufferObjectHandle;
 
@@ -74,6 +75,7 @@ private:
         AttributeData() : backend::Attribute{ .type = backend::ElementType::FLOAT4 } {}
     };
 
+    VertexBufferInfoHandle mVertexBufferInfoHandle;
     VertexBufferHandle mHandle;
     std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
     std::array<BufferObjectHandle, backend::MAX_VERTEX_BUFFER_COUNT> mBufferObjects;


### PR DESCRIPTION
[better to review the CLs separately]

HwVertexBufferInfo is a new backend object that holds the data necessary to create the Vulkan pipeline. Effectively we split HwVertexBuffer in two.

This PR doesn't actually change any functionality, it just splits HwVertexBufferInfo out of HwVertexBuffer and paves the way to actually making use of it.