### PR TITLE
more cleanup-up of timer queries

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -48,7 +48,7 @@ bool OpenGLContext::queryOpenGLVersion(GLint* major, GLint* minor) noexcept {
 #endif
 }
 
-OpenGLContext::OpenGLContext() noexcept {
+OpenGLContext::OpenGLContext(OpenGLPlatform& platform) noexcept {
 
     state.vao.p = &mDefaultVAO;
 
@@ -231,6 +231,12 @@ OpenGLContext::OpenGLContext() noexcept {
         glDebugMessageCallback(cb, nullptr);
     }
 #endif
+
+    mTimerQueryFactory = TimerQueryFactory::init(platform, *this);
+}
+
+OpenGLContext::~OpenGLContext() noexcept {
+    delete mTimerQueryFactory;
 }
 
 void OpenGLContext::setDefaultState() noexcept {
@@ -1009,7 +1015,22 @@ void OpenGLContext::resetState() noexcept {
         state.window.viewport.w
     );
     glDepthRangef(state.window.depthRange.x, state.window.depthRange.y);
-    
+}
+
+void OpenGLContext::createTimerQuery(GLTimerQuery* query) {
+    mTimerQueryFactory->createTimerQuery(query);
+}
+
+void OpenGLContext::destroyTimerQuery(GLTimerQuery* query) {
+    mTimerQueryFactory->destroyTimerQuery(query);
+}
+
+void OpenGLContext::beginTimeElapsedQuery(GLTimerQuery* query) {
+    mTimerQueryFactory->beginTimeElapsedQuery(query);
+}
+
+void OpenGLContext::endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* query) {
+    mTimerQueryFactory->endTimeElapsedQuery(driver, query);
 }
 
 } // namesapce filament

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -20,6 +20,7 @@
 #include "DriverBase.h"
 #include "GLUtils.h"
 #include "OpenGLContext.h"
+#include "OpenGLTimerQuery.h"
 #include "ShaderCompilerService.h"
 
 #include "private/backend/Driver.h"
@@ -38,7 +39,11 @@
 
 #include <tsl/robin_map.h>
 
+#include <atomic>
+#include <memory>
 #include <set>
+
+#include <stdint.h>
 
 #ifndef FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB
 #    define FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB 4
@@ -51,7 +56,7 @@ class PixelBufferDescriptor;
 struct TargetBufferInfo;
 
 class OpenGLProgram;
-class OpenGLTimerQueryInterface;
+class TimerQueryFactoryInterface;
 
 class OpenGLDriver final : public DriverBase {
     inline explicit OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept;
@@ -161,15 +166,7 @@ public:
         OpenGLPlatform::ExternalTexture* externalTexture = nullptr;
     };
 
-    struct GLTimerQuery : public HwTimerQuery {
-        struct State {
-            struct {
-                GLuint query;
-            } gl;
-            std::atomic<int64_t> elapsed{};
-        };
-        std::shared_ptr<State> state;
-    };
+    using GLTimerQuery = filament::backend::GLTimerQuery;
 
     struct GLStream : public HwStream {
         using HwStream::HwStream;
@@ -223,8 +220,8 @@ private:
     OpenGLContext mContext;
     ShaderCompilerService mShaderCompilerService;
 
-    friend class OpenGLTimerQueryFactory;
-    friend class TimerQueryNative;
+    friend class TimerQueryFactory;
+    friend class TimerQueryNativeFactory;
     OpenGLContext& getContext() noexcept { return mContext; }
 
     ShaderCompilerService& getShaderCompilerService() noexcept {
@@ -410,9 +407,6 @@ private:
     void runEveryNowAndThen(std::function<bool()> fn) noexcept;
     void executeEveryNowAndThenOps() noexcept;
     std::vector<std::function<bool()>> mEveryNowAndThenOps;
-
-    // timer query implementation
-    OpenGLTimerQueryInterface* mTimerQueryImpl = nullptr;
 
     const Platform::DriverConfig mDriverConfig;
     Platform::DriverConfig const& getDriverConfig() const noexcept { return mDriverConfig; }

--- a/filament/backend/src/opengl/OpenGLTimerQuery.cpp
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.cpp
@@ -16,60 +16,76 @@
 
 #include "OpenGLTimerQuery.h"
 
+#include "GLUtils.h"
+#include "OpenGLDriver.h"
+
+#include <backend/Platform.h>
 #include <backend/platforms/OpenGLPlatform.h>
+#include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
+#include <utils/debug.h>
 #include <utils/JobSystem.h>
 #include <utils/Log.h>
+#include <utils/Mutex.h>
 #include <utils/Systrace.h>
-#include <utils/debug.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <utility>
+
+#include <stdint.h>
 
 namespace filament::backend {
 
 using namespace backend;
 using namespace GLUtils;
 
+class OpenGLDriver;
+
 // ------------------------------------------------------------------------------------------------
 
-bool OpenGLTimerQueryFactory::mGpuTimeSupported = false;
+bool TimerQueryFactory::mGpuTimeSupported = false;
 
-OpenGLTimerQueryInterface* OpenGLTimerQueryFactory::init(
-        OpenGLPlatform& platform, OpenGLDriver& driver) noexcept {
-    (void)driver;
+TimerQueryFactoryInterface* TimerQueryFactory::init(
+        OpenGLPlatform& platform, OpenGLContext& context) noexcept {
+    (void)context;
 
-    OpenGLTimerQueryInterface* impl;
+    TimerQueryFactoryInterface* impl = nullptr;
 
 #if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
-    auto& context = driver.getContext();
     if (context.ext.EXT_disjoint_timer_query) {
         // timer queries are available
         if (context.bugs.dont_use_timer_query && platform.canCreateFence()) {
             // however, they don't work well, revert to using fences if we can.
-            impl = new(std::nothrow) OpenGLTimerQueryFence(platform);
+            impl = new(std::nothrow) TimerQueryFenceFactory(platform);
         } else {
-            impl = new(std::nothrow) TimerQueryNative(driver);
+            impl = new(std::nothrow) TimerQueryNativeFactory(context);
         }
         mGpuTimeSupported = true;
     } else
 #endif
     if (platform.canCreateFence()) {
         // no timer queries, but we can use fences
-        impl = new(std::nothrow) OpenGLTimerQueryFence(platform);
+        impl = new(std::nothrow) TimerQueryFenceFactory(platform);
         mGpuTimeSupported = true;
     } else {
         // no queries, no fences -- that's a problem
-        impl = new(std::nothrow) TimerQueryFallback();
+        impl = new(std::nothrow) TimerQueryFallbackFactory();
         mGpuTimeSupported = false;
     }
+    assert_invariant(impl);
     return impl;
 }
 
 // ------------------------------------------------------------------------------------------------
 
-OpenGLTimerQueryInterface::~OpenGLTimerQueryInterface() = default;
+TimerQueryFactoryInterface::~TimerQueryFactoryInterface() = default;
 
 // This is a backend synchronous call
-TimerQueryResult OpenGLTimerQueryInterface::getTimerQueryValue(
+TimerQueryResult TimerQueryFactoryInterface::getTimerQueryValue(
         GLTimerQuery* tq, uint64_t* elapsedTime) noexcept {
     if (UTILS_LIKELY(tq->state)) {
         int64_t const elapsed = tq->state->elapsed.load(std::memory_order_relaxed);
@@ -86,42 +102,46 @@ TimerQueryResult OpenGLTimerQueryInterface::getTimerQueryValue(
 
 #if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
 
-TimerQueryNative::TimerQueryNative(OpenGLDriver& driver)
-        : mDriver(driver) {
+TimerQueryNativeFactory::TimerQueryNativeFactory(OpenGLContext& context)
+        : mContext(context) {
 }
 
-TimerQueryNative::~TimerQueryNative() = default;
+TimerQueryNativeFactory::~TimerQueryNativeFactory() = default;
 
-void TimerQueryNative::createTimerQuery(GLTimerQuery* tq) {
-    if (UTILS_UNLIKELY(!tq->state)) {
-        tq->state = std::make_shared<GLTimerQuery::State>();
-    }
-    mDriver.getContext().procs.genQueries(1u, &tq->state->gl.query);
+void TimerQueryNativeFactory::createTimerQuery(GLTimerQuery* tq) {
+    assert_invariant(!tq->state);
+
+    tq->state = std::make_shared<GLTimerQuery::State>();
+    mContext.procs.genQueries(1u, &tq->state->gl.query);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void TimerQueryNative::destroyTimerQuery(GLTimerQuery* tq) {
+void TimerQueryNativeFactory::destroyTimerQuery(GLTimerQuery* tq) {
     assert_invariant(tq->state);
-    mDriver.getContext().procs.deleteQueries(1u, &tq->state->gl.query);
+
+    mContext.procs.deleteQueries(1u, &tq->state->gl.query);
+    CHECK_GL_ERROR(utils::slog.e)
+
+    tq->state.reset();
+}
+
+void TimerQueryNativeFactory::beginTimeElapsedQuery(GLTimerQuery* tq) {
+    assert_invariant(tq->state);
+
+    tq->state->elapsed.store(int64_t(TimerQueryResult::NOT_READY), std::memory_order_relaxed);
+    mContext.procs.beginQuery(GL_TIME_ELAPSED, tq->state->gl.query);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void TimerQueryNative::beginTimeElapsedQuery(GLTimerQuery* tq) {
+void TimerQueryNativeFactory::endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* tq) {
     assert_invariant(tq->state);
-    tq->state->elapsed.store(int64_t(TimerQueryResult::NOT_READY));
-    mDriver.getContext().procs.beginQuery(GL_TIME_ELAPSED, tq->state->gl.query);
-    CHECK_GL_ERROR(utils::slog.e)
-}
 
-void TimerQueryNative::endTimeElapsedQuery(GLTimerQuery* tq) {
-    assert_invariant(tq->state);
-    auto& context = mDriver.getContext();
-    context.procs.endQuery(GL_TIME_ELAPSED);
+    mContext.procs.endQuery(GL_TIME_ELAPSED);
     CHECK_GL_ERROR(utils::slog.e)
 
     std::weak_ptr<GLTimerQuery::State> const weak = tq->state;
 
-    mDriver.runEveryNowAndThen([&context, weak]() -> bool {
+    driver.runEveryNowAndThen([&context = mContext, weak]() -> bool {
         auto state = weak.lock();
         if (state) {
             GLuint available = 0;
@@ -146,7 +166,7 @@ void TimerQueryNative::endTimeElapsedQuery(GLTimerQuery* tq) {
 
 // ------------------------------------------------------------------------------------------------
 
-OpenGLTimerQueryFence::OpenGLTimerQueryFence(OpenGLPlatform& platform)
+TimerQueryFenceFactory::TimerQueryFenceFactory(OpenGLPlatform& platform)
         : mPlatform(platform) {
     mQueue.reserve(2);
     mThread = std::thread([this]() {
@@ -170,7 +190,8 @@ OpenGLTimerQueryFence::OpenGLTimerQueryFence(OpenGLPlatform& platform)
     });
 }
 
-OpenGLTimerQueryFence::~OpenGLTimerQueryFence() {
+TimerQueryFenceFactory::~TimerQueryFenceFactory() {
+    assert_invariant(mQueue.empty());
     if (mThread.joinable()) {
         std::unique_lock<utils::Mutex> lock(mLock);
         mExitRequested = true;
@@ -182,27 +203,26 @@ OpenGLTimerQueryFence::~OpenGLTimerQueryFence() {
     }
 }
 
-void OpenGLTimerQueryFence::enqueue(OpenGLTimerQueryFence::Job&& job) {
+void TimerQueryFenceFactory::push(TimerQueryFenceFactory::Job&& job) {
     std::unique_lock<utils::Mutex> const lock(mLock);
-    mQueue.push_back(std::forward<Job>(job));
+    mQueue.push_back(std::move(job));
     mCondition.notify_one();
 }
 
-void OpenGLTimerQueryFence::createTimerQuery(GLTimerQuery* tq) {
-    if (UTILS_UNLIKELY(!tq->state)) {
-        tq->state = std::make_shared<GLTimerQuery::State>();
-    }
+void TimerQueryFenceFactory::createTimerQuery(GLTimerQuery* tq) {
+    assert_invariant(!tq->state);
+    tq->state = std::make_shared<GLTimerQuery::State>();
 }
 
-void OpenGLTimerQueryFence::destroyTimerQuery(GLTimerQuery* tq) {
+void TimerQueryFenceFactory::destroyTimerQuery(GLTimerQuery* tq) {
     assert_invariant(tq->state);
+    tq->state.reset();
 }
 
-void OpenGLTimerQueryFence::beginTimeElapsedQuery(GLTimerQuery* tq) {
+void TimerQueryFenceFactory::beginTimeElapsedQuery(GLTimerQuery* tq) {
     assert_invariant(tq->state);
-    tq->state->elapsed.store(0);
+    tq->state->elapsed.store(int64_t(TimerQueryResult::NOT_READY), std::memory_order_relaxed);
 
-    Platform::Fence* fence = mPlatform.createFence();
     std::weak_ptr<GLTimerQuery::State> const weak = tq->state;
 
     // FIXME: this implementation of beginTimeElapsedQuery is usually wrong; it ends up
@@ -211,12 +231,11 @@ void OpenGLTimerQueryFence::beginTimeElapsedQuery(GLTimerQuery* tq) {
     //    on a dummy target for instance, or somehow latch the begin time at the next renderpass
     //    start.
 
-    push([&platform = mPlatform, fence, weak]() {
+    push([&platform = mPlatform, fence = mPlatform.createFence(), weak]() {
         auto state = weak.lock();
         if (state) {
             platform.waitFence(fence, FENCE_WAIT_FOR_EVER);
-            int64_t const then = clock::now().time_since_epoch().count();
-            state->elapsed.store(-then, std::memory_order_relaxed);
+            state->then = clock::now().time_since_epoch().count();
             SYSTRACE_CONTEXT();
             SYSTRACE_ASYNC_BEGIN("OpenGLTimerQueryFence", intptr_t(state.get()));
         }
@@ -224,19 +243,16 @@ void OpenGLTimerQueryFence::beginTimeElapsedQuery(GLTimerQuery* tq) {
     });
 }
 
-void OpenGLTimerQueryFence::endTimeElapsedQuery(GLTimerQuery* tq) {
+void TimerQueryFenceFactory::endTimeElapsedQuery(OpenGLDriver&, GLTimerQuery* tq) {
     assert_invariant(tq->state);
-    Platform::Fence* fence = mPlatform.createFence();
     std::weak_ptr<GLTimerQuery::State> const weak = tq->state;
 
-    push([&platform = mPlatform, fence, weak]() {
+    push([&platform = mPlatform, fence = mPlatform.createFence(), weak]() {
         auto state = weak.lock();
         if (state) {
             platform.waitFence(fence, FENCE_WAIT_FOR_EVER);
             int64_t const now = clock::now().time_since_epoch().count();
-            int64_t const then = state->elapsed.load(std::memory_order_relaxed);
-            assert_invariant(then < 0);
-            state->elapsed.store(now + then, std::memory_order_relaxed);
+            state->elapsed.store(now - state->then, std::memory_order_relaxed);
             SYSTRACE_CONTEXT();
             SYSTRACE_ASYNC_END("OpenGLTimerQueryFence", intptr_t(state.get()));
         }
@@ -246,34 +262,32 @@ void OpenGLTimerQueryFence::endTimeElapsedQuery(GLTimerQuery* tq) {
 
 // ------------------------------------------------------------------------------------------------
 
-TimerQueryFallback::TimerQueryFallback() = default;
+TimerQueryFallbackFactory::TimerQueryFallbackFactory() = default;
 
-TimerQueryFallback::~TimerQueryFallback() = default;
+TimerQueryFallbackFactory::~TimerQueryFallbackFactory() = default;
 
-void TimerQueryFallback::createTimerQuery(GLTimerQuery* tq) {
-    if (UTILS_UNLIKELY(!tq->state)) {
-        tq->state = std::make_shared<GLTimerQuery::State>();
-    }
+void TimerQueryFallbackFactory::createTimerQuery(GLTimerQuery* tq) {
+    assert_invariant(!tq->state);
+    tq->state = std::make_shared<GLTimerQuery::State>();
 }
 
-void TimerQueryFallback::destroyTimerQuery(GLTimerQuery* tq) {
+void TimerQueryFallbackFactory::destroyTimerQuery(GLTimerQuery* tq) {
     assert_invariant(tq->state);
+    tq->state.reset();
 }
 
-void TimerQueryFallback::beginTimeElapsedQuery(OpenGLTimerQueryInterface::GLTimerQuery* tq) {
+void TimerQueryFallbackFactory::beginTimeElapsedQuery(GLTimerQuery* tq) {
     assert_invariant(tq->state);
     // this implementation measures the CPU time, but we have no h/w support
-    int64_t const then = clock::now().time_since_epoch().count();
-    tq->state->elapsed.store(-then, std::memory_order_relaxed);
+    tq->state->then = clock::now().time_since_epoch().count();
+    tq->state->elapsed.store(int64_t(TimerQueryResult::NOT_READY), std::memory_order_relaxed);
 }
 
-void TimerQueryFallback::endTimeElapsedQuery(OpenGLTimerQueryInterface::GLTimerQuery* tq) {
+void TimerQueryFallbackFactory::endTimeElapsedQuery(OpenGLDriver&, GLTimerQuery* tq) {
     assert_invariant(tq->state);
     // this implementation measures the CPU time, but we have no h/w support
     int64_t const now = clock::now().time_since_epoch().count();
-    int64_t const then = tq->state->elapsed.load(std::memory_order_relaxed);
-    assert_invariant(then < 0);
-    tq->state->elapsed.store(now + then, std::memory_order_relaxed);
+    tq->state->elapsed.store(now - tq->state->then, std::memory_order_relaxed);
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/OpenGLTimerQuery.h
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.h
@@ -17,18 +17,41 @@
 #ifndef TNT_FILAMENT_BACKEND_OPENGL_TIMERQUERY_H
 #define TNT_FILAMENT_BACKEND_OPENGL_TIMERQUERY_H
 
-#include "OpenGLDriver.h"
+#include <backend/DriverEnums.h>
+
+#include "DriverBase.h"
 
 #include <utils/Condition.h>
 #include <utils/Mutex.h>
 
+#include "gl_headers.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
 #include <thread>
 #include <vector>
+
+#include <stdint.h>
 
 namespace filament::backend {
 
 class OpenGLPlatform;
-class OpenGLTimerQueryInterface;
+class OpenGLContext;
+class OpenGLDriver;
+class TimerQueryFactoryInterface;
+
+struct GLTimerQuery : public HwTimerQuery {
+    struct State {
+        struct {
+            GLuint query;
+        } gl;
+        int64_t then{};
+        std::atomic<int64_t> elapsed{};
+    };
+    std::shared_ptr<State> state;
+};
 
 /*
  * We need two implementation of timer queries (only elapsed time), because
@@ -38,83 +61,80 @@ class OpenGLTimerQueryInterface;
  * These classes implement the various strategies...
  */
 
-
-class OpenGLTimerQueryFactory {
+class TimerQueryFactory {
     static bool mGpuTimeSupported;
 public:
-    static OpenGLTimerQueryInterface* init(
-            OpenGLPlatform& platform, OpenGLDriver& driver) noexcept;
+    static TimerQueryFactoryInterface* init(
+            OpenGLPlatform& platform, OpenGLContext& context) noexcept;
 
     static bool isGpuTimeSupported() noexcept {
         return mGpuTimeSupported;
     }
 };
 
-class OpenGLTimerQueryInterface {
+class TimerQueryFactoryInterface {
 protected:
-    using GLTimerQuery = OpenGLDriver::GLTimerQuery;
+    using GLTimerQuery = filament::backend::GLTimerQuery;
     using clock = std::chrono::steady_clock;
 
 public:
-    virtual ~OpenGLTimerQueryInterface();
+    virtual ~TimerQueryFactoryInterface();
     virtual void createTimerQuery(GLTimerQuery* query) = 0;
     virtual void destroyTimerQuery(GLTimerQuery* query) = 0;
     virtual void beginTimeElapsedQuery(GLTimerQuery* query) = 0;
-    virtual void endTimeElapsedQuery(GLTimerQuery* query) = 0;
+    virtual void endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* query) = 0;
 
     static TimerQueryResult getTimerQueryValue(GLTimerQuery* tq, uint64_t* elapsedTime) noexcept;
 };
 
 #if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
 
-class TimerQueryNative : public OpenGLTimerQueryInterface {
+class TimerQueryNativeFactory final : public TimerQueryFactoryInterface {
 public:
-    explicit TimerQueryNative(OpenGLDriver& driver);
-    ~TimerQueryNative() override;
+    explicit TimerQueryNativeFactory(OpenGLContext& context);
+    ~TimerQueryNativeFactory() override;
 private:
     void createTimerQuery(GLTimerQuery* query) override;
     void destroyTimerQuery(GLTimerQuery* query) override;
     void beginTimeElapsedQuery(GLTimerQuery* query) override;
-    void endTimeElapsedQuery(GLTimerQuery* query) override;
-    OpenGLDriver& mDriver;
+    void endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* query) override;
+    OpenGLContext& mContext;
 };
 
 #endif
 
-class OpenGLTimerQueryFence : public OpenGLTimerQueryInterface {
+class TimerQueryFenceFactory final : public TimerQueryFactoryInterface {
 public:
-    explicit OpenGLTimerQueryFence(OpenGLPlatform& platform);
-    ~OpenGLTimerQueryFence() override;
+    explicit TimerQueryFenceFactory(OpenGLPlatform& platform);
+    ~TimerQueryFenceFactory() override;
 private:
     using Job = std::function<void()>;
+    using Container = std::vector<Job>;
+
     void createTimerQuery(GLTimerQuery* query) override;
     void destroyTimerQuery(GLTimerQuery* query) override;
     void beginTimeElapsedQuery(GLTimerQuery* tq) override;
-    void endTimeElapsedQuery(GLTimerQuery* tq) override;
+    void endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* tq) override;
 
-    void enqueue(Job&& job);
-    template<typename CALLABLE, typename ... ARGS>
-    void push(CALLABLE&& func, ARGS&& ... args) {
-        enqueue(Job(std::bind(std::forward<CALLABLE>(func), std::forward<ARGS>(args)...)));
-    }
+    void push(Job&& job);
 
     OpenGLPlatform& mPlatform;
     std::thread mThread;
     mutable utils::Mutex mLock;
     mutable utils::Condition mCondition;
-    std::vector<Job> mQueue;
+    Container mQueue;
     bool mExitRequested = false;
 };
 
-class TimerQueryFallback : public OpenGLTimerQueryInterface {
+class TimerQueryFallbackFactory final : public TimerQueryFactoryInterface {
 public:
-    explicit TimerQueryFallback();
-    ~TimerQueryFallback() override;
+    explicit TimerQueryFallbackFactory();
+    ~TimerQueryFallbackFactory() override;
 private:
     void createTimerQuery(GLTimerQuery* query) override;
     void destroyTimerQuery(GLTimerQuery* query) override;
     void beginTimeElapsedQuery(GLTimerQuery* query) override;
-    void endTimeElapsedQuery(GLTimerQuery* query) override;
+    void endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* query) override;
 };
 
 } // namespace filament::backend


### PR DESCRIPTION
- better naming
- TimerQueryFactory doesn't depend  on OpenGLDriver anymore, only a OpenGLContext.
- timer query factory is now owned by and accessed through OpenGLDriver
- we can't temporarily store a negative number in the query shared state, because it now indicates an error.