### PR TITLE
Add support for protected contexts

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - Add new API `SwapChain::getFrameScheduledCallback`
 - vulkan: fixed validation error VUID-vkAcquireNextImageKHR-semaphore-01779
+- opengl: Add support for protected content swapchains and contexts

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -22,7 +22,9 @@
 #include <backend/Platform.h>
 
 #include <utils/compiler.h>
+#include <utils/Invocable.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace filament::backend {
@@ -138,6 +140,26 @@ public:
     virtual void makeCurrent(
             SwapChain* UTILS_NONNULL drawSwapChain,
             SwapChain* UTILS_NONNULL readSwapChain) noexcept = 0;
+
+    /**
+     * Called by the driver to make the OpenGL context active on the calling thread and bind
+     * the drawSwapChain to the default render target (FBO) created with createDefaultRenderTarget.
+     * The context used is either the default context or the protected context. When a context
+     * change is necessary, the preContextChange and postContextChange callbacks are called,
+     * before and after the context change respectively. postContextChange is given the index
+     * of the new context (0 for default and 1 for protected).
+     * The default implementation just calls makeCurrent(SwapChain*, SwapChain*).
+     *
+     * @param drawSwapChain SwapChain to draw to. It must be bound to the default FBO.
+     * @param readSwapChain SwapChain to read from (for operation like `glBlitFramebuffer`)
+     * @param preContextChange called before the context changes
+     * @param postContextChange called after the context changes
+     */
+    virtual void makeCurrent(
+            SwapChain* UTILS_NONNULL drawSwapChain,
+            SwapChain* UTILS_NONNULL readSwapChain,
+            utils::Invocable<void()> preContextChange,
+            utils::Invocable<void(size_t index)> postContextChange) noexcept;
 
     /**
      * Called by the driver once the current frame finishes drawing. Typically, this should present

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -523,8 +523,13 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
     rp->gl.vertexBufferWithObjects = vbh;
     rp->type = pt;
 
-    gl.procs.genVertexArrays(1, &rp->gl.vao);
+    // create a name for this VAO in the current context
+    gl.procs.genVertexArrays(1, &rp->gl.vao[gl.contextIndex]);
 
+    // this implies our name is up-to-date
+    rp->gl.nameVersion = gl.state.age;
+
+    // binding the VAO will actually create it
     gl.bindVertexArray(&rp->gl);
 
     // Note: we don't update the vertex buffer bindings in the VAO just yet, we will do that
@@ -864,22 +869,20 @@ void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
 }
 
 void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer const* vb) {
+    // NOTE: this is called from draw() and must be as efficient as possible.
 
     auto& gl = mContext;
 
-    // NOTE: this is called from draw() and must be as efficient as possible.
-
     if (UTILS_LIKELY(gl.ext.OES_vertex_array_object)) {
         // The VAO for the given render primitive must already be bound.
-#ifndef NDEBUG
         GLint vaoBinding;
         glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vaoBinding);
-        assert_invariant(vaoBinding == (GLint)rp->gl.vao);
-#endif
-        rp->gl.vertexBufferVersion = vb->bufferObjectsVersion;
-    } else {
-        // if we don't have OES_vertex_array_object, we never update the buffer version so
-        // that it's always reset in draw
+        assert_invariant(vaoBinding == (GLint)rp->gl.vao[gl.contextIndex]);
+    }
+
+    if (UTILS_LIKELY(rp->gl.vertexBufferVersion == vb->bufferObjectsVersion &&
+                     rp->gl.stateVersion == gl.state.age)) {
+        return;
     }
 
     GLVertexBufferInfo const* const vbi = handle_cast<const GLVertexBufferInfo*>(vb->vbih);
@@ -914,7 +917,7 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
                 glVertexAttribPointer(index, size, type, normalized, stride, pointer);
             }
 
-            gl.enableVertexAttribArray(GLuint(i));
+            gl.enableVertexAttribArray(&rp->gl, GLuint(i));
         } else {
             // In some OpenGL implementations, we must supply a properly-typed placeholder for
             // every integer input that is declared in the vertex shader.
@@ -937,8 +940,16 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
                 glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);
             }
 
-            gl.disableVertexAttribArray(GLuint(i));
+            gl.disableVertexAttribArray(&rp->gl, GLuint(i));
         }
+    }
+
+    rp->gl.stateVersion = gl.state.age;
+    if (UTILS_LIKELY(gl.ext.OES_vertex_array_object)) {
+        rp->gl.vertexBufferVersion = vb->bufferObjectsVersion;
+    } else {
+        // if we don't have OES_vertex_array_object, we never update the buffer version so
+        // that it's always reset in draw
     }
 }
 
@@ -1484,7 +1495,20 @@ void OpenGLDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     if (rph) {
         auto& gl = mContext;
         GLRenderPrimitive const* rp = handle_cast<const GLRenderPrimitive*>(rph);
-        gl.deleteVertexArrays(1, &rp->gl.vao);
+        gl.deleteVertexArray(rp->gl.vao[gl.contextIndex]);
+
+        // If we have a name in the "other" context, we need to schedule the destroy for
+        // later, because it can't be done here. VAOs are "container objects" and are not
+        // shared between contexts.
+        size_t const otherContextIndex = 1 - gl.contextIndex;
+        GLuint const nameInOtherContext = rp->gl.vao[otherContextIndex];
+        if (UTILS_UNLIKELY(nameInOtherContext)) {
+            gl.destroyWithContext(otherContextIndex,
+                    [name = nameInOtherContext](OpenGLContext& gl) {
+                gl.deleteVertexArray(name);
+            });
+        }
+
         destruct(rph, rp);
     }
 }
@@ -2033,7 +2057,18 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 
     GLSwapChain* scDraw = handle_cast<GLSwapChain*>(schDraw);
     GLSwapChain* scRead = handle_cast<GLSwapChain*>(schRead);
-    mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain);
+
+    mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain,
+            [this]() {
+                // OpenGL context is about to change, unbind everything
+                mContext.unbindEverything();
+            },
+            [this](size_t index) {
+                // OpenGL context has changed, resynchronize the state with the cache
+                mContext.synchronizeStateAndCache(index);
+                slog.d << "*** OpenGL context change : " << (index ? "protected" : "default") << io::endl;
+            });
+
     mCurrentDrawSwapChain = scDraw;
 
     // From the GL spec for glViewport and glScissor:
@@ -3776,9 +3811,7 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,
 
     // If necessary, mutate the bindings in the VAO.
     GLVertexBuffer const* const glvb = handle_cast<GLVertexBuffer*>(vb);
-    if (UTILS_UNLIKELY(rp->gl.vertexBufferVersion != glvb->bufferObjectsVersion)) {
-        updateVertexArrayObject(rp, glvb);
-    }
+    updateVertexArrayObject(rp, glvb);
 
     setRasterState(state.rasterState);
     setStencilState(state.stencilState);

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -24,7 +24,10 @@
 
 #include <utils/compiler.h>
 
+#include <utils/Invocable.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 namespace filament::backend {
 
@@ -34,6 +37,11 @@ Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform,
 }
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
+
+void OpenGLPlatform::makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain,
+        utils::Invocable<void()>, utils::Invocable<void(size_t)>) noexcept {
+    makeCurrent(drawSwapChain, readSwapChain);
+}
 
 bool OpenGLPlatform::isProtectedContextSupported() const noexcept {
     return false;

--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -32,6 +32,7 @@
 #include <utils/compiler.h>
 
 #include <utils/debug.h>
+#include <utils/Invocable.h>
 #include <utils/Log.h>
 #include <utils/ostream.h>
 
@@ -281,7 +282,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext, const Platform::DriverCon
         }
     }
 
-    if (UTILS_UNLIKELY(!makeCurrent(mEGLDummySurface, mEGLDummySurface))) {
+    if (UTILS_UNLIKELY(makeCurrent(mEGLContext, mEGLDummySurface, mEGLDummySurface) == EGL_FALSE)) {
         // eglMakeCurrent failed
         logEglError("eglMakeCurrent");
         goto error;
@@ -305,9 +306,13 @@ error:
     if (mEGLContext) {
         eglDestroyContext(mEGLDisplay, mEGLContext);
     }
+    if (mEGLContextProtected) {
+        eglDestroyContext(mEGLDisplay, mEGLContextProtected);
+    }
 
     mEGLDummySurface = EGL_NO_SURFACE;
     mEGLContext = EGL_NO_CONTEXT;
+    mEGLContextProtected = EGL_NO_CONTEXT;
 
     eglTerminate(mEGLDisplay);
     eglReleaseThread();
@@ -358,10 +363,21 @@ void PlatformEGL::releaseContext() noexcept {
 }
 
 EGLBoolean PlatformEGL::makeCurrent(EGLSurface drawSurface, EGLSurface readSurface) noexcept {
-    if (UTILS_UNLIKELY((drawSurface != mCurrentDrawSurface || readSurface != mCurrentReadSurface))) {
-        mCurrentDrawSurface = drawSurface;
-        mCurrentReadSurface = readSurface;
-        return eglMakeCurrent(mEGLDisplay, drawSurface, readSurface, mEGLContext);
+    return makeCurrent(mCurrentContext, drawSurface, readSurface);
+}
+
+EGLBoolean PlatformEGL::makeCurrent(EGLContext context,
+        EGLSurface drawSurface, EGLSurface readSurface) noexcept {
+    if (UTILS_UNLIKELY((mCurrentContext != context ||
+            drawSurface != mCurrentDrawSurface || readSurface != mCurrentReadSurface))) {
+        EGLBoolean const success = eglMakeCurrent(
+                mEGLDisplay, drawSurface, readSurface, context);
+        if (success) {
+            mCurrentDrawSurface = drawSurface;
+            mCurrentReadSurface = readSurface;
+            mCurrentContext = context;
+        }
+        return success;
     }
     return EGL_TRUE;
 }
@@ -373,6 +389,9 @@ void PlatformEGL::terminate() noexcept {
         eglDestroySurface(mEGLDisplay, mEGLDummySurface);
     }
     eglDestroyContext(mEGLDisplay, mEGLContext);
+    if (mEGLContextProtected != EGL_NO_CONTEXT) {
+        eglDestroyContext(mEGLDisplay, mEGLContextProtected);
+    }
     for (auto context : mAdditionalContexts) {
         eglDestroyContext(mEGLDisplay, context);
     }
@@ -447,6 +466,14 @@ EGLConfig PlatformEGL::findSwapChainConfig(uint64_t flags, bool window, bool pbu
 
 bool PlatformEGL::isSRGBSwapChainSupported() const noexcept {
     return ext.egl.KHR_gl_colorspace;
+}
+
+bool PlatformEGL::isSwapChainProtected(Platform::SwapChain const* swapChain) noexcept {
+    if (swapChain) {
+        SwapChainEGL const* const sc = static_cast<SwapChainEGL const*>(swapChain);
+        return bool(sc->flags & SWAP_CHAIN_CONFIG_PROTECTED_CONTENT);
+    }
+    return false;
 }
 
 Platform::SwapChain* PlatformEGL::createSwapChain(
@@ -556,7 +583,7 @@ void PlatformEGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
     if (swapChain) {
         SwapChainEGL const* const sc = static_cast<SwapChainEGL const*>(swapChain);
         if (sc->sur != EGL_NO_SURFACE) {
-            makeCurrent(mEGLDummySurface, mEGLDummySurface);
+            makeCurrent(mCurrentContext, mEGLDummySurface, mEGLDummySurface);
             eglDestroySurface(mEGLDisplay, sc->sur);
             delete sc;
         }
@@ -564,13 +591,68 @@ void PlatformEGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
 }
 
 void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
-                              Platform::SwapChain* readSwapChain) noexcept {
+        Platform::SwapChain* readSwapChain) noexcept {
     SwapChainEGL const* const dsc = static_cast<SwapChainEGL const*>(drawSwapChain);
     SwapChainEGL const* const rsc = static_cast<SwapChainEGL const*>(readSwapChain);
-    if (UTILS_UNLIKELY(dsc->sur == EGL_NO_SURFACE && rsc->sur == EGL_NO_SURFACE)) {
-        return;
+    makeCurrent(mEGLContext, dsc->sur, rsc->sur);
+}
+
+void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
+        Platform::SwapChain* readSwapChain,
+        utils::Invocable<void()> preContextChange,
+        utils::Invocable<void(size_t index)> postContextChange) noexcept {
+    SwapChainEGL const* const dsc = static_cast<SwapChainEGL const*>(drawSwapChain);
+    SwapChainEGL const* const rsc = static_cast<SwapChainEGL const*>(readSwapChain);
+    EGLContext context = mEGLContext;
+    if (ext.egl.EXT_protected_content) {
+        bool const swapChainProtected = PlatformEGL::isSwapChainProtected(dsc);
+        if (UTILS_UNLIKELY(swapChainProtected)) {
+            // we need a protected context
+            if (UTILS_UNLIKELY(mEGLContextProtected == EGL_NO_CONTEXT)) {
+                // we don't have one, create it!
+                EGLConfig config = ext.egl.KHR_no_config_context ? EGL_NO_CONFIG_KHR : mEGLConfig;
+                Config protectedContextAttribs{ mContextAttribs };
+                protectedContextAttribs[EGL_PROTECTED_CONTENT_EXT] = EGL_TRUE;
+                mEGLContextProtected = eglCreateContext(mEGLDisplay, config, mEGLContext,
+                        protectedContextAttribs.data());
+                if (UTILS_UNLIKELY(mEGLContextProtected == EGL_NO_CONTEXT)) {
+                    // couldn't create the protected context
+                    logEglError("eglCreateContext[EGL_PROTECTED_CONTENT_EXT]");
+                    ext.egl.EXT_protected_content = false;
+                    goto error;
+                }
+            }
+            context = mEGLContextProtected;
+            error: ;
+        }
+
+        bool const contextChange = context != mCurrentContext;
+        if (UTILS_UNLIKELY(contextChange)) {
+            preContextChange();
+            EGLBoolean const success = makeCurrent(context, dsc->sur, rsc->sur);
+            if (UTILS_UNLIKELY(!success)) {
+                logEglError("PlatformEGL::makeCurrent");
+                if (mEGLContextProtected != EGL_NO_CONTEXT) {
+                    eglDestroyContext(mEGLDisplay, mEGLContextProtected);
+                    mEGLContextProtected = EGL_NO_CONTEXT;
+                }
+                context = mEGLContext;
+            }
+            if (UTILS_LIKELY(!swapChainProtected && mEGLContextProtected != EGL_NO_CONTEXT)) {
+                // We don't need the protected context anymore, unbind and destroy right away.
+                eglDestroyContext(mEGLDisplay, mEGLContextProtected);
+                mEGLContextProtected = EGL_NO_CONTEXT;
+            }
+            size_t const contextIndex = (context == mEGLContext) ? 0 : 1;
+            postContextChange(contextIndex);
+            return;
+        }
     }
-    makeCurrent(dsc->sur, rsc->sur);
+
+    EGLBoolean const success = makeCurrent(context, dsc->sur, rsc->sur);
+    if (UTILS_UNLIKELY(!success)) {
+        logEglError("PlatformEGL::makeCurrent");
+    }
 }
 
 void PlatformEGL::commit(Platform::SwapChain* swapChain) noexcept {


### PR DESCRIPTION
Protected contexts are now supported by the OpenGLPlatform interface and implemented in EGLPlatform.

Protected contexts can read from regular and protected resources but can only write to protected resources (e.g. protected swap chains or textures backed by protected memory. These can be created on Android via AHardwareBuffer and EGLImage for instance).

The underlaying EGL implementation must support protected contexts.

Switching to a protected context is achieved by using a protected-content SwapChain in Renderer::beginFrame(). A protected-content SwapChain can be created using the new CONFIG_PROTECTED_CONTENT flag at creation time.

The OpenGL backend implementation will then use a protected context for rendering until an unprotected SwapChain is used again.

The crux of this implementation is to use different VAOs in the different contexts, because those can't be shared between contexts. We also need to synchronize the state with our state cache and ensure VAOs objects are destructed properly in the right context.