### PR TITLE
Keep supporting API level 19

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -29,9 +29,11 @@
 
 #include <sys/system_properties.h>
 
-// We require filament to be built with a API 21 toolchain, before that, OpenGLES 3.1 didn't exist
-#if __ANDROID_API__ < 21
-#   error "__ANDROID_API__ must be at least 21"
+// We require filament to be built with an API 19 toolchain, before that, OpenGLES 3.0 didn't exist
+// Actually, OpenGL ES 3.0 was added to API 18, but API 19 is the better target and
+// the minimum for Jetpack at the time of this comment.
+#if __ANDROID_API__ < 19
+#   error "__ANDROID_API__ must be at least 19"
 #endif
 
 using namespace utils;


### PR DESCRIPTION
This is a partial rollback from
d83b3858b3dbc97b2a5e039ae9fb5d170dd95907.

Keep supporting API level 19 for some of our clients.