### PR TITLE
Rename InstancedStereo as Stereo

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -434,7 +434,7 @@ void RenderPass::generateCommands(CommandTypeFlags commandTypeFlags, Command* co
         FScene::RenderableSoa const& soa, Range<uint32_t> range,
         Variant variant, RenderFlags renderFlags,
         FScene::VisibleMaskType visibilityMask, float3 cameraPosition, float3 cameraForward,
-        uint8_t instancedStereoEyeCount) noexcept {
+        uint8_t stereoEyeCount) noexcept {
 
     SYSTRACE_CALL();
 
@@ -466,12 +466,12 @@ void RenderPass::generateCommands(CommandTypeFlags commandTypeFlags, Command* co
         case CommandTypeFlags::COLOR:
             curr = generateCommandsImpl<CommandTypeFlags::COLOR>(commandTypeFlags, curr,
                     soa, range, variant, renderFlags, visibilityMask, cameraPosition, cameraForward,
-                    instancedStereoEyeCount);
+                    stereoEyeCount);
             break;
         case CommandTypeFlags::DEPTH:
             curr = generateCommandsImpl<CommandTypeFlags::DEPTH>(commandTypeFlags, curr,
                     soa, range, variant, renderFlags, visibilityMask, cameraPosition, cameraForward,
-                    instancedStereoEyeCount);
+                    stereoEyeCount);
             break;
         default:
             // we should never end-up here
@@ -494,7 +494,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
         Command* UTILS_RESTRICT curr,
         FScene::RenderableSoa const& UTILS_RESTRICT soa, Range<uint32_t> range,
         Variant const variant, RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
-        float3 cameraPosition, float3 cameraForward, uint8_t instancedStereoEyeCount) noexcept {
+        float3 cameraPosition, float3 cameraForward, uint8_t stereoEyeCount) noexcept {
 
     // generateCommands() writes both the draw and depth commands simultaneously such that
     // we go throw the list of renderables just once.
@@ -520,7 +520,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
 
     const bool hasShadowing = renderFlags & HAS_SHADOWING;
     const bool viewInverseFrontFaces = renderFlags & HAS_INVERSE_FRONT_FACES;
-    const bool hasInstancedStereo = renderFlags & IS_STEREOSCOPIC;
+    const bool hasStereo = renderFlags & IS_STEREOSCOPIC;
 
     Command cmdColor;
 
@@ -589,9 +589,9 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
         // soaInstanceInfo[i].count is the number of instances the user has requested, either for
         // manual or hybrid instancing. Instanced stereo multiplies the number of instances by the
         // eye count.
-        if (UTILS_UNLIKELY(hasInstancedStereo)) {
+        if (UTILS_UNLIKELY(hasStereo)) {
             cmdColor.primitive.instanceCount =
-                    (soaInstanceInfo[i].count * instancedStereoEyeCount) |
+                    (soaInstanceInfo[i].count * stereoEyeCount) |
                     PrimitiveInfo::USER_INSTANCE_MASK;
         }
 
@@ -623,9 +623,9 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
             cmdDepth.primitive.skinningTexture = skinning.handleSampler;
             cmdDepth.primitive.morphWeightBuffer = morphing.handle;
 
-            if (UTILS_UNLIKELY(hasInstancedStereo)) {
+            if (UTILS_UNLIKELY(hasStereo)) {
                 cmdColor.primitive.instanceCount =
-                        (soaInstanceInfo[i].count * instancedStereoEyeCount) |
+                        (soaInstanceInfo[i].count * stereoEyeCount) |
                         PrimitiveInfo::USER_INSTANCE_MASK;
             }
         }

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -679,7 +679,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     RenderPass::RenderFlags renderFlags = 0;
     if (view.hasShadowing())                renderFlags |= RenderPass::HAS_SHADOWING;
     if (view.isFrontFaceWindingInverted())  renderFlags |= RenderPass::HAS_INVERSE_FRONT_FACES;
-    if (view.hasInstancedStereo())          renderFlags |= RenderPass::IS_STEREOSCOPIC;
+    if (view.hasStereo())                   renderFlags |= RenderPass::IS_STEREOSCOPIC;
 
     RenderPassBuilder passBuilder(commandArena);
     passBuilder.renderFlags(renderFlags);
@@ -689,7 +689,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     variant.setDynamicLighting(view.hasDynamicLighting());
     variant.setFog(view.hasFog());
     variant.setVsm(view.hasShadowing() && view.getShadowType() != ShadowType::PCF);
-    variant.setStereo(view.hasInstancedStereo());
+    variant.setStereo(view.hasStereo());
 
     /*
      * Frame graph

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -173,7 +173,7 @@ public:
     bool hasDPCF() const noexcept { return mShadowType == ShadowType::DPCF; }
     bool hasPCSS() const noexcept { return mShadowType == ShadowType::PCSS; }
     bool hasPicking() const noexcept { return mActivePickingQueriesList != nullptr; }
-    bool hasInstancedStereo() const noexcept {
+    bool hasStereo() const noexcept {
         return mIsStereoSupported && mStereoscopicOptions.enabled;
     }
 

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -115,7 +115,7 @@ struct Variant {
     inline bool hasDirectionalLighting() const noexcept { return key & DIR; }
     inline bool hasDynamicLighting() const noexcept     { return key & DYN; }
     inline bool hasSkinningOrMorphing() const noexcept  { return key & SKN; }
-    inline bool hasInstancedStereo() const noexcept     { return key & STE; }
+    inline bool hasStereo() const noexcept              { return key & STE; }
 
     inline void setDirectionalLighting(bool v) noexcept { set(v, DIR); }
     inline void setDynamicLighting(bool v) noexcept     { set(v, DYN); }

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -894,7 +894,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .domain = mMaterialDomain,
                         .materialInfo = &info,
                         .hasFramebufferFetch = mEnableFramebufferFetch,
-                        .usesClipDistance = v.variant.hasInstancedStereo(),
+                        .usesClipDistance = v.variant.hasStereo(),
                         .glsl = {},
                 };
 

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -63,7 +63,7 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
                     out << "#extension GL_OES_EGL_image_external : require\n\n";
                 }
             }
-            if (v.hasInstancedStereo() && stage == ShaderStage::VERTEX) {
+            if (v.hasStereo() && stage == ShaderStage::VERTEX) {
                 // If we're not processing the shader through glslang (in the case of unoptimized
                 // OpenGL shaders), then we need to add the #extension string ourselves.
                 // If we ARE running the shader through glslang, then we must not include it,

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -51,8 +51,8 @@ void ShaderGenerator::generateSurfaceMaterialVariantDefines(utils::io::sstream& 
             litVariants && filament::Variant::isShadowReceiverVariant(variant));
     CodeGenerator::generateDefine(out, "VARIANT_HAS_VSM",
             filament::Variant::isVSMVariant(variant));
-    CodeGenerator::generateDefine(out, "VARIANT_HAS_INSTANCED_STEREO",
-            hasInstancedStereo(variant, featureLevel));
+    CodeGenerator::generateDefine(out, "VARIANT_HAS_STEREO",
+            hasStereo(variant, featureLevel));
 
     switch (stage) {
         case ShaderStage::VERTEX:
@@ -758,9 +758,9 @@ bool ShaderGenerator::hasSkinningOrMorphing(
             && featureLevel > MaterialBuilder::FeatureLevel::FEATURE_LEVEL_0;
 }
 
-bool ShaderGenerator::hasInstancedStereo(
+bool ShaderGenerator::hasStereo(
         filament::Variant variant, MaterialBuilder::FeatureLevel featureLevel) noexcept {
-    return variant.hasInstancedStereo()
+    return variant.hasStereo()
             // HACK(exv): Ignore stereo variant when targeting ESSL 1.0. We should properly build a
             // system in matc which allows the set of included variants to differ per-feature level.
             && featureLevel > MaterialBuilder::FeatureLevel::FEATURE_LEVEL_0;

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -115,7 +115,7 @@ private:
             filament::Variant variant,
             MaterialBuilder::FeatureLevel featureLevel) noexcept;
 
-    static bool hasInstancedStereo(
+    static bool hasStereo(
             filament::Variant variant,
             MaterialBuilder::FeatureLevel featureLevel) noexcept;
 

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -24,7 +24,7 @@ highp mat4 getViewFromClipMatrix() {
 
 /** @public-api */
 highp mat4 getClipFromWorldMatrix() {
-#if defined(VARIANT_HAS_INSTANCED_STEREO)
+#if defined(VARIANT_HAS_STEREO)
     int eye = instance_index % CONFIG_STEREO_EYE_COUNT;
     return frameUniforms.clipFromWorldMatrix[eye];
 #else

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -23,7 +23,7 @@ void main() {
     logical_instance_index = instance_index;
 #endif
 
-#if defined(VARIANT_HAS_INSTANCED_STEREO)
+#if defined(VARIANT_HAS_STEREO)
 #if !defined(FILAMENT_HAS_FEATURE_INSTANCING)
 #error Instanced stereo not supported at this feature level
 #endif
@@ -215,7 +215,7 @@ void main() {
     // this must happen before we compensate for vulkan below
     vertex_position = position;
 
-#if defined(VARIANT_HAS_INSTANCED_STEREO)
+#if defined(VARIANT_HAS_STEREO)
     // We're transforming a vertex whose x coordinate is within the range (-w to w).
     // To move it to the correct portion of the viewport, we need to modify the x coordinate.
     // It's important to do this after computing vertex_position.
@@ -253,7 +253,7 @@ void main() {
     // some PowerVR drivers crash when gl_Position is written more than once
     gl_Position = position;
 
-#if defined(VARIANT_HAS_INSTANCED_STEREO)
+#if defined(VARIANT_HAS_STEREO)
     // Fragment shaders filter out the stereo variant, so we need to set instance_index here.
     instance_index = logical_instance_index;
 #endif

--- a/shaders/src/varyings.glsl
+++ b/shaders/src/varyings.glsl
@@ -34,7 +34,7 @@ LAYOUT_LOCATION(11) VARYING highp vec4 vertex_lightSpacePosition;
 
 // Note that fragColor is an output and is not declared here; see main.fs and depth_main.fs
 
-#if defined(VARIANT_HAS_INSTANCED_STEREO)
+#if defined(VARIANT_HAS_STEREO)
 #if defined(GL_ES) && defined(FILAMENT_GLSLANG)
 // On ES, gl_ClipDistance is not a built-in, so we have to rely on EXT_clip_cull_distance
 // However, this extension is not supported by glslang, so we instead write to
@@ -46,4 +46,4 @@ LAYOUT_LOCATION(100) out float filament_gl_ClipDistance[2];
 // If we're on Desktop GL (or not running shaders through glslang), we're free to use gl_ClipDistance
 #define FILAMENT_CLIPDISTANCE gl_ClipDistance
 #endif // GL_ES && FILAMENT_GLSLANG
-#endif // VARIANT_HAS_INSTANCED_STEREO
+#endif // VARIANT_HAS_STEREO


### PR DESCRIPTION
We're going to add a new implementation of stereoscopic rendering using multiview. Thus we want to remove the word `Instanced` from all methods and properties.