### PR TITLE
Add new PBR Neutral tone mapper

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - android: NDK 26.1.10909125 is used by default
 - android: Minimum API level on Android is now API 21 instead of API 19. This allows the use of OpenGL ES 3.1
+- rendering: New PBR Neutral tone mapper, designed to preserve materials color appearance

--- a/android/filament-android/src/main/cpp/ToneMapper.cpp
+++ b/android/filament-android/src/main/cpp/ToneMapper.cpp
@@ -48,6 +48,11 @@ Java_com_google_android_filament_ToneMapper_nCreateFilmicToneMapper(JNIEnv*, jcl
 }
 
 extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_ToneMapper_nCreatePBRNeutralToneMapper(JNIEnv*, jclass) {
+    return (jlong) new PBRNeutralToneMapper();
+}
+
+extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_ToneMapper_nCreateAgxToneMapper(JNIEnv*, jclass, jint look) {
     return (jlong) new AgxToneMapper(AgxToneMapper::AgxLook(look));
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -16,12 +16,14 @@ package com.google.android.filament;
  * <li>Configurable tone mapping operators</li>
  * <ul>
  *   <li>GenericToneMapper</li>
+ *   <li>AgXToneMapper</li>
  * </ul>
  * <li>Fixed-aesthetic tone mapping operators</li>
  * <ul>
  *   <li>ACESToneMapper</li>
  *   <li>ACESLegacyToneMapper</li>
  *   <li>FilmicToneMapper</li>
+ *   <li>PBRNeutralToneMapper</li>
  * </ul>
  * <li>Debug/validation tone mapping operators</li>
  * <ul>
@@ -101,10 +103,20 @@ public class ToneMapper {
     }
 
     /**
+     * Khronos PBR Neutral tone mapping operator. This tone mapper was designed
+     * to preserve the appearance of materials across lighting conditions while
+     * avoiding artifacts in the highlights in high dynamic range conditions.
+     */
+    public static class PBRNeutralToneMapper extends ToneMapper {
+        public PBRNeutralToneMapper() {
+            super(nCreatePBRNeutralToneMapper());
+        }
+    }
+
+    /**
      * AgX tone mapping operator.
      */
     public static class Agx extends ToneMapper {
-
         public enum AgxLook {
             /**
              * Base contrast with no look applied
@@ -233,6 +245,7 @@ public class ToneMapper {
     private static native long nCreateACESToneMapper();
     private static native long nCreateACESLegacyToneMapper();
     private static native long nCreateFilmicToneMapper();
+    private static native long nCreatePBRNeutralToneMapper();
     private static native long nCreateAgxToneMapper(int look);
     private static native long nCreateGenericToneMapper(
             float contrast, float midGrayIn, float midGrayOut, float hdrMax);

--- a/filament/include/filament/ToneMapper.h
+++ b/filament/include/filament/ToneMapper.h
@@ -21,7 +21,7 @@
 
 #include <math/mathfwd.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace filament {
 
@@ -39,10 +39,12 @@ namespace filament {
  *
  * - Configurable tone mapping operators
  *   - GenericToneMapper
+ *   - AgXToneMapper
  * - Fixed-aesthetic tone mapping operators
  *   - ACESToneMapper
  *   - ACESLegacyToneMapper
  *   - FilmicToneMapper
+ *   - PBRNeutralToneMapper
  * - Debug/validation tone mapping operators
  *   - LinearToneMapper
  *   - DisplayRangeToneMapper
@@ -118,10 +120,21 @@ struct UTILS_PUBLIC FilmicToneMapper final : public ToneMapper {
 };
 
 /**
+ * Khronos PBR Neutral tone mapping operator. This tone mapper was designed
+ * to preserve the appearance of materials across lighting conditions while
+ * avoiding artifacts in the highlights in high dynamic range conditions.
+ */
+struct UTILS_PUBLIC PBRNeutralToneMapper final : public ToneMapper {
+    PBRNeutralToneMapper() noexcept;
+    ~PBRNeutralToneMapper() noexcept final;
+
+    math::float3 operator()(math::float3 x) const noexcept override;
+};
+
+/**
  * AgX tone mapping operator.
  */
 struct UTILS_PUBLIC AgxToneMapper final : public ToneMapper {
-
     enum class AgxLook : uint8_t {
         NONE = 0,   //!< Base contrast with no look applied
         PUNCHY,     //!< A punchy and more chroma laden look for sRGB displays
@@ -184,9 +197,6 @@ struct UTILS_PUBLIC GenericToneMapper final : public ToneMapper {
 
     /** Returns the contrast of the curve as a strictly positive value. */
     float getContrast() const noexcept;
-
-    /** Returns how fast scene referred values map to output white as a value between 0.0 and 1.0. */
-    float getShoulder() const noexcept;
 
     /** Returns the middle gray point for input values as a value between 0.0 and 1.0. */
     float getMidGrayIn() const noexcept;

--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -231,6 +231,32 @@ float3 FilmicToneMapper::operator()(math::float3 x) const noexcept {
 }
 
 //------------------------------------------------------------------------------
+// PBR Neutral tone mapper
+//------------------------------------------------------------------------------
+
+DEFAULT_CONSTRUCTORS(PBRNeutralToneMapper)
+
+float3 PBRNeutralToneMapper::operator()(math::float3 color) const noexcept {
+    // PBR Tone Mapping, https://modelviewer.dev/examples/tone-mapping.html
+    constexpr float startCompression = 0.8f - 0.04f;
+    constexpr float desaturation = 0.15f;
+
+    float x = min(color.r, min(color.g, color.b));
+    float offset = x < 0.08f ? x - 6.25f * x * x : 0.04f;
+    color -= offset;
+
+    float peak = max(color.r, max(color.g, color.b));
+    if (peak < startCompression) return color;
+
+    float d = 1.0f - startCompression;
+    float newPeak = 1.0f - d * d / (peak + d - startCompression);
+    color *= newPeak / peak;
+
+    float g = 1.0f - 1.0f / (desaturation * (peak - newPeak) + 1.0f);
+    return mix(color, float3(1.0f), g);
+}
+
+//------------------------------------------------------------------------------
 // AgX tone mapper
 //------------------------------------------------------------------------------
 
@@ -262,14 +288,14 @@ float3 agxDefaultContrastApprox(float3 x) {
     float3 x2 = x * x;
     float3 x4 = x2 * x2;
     float3 x6 = x4 * x2;
-    return  - 17.86     * x6 * x
-            + 78.01     * x6
-            - 126.7     * x4 * x
-            + 92.06     * x4
-            - 28.72     * x2 * x
-            + 4.361     * x2
-            - 0.1718    * x
-            + 0.002857;
+    return  - 17.86f    * x6 * x
+            + 78.01f    * x6
+            - 126.7f    * x4 * x
+            + 92.06f    * x4
+            - 28.72f    * x2 * x
+            + 4.361f    * x2
+            - 0.1718f   * x
+            + 0.002857f;
 }
 
 // Adapted from https://iolite-engine.com/blog_posts/minimal_agx_implementation
@@ -278,23 +304,23 @@ float3 agxLook(float3 val, AgxToneMapper::AgxLook look) {
         return val;
     }
 
-    const float3 lw = float3(0.2126, 0.7152, 0.0722);
+    const float3 lw = float3(0.2126f, 0.7152f, 0.0722f);
     float luma = dot(val, lw);
 
     // Default
-    float3 offset = float3(0.0);
-    float3 slope = float3(1.0);
-    float3 power = float3(1.0);
-    float sat = 1.0;
+    float3 offset = float3(0.0f);
+    float3 slope = float3(1.0f);
+    float3 power = float3(1.0f);
+    float sat = 1.0f;
 
     if (look == AgxToneMapper::AgxLook::GOLDEN) {
-        slope = float3(1.0, 0.9, 0.5);
-        power = float3(0.8);
+        slope = float3(1.0f, 0.9f, 0.5f);
+        power = float3(0.8f);
         sat = 1.3;
     }
     if (look == AgxToneMapper::AgxLook::PUNCHY) {
-        slope = float3(1.0);
-        power = float3(1.35, 1.35, 1.35);
+        slope = float3(1.0f);
+        power = float3(1.35f, 1.35f, 1.35f);
         sat = 1.4;
     }
 
@@ -305,16 +331,16 @@ float3 agxLook(float3 val, AgxToneMapper::AgxLook look) {
 
 float3 AgxToneMapper::operator()(float3 v) const noexcept {
     // Ensure no negative values
-    v = max(float3(0.0), v);
+    v = max(float3(0.0f), v);
 
     v = AgXInsetMatrix * v;
 
     // Log2 encoding
-    v = max(v, 1E-10); // avoid 0 or negative numbers for log2
+    v = max(v, 1E-10f); // avoid 0 or negative numbers for log2
     v = log2(v);
     v = (v - AgxMinEv) / (AgxMaxEv - AgxMinEv);
 
-    v = clamp(v, 0, 1);
+    v = clamp(v, 0.0f, 1.0f);
 
     // Apply sigmoid
     v = agxDefaultContrastApprox(v);
@@ -325,7 +351,7 @@ float3 AgxToneMapper::operator()(float3 v) const noexcept {
     v = AgXOutsetMatrix * v;
 
     // Linearize
-    v = pow(max(float3(0.0), v), 2.2);
+    v = pow(max(float3(0.0f), v), 2.2f);
 
     return v;
 }

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -59,7 +59,8 @@ enum class ToneMapping : uint8_t {
     FILMIC        = 3,
     AGX           = 4,
     GENERIC       = 5,
-    DISPLAY_RANGE = 6,
+    PBR_NEUTRAL   = 6,
+    DISPLAY_RANGE = 7,
 };
 
 using AmbientOcclusionOptions = filament::View::AmbientOcclusionOptions;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -88,6 +88,7 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ToneMapp
     else if (0 == compare(tokens[i], jsonChunk, "FILMIC")) { *out = ToneMapping::FILMIC; }
     else if (0 == compare(tokens[i], jsonChunk, "AGX")) { *out = ToneMapping::AGX; }
     else if (0 == compare(tokens[i], jsonChunk, "GENERIC")) { *out = ToneMapping::GENERIC; }
+    else if (0 == compare(tokens[i], jsonChunk, "PBR_NEUTRAL")) { *out = ToneMapping::PBR_NEUTRAL; }
     else if (0 == compare(tokens[i], jsonChunk, "DISPLAY_RANGE")) { *out = ToneMapping::DISPLAY_RANGE; }
     else {
         slog.w << "Invalid ToneMapping: '" << STR(tokens[i], jsonChunk) << "'" << io::endl;
@@ -679,11 +680,12 @@ constexpr ToneMapper* createToneMapper(const ColorGradingSettings& settings) noe
         case ToneMapping::FILMIC: return new FilmicToneMapper;
         case ToneMapping::AGX: return new AgxToneMapper(settings.agxToneMapper.look);
         case ToneMapping::GENERIC: return new GenericToneMapper(
-                    settings.genericToneMapper.contrast,
-                    settings.genericToneMapper.midGrayIn,
-                    settings.genericToneMapper.midGrayOut,
-                    settings.genericToneMapper.hdrMax
+                settings.genericToneMapper.contrast,
+                settings.genericToneMapper.midGrayIn,
+                settings.genericToneMapper.midGrayOut,
+                settings.genericToneMapper.hdrMax
         );
+        case ToneMapping::PBR_NEUTRAL: return new PBRNeutralToneMapper;
         case ToneMapping::DISPLAY_RANGE: return new DisplayRangeToneMapper;
     }
 }
@@ -734,6 +736,7 @@ static std::ostream& operator<<(std::ostream& out, ToneMapping in) {
         case ToneMapping::FILMIC: return out << "\"FILMIC\"";
         case ToneMapping::AGX: return out << "\"AGX\"";
         case ToneMapping::GENERIC: return out << "\"GENERIC\"";
+        case ToneMapping::PBR_NEUTRAL: return out << "\"PBR_NEUTRAL\"";
         case ToneMapping::DISPLAY_RANGE: return out << "\"DISPLAY_RANGE\"";
     }
     return out << "\"INVALID\"";

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -145,6 +145,9 @@ static void computeToneMapPlot(ColorGradingSettings& settings, float* plot) {
             );
             hdrMax = settings.genericToneMapper.hdrMax;
             break;
+        case ToneMapping::PBR_NEUTRAL:
+            mapper = new PBRNeutralToneMapper;
+            break;
         case ToneMapping::DISPLAY_RANGE:
             mapper = new DisplayRangeToneMapper;
             break;
@@ -196,7 +199,7 @@ static void colorGradingUI(Settings& settings, float* rangePlot, float* curvePlo
 
         int toneMapping = (int) colorGrading.toneMapping;
         ImGui::Combo("Tone-mapping", &toneMapping,
-                "Linear\0ACES (legacy)\0ACES\0Filmic\0AgX\0Generic\0Display Range\0\0");
+                "Linear\0ACES (legacy)\0ACES\0Filmic\0AgX\0Generic\0PBR Neutral\0Display Range\0\0");
         colorGrading.toneMapping = (decltype(colorGrading.toneMapping)) toneMapping;
         if (colorGrading.toneMapping == ToneMapping::GENERIC) {
             if (ImGui::CollapsingHeader("Tonemap parameters")) {


### PR DESCRIPTION
This tone mapper was designed to preserve the color appearance of materials. It provides good saturation and contrast while controlling the highlights. This new tone mapper solves (most of) the color skews found in ACES and provides a good path to white similar to AgX but with better preservation of contrast and saturation. 

PBR Neutral is a good choice to showcase products or any type of scene where the appearance of the colors is important (it was designed for commerce applications).

### MacBeth color palette in a white furnace

This test compares lit and unlit materials, and the colors should match as closely as possible.

*ACES*
<img width="1390" alt="Screenshot 2024-02-23 at 10 47 30 AM" src="https://github.com/google/filament/assets/869684/daf10ea8-19e1-4118-b90e-1237f706e1e3">

*AgX*
<img width="1390" alt="Screenshot 2024-02-23 at 10 47 37 AM" src="https://github.com/google/filament/assets/869684/be3609a5-f700-48da-85f4-d3cff7b82838">

*PBR Neutral*
<img width="1390" alt="Screenshot 2024-02-23 at 10 47 39 AM" src="https://github.com/google/filament/assets/869684/6592ffb5-185e-41e6-a280-026bc6d66eee">

### Color sweep

*ACES*
<img width="1652" alt="Screenshot 2024-02-23 at 10 49 25 AM" src="https://github.com/google/filament/assets/869684/5ed5f6e5-16dc-49e1-bd64-d895fe3160cd">

*AgX*
<img width="1652" alt="Screenshot 2024-02-23 at 10 49 27 AM" src="https://github.com/google/filament/assets/869684/51aa1c3c-274a-43de-92da-39eff95f2d18">

*PBR Neutral*
<img width="1652" alt="Screenshot 2024-02-23 at 10 49 30 AM" src="https://github.com/google/filament/assets/869684/ad8e0b0a-d1d1-4ee3-a3e8-abee3c8ced82">

### Bistro at night

*ACES*
![aces](https://github.com/google/filament/assets/869684/34fb8cad-9105-4a2d-bcb7-469c21207198)

*AgX*
![agx](https://github.com/google/filament/assets/869684/a1902cd1-fb1a-42d4-940c-23eb8c9d4891)

*PBR Neutral*
![pbrneutral](https://github.com/google/filament/assets/869684/efd1a52b-324c-4027-b246-b30cd9a1903f)
