### PR TITLE
Fix shader compilation in threadpool mode

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -261,12 +261,11 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
                 [this, &gl, program = std::move(program), token]() mutable {
                     // compile the shaders
                     std::array<GLuint, Program::SHADER_TYPE_COUNT> shaders{};
-                    std::array<utils::CString, Program::SHADER_TYPE_COUNT> shaderSourceCode;
                     compileShaders(gl,
                             std::move(program.getShadersSource()),
                             program.getSpecializationConstants(),
                             shaders,
-                            shaderSourceCode);
+                            token->shaderSourceCode);
 
                     // link the program
                     GLuint const glProgram = linkProgram(gl, shaders, token->attributes);


### PR DESCRIPTION
When shader compilation happens in threadpool mode, shader source code isn't stored correctly in the token. This leads to empty error messages if a shader has problems later on.