### PR TITLE
Modernize draw API

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1186,11 +1186,27 @@ struct StencilState {
 
     //! Stencil operations for front-facing polygons
     StencilOperations front = {
-            .stencilFunc = StencilFunction::A, .ref = 0, .readMask = 0xff, .writeMask = 0xff };
+            .stencilFunc = StencilFunction::A,
+            .stencilOpStencilFail = StencilOperation::KEEP,
+            .padding0 = 0,
+            .stencilOpDepthFail = StencilOperation::KEEP,
+            .stencilOpDepthStencilPass = StencilOperation::KEEP,
+            .padding1 = 0,
+            .ref = 0,
+            .readMask = 0xff,
+            .writeMask = 0xff };
 
     //! Stencil operations for back-facing polygons
     StencilOperations back  = {
-            .stencilFunc = StencilFunction::A, .ref = 0, .readMask = 0xff, .writeMask = 0xff };
+            .stencilFunc = StencilFunction::A,
+            .stencilOpStencilFail = StencilOperation::KEEP,
+            .padding0 = 0,
+            .stencilOpDepthFail = StencilOperation::KEEP,
+            .stencilOpDepthStencilPass = StencilOperation::KEEP,
+            .padding1 = 0,
+            .ref = 0,
+            .readMask = 0xff,
+            .writeMask = 0xff };
 
     //! Whether stencil-buffer writes are enabled
     bool stencilWrite = false;

--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -29,10 +29,13 @@ namespace filament::backend {
 //! \privatesection
 
 struct PipelineState {
-    Handle<HwProgram> program;
-    RasterState rasterState;
-    StencilState stencilState;
-    PolygonOffset polygonOffset;
+    Handle<HwProgram> program;                                              //  4
+    Handle<HwVertexBufferInfo> vertexBufferInfo;                            //  4
+    RasterState rasterState;                                                //  4
+    StencilState stencilState;                                              // 12
+    PolygonOffset polygonOffset;                                            //  8
+    PrimitiveType primitiveType = PrimitiveType::TRIANGLES;                 //  1
+    uint8_t padding[3] = {};                                                //  3
 };
 
 } // namespace filament::backend

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -493,12 +493,24 @@ DECL_DRIVER_API_N(blit,
         math::uint2, srcOrigin,
         math::uint2, size)
 
+DECL_DRIVER_API_N(bindPipeline,
+        backend::PipelineState, state)
+
+DECL_DRIVER_API_N(bindRenderPrimitive,
+        backend::RenderPrimitiveHandle, rph)
+
+DECL_DRIVER_API_N(draw2,
+        uint32_t, indexOffset,
+        uint32_t, indexCount,
+        uint32_t, instanceCount)
+
 DECL_DRIVER_API_N(draw,
         backend::PipelineState, state,
         backend::RenderPrimitiveHandle, rph,
         uint32_t, indexOffset,
         uint32_t, indexCount,
         uint32_t, instanceCount)
+
 
 DECL_DRIVER_API_N(dispatchCompute,
         backend::ProgramHandle, program,

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -37,9 +37,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define HandleAllocatorGL  HandleAllocator<24,  64, 136>    // ~3640 / pool / MiB
-#define HandleAllocatorVK  HandleAllocator<80, 176, 320>    // ~1820 / pool / MiB
-#define HandleAllocatorMTL HandleAllocator<48, 160, 592>    // ~1310 / pool / MiB
+#define HandleAllocatorGL  HandleAllocator<32,  64, 136>    // ~4520 / pool / MiB
+#define HandleAllocatorVK  HandleAllocator<64, 160, 312>    // ~1820 / pool / MiB
+#define HandleAllocatorMTL HandleAllocator<32,  48, 552>    // ~1660 / pool / MiB
 
 namespace filament::backend {
 

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -99,6 +99,7 @@ struct MetalContext {
     std::array<BufferState, MAX_SSBO_COUNT> ssboState;
     CullModeStateTracker cullModeState;
     WindingStateTracker windingState;
+    Handle<HwRenderPrimitive> currentRenderPrimitive;
 
     // State caches.
     DepthStencilStateCache depthStencilStateCache;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -48,24 +48,26 @@ Driver* MetalDriverFactory::create(MetalPlatform* const platform, const Platform
     // For reference on a 64-bits machine in Release mode:
     //    MetalTimerQuery              :  16       few
     //    HwStream                     :  24       few
+    //    MetalRenderPrimitive         :  24       many
+    //    MetalVertexBuffer            :  32       moderate
+    // -- less than or equal 32 bytes
     //    MetalIndexBuffer             :  40       moderate
     //    MetalFence                   :  48       few
     //    MetalBufferObject            :  48       many
     // -- less than or equal 48 bytes
     //    MetalSamplerGroup            : 112       few
-    //    MetalProgram                 : 144       moderate
+    //    MetalProgram                 : 152       moderate
     //    MetalTexture                 : 152       moderate
-    //    MetalVertexBuffer            : 152       moderate
-    // -- less than or equal 160 bytes
     //    MetalSwapChain               : 184       few
     //    MetalRenderTarget            : 272       few
-    //    MetalRenderPrimitive         : 584       many
-    // -- less than or equal to 592 bytes
+    //    MetalVertexBufferInfo        : 552       moderate
+    // -- less than or equal to 552 bytes
 
     utils::slog.d
            << "\nMetalSwapChain: " << sizeof(MetalSwapChain)
            << "\nMetalBufferObject: " << sizeof(MetalBufferObject)
            << "\nMetalVertexBuffer: " << sizeof(MetalVertexBuffer)
+           << "\nMetalVertexBufferInfo: " << sizeof(MetalVertexBufferInfo)
            << "\nMetalIndexBuffer: " << sizeof(MetalIndexBuffer)
            << "\nMetalSamplerGroup: " << sizeof(MetalSamplerGroup)
            << "\nMetalRenderPrimitive: " << sizeof(MetalRenderPrimitive)
@@ -1602,11 +1604,13 @@ void MetalDriver::finalizeSamplerGroup(MetalSamplerGroup* samplerGroup) {
     }
 }
 
-void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
-        uint32_t const indexOffset, uint32_t const indexCount, uint32_t const instanceCount) {
+void MetalDriver::bindPipeline(PipelineState ps) {
     ASSERT_PRECONDITION(mContext->currentRenderPassEncoder != nullptr,
-            "Attempted to draw without a valid command encoder.");
-    auto primitive = handle_cast<MetalRenderPrimitive>(rph);
+            "bindPipeline() without a valid command encoder.");
+
+    MetalVertexBufferInfo const* const vbi =
+            handle_cast<MetalVertexBufferInfo>(ps.vertexBufferInfo);
+
     auto program = handle_cast<MetalProgram>(ps.program);
     const auto& rs = ps.rasterState;
 
@@ -1620,7 +1624,7 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
         return;
     }
 
-    functions.validate();
+    ASSERT_PRECONDITION(bool(functions), "Attempting to bind an invalid Metal program.");
 
     auto [fragment, vertex] = functions.getRasterFunctions();
 
@@ -1647,7 +1651,7 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
     MetalPipelineState const pipelineState {
         .vertexFunction = vertex,
         .fragmentFunction = fragment,
-        .vertexDescription = primitive->vertexDescription,
+        .vertexDescription = vbi->vertexDescription,
         .colorAttachmentPixelFormat = {
             colorPixelFormat[0],
             colorPixelFormat[1],
@@ -1741,20 +1745,6 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
         mContext->currentPolygonOffset = ps.polygonOffset;
     }
 
-    // Bind uniform buffers.
-    MetalBuffer* uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
-    NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
-
-    enumerateBoundBuffers(BufferObjectBinding::UNIFORM,
-            [&uniformsToBind, &offsets](const BufferState& state, MetalBuffer* buffer,
-                    uint32_t index) {
-        uniformsToBind[index] = buffer;
-        offsets[index] = state.offset;
-    });
-    MetalBuffer::bindBuffers(getPendingCommandBuffer(mContext), mContext->currentRenderPassEncoder,
-            UNIFORM_BUFFER_BINDING_START, MetalBuffer::Stage::VERTEX | MetalBuffer::Stage::FRAGMENT,
-            uniformsToBind, offsets, Program::UNIFORM_BINDING_COUNT);
-
     // Bind sampler groups (argument buffers).
     for (size_t s = 0; s < Program::SAMPLER_BINDING_COUNT; s++) {
         MetalSamplerGroup* const samplerGroup = mContext->samplerBindings[s];
@@ -1785,19 +1775,29 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
                                                           atIndex:(SAMPLER_GROUP_BINDING_START + s)];
         }
     }
+}
+
+void MetalDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
+    ASSERT_PRECONDITION(mContext->currentRenderPassEncoder != nullptr,
+            "bindRenderPrimitive() without a valid command encoder.");
 
     // Bind the user vertex buffers.
-
     MetalBuffer* vertexBuffers[MAX_VERTEX_BUFFER_COUNT] = {};
     size_t vertexBufferOffsets[MAX_VERTEX_BUFFER_COUNT] = {};
     size_t maxBufferIndex = 0;
 
+    MetalRenderPrimitive const* const primitive = handle_cast<MetalRenderPrimitive>(rph);
+    MetalVertexBufferInfo const* const vbi =
+            handle_cast<MetalVertexBufferInfo>(primitive->vertexBuffer->vbih);
+
+    mContext->currentRenderPrimitive = rph;
+
     auto vb = primitive->vertexBuffer;
-    for (auto m : primitive->bufferMapping) {
+    for (auto m : vbi->bufferMapping) {
         assert_invariant(
                 m.bufferArgumentIndex >= USER_VERTEX_BUFFER_BINDING_START &&
                 m.bufferArgumentIndex < USER_VERTEX_BUFFER_BINDING_START + MAX_VERTEX_BUFFER_COUNT);
-        size_t vertexBufferIndex = m.bufferArgumentIndex - USER_VERTEX_BUFFER_BINDING_START;
+        size_t const vertexBufferIndex = m.bufferArgumentIndex - USER_VERTEX_BUFFER_BINDING_START;
         vertexBuffers[vertexBufferIndex] = vb->buffers[m.sourceBufferIndex];
         maxBufferIndex = std::max(maxBufferIndex, vertexBufferIndex);
     }
@@ -1812,6 +1812,27 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
     [mContext->currentRenderPassEncoder setVertexBytes:bytes
                                                 length:16
                                                atIndex:ZERO_VERTEX_BUFFER_BINDING];
+}
+
+void MetalDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
+    ASSERT_PRECONDITION(mContext->currentRenderPassEncoder != nullptr,
+            "draw() without a valid command encoder.");
+
+    // Bind uniform buffers.
+    MetalBuffer* uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
+    NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
+
+    enumerateBoundBuffers(BufferObjectBinding::UNIFORM,
+            [&uniformsToBind, &offsets](const BufferState& state, MetalBuffer* buffer,
+                    uint32_t index) {
+                uniformsToBind[index] = buffer;
+                offsets[index] = state.offset;
+            });
+    MetalBuffer::bindBuffers(getPendingCommandBuffer(mContext), mContext->currentRenderPassEncoder,
+            UNIFORM_BUFFER_BINDING_START, MetalBuffer::Stage::VERTEX | MetalBuffer::Stage::FRAGMENT,
+            uniformsToBind, offsets, Program::UNIFORM_BINDING_COUNT);
+
+    auto primitive = handle_cast<MetalRenderPrimitive>(mContext->currentRenderPrimitive);
 
     MetalIndexBuffer* indexBuffer = primitive->indexBuffer;
 
@@ -1823,6 +1844,16 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
                                                   indexBuffer:metalIndexBuffer
                                             indexBufferOffset:indexOffset * primitive->indexBuffer->elementSize
                                                 instanceCount:instanceCount];
+}
+
+void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
+        uint32_t const indexOffset, uint32_t const indexCount, uint32_t const instanceCount) {
+    MetalRenderPrimitive const* const rp = handle_cast<MetalRenderPrimitive>(rph);
+    ps.primitiveType = rp->type;
+    ps.vertexBufferInfo = rp->vertexBuffer->vbih;
+    bindPipeline(ps);
+    bindRenderPrimitive(rph);
+    draw2(indexOffset, indexCount, instanceCount);
 }
 
 void MetalDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGroupCount) {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -149,7 +149,21 @@ struct MetalVertexBufferInfo : public HwVertexBufferInfo {
     MetalVertexBufferInfo(MetalContext& context,
             uint8_t bufferCount, uint8_t attributeCount, AttributeArray const& attributes);
 
-    AttributeArray attributes;
+    // This struct is used to create the pipeline description to describe vertex assembly.
+    VertexDescription vertexDescription = {};
+
+    struct Entry {
+        uint8_t sourceBufferIndex = 0;
+        uint8_t stride = 0;
+        // maps to ->
+        uint8_t bufferArgumentIndex = 0;
+
+        Entry(uint8_t sourceBufferIndex, uint8_t stride, uint8_t bufferArgumentIndex)
+                : sourceBufferIndex(sourceBufferIndex),
+                  stride(stride),
+                  bufferArgumentIndex(bufferArgumentIndex) {}
+    };
+    utils::FixedCapacityVector<Entry> bufferMapping;
 };
 
 struct MetalVertexBuffer : public HwVertexBuffer {
@@ -176,22 +190,6 @@ struct MetalRenderPrimitive : public HwRenderPrimitive {
 
     MetalVertexBuffer* vertexBuffer = nullptr;
     MetalIndexBuffer* indexBuffer = nullptr;
-
-    // This struct is used to create the pipeline description to describe vertex assembly.
-    VertexDescription vertexDescription = {};
-
-    struct Entry {
-        uint8_t sourceBufferIndex = 0;
-        uint8_t stride = 0;
-        // maps to ->
-        uint8_t bufferArgumentIndex = 0;
-
-        Entry(uint8_t sourceBufferIndex, uint8_t stride, uint8_t bufferArgumentIndex)
-                : sourceBufferIndex(sourceBufferIndex),
-                  stride(stride),
-                  bufferArgumentIndex(bufferArgumentIndex) {}
-    };
-    utils::FixedCapacityVector<Entry> bufferMapping;
 };
 
 class MetalProgram : public HwProgram {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -350,6 +350,15 @@ void NoopDriver::blit(
         math::uint2 size) {
 }
 
+void NoopDriver::bindPipeline(PipelineState pipelineState) {
+}
+
+void NoopDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
+}
+
+void NoopDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
+}
+
 void NoopDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph,
         uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -142,6 +142,7 @@ public:
     struct GLRenderPrimitive : public HwRenderPrimitive {
         using HwRenderPrimitive::HwRenderPrimitive;
         OpenGLContext::RenderPrimitive gl;
+        Handle<HwVertexBufferInfo> vbih;
     };
 
     struct GLTexture : public HwTexture {
@@ -365,6 +366,10 @@ private:
     GLboolean mRenderPassColorWrite{};
     GLboolean mRenderPassDepthWrite{};
     GLboolean mRenderPassStencilWrite{};
+
+    GLRenderPrimitive const* mBoundRenderPrimitive = nullptr;
+    bool mValidProgram = false;
+
 
     void clearWithRasterPipe(TargetBufferFlags clearFlags,
             math::float4 const& linearColor, GLfloat depth, GLint stencil) noexcept;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -101,10 +101,6 @@ private:
     VulkanDriver& operator=(VulkanDriver const&) = delete;
 
 private:
-    inline void setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
-            Handle<HwVertexBuffer> vbh,
-            Handle<HwIndexBuffer> ibh);
-
     void collectGarbage();
 
     VulkanPlatform* mPlatform = nullptr;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -144,7 +144,48 @@ struct VulkanBufferObject;
 struct VulkanVertexBufferInfo : public HwVertexBufferInfo, VulkanResource {
     VulkanVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount,
             AttributeArray const& attributes);
-    AttributeArray attributes;
+
+    inline VkVertexInputAttributeDescription const* getAttribDescriptions() const {
+        return mInfo.mSoa.data<PipelineInfo::ATTRIBUTE_DESCRIPTION>();
+    }
+
+    inline VkVertexInputBindingDescription const* getBufferDescriptions() const {
+        return mInfo.mSoa.data<PipelineInfo::BUFFER_DESCRIPTION>();
+    }
+
+    inline int8_t const* getAttributeToBuffer() const {
+        return mInfo.mSoa.data<PipelineInfo::ATTRIBUTE_TO_BUFFER_INDEX>();
+    }
+
+    inline VkDeviceSize const* getOffsets() const {
+        return mInfo.mSoa.data<PipelineInfo::OFFSETS>();
+    }
+
+    size_t getAttributeCount() const noexcept {
+        return mInfo.mSoa.size();
+    }
+
+private:
+    struct PipelineInfo {
+        PipelineInfo(size_t size) : mSoa(size /* capacity */) {
+            mSoa.resize(size);
+        }
+
+        // These correspond to the index of the element in the SoA
+        static constexpr uint8_t ATTRIBUTE_DESCRIPTION = 0;
+        static constexpr uint8_t BUFFER_DESCRIPTION = 1;
+        static constexpr uint8_t OFFSETS = 2;
+        static constexpr uint8_t ATTRIBUTE_TO_BUFFER_INDEX = 3;
+
+        utils::StructureOfArrays<
+            VkVertexInputAttributeDescription,
+            VkVertexInputBindingDescription,
+            VkDeviceSize,
+            int8_t
+        > mSoa;
+    };
+
+    PipelineInfo mInfo;
 };
 
 struct VulkanVertexBuffer : public HwVertexBuffer, VulkanResource {
@@ -152,53 +193,20 @@ struct VulkanVertexBuffer : public HwVertexBuffer, VulkanResource {
             VulkanResourceAllocator* allocator,
             uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih);
 
-    ~VulkanVertexBuffer();
-
     void setBuffer(VulkanResourceAllocator const& allocator,
             VulkanBufferObject* bufferObject, uint32_t index);
 
-    inline VkVertexInputAttributeDescription const* getAttribDescriptions() {
-        return mInfo->mSoa.data<PipelineInfo::ATTRIBUTE_DESCRIPTION>();
-    }
-
-    inline VkVertexInputBindingDescription const* getBufferDescriptions() {
-        return mInfo->mSoa.data<PipelineInfo::BUFFER_DESCRIPTION>();
-    }
-
     inline VkBuffer const* getVkBuffers() const {
-        return mInfo->mSoa.data<PipelineInfo::VK_BUFFER>();
+        return mBuffers.data();
     }
 
-    inline VkDeviceSize const* getOffsets() const {
-        return mInfo->mSoa.data<PipelineInfo::OFFSETS>();
+    inline VkBuffer* getVkBuffers() {
+        return mBuffers.data();
     }
 
     Handle<HwVertexBufferInfo> vbih;
-
 private:
-    struct PipelineInfo {
-        PipelineInfo(size_t size)
-            : mSoa(size /* capacity */) {
-            mSoa.resize(size);
-        }
-
-        // These correspond to the index of the element in the SoA
-        static constexpr uint8_t ATTRIBUTE_DESCRIPTION = 0;
-        static constexpr uint8_t BUFFER_DESCRIPTION = 1;
-        static constexpr uint8_t VK_BUFFER = 2;
-        static constexpr uint8_t OFFSETS = 3;
-        static constexpr uint8_t ATTRIBUTE_TO_BUFFER_INDEX = 4;
-
-        utils::StructureOfArrays<
-            VkVertexInputAttributeDescription,
-            VkVertexInputBindingDescription,
-            VkBuffer,
-            VkDeviceSize,
-            int8_t
-        > mSoa;
-    };
-
-    PipelineInfo* mInfo;
+    utils::FixedCapacityVector<VkBuffer> mBuffers;
     FixedSizeVulkanResourceManager<MAX_VERTEX_BUFFER_COUNT> mResources;
 };
 
@@ -231,19 +239,15 @@ struct VulkanSamplerGroup : public HwSamplerGroup, VulkanResource {
 };
 
 struct VulkanRenderPrimitive : public HwRenderPrimitive, VulkanResource {
-    VulkanRenderPrimitive(VulkanResourceAllocator* allocator)
-        : VulkanResource(VulkanResourceType::RENDER_PRIMITIVE),
-          mResources(allocator) {}
+    VulkanRenderPrimitive(VulkanResourceAllocator* resourceAllocator,
+            PrimitiveType pt, Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh);
 
     ~VulkanRenderPrimitive() {
         mResources.clear();
     }
 
-    void setPrimitiveType(PrimitiveType pt);
-    void setBuffers(VulkanVertexBuffer* vertexBuffer, VulkanIndexBuffer* indexBuffer);
     VulkanVertexBuffer* vertexBuffer = nullptr;
     VulkanIndexBuffer* indexBuffer = nullptr;
-    VkPrimitiveTopology primitiveTopology;
 
 private:
     // Keep references to the vertex buffer and the index buffer.

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -191,10 +191,19 @@ public:
         mDummyTargetInfo.imageView = imageView;
     }
 
-    // Acquires a resource to be bound to the current pipeline. The ownership of the resource
-    // will be transferred to the corresponding pipeline when pipeline is bound.
-    void acquireResource(VulkanResource* resource) {
-        mPipelineBoundResources.acquire(resource);
+    static VkPrimitiveTopology getPrimitiveTopology(PrimitiveType pt) noexcept {
+        switch (pt) {
+            case PrimitiveType::POINTS:
+                return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+            case PrimitiveType::LINES:
+                return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+            case PrimitiveType::LINE_STRIP:
+                return VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
+            case PrimitiveType::TRIANGLES:
+                return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+            case PrimitiveType::TRIANGLE_STRIP:
+                return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+        }
     }
 
 private:

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -41,6 +41,7 @@
 #include "details/Material.h"
 #include "details/MaterialInstance.h"
 #include "details/Texture.h"
+#include "details/VertexBuffer.h"
 
 #include "generated/resources/materials.h"
 
@@ -190,8 +191,9 @@ std::pair<backend::PipelineState, backend::Viewport>
     FMaterial* const material = getMaterial(engine);
     material->prepareProgram(Variant{ variantKey });
     return {{
-                    .program = material->getProgram(Variant{ variantKey }),
-                    .rasterState = material->getRasterState() },
+            .program = material->getProgram(Variant{ variantKey }),
+            .vertexBufferInfo = engine.getFullScreenVertexBuffer()->getVertexBufferInfoHandle(),
+            .rasterState = material->getRasterState() },
             material->getDefaultInstance()->getScissor() };
 }
 

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -45,14 +45,15 @@ public:
 
     void set(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
             RenderableManager::PrimitiveType type,
-            FVertexBuffer* vertices, FIndexBuffer* indices, size_t offset,
+            FVertexBuffer* vertexBuffer, FIndexBuffer* indexBuffer, size_t offset,
             size_t count) noexcept;
 
     // frees driver resources, object becomes invalid
     void terminate(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver);
 
     const FMaterialInstance* getMaterialInstance() const noexcept { return mMaterialInstance; }
-    backend::Handle<backend::HwRenderPrimitive> getHwHandle() const noexcept { return mHandle; }
+    backend::RenderPrimitiveHandle getHwHandle() const noexcept { return mHandle; }
+    backend::VertexBufferInfoHandle getVertexBufferInfoHandle() const { return mVertexBufferInfoHandle; }
     uint32_t getIndexOffset() const noexcept { return mIndexOffset; }
     uint32_t getIndexCount() const noexcept { return mIndexCount; }
 
@@ -76,7 +77,7 @@ private:
     struct {
         FMaterialInstance const* mMaterialInstance = nullptr;
         backend::Handle<backend::HwRenderPrimitive> mHandle = {};
-        UTILS_UNUSED uint8_t padding[4]= {};
+        backend::Handle<backend::HwVertexBufferInfo> mVertexBufferInfoHandle = {};
         uint32_t mIndexOffset = 0;
         uint32_t mIndexCount = 0;
     };

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -52,6 +52,8 @@ public:
 
     VertexBufferHandle getHwHandle() const noexcept { return mHandle; }
 
+    VertexBufferInfoHandle getVertexBufferInfoHandle() const { return mVertexBufferInfoHandle; }
+
     size_t getVertexCount() const noexcept;
 
     AttributeBitset getDeclaredAttributes() const noexcept {


### PR DESCRIPTION
PipelineState now holds a handle to a HwVertexBufferInfo. 
DriverAPI::draw() is now technically deprecated and replaced by the
more efficient draw2(), which only takes an index offset, index count 
and instance count. The Pipeline to use is now specified with a new
API bindPipeline() and the primitive to use with bindRenderPrimitive().

This allows clients to reuse RenderPrimitives and ultimately Pipelines.

This change reduces CPU usage significantly on Metal and Vulkan, by 
reducing the need to lookup for a pipeline at every draw call.

The application, however, must be a "good citizen" by reusing 
MaterialInstance and RenderPrimitive as much as possible. We do have
RenderPrimitive cache however, so reusing the same VertexBuffer and
associated parameters also works.
