### PR TITLE
Fixed validation error VUID-vkAcquireNextImageKHR-semaphore-01779

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - Add new API `SwapChain::getFrameScheduledCallback`
+- Fixed Vulkan validation error VUID-vkAcquireNextImageKHR-semaphore-01779

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,4 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - Add new API `SwapChain::getFrameScheduledCallback`
-- Fixed Vulkan validation error VUID-vkAcquireNextImageKHR-semaphore-01779
+- vulkan: fixed validation error VUID-vkAcquireNextImageKHR-semaphore-01779

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -35,7 +35,7 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
       mStagePool(stagePool),
       mHeadless(extent.width != 0 && extent.height != 0 && !nativeWindow),
       mFlushAndWaitOnResize(platform->getCustomization().flushAndWaitOnWindowResize),
-      mImageReady(VK_NULL_HANDLE),
+      mCurrentImageReadyIndex(0),
       mAcquired(false),
       mIsFirstRenderPass(true) {
     swapChain = mPlatform->createSwapChain(nativeWindow, flags, extent);
@@ -46,10 +46,15 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
     };
 
     // No need to wait on this semaphore before drawing when in Headless mode.
-    if (!mHeadless) {
-        VkResult result =
-                vkCreateSemaphore(mPlatform->getDevice(), &createInfo, nullptr, &mImageReady);
-        ASSERT_POSTCONDITION(result == VK_SUCCESS, "Failed to create semaphore");
+    if (mHeadless) {
+		// Set all sempahores to VK_NULL_HANDLE
+		memset(mImageReady, 0, sizeof(mImageReady[0]) * IMAGE_READY_SEMAPHORE_COUNT);
+	} else {
+		for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
+			VkResult result =
+					vkCreateSemaphore(mPlatform->getDevice(), &createInfo, nullptr, mImageReady + i);
+			ASSERT_POSTCONDITION(result == VK_SUCCESS, "Failed to create semaphore");
+		}
     }
 
     update();
@@ -62,9 +67,11 @@ VulkanSwapChain::~VulkanSwapChain() {
     mCommands->wait();
 
     mPlatform->destroy(swapChain);
-    if (mImageReady != VK_NULL_HANDLE) {
-        vkDestroySemaphore(mPlatform->getDevice(), mImageReady, VKALLOC);
-    }
+	for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
+		if (mImageReady[i] != VK_NULL_HANDLE) {
+			vkDestroySemaphore(mPlatform->getDevice(), mImageReady[i], VKALLOC);
+		}
+	}
 }
 
 void VulkanSwapChain::update() {
@@ -131,11 +138,13 @@ void VulkanSwapChain::acquire(bool& resized) {
         update();
     }
 
-    VkResult const result = mPlatform->acquire(swapChain, mImageReady, &mCurrentSwapIndex);
+	mCurrentImageReadyIndex = (mCurrentImageReadyIndex + 1) % IMAGE_READY_SEMAPHORE_COUNT;
+	const VkSemaphore imageReady = mImageReady[mCurrentImageReadyIndex];
+    VkResult const result = mPlatform->acquire(swapChain, imageReady, &mCurrentSwapIndex);
     ASSERT_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR,
             "Cannot acquire in swapchain.");
-    if (mImageReady != VK_NULL_HANDLE) {
-        mCommands->injectDependency(mImageReady);
+    if (imageReady != VK_NULL_HANDLE) {
+        mCommands->injectDependency(imageReady);
     }
     mAcquired = true;
 }

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -69,6 +69,8 @@ struct VulkanSwapChain : public HwSwapChain, VulkanResource {
     }
 
 private:
+	static constexpr int IMAGE_READY_SEMAPHORE_COUNT = FVK_MAX_COMMAND_BUFFERS;
+
     void update();
 
     VulkanPlatform* mPlatform;
@@ -83,7 +85,8 @@ private:
     utils::FixedCapacityVector<std::unique_ptr<VulkanTexture>> mColors;
     std::unique_ptr<VulkanTexture> mDepth;
     VkExtent2D mExtent;
-    VkSemaphore mImageReady;
+    VkSemaphore mImageReady[IMAGE_READY_SEMAPHORE_COUNT];
+	uint32_t mCurrentImageReadyIndex;
     uint32_t mCurrentSwapIndex;
     bool mAcquired;
     bool mIsFirstRenderPass;


### PR DESCRIPTION
The validation error triggers even on **hellotriangle** using AMD (desktop), QCOM (mobile) and Mali (mobile) GPUs.

Prior to this PR, only a single semaphore object was used to synchronize all the calls to **vkAcquireNextImage** (signal) and **vkQueueSubmit** (wait).
The issue is that by the time **vkQueueSubmit** returns, the semaphore is not necessarily reset.
When multiple frames are in flight, calls to **vkAcquireNextImage** might try to reuse the semaphore while it is still in the **wait** status, because the semaphore is reset at a driver/hardware-dependent timing that's likely linked to the GPU queue execution.

The solution proposed by this PR is to use a pool of semaphores big enough to cover all queue submissions even if they were run concurrently.
