### PR TITLE
simplify the ResourceAllocator cache eviction strategy

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -400,16 +400,14 @@ public class Engine {
         public long stereoscopicEyeCount = 2;
 
         /*
-         * Size in MiB of the frame graph texture cache. This should be adjusted based on the
-         * size of used render targets (typically the screen).
+         * @Deprecated This value is no longer used.
          */
         public long resourceAllocatorCacheSizeMB = 64;
 
         /*
          * This value determines for how many frames are texture entries kept in the cache.
-         * The default value of 30 corresponds to about half a second at 60 fps.
          */
-        public long resourceAllocatorCacheMaxAge = 30;
+        public long resourceAllocatorCacheMaxAge = 2;
     }
 
     private Engine(long nativeEngine, Config config) {

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -327,16 +327,14 @@ public:
         uint8_t stereoscopicEyeCount = 2;
 
         /*
-         * Size in MiB of the frame graph texture cache. This should be adjusted based on the
-         * size of used render targets (typically the screen).
+         * @deprecated This value is no longer used.
          */
         uint32_t resourceAllocatorCacheSizeMB = 64;
 
         /*
          * This value determines for how many frames are texture entries kept in the cache.
-         * The default value of 30 corresponds to about half a second at 60 fps.
          */
-        uint32_t resourceAllocatorCacheMaxAge = 30;
+        uint32_t resourceAllocatorCacheMaxAge = 2;
     };
 
 

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -94,7 +94,6 @@ public:
     void gc() noexcept;
 
 private:
-    size_t const mCacheCapacity;
     size_t const mCacheMaxAge;
 
     struct TextureKey {
@@ -194,7 +193,7 @@ private:
     using CacheContainer = AssociativeContainer<TextureKey, TextureCachePayload>;
     using InUseContainer = AssociativeContainer<backend::TextureHandle, TextureKey>;
 
-    CacheContainer::iterator purge(CacheContainer::iterator const& pos);
+    void purge(ResourceAllocator::CacheContainer::iterator const& pos);
 
     backend::DriverApi& mBackend;
     CacheContainer mTextureCache;


### PR DESCRIPTION
Previously the cache would try to keep its size below a user-settable value. This was not effective because when that value was too small, it would cause a lot of churn every frame without actually keeping the memory usage below the specified value.

We now evict buffer aggressively after they've not been used (for two frames by default), but we don't cap the size of the cache. The cache will naturally settle at the size it needs. When dynamic resolution is used, it might be needed to increase resources  maximum age, which is a user-settable value still.

This improves performance on mobile on many scenes because the 64MB default value was too low, causing the crash to thrash.