### PR TITLE
Add layerCount to createRenderTarget

### DIFF
--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -83,8 +83,8 @@ public:
     }
 
     // this is here for backward compatibility
-    MRT(Handle<HwTexture> handle, uint8_t layerCount, uint8_t level, uint16_t layer) noexcept
-            : mInfos{{ handle, layerCount, level, layer }} {
+    MRT(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
+            : mInfos{{ handle, 0, level, layer }} {
     }
 };
 

--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -32,6 +32,10 @@ struct TargetBufferInfo {
     // texture to be used as render target
     Handle<HwTexture> handle;
 
+    // starting layer index for multiview. This value is only used when the `layerCount` for the
+    // render target is greater than 1.
+    uint8_t baseViewIndex = 0;
+
     // level to be used
     uint8_t level = 0;
 
@@ -79,8 +83,8 @@ public:
     }
 
     // this is here for backward compatibility
-    MRT(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
-            : mInfos{{ handle, level, layer }} {
+    MRT(Handle<HwTexture> handle, uint8_t layerCount, uint8_t level, uint16_t layer) noexcept
+            : mInfos{{ handle, layerCount, level, layer }} {
     }
 };
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -239,6 +239,7 @@ DECL_DRIVER_API_R_N(backend::RenderTargetHandle, createRenderTarget,
         uint32_t, width,
         uint32_t, height,
         uint8_t, samples,
+        uint8_t, layerCount,
         backend::MRT, color,
         backend::TargetBufferInfo, depth,
         backend::TargetBufferInfo, stencil)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -376,7 +376,7 @@ void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int dum
 
 void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, MRT color,
+        uint8_t samples, uint8_t layerCount, MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
             "createRenderTarget must be called outside of a render pass.");

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1094,11 +1094,16 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
             case GL_TEXTURE_2D_ARRAY:
             case GL_TEXTURE_CUBE_MAP_ARRAY:
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+
+                // TODO: support multiview for iOS and WebGL
+#if !defined(__EMSCRIPTEN__) && !defined(IOS)
                 if (layerCount > 1) {
                     // if layerCount > 1, it means we use the multiview extension.
                     glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, attachment,
                         t->gl.id, 0, binfo.baseViewIndex, layerCount);
-                } else {
+                } else
+#endif // !defined(__EMSCRIPTEN__) && !defined(IOS)
+                {
                     // GL_TEXTURE_2D_MULTISAMPLE_ARRAY is not supported in GLES
                     glFramebufferTextureLayer(GL_FRAMEBUFFER, attachment,
                         t->gl.id, binfo.level, binfo.layer);

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -302,7 +302,7 @@ private:
     void updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer const* vb);
 
     void framebufferTexture(TargetBufferInfo const& binfo,
-            GLRenderTarget const* rt, GLenum attachment) noexcept;
+            GLRenderTarget const* rt, GLenum attachment, uint8_t layerCount) noexcept;
 
     void setRasterState(RasterState rs) noexcept;
 

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -67,12 +67,14 @@ PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
 #ifdef GL_KHR_parallel_shader_compile
 PFNGLMAXSHADERCOMPILERTHREADSKHRPROC glMaxShaderCompilerThreadsKHR;
 #endif
+#ifdef GL_OVR_multiview
+PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC glFramebufferTextureMultiviewOVR;
+#endif
 
 #if defined(__ANDROID__) && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
 // On Android, If we want to support a build system less than ANDROID_API 21, we need to
 // use getProcAddress for ES3.1 and above entry points.
 PFNGLDISPATCHCOMPUTEPROC glDispatchCompute;
-PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC glFramebufferTextureMultiviewOVR;
 #endif
 static std::once_flag sGlExtInitialized;
 #endif // __EMSCRIPTEN__
@@ -118,9 +120,11 @@ void importGLESExtensionsEntryPoints() {
 #ifdef GL_KHR_parallel_shader_compile
         getProcAddress(glMaxShaderCompilerThreadsKHR, "glMaxShaderCompilerThreadsKHR");
 #endif
+#ifdef GL_OVR_multiview
+        getProcAddress(glFramebufferTextureMultiviewOVR, "glFramebufferTextureMultiviewOVR");
+#endif
 #if defined(__ANDROID__) && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
         getProcAddress(glDispatchCompute, "glDispatchCompute");
-        getProcAddress(glFramebufferTextureMultiviewOVR, "glFramebufferTextureMultiviewOVR");
 #endif
     });
 #endif // __EMSCRIPTEN__

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -151,9 +151,11 @@ extern PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
 #ifdef GL_KHR_parallel_shader_compile
 extern PFNGLMAXSHADERCOMPILERTHREADSKHRPROC glMaxShaderCompilerThreadsKHR;
 #endif
+#ifdef GL_OVR_multiview
+extern PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC glFramebufferTextureMultiviewOVR;
+#endif
 #if defined(__ANDROID__) && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
 extern PFNGLDISPATCHCOMPUTEPROC glDispatchCompute;
-extern PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC glFramebufferTextureMultiviewOVR;
 #endif
 #endif // __EMSCRIPTEN__
 } // namespace glext

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -556,7 +556,7 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
-        MRT color, TargetBufferInfo depth, TargetBufferInfo stencil) {
+        uint8_t layerCount, MRT color, TargetBufferInfo depth, TargetBufferInfo stencil) {
     UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmin = {std::numeric_limits<uint32_t>::max()};
     UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmax = {0};
     UTILS_UNUSED_IN_RELEASE size_t attachmentCount = 0;

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -226,9 +226,9 @@ TEST_F(BackendTest, ColorMagnify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, 0 }, {}, {});
     }
 
     // Do a "magnify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -301,9 +301,9 @@ TEST_F(BackendTest, ColorMinify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, 0 }, {}, {});
     }
 
     // Do a "minify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -473,9 +473,9 @@ TEST_F(BackendTest, Blit2DTextureArray) {
     // Create two RenderTargets.
     const int level = 0;
     Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, kSrcTexLayer }, {}, {});
+            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, kSrcTexLayer }, {}, {});
     Handle<HwRenderTarget> dstRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, kDstTexLayer }, {}, {});
+            kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, kDstTexLayer }, {}, {});
 
     // Do a blit from kSrcTexLayer of the source RT to kDstTexLayer of the destination RT.
     const int srcLevel = 0;
@@ -565,10 +565,10 @@ TEST_F(BackendTest, BlitRegion) {
     // that this case is handled correctly.
     Handle<HwRenderTarget> srcRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, srcRect.width,
-                    srcRect.height, 1, 0, {srcTexture, kSrcLevel, 0}, {}, {});
+                    srcRect.height, 1, 0, {srcTexture, 0, kSrcLevel, 0}, {}, {});
     Handle<HwRenderTarget> dstRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, kDstTexWidth >> kDstLevel,
-                    kDstTexHeight >> kDstLevel, 1, 0, {dstTexture, kDstLevel, 0}, {}, {});
+                    kDstTexHeight >> kDstLevel, 1, 0, {dstTexture, 0, kDstLevel, 0}, {}, {});
 
     api.blitDEPRECATED(TargetBufferFlags::COLOR0, dstRenderTarget, dstRect, srcRenderTarget, srcRect,
             SamplerMagFilter::LINEAR);
@@ -637,7 +637,7 @@ TEST_F(BackendTest, BlitRegionToSwapChain) {
     Handle<HwRenderTarget> srcRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
     }
 
     // Blit one-quarter of src level 1 to dst level 0.

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -226,9 +226,9 @@ TEST_F(BackendTest, ColorMagnify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
     }
 
     // Do a "magnify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -301,9 +301,9 @@ TEST_F(BackendTest, ColorMinify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
     }
 
     // Do a "minify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -473,9 +473,9 @@ TEST_F(BackendTest, Blit2DTextureArray) {
     // Create two RenderTargets.
     const int level = 0;
     Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, kSrcTexLayer }, {}, {});
+            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, kSrcTexLayer }, {}, {});
     Handle<HwRenderTarget> dstRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, 0, level, kDstTexLayer }, {}, {});
+            kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, kDstTexLayer }, {}, {});
 
     // Do a blit from kSrcTexLayer of the source RT to kDstTexLayer of the destination RT.
     const int srcLevel = 0;
@@ -565,10 +565,10 @@ TEST_F(BackendTest, BlitRegion) {
     // that this case is handled correctly.
     Handle<HwRenderTarget> srcRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, srcRect.width,
-                    srcRect.height, 1, 0, {srcTexture, 0, kSrcLevel, 0}, {}, {});
+                    srcRect.height, 1, 0, {srcTexture, kSrcLevel, 0}, {}, {});
     Handle<HwRenderTarget> dstRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, kDstTexWidth >> kDstLevel,
-                    kDstTexHeight >> kDstLevel, 1, 0, {dstTexture, 0, kDstLevel, 0}, {}, {});
+                    kDstTexHeight >> kDstLevel, 1, 0, {dstTexture, kDstLevel, 0}, {}, {});
 
     api.blitDEPRECATED(TargetBufferFlags::COLOR0, dstRenderTarget, dstRect, srcRenderTarget, srcRect,
             SamplerMagFilter::LINEAR);
@@ -637,7 +637,7 @@ TEST_F(BackendTest, BlitRegionToSwapChain) {
     Handle<HwRenderTarget> srcRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, 0, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
     }
 
     // Blit one-quarter of src level 1 to dst level 0.

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -226,9 +226,9 @@ TEST_F(BackendTest, ColorMagnify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, { dstTexture, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
     }
 
     // Do a "magnify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -301,9 +301,9 @@ TEST_F(BackendTest, ColorMinify) {
     Handle<HwRenderTarget> dstRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
         dstRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kDstTexWidth >> level, kDstTexHeight >> level, 1, { dstTexture, level, 0 }, {}, {});
+                kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, 0 }, {}, {});
     }
 
     // Do a "minify" blit from level 1 of the source RT to the level 0 of the destination RT.
@@ -369,12 +369,12 @@ TEST_F(BackendTest, ColorResolve) {
 
     // Create a 4-sample render target with the 4-sample texture.
     Handle<HwRenderTarget> const srcRenderTarget = api.createRenderTarget(
-            TargetBufferFlags::COLOR, kSrcTexWidth, kSrcTexHeight, kSampleCount,
+            TargetBufferFlags::COLOR, kSrcTexWidth, kSrcTexHeight, kSampleCount, 0,
             {{ srcColorTexture }}, {}, {});
 
     // Create a 1-sample render target with the 1-sample texture.
     Handle<HwRenderTarget> const dstRenderTarget = api.createRenderTarget(
-            TargetBufferFlags::COLOR, kDstTexWidth, kDstTexHeight, 1,
+            TargetBufferFlags::COLOR, kDstTexWidth, kDstTexHeight, 1, 0,
             {{ dstColorTexture }}, {}, {});
 
     // Prep for rendering.
@@ -473,9 +473,9 @@ TEST_F(BackendTest, Blit2DTextureArray) {
     // Create two RenderTargets.
     const int level = 0;
     Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, { srcTexture, level, kSrcTexLayer }, {}, {});
+            kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, kSrcTexLayer }, {}, {});
     Handle<HwRenderTarget> dstRenderTarget = api.createRenderTarget( TargetBufferFlags::COLOR,
-            kDstTexWidth >> level, kDstTexHeight >> level, 1, { dstTexture, level, kDstTexLayer }, {}, {});
+            kDstTexWidth >> level, kDstTexHeight >> level, 1, 0, { dstTexture, level, kDstTexLayer }, {}, {});
 
     // Do a blit from kSrcTexLayer of the source RT to kDstTexLayer of the destination RT.
     const int srcLevel = 0;
@@ -565,10 +565,10 @@ TEST_F(BackendTest, BlitRegion) {
     // that this case is handled correctly.
     Handle<HwRenderTarget> srcRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, srcRect.width,
-                    srcRect.height, 1, {srcTexture, kSrcLevel, 0}, {}, {});
+                    srcRect.height, 1, 0, {srcTexture, kSrcLevel, 0}, {}, {});
     Handle<HwRenderTarget> dstRenderTarget =
             api.createRenderTarget(TargetBufferFlags::COLOR, kDstTexWidth >> kDstLevel,
-                    kDstTexHeight >> kDstLevel, 1, {dstTexture, kDstLevel, 0}, {}, {});
+                    kDstTexHeight >> kDstLevel, 1, 0, {dstTexture, kDstLevel, 0}, {}, {});
 
     api.blitDEPRECATED(TargetBufferFlags::COLOR0, dstRenderTarget, dstRect, srcRenderTarget, srcRect,
             SamplerMagFilter::LINEAR);
@@ -637,7 +637,7 @@ TEST_F(BackendTest, BlitRegionToSwapChain) {
     Handle<HwRenderTarget> srcRenderTargets[kNumLevels];
     for (uint8_t level = 0; level < kNumLevels; level++) {
         srcRenderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, { srcTexture, level, 0 }, {}, {});
+                kSrcTexWidth >> level, kSrcTexHeight >> level, 1, 0, { srcTexture, level, 0 }, {}, {});
     }
 
     // Blit one-quarter of src level 1 to dst level 0.

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -216,7 +216,7 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
     auto colorTexture = getDriverApi().createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 512, 512, 1, TextureUsage::COLOR_ATTACHMENT);
     auto renderTarget = getDriverApi().createRenderTarget(
-            TargetBufferFlags::COLOR0, 512, 512, 1, {{colorTexture}}, {}, {});
+            TargetBufferFlags::COLOR0, 512, 512, 1, 0, {{colorTexture}}, {}, {});
 
     // Upload uniforms for the first triangle.
     {

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -160,7 +160,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             slog.i << "Level " << int(level) << ": " <<
                     (kTexWidth >> level) << "x" << (kTexHeight >> level) << io::endl;
             renderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                    kTexWidth >> level, kTexHeight >> level, 1, { texture, level, 0 }, {}, {});
+                    kTexWidth >> level, kTexHeight >> level, 1, 0, { texture, level, 0 }, {}, {});
         }
 
         // Fill the base level of the texture with interesting colors.

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -160,7 +160,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             slog.i << "Level " << int(level) << ": " <<
                     (kTexWidth >> level) << "x" << (kTexHeight >> level) << io::endl;
             renderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                    kTexWidth >> level, kTexHeight >> level, 1, 0, { texture, 0, level, 0 }, {}, {});
+                    kTexWidth >> level, kTexHeight >> level, 1, 0, { texture, level, 0 }, {}, {});
         }
 
         // Fill the base level of the texture with interesting colors.

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -160,7 +160,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             slog.i << "Level " << int(level) << ": " <<
                     (kTexWidth >> level) << "x" << (kTexHeight >> level) << io::endl;
             renderTargets[level] = api.createRenderTarget( TargetBufferFlags::COLOR,
-                    kTexWidth >> level, kTexHeight >> level, 1, 0, { texture, level, 0 }, {}, {});
+                    kTexWidth >> level, kTexHeight >> level, 1, 0, { texture, 0, level, 0 }, {}, {});
         }
 
         // Fill the base level of the texture with interesting colors.

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -105,7 +105,8 @@ TEST_F(BackendTest, MRT) {
                 512,                                       // width
                 512,                                       // height
                 1,                                         // samples
-                {{textureA },{textureB }}, // color
+                0,                                         // layerCount
+                {{textureA },{textureB }},                 // color
                 {},                                        // depth
                 {});                                       // stencil
 

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -156,7 +156,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         // We specify mip level 2, because minMaxLevels has no effect when rendering into a texture.
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR, 32, 32, 1, 0,
-                {texture, 2 /* level */, 0 /* layer */}, {}, {});
+                {texture, 0 /* baseViewIndex */, 2 /* level */, 0 /* layer */}, {}, {});
         {
             RenderPassParams params = {};
             fullViewport(params);

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -155,7 +155,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         // Render a white triangle into level 2.
         // We specify mip level 2, because minMaxLevels has no effect when rendering into a texture.
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
-                TargetBufferFlags::COLOR, 32, 32, 1,
+                TargetBufferFlags::COLOR, 32, 32, 1, 0,
                 {texture, 2 /* level */, 0 /* layer */}, {}, {});
         {
             RenderPassParams params = {};

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -156,7 +156,7 @@ TEST_F(BackendTest, SetMinMaxLevel) {
         // We specify mip level 2, because minMaxLevels has no effect when rendering into a texture.
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR, 32, 32, 1, 0,
-                {texture, 0 /* baseViewIndex */, 2 /* level */, 0 /* layer */}, {}, {});
+                {texture, 2 /* level */, 0 /* layer */}, {}, {});
         {
             RenderPassParams params = {};
             fullViewport(params);

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -279,7 +279,7 @@ TEST_F(ReadPixelsTest, ReadPixels) {
             // level (at least for OpenGL).
             renderTarget = getDriverApi().createRenderTarget(
                     TargetBufferFlags::COLOR, t.getRenderTargetSize(),
-                    t.getRenderTargetSize(), t.samples, {{ texture, uint8_t(t.mipLevel) }}, {},
+                    t.getRenderTargetSize(), t.samples, 0, {{ texture, uint8_t(t.mipLevel) }}, {},
                     {});
         }
 
@@ -318,9 +318,8 @@ TEST_F(ReadPixelsTest, ReadPixels) {
             // correct mip.
             RenderPassParams p = params;
             Handle<HwRenderTarget> mipLevelOneRT = getDriverApi().createRenderTarget(
-                    TargetBufferFlags::COLOR, renderTargetBaseSize, renderTargetBaseSize, 1,
-                    {{ texture }}, {},
-                    {});
+                    TargetBufferFlags::COLOR, renderTargetBaseSize, renderTargetBaseSize, 1, 0,
+                    {{ texture }}, {}, {});
             p.clearColor = {1.f, 0.f, 0.f, 1.f};
             getDriverApi().beginRenderPass(mipLevelOneRT, p);
             getDriverApi().endRenderPass();
@@ -402,6 +401,7 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
             renderTargetSize,                          // width
             renderTargetSize,                          // height
             1,                                         // samples
+            0,                                         // layerCount
             {{ texture }},                             // color
             {},                                        // depth
             {});                                       // stencil

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -114,11 +114,11 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         // that this case is handled correctly.
         Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH, kSrcRtHeight, kSrcRtHeight, 1, 0,
-                {srcTexture, kSrcLevel, 0}, {depthTexture, 0, 0}, {});
+                {srcTexture, 0, kSrcLevel, 0}, {depthTexture, 0, 0, 0}, {});
 
         Handle<HwRenderTarget> fullRenderTarget = api.createRenderTarget(TargetBufferFlags::COLOR,
                 kSrcTexHeight >> kSrcLevel, kSrcTexWidth >> kSrcLevel, 1, 0,
-                {srcTexture, kSrcLevel, 0}, {}, {});
+                {srcTexture, 0, kSrcLevel, 0}, {}, {});
 
         TrianglePrimitive triangle(api);
 
@@ -209,7 +209,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
 
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR, 512, 512, 1, 0,
-                {srcTexture, 0, 0}, {}, {});
+                {srcTexture, 0, 0, 0}, {}, {});
 
         TrianglePrimitive triangle(api);
 

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -113,11 +113,11 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         // We purposely set the render target width and height to smaller than the texture, to check
         // that this case is handled correctly.
         Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget(
-                TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH, kSrcRtHeight, kSrcRtHeight, 1,
+                TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH, kSrcRtHeight, kSrcRtHeight, 1, 0,
                 {srcTexture, kSrcLevel, 0}, {depthTexture, 0, 0}, {});
 
         Handle<HwRenderTarget> fullRenderTarget = api.createRenderTarget(TargetBufferFlags::COLOR,
-                kSrcTexHeight >> kSrcLevel, kSrcTexWidth >> kSrcLevel, 1,
+                kSrcTexHeight >> kSrcLevel, kSrcTexWidth >> kSrcLevel, 1, 0,
                 {srcTexture, kSrcLevel, 0}, {}, {});
 
         TrianglePrimitive triangle(api);
@@ -208,7 +208,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
                 (uint32_t)std::numeric_limits<int32_t>::max()};
 
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
-                TargetBufferFlags::COLOR, 512, 512, 1,
+                TargetBufferFlags::COLOR, 512, 512, 1, 0,
                 {srcTexture, 0, 0}, {}, {});
 
         TrianglePrimitive triangle(api);

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -114,11 +114,11 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         // that this case is handled correctly.
         Handle<HwRenderTarget> srcRenderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH, kSrcRtHeight, kSrcRtHeight, 1, 0,
-                {srcTexture, 0, kSrcLevel, 0}, {depthTexture, 0, 0, 0}, {});
+                {srcTexture, kSrcLevel, 0}, {depthTexture, 0, 0}, {});
 
         Handle<HwRenderTarget> fullRenderTarget = api.createRenderTarget(TargetBufferFlags::COLOR,
                 kSrcTexHeight >> kSrcLevel, kSrcTexWidth >> kSrcLevel, 1, 0,
-                {srcTexture, 0, kSrcLevel, 0}, {}, {});
+                {srcTexture, kSrcLevel, 0}, {}, {});
 
         TrianglePrimitive triangle(api);
 
@@ -209,7 +209,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
 
         Handle<HwRenderTarget> renderTarget = api.createRenderTarget(
                 TargetBufferFlags::COLOR, 512, 512, 1, 0,
-                {srcTexture, 0, 0, 0}, {}, {});
+                {srcTexture, 0, 0}, {}, {});
 
         TrianglePrimitive triangle(api);
 

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -150,7 +150,7 @@ TEST_F(BasicStencilBufferTest, StencilBuffer) {
     auto stencilTexture = api.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::STENCIL8, 1, 512, 512, 1, TextureUsage::STENCIL_ATTACHMENT);
     auto renderTarget = getDriverApi().createRenderTarget(
-            TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL, 512, 512, 1,
+            TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL, 512, 512, 1, 0,
             {{colorTexture}}, {}, {{stencilTexture}});
 
     RunTest(renderTarget);
@@ -174,7 +174,7 @@ TEST_F(BasicStencilBufferTest, DepthAndStencilBuffer) {
     auto depthStencilTexture = api.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::DEPTH24_STENCIL8, 1, 512, 512, 1, TextureUsage::STENCIL_ATTACHMENT | TextureUsage::DEPTH_ATTACHMENT);
     auto renderTarget = getDriverApi().createRenderTarget(
-            TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL, 512, 512, 1,
+            TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL, 512, 512, 1, 0,
             {{colorTexture}}, {depthStencilTexture}, {{depthStencilTexture}});
 
     RunTest(renderTarget);
@@ -202,10 +202,10 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     auto depthStencilTextureMSAA = api.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::DEPTH24_STENCIL8, 4, 512, 512, 1, TextureUsage::STENCIL_ATTACHMENT | TextureUsage::DEPTH_ATTACHMENT);
     auto renderTarget0 = getDriverApi().createRenderTarget(
-            TargetBufferFlags::DEPTH_AND_STENCIL, 512, 512, 4,
+            TargetBufferFlags::DEPTH_AND_STENCIL, 512, 512, 4, 0,
             {{}}, {depthStencilTextureMSAA}, {depthStencilTextureMSAA});
     auto renderTarget1 = getDriverApi().createRenderTarget(
-            TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH_AND_STENCIL, 512, 512, 4,
+            TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH_AND_STENCIL, 512, 512, 4, 0,
             {{colorTexture}}, {depthStencilTextureMSAA}, {depthStencilTextureMSAA});
 
     api.startCapture(0);

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -57,6 +57,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                 TargetBufferFlags const clearColorFlags = config.clearFlags & TargetBufferFlags::COLOR;
                 TargetBufferFlags clearDepthFlags = config.clearFlags & TargetBufferFlags::DEPTH;
                 TargetBufferFlags clearStencilFlags = config.clearFlags & TargetBufferFlags::STENCIL;
+                uint8_t layerCount = 0;
 
                 data.shadows = blackboard.get<FrameGraphTexture>("shadows");
                 data.ssao = blackboard.get<FrameGraphTexture>("ssao");
@@ -150,7 +151,17 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                 data.depth = builder.read(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
 
                 data.color = builder.write(data.color, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                data.depth = builder.write(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                if (engine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW) {
+                    // Add sampleable usage flag for depth in multiview rendering, othewise it's
+                    // treated renderbuffer in the backend and crashed.
+                    data.depth = builder.write(data.depth,
+                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
+                        FrameGraphTexture::Usage::SAMPLEABLE);
+                    layerCount = engine.getConfig().stereoscopicEyeCount;
+                } else {
+                    data.depth = builder.write(data.depth,
+                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                }
 
                 /*
                  * There is a bit of magic happening here regarding the viewport used.
@@ -172,7 +183,8 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                         .stencil = data.stencil },
                         .clearColor = config.clearColor,
                         .samples = config.msaa,
-                        .clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags });
+                        .layerCount = layerCount,
+                        .clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags});
                 blackboard["depth"] = data.depth;
             },
             [=, &view, &engine](FrameGraphResources const& resources,

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -153,7 +153,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                 data.color = builder.write(data.color, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 if (engine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW) {
                     // Add sampleable usage flag for depth in multiview rendering, othewise it's
-                    // treated renderbuffer in the backend and crashed.
+                    // treated as renderbuffer in the backend and crashed.
                     data.depth = builder.write(data.depth,
                         FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
                         FrameGraphTexture::Usage::SAMPLEABLE);

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -129,10 +129,10 @@ void ResourceAllocator::terminate() noexcept {
 
 RenderTargetHandle ResourceAllocator::createRenderTarget(const char*,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, MRT color, TargetBufferInfo depth,
+        uint8_t samples, uint8_t layerCount, MRT color, TargetBufferInfo depth,
         TargetBufferInfo stencil) noexcept {
     return mBackend.createRenderTarget(targetBufferFlags,
-            width, height, samples ? samples : 1u, color, depth, stencil);
+            width, height, samples ? samples : 1u, layerCount, color, depth, stencil);
 }
 
 void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -45,6 +45,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
+            uint8_t layerCount,
             backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept = 0;
@@ -77,6 +78,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
+            uint8_t layerCount,
             backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept override;

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -34,6 +34,7 @@ struct RenderTarget::BuilderDetails {
     uint32_t mWidth{};
     uint32_t mHeight{};
     uint8_t mSamples = 1;   // currently not settable in the public facing API
+    uint8_t mLayerCount = 0;// currently not settable in the public facing API
 };
 
 using BuilderType = RenderTarget;
@@ -160,7 +161,8 @@ FRenderTarget::FRenderTarget(FEngine& engine, const RenderTarget::Builder& build
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createRenderTarget(mAttachmentMask,
-            builder.mImpl->mWidth, builder.mImpl->mHeight, builder.mImpl->mSamples, mrt, dinfo, {});
+            builder.mImpl->mWidth, builder.mImpl->mHeight, builder.mImpl->mSamples,
+            builder.mImpl->mLayerCount, mrt, dinfo, {});
 }
 
 void FRenderTarget::terminate(FEngine& engine) {

--- a/filament/src/fg/FrameGraphRenderPass.h
+++ b/filament/src/fg/FrameGraphRenderPass.h
@@ -47,7 +47,8 @@ struct FrameGraphRenderPass {
         Attachments attachments{};
         Viewport viewport{};
         math::float4 clearColor{};
-        uint8_t samples = 0; // # of samples (0 = unset, default)
+        uint8_t samples = 0;    // # of samples (0 = unset, default)
+        uint8_t layerCount = 0; // # of layer (# > 1 = multiview)
         backend::TargetBufferFlags clearFlags{};
         backend::TargetBufferFlags discardStart{};
     };

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -276,8 +276,8 @@ void RenderPassNode::RenderPassData::devirtualize(FrameGraph& fg,
                 name, targetBufferFlags,
                 backend.params.viewport.width,
                 backend.params.viewport.height,
-                descriptor.samples,
-                colorInfo,info[0], info[1]);
+                descriptor.samples, descriptor.layerCount,
+                colorInfo, info[0], info[1]);
     }
 }
 

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -40,6 +40,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
+            uint8_t layerCount,
             backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept override {


### PR DESCRIPTION
This new parameter indicates whether the render target will be created for multiview.

If the value is greater than 1, it tells the render target should be created for multiview. Otherwise, 1 or 0, it creates a single layer render target.