### PR TITLE
gltfio: add extended tangents job

### DIFF
--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -86,6 +86,12 @@ set(GLTFIO_SRCS
         ${GLTFIO_DIR}/src/Wireframe.cpp
         ${GLTFIO_DIR}/src/Wireframe.h
         ${GLTFIO_DIR}/src/downcast.h
+        ${GLTFIO_DIR}/src/extended/AssetLoaderExtended.h
+        ${GLTFIO_DIR}/src/extended/TangentsJobExtended.cpp
+        ${GLTFIO_DIR}/src/extended/TangentsJobExtended.h
+        ${GLTFIO_DIR}/src/extended/TangentSpaceMeshWrapper.cpp
+        ${GLTFIO_DIR}/src/extended/TangentSpaceMeshWrapper.h
+
 
         src/main/cpp/Animator.cpp
         src/main/cpp/AssetLoader.cpp

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -52,6 +52,11 @@ set(SRCS
         src/Wireframe.cpp
         src/Wireframe.h
         src/downcast.h
+        src/extended/AssetLoaderExtended.h
+        src/extended/TangentsJobExtended.cpp
+        src/extended/TangentsJobExtended.h
+        src/extended/TangentSpaceMeshWrapper.cpp
+        src/extended/TangentSpaceMeshWrapper.h
 )
 
 # ==================================================================================================

--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_ASSETLOADEREXTENDED_H
+#define GLTFIO_ASSETLOADEREXTENDED_H
+
+#include <cgltf.h>
+
+namespace filament::gltfio {
+
+// The cgltf attribute is a type and the attribute index
+struct Attribute {
+    cgltf_attribute_type type; // positions, tangents
+    int index;
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_ASSETLOADEREXTENDED_H

--- a/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
+++ b/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TangentSpaceMeshWrapper.h"
+
+#include <utils/Panic.h>
+
+#include <memory>
+#include <unordered_map>
+
+namespace filament::gltfio {
+
+namespace {
+
+using AuxType = TangentSpaceMeshWrapper::AuxType;
+using Builder = TangentSpaceMeshWrapper::Builder;
+
+struct Passthrough {
+    static constexpr int POSITION = 256;
+    static constexpr int UV0 = 257;
+    static constexpr int NORMALS = 258;
+    static constexpr int TANGENTS = 259;
+    static constexpr int TRIANGLES = 260;
+
+    std::unordered_map<int, void const*> data;
+    size_t vertexCount = 0;
+    size_t triangleCount = 0;
+};
+
+// Note that the method signatures here match TangentSpaceMesh
+struct PassthroughMesh {
+    explicit PassthroughMesh(Passthrough const& passthrough)
+        : mPassthrough(passthrough) {}
+
+    void getPositions(float3* data) noexcept {
+        size_t const nbytes = mPassthrough.vertexCount * sizeof(float3);
+        std::memcpy(data, mPassthrough.data[Passthrough::POSITION], nbytes);
+    }
+
+    void getUVs(float2* data) noexcept {
+        size_t const nbytes = mPassthrough.vertexCount * sizeof(float2);
+        std::memcpy(data, mPassthrough.data[Passthrough::UV0], nbytes);
+    }
+
+    void getQuats(short4* data) noexcept {
+        size_t const nbytes = mPassthrough.vertexCount * sizeof(short4);
+        std::memcpy(data, mPassthrough.data[Passthrough::TANGENTS], nbytes);
+    }
+
+    void getTriangles(uint3* data) {
+        size_t const nbytes = mPassthrough.triangleCount * sizeof(uint3);
+        std::memcpy(data, mPassthrough.data[Passthrough::TRIANGLES], nbytes);
+    }
+
+    template<typename T>
+    void getAux(AuxType attribute, T data) noexcept {
+        size_t const nbytes = mPassthrough.vertexCount * sizeof(std::remove_pointer_t<T>);
+        std::memcpy(data, (T) mPassthrough.data[static_cast<int>(attribute)], nbytes);
+    }
+
+    size_t getVertexCount() const noexcept { return mPassthrough.vertexCount; }
+    size_t getTriangleCount() const noexcept { return mPassthrough.triangleCount; }
+
+private:
+    Passthrough mPassthrough;
+};
+
+// Note that the method signatures here match TangentSpaceMesh::Builder
+struct PassthroughBuilder {
+    void vertexCount(size_t count) noexcept { mPassthrough.vertexCount = count; }
+
+    void normals(float3 const* normals) noexcept {
+        mPassthrough.data[Passthrough::NORMALS] = normals;
+    }
+
+    void tangents(float4 const* tangents) noexcept {
+        mPassthrough.data[Passthrough::TANGENTS] = tangents;
+    }
+    void uvs(float2 const* uvs) noexcept { mPassthrough.data[Passthrough::UV0] = uvs; }
+
+    void positions(float3 const* positions) noexcept {
+        mPassthrough.data[Passthrough::POSITION] = positions;
+    }
+
+    void triangleCount(size_t triangleCount) noexcept {
+        mPassthrough.triangleCount = triangleCount;
+    }
+
+    void triangles(uint3 const* triangles) noexcept {
+        mPassthrough.data[Passthrough::TRIANGLES] = triangles;
+    }
+
+    void aux(AuxType type, void* data) noexcept {
+        mPassthrough.data[static_cast<int>(type)] = data;
+    }
+
+    PassthroughMesh* build() const noexcept {
+        return new PassthroughMesh(mPassthrough);
+    }
+
+private:
+    Passthrough mPassthrough;
+    friend struct PassthroughMesh;
+};
+
+} // anonymous
+
+#define DO_MESH_IMPL(METHOD, ...)                                                                  \
+    do {                                                                                           \
+        if (mTsMesh) {                                                                             \
+            mTsMesh->METHOD(__VA_ARGS__);                                                          \
+        } else {                                                                                   \
+            mPassthroughMesh->METHOD(__VA_ARGS__);                                                 \
+        }                                                                                          \
+    } while (0)
+
+#define DO_MESH_RET_IMPL(METHOD)                                                                   \
+    do {                                                                                           \
+        if (mTsMesh) {                                                                             \
+            return mTsMesh->METHOD();                                                              \
+        } else {                                                                                   \
+            return mPassthroughMesh->METHOD();                                                     \
+        }                                                                                          \
+    } while (0)
+
+struct TangentSpaceMeshWrapper::Impl {
+    Impl(geometry::TangentSpaceMesh* tsMesh)
+        : mTsMesh(tsMesh) {}
+
+    Impl(PassthroughMesh* passthroughMesh)
+        : mPassthroughMesh(passthroughMesh) {}
+
+    ~Impl() {
+        if (mTsMesh) {
+            geometry::TangentSpaceMesh::destroy(mTsMesh);
+        }
+        if (mPassthroughMesh) {
+            delete mPassthroughMesh;
+        }
+    }
+
+    inline size_t getVertexCount() const noexcept {
+        DO_MESH_RET_IMPL(getVertexCount);
+    }
+
+    float3* getPositions() noexcept {
+        size_t const nbytes = getVertexCount() * sizeof(float3);
+        auto data = (float3*) malloc(nbytes);
+        DO_MESH_IMPL(getPositions, data);
+        return data;
+    }
+
+    float2* getUVs() noexcept {
+        size_t const nbytes = getVertexCount() * sizeof(float2);
+        auto data = (float2*) malloc(nbytes);
+        DO_MESH_IMPL(getUVs, data);
+        return data;
+    }
+
+    short4* getQuats() noexcept {
+        size_t const nbytes = getVertexCount() * sizeof(short4);
+        auto data = (short4*) malloc(nbytes);
+        DO_MESH_IMPL(getQuats, data);
+        return data;
+    }
+
+    uint3* getTriangles() {
+        size_t const nbytes = getTriangleCount() * sizeof(uint3);
+        auto data = (uint3*) malloc(nbytes);
+        DO_MESH_IMPL(getTriangles, data);
+        return data;
+    }
+
+    template<typename T>
+    using is_supported_aux_t =
+            typename std::enable_if<std::is_same<float2*, T>::value ||
+                                    std::is_same<float3*, T>::value ||
+                                    std::is_same<float4*, T>::value ||
+                                    std::is_same<ushort3*, T>::value ||
+                                    std::is_same<ushort4*, T>::value>::type;
+    template<typename T, typename = is_supported_aux_t<T>>
+    T getAux(AuxType attribute) noexcept {
+        size_t const nbytes = getVertexCount() * sizeof(std::remove_pointer_t<T>);
+        auto data = (T) malloc(nbytes);
+        DO_MESH_IMPL(getAux, data);
+        return data;
+    }
+
+    inline size_t getTriangleCount() const noexcept {
+        DO_MESH_RET_IMPL(getTriangleCount);
+    }
+
+private:
+    geometry::TangentSpaceMesh* mTsMesh = nullptr;
+    PassthroughMesh* mPassthroughMesh = nullptr;
+};
+
+#undef DO_MESH_IMPL
+#undef DO_MESH_RET_IMPL
+
+#define DO_BUILDER_IMPL(METHOD, ...)                                                               \
+    do {                                                                                           \
+        if (mPassthroughBuilder) {                                                                 \
+            mPassthroughBuilder->METHOD(__VA_ARGS__);                                              \
+        } else {                                                                                   \
+            mTsmBuilder->METHOD(__VA_ARGS__);                                                      \
+        }                                                                                          \
+    } while (0)
+
+struct TangentSpaceMeshWrapper::Builder::Impl {
+    explicit Impl(bool isUnlit)
+        : mPassthroughBuilder(isUnlit ? std::make_unique<PassthroughBuilder>() : nullptr),
+          mTsmBuilder(
+                  !isUnlit ? std::make_unique<geometry::TangentSpaceMesh::Builder>() : nullptr) {}
+
+    void vertexCount(size_t count) noexcept { DO_BUILDER_IMPL(vertexCount, count); }
+    void normals(float3 const* normals) noexcept { DO_BUILDER_IMPL(normals, normals); }
+    void tangents(float4 const* tangents) noexcept { DO_BUILDER_IMPL(tangents, tangents); }
+    void uvs(float2 const* uvs) noexcept { DO_BUILDER_IMPL(uvs, uvs); }
+    void positions(float3 const* positions) noexcept { DO_BUILDER_IMPL(positions, positions); }
+    void triangles(uint3 const* triangles) noexcept { DO_BUILDER_IMPL(triangles, triangles); }
+    void triangleCount(size_t count) noexcept { DO_BUILDER_IMPL(triangleCount, count); }
+
+    template<typename T>
+    void aux(AuxType type, T data) {
+        DO_BUILDER_IMPL(aux, type, data);
+    }
+
+    TangentSpaceMeshWrapper* build() {
+        auto ret = new TangentSpaceMeshWrapper();
+        if (mPassthroughBuilder) {
+            ret->mImpl = new TangentSpaceMeshWrapper::Impl{ mPassthroughBuilder->build() };
+        } else {
+            ret->mImpl = new TangentSpaceMeshWrapper::Impl{ mTsmBuilder->build() };
+        }
+        return ret;
+    }
+
+private:
+    std::unique_ptr<PassthroughBuilder> mPassthroughBuilder;
+    std::unique_ptr<geometry::TangentSpaceMesh::Builder> mTsmBuilder;
+};
+
+#undef DO_BUILDER_IMPL
+
+Builder::Builder(bool isUnlit)
+    : mImpl(new Impl{isUnlit}) {}
+
+
+Builder& Builder::vertexCount(size_t count) noexcept {
+    mImpl->vertexCount(count);
+    return *this;
+}
+
+Builder& Builder::normals(float3 const* normals) noexcept {
+    mImpl->normals(normals);
+    return *this;
+}
+
+Builder& Builder::tangents(float4 const* tangents) noexcept {
+    mImpl->tangents(tangents);
+    return *this;
+}
+
+Builder& Builder::uvs(float2 const* uvs) noexcept {
+    mImpl->uvs(uvs);
+    return *this;
+}
+
+Builder& Builder::positions(float3 const* positions) noexcept{
+    mImpl->positions(positions);
+    return *this;
+}
+
+Builder& Builder::triangleCount(size_t triangleCount) noexcept {
+    mImpl->triangleCount(triangleCount);
+    return *this;
+}
+
+Builder& Builder::triangles(uint3 const* triangles) noexcept {
+    mImpl->triangles(triangles);
+    return *this;
+}
+
+template<typename T>
+Builder& Builder::aux(AuxType type, T data) {
+    mImpl->aux<T>(type, data);
+    return *this;
+}
+
+TangentSpaceMeshWrapper* Builder::build() {
+    return mImpl->build();
+}
+
+void TangentSpaceMeshWrapper::destroy(TangentSpaceMeshWrapper* mesh) {
+    assert_invariant(mesh->mImpl);
+    assert_invariant(mesh);
+    delete mesh->mImpl;
+    delete mesh;
+}
+
+float3* TangentSpaceMeshWrapper::getPositions() noexcept { return mImpl->getPositions(); }
+float2* TangentSpaceMeshWrapper::getUVs() noexcept { return mImpl->getUVs(); }
+short4* TangentSpaceMeshWrapper::getQuats() noexcept { return mImpl->getQuats(); }
+uint3* TangentSpaceMeshWrapper::getTriangles() { return mImpl->getTriangles(); }
+size_t TangentSpaceMeshWrapper::getVertexCount() const noexcept { return mImpl->getVertexCount(); }
+
+template<typename T, typename>
+T TangentSpaceMeshWrapper::getAux(AuxType attribute) noexcept {
+    return mImpl->getAux<T>(attribute);
+}
+
+size_t TangentSpaceMeshWrapper::getTriangleCount() const noexcept {
+    return mImpl->getTriangleCount();
+}
+
+} // filament::gltfio

--- a/libs/gltfio/src/extended/TangentSpaceMeshWrapper.h
+++ b/libs/gltfio/src/extended/TangentSpaceMeshWrapper.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_TANGENT_SPACE_MESH_WRAPPER_H
+#define GLTFIO_TANGENT_SPACE_MESH_WRAPPER_H
+
+#include <geometry/TangentSpaceMesh.h>
+
+#include <math/vec4.h>
+
+namespace filament::gltfio {
+
+using namespace math;
+
+// Wrapper around TangentSpaceMesh because in the case of unlit material, we do not need to go
+// through TSM transformation, and we simply passthrough any given input as output.
+struct TangentSpaceMeshWrapper {
+    using AuxType = geometry::TangentSpaceMesh::AuxAttribute;
+
+    struct Builder {
+        struct Impl;
+
+        Builder(bool isUnlit);
+
+        Builder& vertexCount(size_t count) noexcept;
+        Builder& normals(float3 const* normals) noexcept;
+        Builder& tangents(float4 const* tangents) noexcept;
+        Builder& uvs(float2 const* uvs) noexcept;
+        Builder& positions(float3 const* positions) noexcept;
+        Builder& triangleCount(size_t triangleCount) noexcept;
+        Builder& triangles(uint3 const* triangles) noexcept;
+        template<typename T>
+        Builder& aux(AuxType type, T data);
+        TangentSpaceMeshWrapper* build();
+
+    private:
+        Impl* mImpl;
+    };
+
+    explicit TangentSpaceMeshWrapper() = default;
+    
+    static void destroy(TangentSpaceMeshWrapper* mesh);
+
+    float3* getPositions() noexcept;
+    float2* getUVs() noexcept;
+    short4* getQuats() noexcept;
+    uint3* getTriangles();
+
+    template<typename T>
+    using is_supported_aux_t = typename std::enable_if<
+            std::is_same<float2*, T>::value || std::is_same<float3*, T>::value ||
+            std::is_same<float4*, T>::value || std::is_same<ushort3*, T>::value ||
+            std::is_same<ushort4*, T>::value>::type;
+    template<typename T, typename = is_supported_aux_t<T>>
+    T getAux(AuxType attribute) noexcept;
+
+    size_t getVertexCount() const noexcept;
+    size_t getTriangleCount() const noexcept;
+
+private:
+    struct Impl;
+    Impl* mImpl;
+
+    friend struct Builder::Impl;
+};
+
+} // namespace filament
+
+#endif // GLTFIO_TANGENTS_JOB_EXTENDED_H

--- a/libs/gltfio/src/extended/TangentsJobExtended.cpp
+++ b/libs/gltfio/src/extended/TangentsJobExtended.cpp
@@ -1,0 +1,549 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TangentsJobExtended.h"
+
+#include "AssetLoaderExtended.h"
+#include "TangentSpaceMeshWrapper.h"
+#include "../GltfEnums.h"
+#include "../FFilamentAsset.h"
+#include "../Utility.h"
+
+#include <geometry/TangentSpaceMesh.h>
+#include <utils/Log.h>
+#include <utils/StructureOfArrays.h>
+
+#include <memory>
+#include <unordered_map>
+
+using namespace filament;
+using namespace filament::gltfio;
+using namespace filament::math;
+
+namespace {
+
+constexpr uint8_t POSITIONS_ID = 0;
+constexpr uint8_t TANGENTS_ID = 1;
+constexpr uint8_t COLORS_ID = 3;
+constexpr uint8_t NORMALS_ID = 4;
+constexpr uint8_t UV0_ID = 5;
+constexpr uint8_t UV1_ID = 6;
+constexpr uint8_t WEIGHTS_ID = 7;
+constexpr uint8_t JOINTS_ID = 8;
+constexpr uint8_t INVALID_ID = 0xFF;
+
+using POSITIONS_TYPE = float3*;
+using TANGENTS_TYPE = float4*;
+using COLORS_TYPE = float4*;
+using NORMALS_TYPE = float3*;
+using UV0_TYPE = float2*;
+using UV1_TYPE = float2*;
+using WEIGHTS_TYPE = float4*;
+using JOINTS_TYPE = ushort4*;
+
+// Used in template specifier.
+#define POSITIONS_T POSITIONS_TYPE, POSITIONS_ID
+#define TANGENTS_T TANGENTS_TYPE, TANGENTS_ID
+#define COLORS_T COLORS_TYPE, COLORS_ID
+#define NORMALS_T NORMALS_TYPE, NORMALS_ID
+#define UV0_T UV0_TYPE, UV0_ID
+#define UV1_T UV1_TYPE, UV1_ID
+#define WEIGHTS_T WEIGHTS_TYPE, WEIGHTS_ID
+#define JOINTS_T JOINTS_TYPE, JOINTS_ID
+
+using DataType = std::variant<float2*, float3*, float4*, ubyte4*, ushort4*>;
+using AttributeDataMap = std::unordered_map<uint8_t, DataType>;
+
+// This converts from cgltf attributes to the representation in this file.
+inline uint8_t toCode(Attribute attr, UvMap const& uvmap, bool hasUv0) {
+    switch (attr.type) {
+        case cgltf_attribute_type_normal:
+            assert_invariant(attr.index == 0);
+            return NORMALS_ID;
+        case cgltf_attribute_type_tangent:
+            assert_invariant(attr.index == 0);
+            return TANGENTS_ID;
+        case cgltf_attribute_type_color:
+            assert_invariant(attr.index == 0);
+            return COLORS_ID;
+        case cgltf_attribute_type_position:
+            assert_invariant(attr.index == 0);
+            return POSITIONS_ID;
+        // This logic is replicating slot assignment in AssetLoaderExtended.cpp
+        case cgltf_attribute_type_texcoord: {
+            assert_invariant(attr.index < UvMapSize);
+            UvSet uvset = uvmap[attr.index];
+            switch (uvset) {
+                case gltfio::UV0:
+                    return UV0_ID;
+                case gltfio::UV1:
+                    return UV1_ID;
+                case gltfio::UNUSED:
+                    // If we have a free slot, then include this unused UV set in the VertexBuffer.
+                    // This allows clients to swap the glTF material with a custom material.
+                    if (!hasUv0 && getNumUvSets(uvmap) == 0) {
+                        return UV0_ID;
+                    }
+            }
+            utils::slog.w << "Only two sets of UVs are available" << utils::io::endl;
+            return INVALID_ID;
+        }
+        case cgltf_attribute_type_weights:
+            assert_invariant(attr.index == 0);
+            return WEIGHTS_ID;
+        case cgltf_attribute_type_joints:
+            assert_invariant(attr.index == 0);
+            return JOINTS_ID;
+        default:
+            // Otherwise, this is not an attribute supported by Filament.
+            return INVALID_ID;
+    }
+}
+
+// These methods extra and/or transform the data from the cgltf accessors.
+namespace data {
+
+template<typename T, uint8_t attrib>
+inline T get(AttributeDataMap const& data) {
+    auto iter = data.find(attrib);
+    if (iter != data.end()) {
+        return std::get<T>(iter->second);
+    }
+    return nullptr;
+}
+
+template<typename T, uint8_t attrib>
+void allocate(AttributeDataMap& data, size_t count) {
+    assert_invariant(data.find(attrib) == data.end());
+    data[attrib]  = (T) malloc(sizeof(std::remove_pointer_t<T>) * count);
+}
+
+template<typename T, uint8_t attrib>
+void free(AttributeDataMap& data) {
+    if (data.find(attrib) == data.end()) {
+        return;
+    }
+    std::free(std::get<T>(data[attrib]));
+    data.erase(attrib);
+}
+
+constexpr uint8_t UBYTE_TYPE = 1;
+constexpr uint8_t USHORT_TYPE = 2;
+constexpr uint8_t FLOAT_TYPE = 3;
+
+template<typename T>
+constexpr uint8_t componentType() {
+    if constexpr (std::is_same_v<T, float2*> ||
+            std::is_same_v<T, float3*> ||
+            std::is_same_v<T, float4*>) {
+        return FLOAT_TYPE;
+    } else if constexpr (std::is_same_v<T, ubyte2*> ||
+            std::is_same_v<T, ubyte3*> ||
+            std::is_same_v<T, ubyte4*>) {
+        return UBYTE_TYPE;
+    } else if constexpr (std::is_same_v<T, ushort2*> ||
+            std::is_same_v<T, ushort3*> ||
+            std::is_same_v<T, ushort4*>) {
+        return USHORT_TYPE;
+    }
+    return 0;
+}
+
+template<typename T>
+constexpr size_t byteCount() {
+    return sizeof(std::remove_pointer_t<T>);
+}
+
+template<typename T>
+constexpr size_t componentCount() {
+    if constexpr (std::is_same_v<T, float2*> || std::is_same_v<T, ubyte2*> ||
+                  std::is_same_v<T, ushort2*>) {
+        return 2;
+    } else if constexpr (std::is_same_v<T, float3*> || std::is_same_v<T, ubyte3*> ||
+                         std::is_same_v<T, ushort3*>) {
+        return 3;
+    } else if constexpr (std::is_same_v<T, float4*> || std::is_same_v<T, ubyte4*> ||
+                         std::is_same_v<T, ushort4*>) {
+        return 4;
+    }
+    return 0;
+}
+
+// This method will copy when the input/output types are the same and will do conversion where it
+// makes sense.
+template<typename InDataType, typename OutDataType>
+void copy(InDataType in, size_t inStride, OutDataType out, size_t outStride, size_t count) {
+    uint8_t* inBytes = (uint8_t*) in;
+    uint8_t* outBytes = (uint8_t*) out;
+
+    if constexpr (componentType<InDataType>() == componentType<OutDataType>()) {
+        if constexpr (componentCount<InDataType>() == 3 && componentCount<OutDataType>() == 4) {
+            for (size_t i = 0; i < count; ++i) {
+                *((OutDataType) (outBytes + (i * outStride))) = std::remove_pointer_t<OutDataType>(
+                        *((InDataType) (inBytes + (i * inStride))), 1);
+            }
+            return;
+        } else if constexpr (componentCount<InDataType>() == componentCount<OutDataType>()) {
+            if (inStride == outStride) {
+                std::memcpy(out, in, data::byteCount<InDataType>() * count);
+            } else {
+                for (size_t i = 0; i < count; ++i) {
+                    *((OutDataType) (outBytes + (i * outStride))) =
+                            std::remove_pointer_t<OutDataType>(
+                                    *((InDataType) (inBytes + (i * inStride))));
+                }
+            }
+            return;
+        }
+
+        PANIC_POSTCONDITION("Invalid component count in conversion");
+    } else if constexpr (componentCount<InDataType>() == componentCount<OutDataType>()) {
+        // byte to float conversion
+        constexpr size_t const compCount = componentCount<InDataType>();
+        if constexpr (componentType<InDataType>() == UBYTE_TYPE &&
+                      componentType<OutDataType>() == FLOAT_TYPE) {
+            for (size_t i = 0; i < count; ++i) {
+                for (size_t j = 0; j < compCount; ++j) {
+                    *(((float*) (outBytes + (i * outStride))) + j) =
+                            *(((uint8_t*) (inBytes + (i * inStride))) + j) / 255.0f;
+                }
+            }
+            return;
+        } else if constexpr (componentType<InDataType>() == UBYTE_TYPE &&
+                             componentType<OutDataType>() == USHORT_TYPE) {
+            for (size_t i = 0; i < count; ++i) {
+                for (size_t j = 0; j < compCount; ++j) {
+                    *(((uint16_t*) (outBytes + (i * outStride))) + j) =
+                            *(((uint8_t*) (inBytes + (i * inStride))) + j);
+                }
+            }
+            return;
+        }
+    }
+    PANIC_POSTCONDITION("Invalid conversion");
+}
+
+template<typename T>
+void unpack(cgltf_accessor const* accessor, size_t const vertexCount, T out,
+        bool isMorphTarget = false) {
+    assert_invariant(accessor->count == vertexCount);
+    uint8_t const* data = nullptr;
+    if (accessor->buffer_view->has_meshopt_compression) {
+        data = (uint8_t const*) accessor->buffer_view->data + accessor->offset;
+    } else {
+        data = (uint8_t const*) accessor->buffer_view->buffer->data +
+               utility::computeBindingOffset(accessor);
+    }
+    auto componentType = accessor->component_type;
+    size_t const inDim = cgltf_num_components(accessor->type);
+    size_t const outDim = componentCount<T>();
+
+    if (componentType == cgltf_component_type_r_32f) {
+        assert_invariant(accessor->buffer_view);
+        assert_invariant(data::componentType<T>() == FLOAT_TYPE);
+        size_t const elementCount = outDim * vertexCount;
+
+        if ((isMorphTarget && utility::requiresPacking(accessor)) ||
+                utility::requiresConversion(accessor)) {
+            cgltf_accessor_unpack_floats(accessor, (float*) out, elementCount);
+            return;
+        } else {
+            if (inDim == 3 && outDim == 4) {
+                data::copy<float3*, T>((float3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else {
+                assert_invariant(inDim == outDim);
+                data::copy<T, T>((T) data, accessor->stride, (T) out, data::byteCount<T>(),
+                        vertexCount);
+                return;
+            }
+        }
+    } else {
+        assert_invariant(outDim == inDim);
+        if (componentType == cgltf_component_type_r_8u) {
+            if (inDim == 2) {
+                data::copy<ubyte2*, T>((ubyte2*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 3) {
+                data::copy<ubyte3*, T>((ubyte3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 4) {
+                data::copy<ubyte4*, T>((ubyte4*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            }
+        } else if (componentType == cgltf_component_type_r_16u) {
+            if (inDim == 2) {
+                data::copy<ushort2*, T>((ushort2*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 3) {
+                data::copy<ushort3*, T>((ushort3*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            } else if (inDim == 4) {
+                data::copy<ushort4*, T>((ushort4*) data, accessor->stride, (T) out,
+                        data::byteCount<T>(), vertexCount);
+                return;
+            }
+        }
+
+        PANIC_POSTCONDITION("Only ubyte or ushort accepted as input");
+    }
+}
+
+template<typename T, uint8_t attrib>
+void unpack(cgltf_accessor const* accessor, AttributeDataMap& data, size_t const vertexCount,
+        bool isMorphTarget = false) {
+    assert_invariant(accessor->count == vertexCount);
+    assert_invariant(data.find(attrib) != data.end());
+
+    unpack(accessor, vertexCount, data::get<T, attrib>(data), isMorphTarget);
+}
+
+template<typename T, uint8_t attrib>
+void add(AttributeDataMap& data, size_t const vertexCount, float3* addition) {
+    assert_invariant(data.find(attrib) != data.end());
+
+    T datav = std::get<T>(data[attrib]);
+    for (size_t i = 0; i < vertexCount; ++i) {
+        if constexpr(std::is_same_v<T, float2*>) {
+            datav[i] += addition[i].xy;
+        } else if constexpr(std::is_same_v<T, float3*>) {
+            datav[i] += addition[i];
+        } else if constexpr(std::is_same_v<T, float4*>) {
+            datav[i].xyz += addition[i];
+        }
+    }
+}
+
+} // namespace data
+
+void destroy(AttributeDataMap& data) {
+    data::free<POSITIONS_T>(data);
+    data::free<TANGENTS_T>(data);
+    data::free<COLORS_T>(data);
+    data::free<NORMALS_T>(data);
+    data::free<UV0_T>(data);
+    data::free<UV1_T>(data);
+    data::free<WEIGHTS_T>(data);
+    data::free<JOINTS_T>(data);
+}
+
+} // anonymous namespace
+
+namespace filament::gltfio {
+
+void TangentsJobExtended::run(Params* params) {
+    cgltf_primitive const& prim = *params->in.prim;
+    int const morphTargetIndex = params->in.morphTargetIndex;
+    bool const isMorphTarget = morphTargetIndex != kMorphTargetUnused;
+    bool const isUnlit = prim.material ? prim.material->unlit : false;
+
+    // Extract the vertex count from the first attribute. All attributes must have the same count.
+    assert_invariant(prim.attributes_count > 0);
+    auto const vertexCount = prim.attributes[0].data->count;
+    assert_invariant(vertexCount > 0);
+
+    std::unordered_map<uint8_t, cgltf_accessor const*> accessors;
+    std::unordered_map<uint8_t, cgltf_accessor const*> morphAccessors;
+    AttributeDataMap attributes;
+
+    // Extract the accessor per attribute from cgltf into our attributes mapping.
+    bool hasUV0 = false;
+    for (cgltf_size aindex = 0; aindex < prim.attributes_count; ++aindex) {
+        cgltf_attribute const& attr = prim.attributes[aindex];
+        cgltf_accessor* accessor = attr.data;
+        assert_invariant(accessor);
+        if (auto const attrCode = toCode({attr.type, attr.index}, params->in.uvmap, hasUV0);
+                attrCode != INVALID_ID) {
+            hasUV0 = hasUV0 || attrCode == UV0_ID;
+            accessors[attrCode] = accessor;
+        }
+    }
+
+    std::vector<float3> morphDelta;
+    if (isMorphTarget) {
+        auto const& morphTarget = prim.targets[morphTargetIndex];
+        decltype(params->in.uvmap) tmpUvmap; // just a placeholder since we don't consider morph target uvs.
+        for (cgltf_size aindex = 0; aindex < morphTarget.attributes_count; aindex++) {
+            cgltf_attribute const& attr = morphTarget.attributes[aindex];
+            if (auto const attrCode = toCode({attr.type, attr.index}, tmpUvmap, false);
+                    attrCode != INVALID_ID) {
+                assert_invariant(accessors.find(attrCode) != accessors.end() &&
+                                 "Morph target data has no corresponding base vertex data.");
+                morphAccessors[attrCode] = attr.data;
+            }
+        }
+        morphDelta.resize(vertexCount);
+    }
+    using AuxType = TangentSpaceMeshWrapper::AuxType;
+    TangentSpaceMeshWrapper::Builder tob(isUnlit);
+    tob.vertexCount(vertexCount);
+
+    // We go through all of the accessors (that we care about) associated with the primitive and
+    // extra the associated data. For morph targets, we also find the associated morph target offset
+    // and apply offsets where possible.
+    for (auto [attr, accessor]: accessors) {
+        switch (attr) {
+            case POSITIONS_ID:
+                data::allocate<POSITIONS_T>(attributes, vertexCount);
+                data::unpack<POSITIONS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data(),
+                            isMorphTarget);
+                    data::add<POSITIONS_T>(attributes, vertexCount, morphDelta.data());
+
+                    // We stash the positions as colors so that they can be retrieved without change
+                    // after the TBN algo, which might have remeshed the input.
+                    data::allocate<COLORS_T>(attributes, vertexCount);
+                    float4* storage = data::get<COLORS_T>(attributes);
+                    for (size_t i = 0; i < vertexCount; i++) {
+                        storage[i] = float4{morphDelta[i], 0.0};
+                    }
+                    tob.aux(AuxType::COLORS, storage);
+                }
+                tob.positions(data::get<POSITIONS_T>(attributes));
+                break;
+            case TANGENTS_ID:
+                data::allocate<TANGENTS_T>(attributes, vertexCount);
+                data::unpack<TANGENTS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data());
+                    data::add<TANGENTS_T>(attributes, vertexCount, morphDelta.data());
+                }
+                tob.tangents(data::get<TANGENTS_T>(attributes));
+                break;
+            case NORMALS_ID:
+                data::allocate<NORMALS_T>(attributes, vertexCount);
+                data::unpack<NORMALS_T>(accessor, attributes, vertexCount);
+                if (auto itr = morphAccessors.find(attr); itr != morphAccessors.end()) {
+                    data::unpack<float3*>(itr->second, vertexCount, morphDelta.data());
+                    data::add<NORMALS_T>(attributes, vertexCount, morphDelta.data());
+                }
+                tob.normals(data::get<NORMALS_T>(attributes));
+                break;
+            case COLORS_ID:
+                data::allocate<COLORS_T>(attributes, vertexCount);
+                data::unpack<COLORS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::COLORS, data::get<COLORS_T>(attributes));
+                break;
+            case UV0_ID:
+                data::allocate<UV0_T>(attributes, vertexCount);
+                data::unpack<UV0_T>(accessor, attributes, vertexCount);
+                tob.uvs(data::get<UV0_T>(attributes));
+                break;
+            case UV1_ID:
+                data::allocate<UV1_T>(attributes, vertexCount);
+                data::unpack<UV1_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::UV1, data::get<UV1_T>(attributes));
+                break;
+            case WEIGHTS_ID:
+                data::allocate<WEIGHTS_T>(attributes, vertexCount);
+                data::unpack<WEIGHTS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::WEIGHTS, data::get<WEIGHTS_T>(attributes));
+                break;
+            case JOINTS_ID:
+                data::allocate<JOINTS_T>(attributes, vertexCount);
+                data::unpack<JOINTS_T>(accessor, attributes, vertexCount);
+                tob.aux(AuxType::JOINTS, data::get<JOINTS_T>(attributes));
+                break;
+            default:
+                break;
+        }
+    }
+
+    std::unique_ptr<uint3[]> unpackedTriangles;    
+    size_t const triangleCount = prim.indices ? (prim.indices->count / 3) : (vertexCount / 3);
+    unpackedTriangles.reset(new uint3[triangleCount]);
+
+    // TODO: this is slow. We might be able to skip the manual read if the indices are already in
+    // the right format.
+    if (prim.indices) {
+        for (size_t tri = 0, j = 0; tri < triangleCount; ++tri) {
+            auto& triangle = unpackedTriangles[tri];
+            triangle.x = cgltf_accessor_read_index(prim.indices, j++);
+            triangle.y = cgltf_accessor_read_index(prim.indices, j++);
+            triangle.z = cgltf_accessor_read_index(prim.indices, j++);
+        }
+    } else {
+        for (size_t tri = 0, j = 0; tri < triangleCount; ++tri) {
+            auto& triangle = unpackedTriangles[tri];
+            triangle.x = j++;
+            triangle.y = j++;
+            triangle.z = j++;
+        }
+    }
+
+    tob.triangleCount(triangleCount);
+    tob.triangles(unpackedTriangles.get());
+    auto const mesh = tob.build();
+
+    auto& out = params->out;
+    out.vertexCount = mesh->getVertexCount();
+
+    out.triangleCount = mesh->getTriangleCount();
+    out.triangles = mesh->getTriangles();
+
+    if (!isUnlit) {
+        out.tbn = mesh->getQuats();
+    }
+
+    if (isMorphTarget) {
+        // For morph targets, we need to retrieve the positions, but note that the unadjusted
+        // positions are stored as colors.
+        // For morph targets, we use COLORS as a way to store the original positions.
+        auto data = mesh->getAux<COLORS_TYPE>(AuxType::COLORS);
+        out.positions = (float3*) malloc(sizeof(float3) * out.vertexCount);
+        for (size_t i = 0; i < out.vertexCount; ++i) {
+            out.positions[i] = data[i].xyz;
+        }
+        free(data);
+    } else {
+        for (auto [attr, data]: attributes) {
+            switch (attr) {
+                case POSITIONS_ID:
+                    out.positions = mesh->getPositions();
+                    break;
+                case COLORS_ID:
+                    out.colors = mesh->getAux<COLORS_TYPE>(AuxType::COLORS);
+                    break;
+                case UV0_ID:
+                    out.uv0 = mesh->getUVs();
+                    break;
+                case UV1_ID:
+                    out.uv1 = mesh->getAux<UV1_TYPE>(AuxType::UV1);
+                    break;
+                case WEIGHTS_ID:
+                    out.weights = mesh->getAux<WEIGHTS_TYPE>(AuxType::WEIGHTS);
+                    break;
+                case JOINTS_ID:
+                    out.joints = mesh->getAux<JOINTS_TYPE>(AuxType::JOINTS);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    destroy(attributes);
+    TangentSpaceMeshWrapper::destroy(mesh);
+}
+
+} // namespace filament::gltfio

--- a/libs/gltfio/src/extended/TangentsJobExtended.h
+++ b/libs/gltfio/src/extended/TangentsJobExtended.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_TANGENTS_JOB_EXTENDED_H
+#define GLTFIO_TANGENTS_JOB_EXTENDED_H
+
+#include <gltfio/MaterialProvider.h> // for UvMap
+#include <math/vec4.h>
+
+#include <cgltf.h>
+
+namespace filament::gltfio {
+
+// Encapsulates a tangent-space transformation, which computes tangents (and maybe transform the
+// mesh vertices/indices depending on the algorithm used). Input to this job can be the base mesh
+// and attributes, or it could be a specific morph target, where offsets to the base mesh will be
+// computed with respect to the morph target index.
+struct TangentsJobExtended {
+    static constexpr int kMorphTargetUnused = -1;
+
+    // The inputs to the procedure. The prim is owned by the client, which should ensure that it
+    // stays alive for the duration of the procedure.
+    struct InputParams {
+        cgltf_primitive const* prim;
+        int morphTargetIndex = kMorphTargetUnused;
+        UvMap uvmap;
+    };
+
+    // The outputs of the procedure. The results array gets malloc'd by the procedure, so clients
+    // should remember to free it.
+    struct OutputParams {
+        size_t triangleCount = 0;
+        math::uint3* triangles = nullptr;
+
+        size_t vertexCount = 0;
+        math::short4* tbn = nullptr;
+        math::float2* uv0 = nullptr;
+        math::float2* uv1 = nullptr;
+        math::float3* positions = nullptr;
+        math::ushort4* joints = nullptr;
+        math::float4* weights = nullptr;
+        math::float4* colors = nullptr;
+
+        bool isEmpty() const {
+            return !tbn && !uv0 && !uv1 && !positions && !joints && !weights && !colors;
+        }
+    };
+
+    // Clients might want to track the jobs in an array, so the arguments are bundled into a struct.
+    struct Params {
+        InputParams in;
+        OutputParams out;
+        uint8_t jobType = 0;        
+    };
+
+    // Performs tangents generation synchronously. This can be invoked from inside a job if desired.
+    // The parameters structure is owned by the client.
+    static void run(Params* params);
+};
+
+} // namespace filament::gltfio
+
+#endif // GLTFIO_TANGENTS_JOB_EXTENDED_H


### PR DESCRIPTION
 - TangentsJobExtended extracts data from cgltf accessor and runs geometry::TangentSpaceMesh on the attributes and computes the tangent space.
 - The /extended folder is meant for running this process. Note that this API might remesh the input and will require corresponding changes that might break previous assumptions.
 - The general flow of the code is modeled after src/TangentsJob.h
 - This is not hooked into current code and should have no practical effect on gltfio.