### PR TITLE
Metal: throw an NSException when attempting to draw with invalid program

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1598,7 +1598,7 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
         return;
     }
 
-    ASSERT_PRECONDITION(bool(functions), "Attempting to draw with an invalid Metal program.");
+    functions.validate();
 
     auto [fragment, vertex] = functions.getRasterFunctions();
 

--- a/filament/backend/src/metal/MetalShaderCompiler.h
+++ b/filament/backend/src/metal/MetalShaderCompiler.h
@@ -59,7 +59,7 @@ public:
 
         /**
          * If this MetalFunctionBundle contains an error, will throw an NSException with the error
-         * string that was passed to MetalFunctionBundle::error(NSString*).
+         * string and program name passed to MetalFunctionBundle::error(NSString*, NSString*).
          */
         void validate() const;
 

--- a/filament/backend/src/metal/MetalShaderCompiler.h
+++ b/filament/backend/src/metal/MetalShaderCompiler.h
@@ -58,8 +58,13 @@ public:
         }
 
         /**
-         * If this MetalFunctionBundle contains an error, will throw an NSException with the error
-         * string and program name passed to MetalFunctionBundle::error(NSString*, NSString*).
+         * Throws an NSException if this MetalFunctionBundle either contains an error or is empty.
+         *
+         * If this MetalFunctionBundle contains an error, will throw a MetalCompilationFailure
+         * NSException with the error string and program name passed to
+         * MetalFunctionBundle::error(NSString*, NSString*).
+         *
+         * If this MetalFunctionBundle is empty, will throw a MetalEmptyFunctionBundle NSException.
          */
         void validate() const;
 

--- a/filament/backend/src/metal/MetalShaderCompiler.h
+++ b/filament/backend/src/metal/MetalShaderCompiler.h
@@ -30,6 +30,8 @@
 
 #include <array>
 #include <memory>
+#include <tuple>
+#include <variant>
 
 namespace filament::backend {
 
@@ -41,36 +43,74 @@ class MetalShaderCompiler {
 public:
     class MetalFunctionBundle {
     public:
-        MetalFunctionBundle() = default;
-        MetalFunctionBundle(id<MTLFunction> fragment, id<MTLFunction> vertex)
-            : functions{fragment, vertex} {
+        using Raster = std::tuple<id<MTLFunction>, id<MTLFunction>>;
+        using Compute = id<MTLFunction>;
+        using Error = NSString*;
+        struct None {};
+
+        MetalFunctionBundle() : mPrograms{None{}} {}
+
+        explicit operator bool() const { return isValid(); }
+
+        bool isValid() const noexcept {
+            return std::holds_alternative<Raster>(mPrograms) ||
+                std::holds_alternative<Compute>(mPrograms);
+        }
+
+        void validate() const {
+            if (UTILS_LIKELY(!std::holds_alternative<Error>(mPrograms))) {
+                return;
+            }
+            NSString* errorMessage = std::get<Error>(mPrograms);
+            NSString* reason =
+                    [NSString stringWithFormat:
+                            @"Attempting to draw with an id<MTLFunction> that "
+                            @"failed to compile. Compiler error: %@", errorMessage];
+            NSException* compilationFailureException =
+                    [NSException exceptionWithName:@"MetalCompilationFailure"
+                                            reason:reason
+                                          userInfo:nil];
+            [compilationFailureException raise];
+        }
+
+        Raster getRasterFunctions() const {
+            assert_invariant(std::holds_alternative<Raster>(mPrograms));
+            return std::get<Raster>(mPrograms);
+        }
+
+        Compute getComputeFunction() const {
+            assert_invariant(std::holds_alternative<Compute>(mPrograms));
+            return std::get<Compute>(mPrograms);
+        }
+
+        static MetalFunctionBundle none() {
+            return MetalFunctionBundle(None{});
+        }
+
+        static MetalFunctionBundle raster(id<MTLFunction> fragment, id<MTLFunction> vertex) {
             assert_invariant(fragment && vertex);
             assert_invariant(fragment.functionType == MTLFunctionTypeFragment);
             assert_invariant(vertex.functionType == MTLFunctionTypeVertex);
+            return MetalFunctionBundle(Raster{fragment, vertex});
         }
-        explicit MetalFunctionBundle(id<MTLFunction> compute) : functions{compute, nil} {
+
+        static MetalFunctionBundle compute(id<MTLFunction> compute) {
             assert_invariant(compute);
             assert_invariant(compute.functionType == MTLFunctionTypeKernel);
+            return MetalFunctionBundle(Compute{compute});
         }
 
-        std::pair<id<MTLFunction>, id<MTLFunction>> getRasterFunctions() const noexcept {
-            assert_invariant(functions[0].functionType == MTLFunctionTypeFragment);
-            assert_invariant(functions[1].functionType == MTLFunctionTypeVertex);
-            return {functions[0], functions[1]};
+        static MetalFunctionBundle error(NSString* error) {
+            return MetalFunctionBundle(Error{error});
         }
-
-        id<MTLFunction> getComputeFunction() const noexcept {
-            assert_invariant(functions[0].functionType == MTLFunctionTypeKernel);
-            return functions[0];
-        }
-
-        explicit operator bool() const { return functions[0] != nil; }
 
     private:
-        // Can hold two functions, either:
-        // - fragment and vertex (for rasterization pipelines)
-        // - compute (for compute pipelines)
-        id<MTLFunction> functions[2] = {nil, nil};
+        MetalFunctionBundle(None&& t) : mPrograms(std::move(t)) {}
+        MetalFunctionBundle(Raster&& t) : mPrograms(std::move(t)) {}
+        MetalFunctionBundle(Compute&& t) : mPrograms(std::move(t)) {}
+        MetalFunctionBundle(Error&& t) : mPrograms(std::move(t)) {}
+
+        std::variant<Raster, Compute, None, Error> mPrograms;
     };
 
     using program_token_t = std::shared_ptr<MetalProgramToken>;

--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -104,8 +104,6 @@ void MetalShaderCompiler::terminate() noexcept {
                                                         length:source.size() - 1
                                                       encoding:NSUTF8StringEncoding];
 
-        objcSource = [NSString stringWithFormat:@"%@ foobar crash!!", objcSource];
-
         // By default, Metal uses the most recent language version.
         MTLCompileOptions* options = [MTLCompileOptions new];
 


### PR DESCRIPTION
Throw an NSException when a program fails to compile and then is used for drawing; this helps aid debugging compiler errors in production, where stdout logs are not available.

b/325321035