### PR TITLE
Add multiview filamat for default materials

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -256,6 +256,11 @@ set(MATERIAL_FL0_SRCS
         src/materials/skybox.mat
 )
 
+set(MATERIAL_MULTIVIEW_SRCS
+        src/materials/defaultMaterial.mat
+        src/materials/skybox.mat
+)
+
 # Embed the binary resource blob for materials.
 get_resgen_vars(${RESOURCE_DIR} materials)
 list(APPEND PRIVATE_HDRS ${RESGEN_HEADER})
@@ -315,30 +320,41 @@ foreach (mat_src ${MATERIAL_SRCS})
     get_filename_component(localname "${mat_src}" NAME_WE)
     get_filename_component(fullname "${mat_src}" ABSOLUTE)
     set(output_path "${MATERIAL_DIR}/${localname}.filamat")
+    add_custom_command(
+            OUTPUT ${output_path}
+            COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${fullname}
+            MAIN_DEPENDENCY ${fullname}
+            DEPENDS matc
+            COMMENT "Compiling material ${fullname} to ${output_path}"
+    )
+    list(APPEND MATERIAL_BINS ${output_path})
 
     list(FIND MATERIAL_FL0_SRCS ${mat_src} index)
     if (${index} GREATER -1 AND FILAMENT_ENABLE_FEATURE_LEVEL_0)
-        string(REGEX REPLACE "[.]filamat$" "0.filamat" output_path0 ${output_path})
+        string(REGEX REPLACE "[.]filamat$" "_fl0.filamat" output_path_fl0 ${output_path})
         add_custom_command(
-                OUTPUT ${output_path} ${output_path0}
-                COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${fullname}
-                COMMAND matc ${MATC_BASE_FLAGS} -PfeatureLevel=0 -o ${output_path0} ${fullname}
+                OUTPUT ${output_path_fl0}
+                COMMAND matc ${MATC_BASE_FLAGS} -PfeatureLevel=0 -o ${output_path_fl0} ${fullname}
                 MAIN_DEPENDENCY ${fullname}
                 DEPENDS matc
-                COMMENT "Compiling material ${fullname} to ${output_path} and ${output_path0}"
+                COMMENT "Compiling material ${fullname} to ${output_path_fl0}"
         )
-        list(APPEND MATERIAL_BINS ${output_path0})
-    else ()
-        add_custom_command(
-                OUTPUT ${output_path}
-                COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${fullname}
-                MAIN_DEPENDENCY ${fullname}
-                DEPENDS matc
-                COMMENT "Compiling material ${fullname} to ${output_path}"
-        )
+        list(APPEND MATERIAL_BINS ${output_path_fl0})
     endif ()
 
-    list(APPEND MATERIAL_BINS ${output_path})
+    list(FIND MATERIAL_MULTIVIEW_SRCS ${mat_src} index)
+    if (${index} GREATER -1)
+        string(REGEX REPLACE "[.]filamat$" "_multiview.filamat" output_path_multiview ${output_path})
+        add_custom_command(
+                OUTPUT ${output_path_multiview}
+                COMMAND matc ${MATC_BASE_FLAGS} -PstereoscopicType=multiview -o ${output_path_multiview} ${fullname}
+                MAIN_DEPENDENCY ${fullname}
+                DEPENDS matc
+                COMMENT "Compiling material ${fullname} to ${output_path_multiview}"
+        )
+        list(APPEND MATERIAL_BINS ${output_path_multiview})
+    endif ()
+
 endforeach()
 
 # Additional dependencies on included files for materials

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -339,7 +339,7 @@ void FEngine::init() {
     if (UTILS_UNLIKELY(mActiveFeatureLevel == FeatureLevel::FEATURE_LEVEL_0)) {
         FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
         defaultMaterialBuilder.package(
-                MATERIALS_DEFAULTMATERIAL0_DATA, MATERIALS_DEFAULTMATERIAL0_SIZE);
+                MATERIALS_DEFAULTMATERIAL_FL0_DATA, MATERIALS_DEFAULTMATERIAL_FL0_SIZE);
         mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
     } else
 #endif
@@ -347,8 +347,16 @@ void FEngine::init() {
         mDefaultColorGrading = downcast(ColorGrading::Builder().build(*this));
 
         FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
-        defaultMaterialBuilder.package(
-                MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
+        switch (mConfig.stereoscopicType) {
+            case StereoscopicType::INSTANCED:
+                defaultMaterialBuilder.package(
+                    MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
+                break;
+            case StereoscopicType::MULTIVIEW:
+                defaultMaterialBuilder.package(
+                    MATERIALS_DEFAULTMATERIAL_MULTIVIEW_DATA, MATERIALS_DEFAULTMATERIAL_MULTIVIEW_SIZE);
+                break;
+        }
         mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
 
         float3 dummyPositions[1] = {};

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -120,11 +120,18 @@ FMaterial const* FSkybox::createMaterial(FEngine& engine) {
     Material::Builder builder;
 #ifdef FILAMENT_ENABLE_FEATURE_LEVEL_0
     if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == Engine::FeatureLevel::FEATURE_LEVEL_0)) {
-        builder.package(MATERIALS_SKYBOX0_DATA, MATERIALS_SKYBOX0_SIZE);
+        builder.package(MATERIALS_SKYBOX_FL0_DATA, MATERIALS_SKYBOX_FL0_SIZE);
     } else
 #endif
     {
-        builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
+        switch (engine.getConfig().stereoscopicType) {
+            case Engine::StereoscopicType::INSTANCED:
+                builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
+                break;
+            case Engine::StereoscopicType::MULTIVIEW:
+                builder.package(MATERIALS_SKYBOX_MULTIVIEW_DATA, MATERIALS_SKYBOX_MULTIVIEW_SIZE);
+                break;
+        }
     }
     auto material = builder.build(engine);
     return downcast(material);

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -169,6 +169,7 @@ void GLSLPostProcessor::spirvToMsl(const SpirvBlob *spirv, std::string *outMsl,
     }
 
     mslOptions.argument_buffers = true;
+    mslOptions.ios_support_base_vertex_instance = true;
 
     // We're using argument buffers for texture resources, however, we cannot rely on spirv-cross to
     // generate the argument buffer definitions.

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -906,7 +906,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .domain = mMaterialDomain,
                         .materialInfo = &info,
                         .hasFramebufferFetch = mEnableFramebufferFetch,
-                        .usesClipDistance = v.variant.hasStereo(),
+                        .usesClipDistance = v.variant.hasStereo() && info.stereoscopicType == StereoscopicType::INSTANCED,
                         .glsl = {},
                 };
 

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -331,6 +331,7 @@ Material* createMaterial(Engine* engine, const MaterialKey& config, const UvMap&
            MaterialBuilder::TransparencyMode::DEFAULT)
            .reflectionMode(MaterialBuilder::ReflectionMode::SCREEN_SPACE)
            .targetApi(filamat::targetApiFromBackend(engine->getBackend()))
+           .stereoscopicType(engine->getConfig().stereoscopicType)
            .stereoscopicEyeCount(engine->getConfig().stereoscopicEyeCount);
 
     if (!optimizeShaders) {


### PR DESCRIPTION
Add prebuilt materials for the engine default materials. They'll be selected for multiview stereoscopic implementation.