### PR TITLE
cleanup of attributes management

### DIFF
--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -63,7 +63,7 @@ struct HwVertexBufferInfo : public HwBase {
 
 struct HwVertexBuffer : public HwBase {
     uint32_t vertexCount{};               //   4
-    uint8_t bufferObjectsVersion{};       //   1
+    uint8_t bufferObjectsVersion{0xff};   //   1
     bool padding[3]{};                    //   2
     HwVertexBuffer() noexcept = default;
     explicit HwVertexBuffer(uint32_t vertextCount) noexcept

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -70,14 +70,9 @@ public:
 
 private:
     friend class VertexBuffer;
-
-    struct AttributeData : backend::Attribute {
-        AttributeData() : backend::Attribute{ .type = backend::ElementType::FLOAT4 } {}
-    };
-
     VertexBufferInfoHandle mVertexBufferInfoHandle;
     VertexBufferHandle mHandle;
-    std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
+    backend::AttributeArray mAttributes;
     std::array<BufferObjectHandle, backend::MAX_VERTEX_BUFFER_COUNT> mBufferObjects;
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;


### PR DESCRIPTION
- added many precondition checks and asserts to VertexBuffer creation
- simplified code in VertexBuffer as well
- enforce BONE_INDICES to integer when specified by user since that's what shaders expect.
- better comments about *always* setting BONE_INDICES to integer
- some code simplification in RenderPass + some comments about skinning
- in the GL backend we no longer set the vertex buffer objects at renderprimitive creation time, because they might not be available yet. Instead, we let the natural age mechanism update them next time it's needed.  This allows us to add some asserts about the declared buffer being present