### PR TITLE
Add protected mode to the FrameGraph.

### DIFF
--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -218,7 +218,13 @@ public:
 
     // --------------------------------------------------------------------------------------------
 
-    explicit FrameGraph(ResourceAllocatorInterface& resourceAllocator);
+    enum class Mode {
+        UNPROTECTED,
+        PROTECTED,
+    };
+
+    explicit FrameGraph(ResourceAllocatorInterface& resourceAllocator,
+            Mode mode = Mode::UNPROTECTED);
     FrameGraph(FrameGraph const&) = delete;
     FrameGraph& operator=(FrameGraph const&) = delete;
     ~FrameGraph() noexcept;
@@ -517,6 +523,7 @@ private:
     ResourceAllocatorInterface& mResourceAllocator;
     LinearAllocatorArena mArena;
     DependencyGraph mGraph;
+    const Mode mMode;
 
     Vector<ResourceSlot> mResourceSlots;
     Vector<VirtualResource*> mResources;

--- a/filament/src/fg/FrameGraphTexture.cpp
+++ b/filament/src/fg/FrameGraphTexture.cpp
@@ -23,7 +23,12 @@
 namespace filament {
 
 void FrameGraphTexture::create(ResourceAllocatorInterface& resourceAllocator, const char* name,
-        FrameGraphTexture::Descriptor const& descriptor, FrameGraphTexture::Usage usage) noexcept {
+        FrameGraphTexture::Descriptor const& descriptor, FrameGraphTexture::Usage usage,
+        bool useProtectedMemory) noexcept {
+    if (useProtectedMemory) {
+        // FIXME: I think we should restrict this to attachments and blit destinations only
+        usage |= FrameGraphTexture::Usage::PROTECTED;
+    }
     std::array<backend::TextureSwizzle, 4> swizzle = {
             descriptor.swizzle.r,
             descriptor.swizzle.g,

--- a/filament/src/fg/FrameGraphTexture.h
+++ b/filament/src/fg/FrameGraphTexture.h
@@ -34,7 +34,8 @@ namespace filament {
  *      struct SubResourceDescriptor;
  *      a Usage bitmask
  * And declares and define:
- *      void create(ResourceAllocatorInterface&, const char* name, Descriptor const&, Usage) noexcept;
+ *      void create(ResourceAllocatorInterface&, const char* name, Descriptor const&, Usage,
+ *              bool useProtectedMemory) noexcept;
  *      void destroy(ResourceAllocatorInterface&) noexcept;
  */
 struct FrameGraphTexture {
@@ -78,7 +79,7 @@ struct FrameGraphTexture {
      * @param descriptor Descriptor to the resource
      */
     void create(ResourceAllocatorInterface& resourceAllocator, const char* name,
-            Descriptor const& descriptor, Usage usage) noexcept;
+            Descriptor const& descriptor, Usage usage, bool useProtectedMemory) noexcept;
 
     /**
      * Destroy the concrete resource

--- a/filament/src/fg/details/Resource.h
+++ b/filament/src/fg/details/Resource.h
@@ -84,7 +84,8 @@ public:
             ResourceEdgeBase const* writer) noexcept = 0;
 
     /* Instantiate the concrete resource */
-    virtual void devirtualize(ResourceAllocatorInterface& resourceAllocator) noexcept = 0;
+    virtual void devirtualize(ResourceAllocatorInterface& resourceAllocator,
+            bool useProtectedMemory) noexcept = 0;
 
     /* Destroy the concrete resource */
     virtual void destroy(ResourceAllocatorInterface& resourceAllocator) noexcept = 0;
@@ -229,9 +230,10 @@ protected:
         delete static_cast<ResourceEdge *>(edge);
     }
 
-    void devirtualize(ResourceAllocatorInterface& resourceAllocator) noexcept override {
+    void devirtualize(ResourceAllocatorInterface& resourceAllocator,
+            bool useProtectedMemory) noexcept override {
         if (!isSubResource()) {
-            resource.create(resourceAllocator, name, descriptor, usage);
+            resource.create(resourceAllocator, name, descriptor, usage, useProtectedMemory);
         } else {
             // resource is guaranteed to be initialized before we are by construction
             resource = static_cast<Resource const*>(parent)->resource;
@@ -268,7 +270,7 @@ public:
     }
 
 protected:
-    void devirtualize(ResourceAllocatorInterface&) noexcept override {
+    void devirtualize(ResourceAllocatorInterface&, bool) noexcept override {
         // imported resources don't need to devirtualize
     }
     void destroy(ResourceAllocatorInterface&) noexcept override {


### PR DESCRIPTION
In protected mode, the FrameGraph will automatically add the PROTECTED usage bit to texture resources.