### PR TITLE
remove scissor from PipelineState

### DIFF
--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -33,7 +33,6 @@ struct PipelineState {
     RasterState rasterState;
     StencilState stencilState;
     PolygonOffset polygonOffset;
-    Viewport scissor{ 0, 0, (uint32_t)INT32_MAX, (uint32_t)INT32_MAX };
 };
 
 } // namespace filament::backend

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -498,6 +498,9 @@ DECL_DRIVER_API_N(dispatchCompute,
         backend::ProgramHandle, program,
         math::uint3, workGroupCount)
 
+DECL_DRIVER_API_N(scissor,
+        Viewport, scissor)
+
 
 #pragma clang diagnostic pop
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1714,36 +1714,6 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph,
         mContext->currentPolygonOffset = ps.polygonOffset;
     }
 
-    // Set scissor-rectangle.
-    // In order to do this, we compute the intersection between:
-    //  1. the scissor rectangle
-    //  2. the render target attachment dimensions (important, as the scissor can't be set larger)
-    // fmax/min are used below to guard against NaN and because the MTLViewport/MTLRegion
-    // coordinates are doubles.
-    MTLRegion scissor = mContext->currentRenderTarget->getRegionFromClientRect(ps.scissor);
-    const float sleft = scissor.origin.x, sright = scissor.origin.x + scissor.size.width;
-    const float stop = scissor.origin.y, sbottom = scissor.origin.y + scissor.size.height;
-
-    // Attachment extent
-    const auto attachmentSize = mContext->currentRenderTarget->getAttachmentSize();
-    const float aleft = 0.0f, atop = 0.0f;
-    const float aright = static_cast<float>(attachmentSize.x);
-    const float abottom = static_cast<float>(attachmentSize.y);
-
-    const auto left   = std::fmax(sleft, aleft);
-    const auto right  = std::fmin(sright, aright);
-    const auto top    = std::fmax(stop, atop);
-    const auto bottom = std::fmin(sbottom, abottom);
-
-    MTLScissorRect scissorRect = {
-        .x      = static_cast<NSUInteger>(left),
-        .y      = static_cast<NSUInteger>(top),
-        .width  = static_cast<NSUInteger>(right  - left),
-        .height = static_cast<NSUInteger>(bottom - top)
-    };
-
-    [mContext->currentRenderPassEncoder setScissorRect:scissorRect];
-
     // Bind uniform buffers.
     MetalBuffer* uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
     NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
@@ -1895,6 +1865,38 @@ void MetalDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGro
                    threadsPerThreadgroup:threadsPerThreadgroup];
 
     [computeEncoder endEncoding];
+}
+
+void MetalDriver::scissor(Viewport scissorBox) {
+    // Set scissor-rectangle.
+    // In order to do this, we compute the intersection between:
+    //  1. the scissor rectangle
+    //  2. the render target attachment dimensions (important, as the scissor can't be set larger)
+    // fmax/min are used below to guard against NaN and because the MTLViewport/MTLRegion
+    // coordinates are doubles.
+    MTLRegion scissor = mContext->currentRenderTarget->getRegionFromClientRect(scissorBox);
+    const float sleft = scissor.origin.x, sright = scissor.origin.x + scissor.size.width;
+    const float stop = scissor.origin.y, sbottom = scissor.origin.y + scissor.size.height;
+
+    // Attachment extent
+    const auto attachmentSize = mContext->currentRenderTarget->getAttachmentSize();
+    const float aleft = 0.0f, atop = 0.0f;
+    const float aright = static_cast<float>(attachmentSize.x);
+    const float abottom = static_cast<float>(attachmentSize.y);
+
+    const auto left   = std::fmax(sleft, aleft);
+    const auto right  = std::fmin(sright, aright);
+    const auto top    = std::fmax(stop, atop);
+    const auto bottom = std::fmin(sbottom, abottom);
+
+    MTLScissorRect scissorRect = {
+            .x      = static_cast<NSUInteger>(left),
+            .y      = static_cast<NSUInteger>(top),
+            .width  = static_cast<NSUInteger>(right  - left),
+            .height = static_cast<NSUInteger>(bottom - top)
+    };
+
+    [mContext->currentRenderPassEncoder setScissorRect:scissorRect];
 }
 
 void MetalDriver::beginTimerQuery(Handle<HwTimerQuery> tqh) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -346,6 +346,10 @@ void NoopDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph
 void NoopDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGroupCount) {
 }
 
+void NoopDriver::scissor(
+        Viewport scissor) {
+}
+
 void NoopDriver::beginTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3736,8 +3736,6 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,
 
     gl.polygonOffset(state.polygonOffset.slope, state.polygonOffset.constant);
 
-    setScissor(state.scissor);
-
     if (UTILS_LIKELY(instanceCount <= 1)) {
         glDrawElements(GLenum(rp->type), (GLsizei)indexCount, rp->gl.getIndicesType(),
                 reinterpret_cast<const void*>(indexOffset * rp->gl.indicesSize));
@@ -3756,6 +3754,10 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,
 #else
     CHECK_GL_ERROR(utils::slog.e)
 #endif
+}
+
+void OpenGLDriver::scissor(Viewport scissor) {
+    setScissor(scissor);
 }
 
 void OpenGLDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGroupCount) {

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -182,7 +182,6 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         params.flags.discardEnd = TargetBufferFlags::NONE;
 
         PipelineState state;
-        state.scissor = params.viewport;
         state.program = textureProgram;
         state.rasterState.colorWrite = true;
         state.rasterState.depthWrite = false;
@@ -203,6 +202,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         // Because the min level is 1, the result color should be the white triangle drawn in the
         // previous pass.
         api.beginRenderPass(defaultRenderTarget, params);
+        api.scissor(params.viewport);
         api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
@@ -221,6 +221,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         params.flags.clear = TargetBufferFlags::NONE;
         params.flags.discardStart = TargetBufferFlags::NONE;
         api.beginRenderPass(defaultRenderTarget, params);
+        api.scissor(params.viewport);
         api.draw(state, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -134,12 +134,12 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         ps.program = program;
         ps.rasterState.colorWrite = true;
         ps.rasterState.depthWrite = false;
-        ps.scissor = scissor;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
 
         api.beginRenderPass(srcRenderTarget, params);
+        api.scissor(scissor);
         api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
@@ -225,12 +225,12 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         ps.program = program;
         ps.rasterState.colorWrite = true;
         ps.rasterState.depthWrite = false;
-        ps.scissor = scissor;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
 
         api.beginRenderPass(renderTarget, params);
+        api.scissor(scissor);
         api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 
@@ -238,6 +238,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         params.flags.clear = TargetBufferFlags::NONE;
         params.flags.discardStart = TargetBufferFlags::NONE;
         api.beginRenderPass(renderTarget, params);
+        api.scissor(scissor);
         api.draw(ps, triangle.getRenderPrimitive(), 0, 3, 1);
         api.endRenderPass();
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -184,15 +184,15 @@ FMaterial* PostProcessManager::PostProcessMaterial::getMaterial(FEngine& engine)
 }
 
 UTILS_NOINLINE
-PipelineState PostProcessManager::PostProcessMaterial::getPipelineState(
+std::pair<backend::PipelineState, backend::Viewport>
+        PostProcessManager::PostProcessMaterial::getPipelineState(
         FEngine& engine, Variant::type_t variantKey) const noexcept {
     FMaterial* const material = getMaterial(engine);
     material->prepareProgram(Variant{ variantKey });
-    return {
-            .program = material->getProgram(Variant{ variantKey }),
-            .rasterState = material->getRasterState(),
-            .scissor = material->getDefaultInstance()->getScissor()
-    };
+    return {{
+                    .program = material->getProgram(Variant{ variantKey }),
+                    .rasterState = material->getRasterState() },
+            material->getDefaultInstance()->getScissor() };
 }
 
 UTILS_NOINLINE
@@ -381,7 +381,7 @@ backend::Handle<backend::HwTexture> PostProcessManager::getZeroTextureArray() co
 
 UTILS_NOINLINE
 void PostProcessManager::render(FrameGraphResources::RenderPassInfo const& out,
-        backend::PipelineState const& pipeline,
+        backend::PipelineState const& pipeline, backend::Viewport const& scissor,
         DriverApi& driver) const noexcept {
 
     assert_invariant(
@@ -392,6 +392,7 @@ void PostProcessManager::render(FrameGraphResources::RenderPassInfo const& out,
     FEngine const& engine = mEngine;
     Handle<HwRenderPrimitive> const fullScreenQuad = engine.getFullScreenRenderPrimitive();
     driver.beginRenderPass(out.target, out.params);
+    driver.scissor(scissor);
     driver.draw(pipeline, fullScreenQuad, 0, 3, 1);
     driver.endRenderPass();
 }
@@ -878,8 +879,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                 mi->commit(driver);
                 mi->use(driver);
 
-                PipelineState pipeline(material.getPipelineState(mEngine));
-                pipeline.rasterState.depthFunc = RasterState::DepthFunc::L;
+                auto pipeline = material.getPipelineState(mEngine);
+                pipeline.first.rasterState.depthFunc = RasterState::DepthFunc::L;
                 assert_invariant(ssao.params.readOnlyDepthStencil & RenderPassParams::READONLY_DEPTH);
                 render(ssao, pipeline, driver);
             });
@@ -993,8 +994,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bilateralBlurPass(FrameGraph
                 mi->commit(driver);
                 mi->use(driver);
 
-                PipelineState pipeline(material.getPipelineState(mEngine));
-                pipeline.rasterState.depthFunc = RasterState::DepthFunc::L;
+                auto pipeline = material.getPipelineState(mEngine);
+                pipeline.first.rasterState.depthFunc = RasterState::DepthFunc::L;
                 render(blurred, pipeline, driver);
             });
 
@@ -1653,7 +1654,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 mi->setParameter("coc",   inOutCoc,   { .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST });
                 mi->use(driver);
 
-                const PipelineState pipeline(material.getPipelineState(mEngine, variant));
+                auto const pipeline = material.getPipelineState(mEngine, variant);
 
                 for (size_t level = 0 ; level < mipmapCount - 1u ; level++) {
                     const float w = FTexture::valueForLevel(level, desc.width);
@@ -2100,7 +2101,7 @@ PostProcessManager::BloomPassOutput PostProcessManager::bloom(FrameGraph& fg,
                 mi13->commit(driver);
 
                 // PipelineState for both materials should be the same
-                const PipelineState pipeline(material9.getPipelineState(mEngine));
+                auto const pipeline = material9.getPipelineState(mEngine);
 
                 for (size_t i = 1; i < inoutBloomOptions.levels; i++) {
                     auto hwDstRT = resources.getRenderPassInfo(data.outRT[i]);
@@ -2144,9 +2145,9 @@ PostProcessManager::BloomPassOutput PostProcessManager::bloom(FrameGraph& fg,
                         .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST});
                 mi->use(driver);
 
-                PipelineState pipeline(material.getPipelineState(mEngine));
-                pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
-                pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
+                auto pipeline = material.getPipelineState(mEngine);
+                pipeline.first.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
+                pipeline.first.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
 
                 for (size_t j = inoutBloomOptions.levels, i = j - 1; i >= 1; i--, j++) {
                     auto hwDstRT = resources.getRenderPassInfo(data.outRT[i - 1]);
@@ -2299,8 +2300,11 @@ void PostProcessManager::colorGradingSubpass(DriverApi& driver,
     const Variant::type_t variant = Variant::type_t(colorGradingConfig.translucent ?
             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
+    auto const pipeline = material.getPipelineState(mEngine, variant);
+
     driver.nextSubpass();
-    driver.draw(material.getPipelineState(mEngine, variant), fullScreenRenderPrimitive, 0, 3, 1);
+    driver.scissor(pipeline.second);
+    driver.draw(pipeline.first, fullScreenRenderPrimitive, 0, 3, 1);
 }
 
 void PostProcessManager::customResolvePrepareSubpass(DriverApi& driver, CustomResolveOp op) noexcept {
@@ -2316,10 +2320,12 @@ void PostProcessManager::customResolveSubpass(DriverApi& driver) noexcept {
     Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine.getFullScreenRenderPrimitive();
     auto const& material = getPostProcessMaterial("customResolveAsSubpass");
     // the UBO has been set and committed in colorGradingPrepareSubpass()
+    auto const pipeline = material.getPipelineState(mEngine);
     FMaterialInstance* mi = material.getMaterialInstance(mEngine);
     mi->use(driver);
     driver.nextSubpass();
-    driver.draw(material.getPipelineState(mEngine), fullScreenRenderPrimitive, 0, 3, 1);
+    driver.scissor(pipeline.second);
+    driver.draw(pipeline.first, fullScreenRenderPrimitive, 0, 3, 1);
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::customResolveUncompressPass(FrameGraph& fg,
@@ -2762,9 +2768,10 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
                 if (colorGradingConfig.asSubpass) {
                     out.params.subpassMask = 1;
                 }
-                PipelineState const pipeline(material.getPipelineState(mEngine, variant));
+                auto const pipeline = material.getPipelineState(mEngine, variant);
                 driver.beginRenderPass(out.target, out.params);
-                driver.draw(pipeline, mEngine.getFullScreenRenderPrimitive(), 0, 3, 1);
+                driver.scissor(pipeline.second);
+                driver.draw(pipeline.first, mEngine.getFullScreenRenderPrimitive(), 0, 3, 1);
                 if (colorGradingConfig.asSubpass) {
                     colorGradingSubpass(driver, colorGradingConfig);
                 }
@@ -2838,7 +2845,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::rcas(
                 const uint8_t variant = uint8_t(
                         translucent ? PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
-                PipelineState const pipeline(material.getPipelineState(mEngine, variant));
+                auto const pipeline = material.getPipelineState(mEngine, variant);
                 render(out, pipeline, driver);
             });
 
@@ -2980,25 +2987,25 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::upscale(FrameGraph& fg, bool
                 auto out = resources.getRenderPassInfo();
 
                 if (UTILS_UNLIKELY(twoPassesEASU)) {
-                    PipelineState pipeline0(splitEasuMaterial->getPipelineState(mEngine));
-                    PipelineState pipeline1(easuMaterial->getPipelineState(mEngine));
-                    pipeline1.rasterState.depthFunc = backend::SamplerCompareFunc::NE;
+                    auto pipeline0 = splitEasuMaterial->getPipelineState(mEngine);
+                    auto pipeline1 = easuMaterial->getPipelineState(mEngine);
+                    pipeline1.first.rasterState.depthFunc = backend::SamplerCompareFunc::NE;
                     if (translucent) {
-                        enableTranslucentBlending(pipeline0);
-                        enableTranslucentBlending(pipeline1);
+                        enableTranslucentBlending(pipeline0.first);
+                        enableTranslucentBlending(pipeline1.first);
                     }
                     driver.beginRenderPass(out.target, out.params);
-                    driver.draw(pipeline0, fullScreenRenderPrimitive, 0, 3, 1);
-                    driver.draw(pipeline1, fullScreenRenderPrimitive, 0, 3, 1);
+                    driver.scissor(pipeline0.second);
+                    driver.draw(pipeline0.first, fullScreenRenderPrimitive, 0, 3, 1);
+                    driver.scissor(pipeline1.second);
+                    driver.draw(pipeline1.first, fullScreenRenderPrimitive, 0, 3, 1);
                     driver.endRenderPass();
                 } else {
-                    PipelineState pipeline(easuMaterial->getPipelineState(mEngine));
+                    auto pipeline = easuMaterial->getPipelineState(mEngine);
                     if (translucent) {
-                        enableTranslucentBlending(pipeline);
+                        enableTranslucentBlending(pipeline.first);
                     }
-                    driver.beginRenderPass(out.target, out.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive, 0, 3, 1);
-                    driver.endRenderPass();
+                    render(out, pipeline, driver);
                 }
             });
 
@@ -3067,12 +3074,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blit(FrameGraph& fg, bool tr
                 mi->commit(driver);
                 mi->use(driver);
 
-                PipelineState pipeline(material.getPipelineState(mEngine));
+                auto pipeline = material.getPipelineState(mEngine);
                 if (translucent) {
-                    pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
-                    pipeline.rasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
-                    pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE_MINUS_SRC_ALPHA;
-                    pipeline.rasterState.blendFunctionDstAlpha = BlendFunction::ONE_MINUS_SRC_ALPHA;
+                    pipeline.first.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
+                    pipeline.first.rasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
+                    pipeline.first.rasterState.blendFunctionDstRGB = BlendFunction::ONE_MINUS_SRC_ALPHA;
+                    pipeline.first.rasterState.blendFunctionDstAlpha = BlendFunction::ONE_MINUS_SRC_ALPHA;
                 }
                 render(out, pipeline, driver);
             });
@@ -3218,8 +3225,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
 
                 // When generating shadow map mip levels, we want to preserve the 1 texel border.
                 // (note clearing never respects the scissor in Filament)
-                PipelineState pipeline(material.getPipelineState(mEngine));
-                pipeline.scissor = { 1u, 1u, dim - 2u, dim - 2u };
+                auto const [pipeline, _] = material.getPipelineState(mEngine);
+                backend::Viewport const scissor = { 1u, 1u, dim - 2u, dim - 2u };
 
                 FMaterialInstance* const mi = material.getMaterialInstance(mEngine);
                 mi->setParameter("color", in, {
@@ -3230,7 +3237,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
                 mi->setParameter("uvscale", 1.0f / float(dim));
                 mi->commit(driver);
                 mi->use(driver);
-                render(out, pipeline, driver);
+                render(out, pipeline, scissor, driver);
 
                 if (finalize) {
                    driver.setMinMaxLevels(in, 0, level);
@@ -3263,7 +3270,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::debugShadowCascades(FrameGra
                 auto depth = resources.getTexture(data.depth);
                 auto out = resources.getRenderPassInfo();
                 auto& material = getPostProcessMaterial("debugShadowCascades");
-                PipelineState const pipeline(material.getPipelineState(mEngine));
+                auto const pipeline = material.getPipelineState(mEngine);
                 FMaterialInstance* mi = material.getMaterialInstance(mEngine);
                 mi->setParameter("color",  color, {});  // nearest
                 mi->setParameter("depth",  depth, {});  // nearest

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -311,7 +311,7 @@ public:
         FMaterial* getMaterial(FEngine& engine) const noexcept;
         FMaterialInstance* getMaterialInstance(FEngine& engine) const noexcept;
 
-        backend::PipelineState getPipelineState(FEngine& engine,
+        std::pair<backend::PipelineState, backend::Viewport> getPipelineState(FEngine& engine,
                 Variant::type_t variantKey = 0u) const noexcept;
 
     private:
@@ -339,8 +339,14 @@ public:
             backend::DriverApi& driver) const noexcept;
 
     void render(FrameGraphResources::RenderPassInfo const& out,
-            backend::PipelineState const& pipeline,
+            backend::PipelineState const& pipeline, backend::Viewport const& scissor,
             backend::DriverApi& driver) const noexcept;
+
+    void render(FrameGraphResources::RenderPassInfo const& out,
+            std::pair<backend::PipelineState, backend::Viewport> const& combo,
+            backend::DriverApi& driver) const noexcept {
+        render(out, combo.first, combo.second, driver);
+    }
 
 private:
     FEngine& mEngine;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -817,6 +817,28 @@ void RenderPass::Executor::execute(FEngine& engine, const char*) const noexcept 
 }
 
 UTILS_NOINLINE // no need to be inlined
+backend::Viewport RenderPass::Executor::applyScissorViewport(
+        backend::Viewport const& scissorViewport, backend::Viewport const& scissor) noexcept {
+    // scissor is set, we need to apply the offset/clip
+    // clang vectorizes this!
+    constexpr int32_t maxvali = std::numeric_limits<int32_t>::max();
+    // compute new left/bottom, assume no overflow
+    int32_t l = scissor.left + scissorViewport.left;
+    int32_t b = scissor.bottom + scissorViewport.bottom;
+    // compute right/top without overflowing, scissor.width/height guaranteed
+    // to convert to int32
+    int32_t r = (l > maxvali - int32_t(scissor.width)) ? maxvali : l + int32_t(scissor.width);
+    int32_t t = (b > maxvali - int32_t(scissor.height)) ? maxvali : b + int32_t(scissor.height);
+    // clip to the viewport
+    l = std::max(l, scissorViewport.left);
+    b = std::max(b, scissorViewport.bottom);
+    r = std::min(r, scissorViewport.left + int32_t(scissorViewport.width));
+    t = std::min(t, scissorViewport.bottom + int32_t(scissorViewport.height));
+    assert_invariant(r >= l && t >= b);
+    return { l, b, uint32_t(r - l), uint32_t(t - b) };
+}
+
+UTILS_NOINLINE // no need to be inlined
 void RenderPass::Executor::execute(FEngine& engine,
         const Command* first, const Command* last) const noexcept {
 
@@ -830,16 +852,17 @@ void RenderPass::Executor::execute(FEngine& engine,
     if (first != last) {
         SYSTRACE_VALUE32("commandCount", last - first);
 
+        bool const scissorOverride = mScissorOverride;
+        if (UTILS_UNLIKELY(scissorOverride)) {
+            // initialize with scissor overide
+            driver.scissor(mScissor);
+        }
+
+        bool const polygonOffsetOverride = mPolygonOffsetOverride;
         PipelineState pipeline{
+                // initialize with polygon offset override
                 .polygonOffset = mPolygonOffset,
-                .scissor = mScissor
-        }, dummyPipeline;
-
-        auto* const pPipelinePolygonOffset =
-                mPolygonOffsetOverride ? &dummyPipeline.polygonOffset : &pipeline.polygonOffset;
-
-        auto* const pScissor =
-                mScissorOverride ? &dummyPipeline.scissor : &pipeline.scissor;
+        };
 
         FMaterialInstance const* UTILS_RESTRICT mi = nullptr;
         FMaterial const* UTILS_RESTRICT ma = nullptr;
@@ -891,7 +914,7 @@ void RenderPass::Executor::execute(FEngine& engine,
                 }
 
                 // per-renderable uniform
-                const PrimitiveInfo info = first->primitive;
+                PrimitiveInfo const info = first->primitive;
                 pipeline.rasterState = info.rasterState;
 
                 if (UTILS_UNLIKELY(mi != info.mi)) {
@@ -901,34 +924,17 @@ void RenderPass::Executor::execute(FEngine& engine,
 
                     ma = mi->getMaterial();
 
-                    auto const& scissor = mi->getScissor();
-                    if (UTILS_UNLIKELY(mi->hasScissor())) {
-                        // scissor is set, we need to apply the offset/clip
-                        // clang vectorizes this!
-                        constexpr int32_t maxvali = std::numeric_limits<int32_t>::max();
-                        const backend::Viewport scissorViewport = mScissorViewport;
-                        // compute new left/bottom, assume no overflow
-                        int32_t l = scissor.left + scissorViewport.left;
-                        int32_t b = scissor.bottom + scissorViewport.bottom;
-                        // compute right/top without overflowing, scissor.width/height guaranteed
-                        // to convert to int32
-                        int32_t r = (l > maxvali - int32_t(scissor.width)) ?
-                                    maxvali : l + int32_t(scissor.width);
-                        int32_t t = (b > maxvali - int32_t(scissor.height)) ?
-                                    maxvali : b + int32_t(scissor.height);
-                        // clip to the viewport
-                        l = std::max(l, scissorViewport.left);
-                        b = std::max(b, scissorViewport.bottom);
-                        r = std::min(r, scissorViewport.left + int32_t(scissorViewport.width));
-                        t = std::min(t, scissorViewport.bottom + int32_t(scissorViewport.height));
-                        assert_invariant(r >= l && t >= b);
-                        *pScissor = { l, b, uint32_t(r - l), uint32_t(t - b) };
-                    } else {
-                        // no scissor set (common case), 'scissor' has its default value, use that.
-                        *pScissor = scissor;
-                    }
+                   if (UTILS_LIKELY(!scissorOverride)) {
+                       backend::Viewport scissor = mi->getScissor();
+                       if (UTILS_UNLIKELY(mi->hasScissor())) {
+                           scissor = applyScissorViewport(mScissorViewport, scissor);
+                       }
+                       driver.scissor(scissor);
+                   }
 
-                    *pPipelinePolygonOffset = mi->getPolygonOffset();
+                   if (UTILS_LIKELY(!polygonOffsetOverride)) {
+                       pipeline.polygonOffset = mi->getPolygonOffset();
+                   }
                     pipeline.stencilState = mi->getStencilState();
                     mi->use(driver);
                 }

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -330,6 +330,10 @@ public:
 
         void execute(FEngine& engine, const Command* first, const Command* last) const noexcept;
 
+        static backend::Viewport applyScissorViewport(
+                backend::Viewport const& scissorViewport,
+                backend::Viewport const& scissor) noexcept;
+
     public:
         Executor() = default;
         Executor(Executor const& rhs);


### PR DESCRIPTION
We do this to better match Gl, Vulkan and Metal, which don't need to specify the scissor in the pipeline. In practice, this will also allow us to set the scissor less often, saving a bit of CPU.