### PR TITLE
vk: clean up debug tools

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -435,7 +435,7 @@ void VulkanCommands::popGroupMarker() {
         auto const [marker, startTime] = mGroupMarkers->pop();
         auto const endTime = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> diff = endTime - startTime;
-        utils::slog.d << "<---- " << marker << " elapsed: " << (diff.count() * 1000) << " ms\n"
+        utils::slog.d << "<---- " << marker << " elapsed: " << (diff.count() * 1000) << " ms"
                       << utils::io::endl;
 #else
         mGroupMarkers->pop();

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -436,7 +436,7 @@ void VulkanCommands::popGroupMarker() {
         auto const endTime = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> diff = endTime - startTime;
         utils::slog.d << "<---- " << marker << " elapsed: " << (diff.count() * 1000) << " ms\n"
-                      << utils::io::flush;
+                      << utils::io::endl;
 #else
         mGroupMarkers->pop();
 #endif

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -63,11 +63,12 @@
 // Enable the debug utils extension if it is available.
 #define FVK_DEBUG_DEBUG_UTILS             0x00008000
 
+#define FVK_DEBUG_RESOURCE_LEAK           0x00010000
+
 // Usefaul default combinations
 #define FVK_DEBUG_EVERYTHING              0xFFFFFFFF
 #define FVK_DEBUG_PERFORMANCE     \
-    FVK_DEBUG_SYSTRACE |          \
-    FVK_DEBUG_GROUP_MARKERS
+    FVK_DEBUG_SYSTRACE
 
 #define FVK_DEBUG_CORRECTNESS     \
     FVK_DEBUG_VALIDATION |        \
@@ -80,14 +81,12 @@
     FVK_DEBUG_PRINT_GROUP_MARKERS
 
 #ifndef NDEBUG
-#define FVK_DEBUG_FLAGS (FVK_DEBUG_PERFORMANCE | FVK_DEBUG_DEBUG_UTILS | FVK_DEBUG_VALIDATION)
+#define FVK_DEBUG_FLAGS (FVK_DEBUG_PERFORMANCE)
 #else
 #define FVK_DEBUG_FLAGS 0
 #endif
 
-#define FVK_ENABLED(flags) ((FVK_DEBUG_FLAGS) & (flags))
-#define FVK_ENABLED_BOOL(flags) ((bool) FVK_ENABLED(flags))
-
+#define FVK_ENABLED(flags) (((FVK_DEBUG_FLAGS) & (flags)) == (flags))
 
 // Group marker only works only if validation or debug utils is enabled since it uses
 // vkCmd(Begin/End)DebugUtilsLabelEXT or vkCmdDebugMarker(Begin/End)EXT
@@ -106,6 +105,15 @@ static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 #endif
 
 // end dependcy checks
+
+// Shorthand for combination of enabled debug flags
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS) || FVK_ENABLED(FVK_DEBUG_TEXTURE)
+#define FVK_ENABLED_DEBUG_SAMPLER_NAME 1
+#else
+#define FVK_ENABLED_DEBUG_SAMPLER_NAME 0
+#endif
+
+// end shorthands
 
 #if FVK_ENABLED(FVK_DEBUG_SYSTRACE)
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -99,6 +99,10 @@ VulkanProgram::VulkanProgram(VkDevice device, Program const& builder) noexcept
 #endif
     }
 
+#if FVK_ENABLED_DEBUG_SAMPLER_NAME
+    auto& bindingToName = mInfo->bindingToName;
+#endif
+
     auto& groupInfo = builder.getSamplerGroupInfo();
     auto& bindingToSamplerIndex = mInfo->bindingToSamplerIndex;
     auto& usage = mInfo->usage;
@@ -109,12 +113,16 @@ VulkanProgram::VulkanProgram(VkDevice device, Program const& builder) noexcept
             uint32_t const binding = samplers[i].binding;
             bindingToSamplerIndex[binding] = (groupInd << 8) | (0xff & i);
             usage = VulkanPipelineCache::getUsageFlags(binding, group.stageFlags, usage);
+
+#if FVK_ENABLED_DEBUG_SAMPLER_NAME
+            bindingToName[binding] = samplers[i].name.c_str();
+#endif
         }
     }
 
 #if FVK_ENABLED(FVK_DEBUG_SHADER_MODULE)
-    utils::slog.d << "Created VulkanProgram " << builder << ", shaders = (" << bundle.vertex
-                  << ", " << bundle.fragment << ")" << utils::io::endl;
+    utils::slog.d << "Created VulkanProgram " << builder << ", shaders = (" << modules[0]
+                  << ", " << modules[1] << ")" << utils::io::endl;
 #endif
 }
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -64,6 +64,12 @@ struct VulkanProgram : public HwProgram, VulkanResource {
         return mInfo->bindingToSamplerIndex;
     }
 
+#if FVK_ENABLED_DEBUG_SAMPLER_NAME
+    inline utils::FixedCapacityVector<std::string> const& getBindingToName() const {
+        return mInfo->bindingToName;
+    }
+#endif
+
 private:
     // TODO: handle compute shaders.
     // The expected order of shaders - from frontend to backend - is vertex, fragment, compute.
@@ -80,6 +86,12 @@ private:
         // We store the samplerGroupIndex as the top 8-bit and the index within each group as the lower 8-bit.
         utils::FixedCapacityVector<uint16_t> bindingToSamplerIndex;
         VkShaderModule shaders[MAX_SHADER_MODULES] = { VK_NULL_HANDLE };
+
+#if FVK_ENABLED_DEBUG_SAMPLER_NAME
+        // We store the sampler name mapped from binding index (only for debug purposes).
+        utils::FixedCapacityVector<std::string> bindingToName;
+#endif
+
     };
 
     PipelineInfo* mInfo;

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -563,6 +563,14 @@ VulkanPipelineCache::PipelineLayoutCacheEntry* VulkanPipelineCache::getOrCreateP
 void VulkanPipelineCache::bindProgram(VulkanProgram* program) noexcept {
     mPipelineRequirements.shaders[0] = program->getVertexShader();
     mPipelineRequirements.shaders[1] = program->getFragmentShader();
+
+    // If this is a debug build, validate the current shader.
+#if FVK_ENABLED(FVK_DEBUG_SHADER_MODULE)
+    if (mPipelineRequirements.shaders[0] == VK_NULL_HANDLE ||
+            mPipelineRequirements.shaders[1] == VK_NULL_HANDLE) {
+        utils::slog.e << "Binding missing shader: " << program->name.c_str() << utils::io::endl;
+    }
+#endif
 }
 
 void VulkanPipelineCache::bindRasterState(const RasterState& rasterState) noexcept {

--- a/filament/backend/src/vulkan/VulkanResourceAllocator.h
+++ b/filament/backend/src/vulkan/VulkanResourceAllocator.h
@@ -17,6 +17,7 @@
 #ifndef TNT_FILAMENT_BACKEND_VULKANRESOURCEALLOCATOR_H
 #define TNT_FILAMENT_BACKEND_VULKANRESOURCEALLOCATOR_H
 
+#include "VulkanConstants.h"
 #include "VulkanHandles.h"
 
 #include <private/backend/HandleAllocator.h>
@@ -29,18 +30,17 @@
 
 namespace filament::backend {
 
-// RESOURCE_TYPE_COUNT matches the count of enum VulkanResourceType.
-#define RESOURCE_TYPE_COUNT 12
-#define DEBUG_RESOURCE_LEAKS 0
+#define RESOURCE_TYPE_COUNT (static_cast<int>(VulkanResourceType::END_TYPE))
+#define DEBUG_RESOURCE_LEAKS FVK_ENABLED(FVK_DEBUG_RESOURCE_LEAK)
 
 #if DEBUG_RESOURCE_LEAKS
-    #define TRACK_INCREMENT()                                       \
-    if (!IS_MANAGED_TYPE(obj->mType)) {                             \
-        mDebugOnlyResourceCount[static_cast<size_t>(obj->mType)]++; \
+    #define TRACK_INCREMENT()                                           \
+    if (!IS_HEAP_ALLOC_TYPE(obj->getType())) {                          \
+        mDebugOnlyResourceCount[static_cast<size_t>(obj->getType())]++; \
     }
-    #define TRACK_DECREMENT()                                       \
-    if (!IS_MANAGED_TYPE(obj->mType)) {                             \
-        mDebugOnlyResourceCount[static_cast<size_t>(obj->mType)]--; \
+    #define TRACK_DECREMENT()                                           \
+    if (!IS_HEAP_ALLOC_TYPE(obj->getType())) {                          \
+        mDebugOnlyResourceCount[static_cast<size_t>(obj->getType())]--; \
     }
 #else
     // No-op

--- a/filament/backend/src/vulkan/VulkanResources.cpp
+++ b/filament/backend/src/vulkan/VulkanResources.cpp
@@ -70,6 +70,7 @@ void deallocateResource(VulkanResourceAllocator* allocator, VulkanResourceType t
         // destruction.
         case VulkanResourceType::FENCE:
         case VulkanResourceType::HEAP_ALLOCATED:
+        case VulkanResourceType::END_TYPE:
             break;
     }
 }

--- a/filament/backend/src/vulkan/VulkanResources.h
+++ b/filament/backend/src/vulkan/VulkanResources.h
@@ -51,6 +51,8 @@ enum class VulkanResourceType : uint8_t {
     // Below are resources that are managed manually (i.e. not ref counted).
     FENCE,
     HEAP_ALLOCATED,
+
+    END_TYPE,  // A placeholder
 };
 
 #define IS_HEAP_ALLOC_TYPE(f)                                                                      \

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -159,7 +159,7 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
     imageInfo.samples = (VkSampleCountFlagBits) samples;
 
     VkResult error = vkCreateImage(mDevice, &imageInfo, VKALLOC, &mTextureImage);
-    if (error || FVK_ENABLED_BOOL(FVK_DEBUG_TEXTURE)) {
+    if (error || FVK_ENABLED(FVK_DEBUG_TEXTURE)) {
         utils::slog.d << "vkCreateImage: "
             << "image = " << mTextureImage << ", "
             << "result = " << error << ", "


### PR DESCRIPTION
 - Fix broken resource leak print out.
 - Add sampler name to debugUtils when enabled