### PR TITLE
IBLs were mirrored when using IBLPrefilter

### DIFF
--- a/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
+++ b/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
@@ -88,11 +88,22 @@ public:
      */
     class EquirectangularToCubemap {
     public:
+
+        struct Config {
+            bool mirror = true;  //!< mirror the source horizontally
+        };
+
         /**
-         * Creates a EquirectangularToCubemap processor.
+         * Creates a EquirectangularToCubemap processor using the default Config
          * @param context IBLPrefilterContext to use
          */
         explicit EquirectangularToCubemap(IBLPrefilterContext& context);
+
+        /**
+         * Creates a EquirectangularToCubemap processor using the provided Config
+         * @param context IBLPrefilterContext to use
+         */
+       EquirectangularToCubemap(IBLPrefilterContext& context, Config const& config);
 
         /**
          * Destroys all GPU resources created during initialization.
@@ -125,6 +136,7 @@ public:
     private:
         IBLPrefilterContext& mContext;
         filament::Material* mEquirectMaterial = nullptr;
+        Config mConfig{};
     };
 
     /**

--- a/libs/iblprefilter/src/materials/equirectToCube.mat
+++ b/libs/iblprefilter/src/materials/equirectToCube.mat
@@ -10,6 +10,11 @@ material {
             type : float,
             name : side,
             precision: medium
+        },
+        {
+            type : float,
+            name : mirror,
+            precision: medium
         }
     ],
     outputs : [
@@ -51,7 +56,7 @@ highp vec2 toEquirect(const highp vec3 s) {
     highp float xf = atan(s.x, s.z) * (1.0 / PI);   // range [-1.0, 1.0]
     highp float yf = asin(s.y) * (2.0 / PI);        // range [-1.0, 1.0]
     xf = (xf + 1.0) * 0.5;                          // range [0, 1.0]
-    yf = (1.0 - yf) * 0.5;                          // range [0, 1.0]
+    yf = (yf + 1.0) * 0.5;                          // range [0, 1.0]
     return vec2(xf, yf);
 }
 
@@ -62,18 +67,16 @@ mediump vec3 sampleEquirect(mediump sampler2D equirect, const highp vec3 r) {
 
 void postProcess(inout PostProcessInputs postProcess) {
     highp vec2 uv = variable_vertex.xy; // interpolated at pixel's center
-    highp vec2 p = vec2(
-        uv.x * 2.0 - 1.0,
-        1.0 - uv.y * 2.0);
+    highp vec2 p = uv * 2.0 - 1.0;
 
     float side = materialParams.side;
+    float mirror = materialParams.mirror;
     highp float l = inversesqrt(p.x * p.x + p.y * p.y + 1.0);
 
     // compute the view (and normal, since v = n) direction for each face
-    highp vec3 rx = vec3(      side,  p.y,  side * -p.x);
-    highp vec3 ry = vec3(       p.x,  side, side * -p.y);
-    highp vec3 rz = vec3(side * p.x,  p.y,  side);
-
+    highp vec3 rx = vec3(      side * mirror,  p.y,  side * -p.x);
+    highp vec3 ry = vec3(       p.x * mirror,  side, side * -p.y);
+    highp vec3 rz = vec3(side * p.x * mirror,  p.y,  side);
 
     postProcess.outx = sampleEquirect(materialParams_equirect, rx * l);
     postProcess.outy = sampleEquirect(materialParams_equirect, ry * l);

--- a/libs/iblprefilter/src/materials/iblprefilter.mat
+++ b/libs/iblprefilter/src/materials/iblprefilter.mat
@@ -122,9 +122,10 @@ void postProcess(inout PostProcessInputs postProcess) {
     float side = materialParams.side;
 
     // compute the view (and normal, since v = n) direction for each face
-    vec3 rx = normalize(vec3(      side,  -p.y, side * -p.x));
-    vec3 ry = normalize(vec3(       p.x,  side, side *  p.y));
-    vec3 rz = normalize(vec3(side * p.x,  -p.y, side));
+    float l = inversesqrt(p.x * p.x + p.y * p.y + 1.0);
+    vec3 rx = vec3(      side,  p.y,  side * -p.x) * l;
+    vec3 ry = vec3(       p.x,  side, side * -p.y) * l;
+    vec3 rz = vec3(side * p.x,  p.y,  side)        * l;
 
     // random rotation around r
     mediump float a = 2.0 * PI * random(gl_FragCoord.xy);


### PR DESCRIPTION
cmgen mirrors environment maps by default so that the reflection map appears un-mirrored. IBLPrefilter didn't do that. 

EquirectangularToCubemap now takes a Config parameter that allows to specify the mirroring, which is enabled by default.


FIXES=[320856413]