### PR TITLE
fix: apply applyCrossFade to correct entity

### DIFF
--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -395,7 +395,9 @@ void AnimatorImpl::applyCrossFade(float alpha) {
         }
         return index;
     };
-    recursiveFn(tm.getInstance(asset->mRoot), 0, recursiveFn);
+    const Entity rootEntity = instance ? instance->getRoot() : asset->mRoot;
+    const Instance root = tm.getInstance(rootEntity);
+    recursiveFn(root, 0, recursiveFn);
 }
 
 void AnimatorImpl::addChannels(const FixedCapacityVector<Entity>& nodeMap,

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -368,7 +368,8 @@ void AnimatorImpl::stashCrossFade() {
         return index;
     };
 
-    const Instance root = tm.getInstance(asset->mRoot);
+    const Entity rootEntity = instance ? instance->getRoot() : asset->mRoot;
+    const Instance root = tm.getInstance(rootEntity);
     const size_t count = recursiveCount(root, 0, recursiveCount);
     crossFade.reserve(count);
     crossFade.resize(count);


### PR DESCRIPTION
A while ago an API was added that supports creating multiple instances from one asset.

Due to that that instance used in an Animator might not be `asset->mRoot`, but another instance. To account for that.
The `applyAnimation` function handled this correctly, however the `applyCrossFade` wasn't updated and was still using  `asset->mRoot`.

This PR adds a conditional to either use the provided instance in `applyCrossFade` or to use the asset's root entity.