### PR TITLE
Add blit array shader

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -215,6 +215,7 @@ set(MATERIAL_SRCS
         src/materials/antiAliasing/fxaa.mat
         src/materials/antiAliasing/taa.mat
         src/materials/blitLow.mat
+        src/materials/blitArray.mat
         src/materials/bloom/bloomDownsample.mat
         src/materials/bloom/bloomDownsample2x.mat
         src/materials/bloom/bloomDownsample9.mat

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -288,6 +288,15 @@ public:
             FrameGraphId<FrameGraphTexture> shadowmap, float scale,
             uint8_t layer, uint8_t level, uint8_t channel, float power) noexcept;
 
+    // Combine an array texture pointed to by `input` into a single image, then return it.
+    // This is only useful to check the multiview rendered scene as a debugging purpose, thus this
+    // is not expected to be used in normal cases.
+    FrameGraphId<FrameGraphTexture> debugCombineArrayTexture(FrameGraph& fg, bool translucent,
+        FrameGraphId<FrameGraphTexture> input,
+        filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+        backend::SamplerMagFilter filterMag,
+        backend::SamplerMinFilter filterMin) noexcept;
+
     backend::Handle<backend::HwTexture> getOneTexture() const;
     backend::Handle<backend::HwTexture> getZeroTexture() const;
     backend::Handle<backend::HwTexture> getOneTextureArray() const;

--- a/filament/src/materials/blitArray.mat
+++ b/filament/src/materials/blitArray.mat
@@ -1,0 +1,38 @@
+material {
+    name : blitArray,
+    parameters : [
+        {
+            type : sampler2dArray,
+            name : color,
+            precision: medium
+        },
+        {
+            type : int,
+            name : layerIndex
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision: high
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.vertex.xy);
+    }
+}
+
+fragment {
+    void postProcess(inout PostProcessInputs postProcess) {
+        postProcess.color = textureLod(materialParams_color, vec3(variable_vertex.xy, materialParams.layerIndex), 0.0);
+    }
+}


### PR DESCRIPTION
This shader takes an array texture and a layer index to draw to the current render target.

This will be used for debugging purpose to combine an array texture rendered from the multiview feature that is going to be implemented later, so that we can verify the feature properly performed.