### PR TITLE
Better fix for OOB when we have no renderable

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -99,10 +99,6 @@ RenderPass::RenderPass(FEngine& engine, RenderPassBuilder const& builder) noexce
           mScissorViewport(builder.mScissorViewport),
           mCustomCommands(engine.getPerRenderPassArena()) {
 
-    if (mVisibleRenderables.empty()) {
-        return;
-    }
-
     // compute the number of commands we need
     updateSummedPrimitiveCounts(
             const_cast<FScene::RenderableSoa&>(mRenderableSoa), mVisibleRenderables);

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -148,7 +148,7 @@ void FScene::prepare(utils::JobSystem& js,
 
     // TODO: the resize below could happen in a job
 
-    if (sceneData.size() != renderableInstances.size()) {
+    if (!sceneData.capacity() || sceneData.size() != renderableInstances.size()) {
         sceneData.clear();
         if (sceneData.capacity() < renderableDataCapacity) {
             sceneData.setCapacity(renderableDataCapacity);


### PR DESCRIPTION
The OOB would happen is the scene never had any renderables, in that case the scene's SoA would stay unallocated, but the summedAreaTable code relies on it have at least a capacity of 1.

It was incorrect to skip the RenderPass entirely because it might have had some custom commands that needed to be executed (e.g. for applying post-processing in subpass mode).