### PR TITLE
Metal: change shader compilation pool size to 1

### DIFF
--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -77,7 +77,7 @@ MetalShaderCompiler::MetalShaderCompiler(id<MTLDevice> device, MetalDriver& driv
 }
 
 void MetalShaderCompiler::init() noexcept {
-    const uint32_t poolSize = 2;
+    const uint32_t poolSize = 1;
     mCompilerThreadPool.init(poolSize, []() {}, []() {});
 }
 


### PR DESCRIPTION
Metal appears to serialize all shader compilation requests anyway, so we only need a single background thread.