### PR TITLE
Add new parameter -P for matc

### DIFF
--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -74,6 +74,11 @@ static void usage(char* name) {
             "       Unlike --define, this applies to the material specification, not GLSL.\n"
             "       Can be repeated to specify multiple macros:\n"
             "           MATC -TBLENDING=fade -TDOUBLESIDED=false ...\n\n"
+            "   --material-parameter <key>=<value>, -P<key>=<value>\n"
+            "       Set the material property pointed to by <key> to <value>\n"
+            "       This overwrites the value configured in the material file.\n"
+            "       Material property of array type is not supported.\n"
+            "           MATC -PflipUV=false -PshadingModel=lit -Pname=myMat ...\n\n"
             "   --reflect, -r\n"
             "       Reflect the specified metadata as JSON: parameters\n\n"
             "   --variant-filter=<filter>, -V <filter>\n"
@@ -174,7 +179,7 @@ static void parseDefine(std::string defineString, Config::StringReplacementMap& 
 }
 
 bool CommandlineConfig::parse() {
-    static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:OSEr:vV:gtwF1";
+    static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:P:OSEr:vV:gtwF1";
     static const struct option OPTIONS[] = {
             { "help",                    no_argument, nullptr, 'h' },
             { "license",                 no_argument, nullptr, 'L' },
@@ -193,6 +198,7 @@ bool CommandlineConfig::parse() {
             { "no-essl1",                no_argument, nullptr, '1' },
             { "define",            required_argument, nullptr, 'D' },
             { "template",          required_argument, nullptr, 'T' },
+            { "material-parameter",required_argument, nullptr, 'P' },
             { "reflect",           required_argument, nullptr, 'r' },
             { "print",                   no_argument, nullptr, 't' },
             { "version",                 no_argument, nullptr, 'v' },
@@ -282,6 +288,9 @@ bool CommandlineConfig::parse() {
                 break;
             case 'T':
                 parseDefine(arg, mTemplateMap);
+                break;
+            case 'P':
+                parseDefine(arg, mMaterialParameters);
                 break;
             case 'v':
                 // Similar to --help, the --version command does an early exit in order to avoid

--- a/tools/matc/src/matc/Config.h
+++ b/tools/matc/src/matc/Config.h
@@ -41,7 +41,7 @@ public:
     using TargetApi = filamat::MaterialBuilder::TargetApi;
     using Optimization = filamat::MaterialBuilder::Optimization;
 
-    // For defines and template args, we use an ordered map with a transparent comparator.
+    // For defines, template, and material parameters, we use an ordered map with a transparent comparator.
     // Even though the key is stored using std::string, this allows you to make lookups using
     // std::string_view. There is no need to construct a std::string object just to make a lookup.
     using StringReplacementMap = std::map<std::string, std::string, std::less<>>;
@@ -135,6 +135,10 @@ public:
         return mTemplateMap;
     }
 
+    const StringReplacementMap& getMaterialParameters() const noexcept {
+        return mMaterialParameters;
+    }
+
     filament::backend::FeatureLevel getFeatureLevel() const noexcept {
         return mFeatureLevel;
     }
@@ -153,6 +157,7 @@ protected:
     filament::backend::FeatureLevel mFeatureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
     StringReplacementMap mDefines;
     StringReplacementMap mTemplateMap;
+    StringReplacementMap mMaterialParameters;
     filament::UserVariantFilterMask mVariantFilter = 0;
     bool mIncludeEssl1 = true;
 };

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -626,7 +626,7 @@ bool MaterialCompiler::compileRawShader(const char* glsl, size_t size, bool isDe
 }
 
 bool MaterialCompiler::processMaterialParameters(filamat::MaterialBuilder& builder,
-    const Config& config) const {
+        const Config& config) const {
     ParametersProcessor parametersProcessor;
     bool ok = true;
     for (const auto& param : config.getMaterialParameters()) {

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -415,6 +415,11 @@ bool MaterialCompiler::run(const Config& config) {
         builder.shaderDefine(define.first.c_str(), define.second.c_str());
     }
 
+    if (!processMaterialParameters(builder, config)) {
+        std::cerr << "Error while processing material parameters." << std::endl;
+        return false;
+    }
+
     JobSystem js;
     js.adopt();
 
@@ -618,6 +623,16 @@ bool MaterialCompiler::compileRawShader(const char* glsl, size_t size, bool isDe
     output->close();
 
     return true;
+}
+
+bool MaterialCompiler::processMaterialParameters(filamat::MaterialBuilder& builder,
+    const Config& config) const {
+    ParametersProcessor parametersProcessor;
+    bool ok = true;
+    for (const auto& param : config.getMaterialParameters()) {
+        ok &= parametersProcessor.process(builder, param.first, param.second);
+    }
+    return ok;
 }
 
 } // namespace matc

--- a/tools/matc/src/matc/MaterialCompiler.h
+++ b/tools/matc/src/matc/MaterialCompiler.h
@@ -70,6 +70,8 @@ private:
     bool compileRawShader(const char* glsl, size_t size, bool isDebug, Config::Output* output,
                 const char* ext) const noexcept;
 
+    bool processMaterialParameters(filamat::MaterialBuilder& builder, const Config& config) const;
+
     // Member function pointer type, this is used to implement a Command design
     // pattern.
     using MaterialConfigProcessor = bool (MaterialCompiler::*)

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -1266,23 +1266,23 @@ bool ParametersProcessor::process(filamat::MaterialBuilder& builder, const std::
 
     std::unique_ptr<JsonishValue> var;
     switch (mParameters.at(key).rootAssert) {
-    case JsonishValue::Type::BOOL: {
-        std::string lower;
-        std::transform(value.begin(), value.end(), std::back_inserter(lower), ::tolower);
-        if (lower.empty() || lower == "false" || lower == "f" || lower == "0") {
-            var = std::make_unique<JsonishBool>(false);
+        case JsonishValue::Type::BOOL: {
+            std::string lower;
+            std::transform(value.begin(), value.end(), std::back_inserter(lower), ::tolower);
+            if (lower.empty() || lower == "false" || lower == "f" || lower == "0") {
+                var = std::make_unique<JsonishBool>(false);
+            }
+            else {
+                var = std::make_unique<JsonishBool>(true);
+            }
+            break;
         }
-        else {
-            var = std::make_unique<JsonishBool>(true);
-        }
-        break;
-    }
-    case JsonishValue::Type::NUMBER:
-        var = std::make_unique<JsonishNumber>(std::stof(value));
-        break;
-    case JsonishValue::Type::STRING:
-        var = std::make_unique<JsonishString>(value);
-        break;
+        case JsonishValue::Type::NUMBER:
+            var = std::make_unique<JsonishNumber>(std::stof(value));
+            break;
+        case JsonishValue::Type::STRING:
+            var = std::make_unique<JsonishString>(value);
+            break;
     }
 
     auto fPointer = mParameters[key].callback;

--- a/tools/matc/src/matc/ParametersProcessor.h
+++ b/tools/matc/src/matc/ParametersProcessor.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <variant>
 
 #include "JsonishLexeme.h"
 #include "JsonishParser.h"
@@ -33,6 +34,7 @@ public:
     ParametersProcessor();
     ~ParametersProcessor() = default;
     bool process(filamat::MaterialBuilder& builder, const JsonishObject& jsonObject);
+    bool process(filamat::MaterialBuilder& builder, const std::string& key, const std::string& value);
 
 private:
 


### PR DESCRIPTION
This new matc parameter `-P` or `--material-parameter` allows users to set material properties to the specified value.

Values passed through this matc parameters have the highest priorities. I.e., they overwrite material properties specified in the material file.