### PR TITLE
vk: clean-up initialization of classes

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -154,15 +154,9 @@ struct BlitterUniforms {
 
 }// anonymous namespace
 
-VulkanBlitter::VulkanBlitter() noexcept = default;
-
-void VulkanBlitter::initialize(VkPhysicalDevice physicalDevice, VkDevice device,
-        VmaAllocator allocator, VulkanCommands* commands) noexcept {
-    mPhysicalDevice = physicalDevice;
-    mDevice = device;
-    mAllocator = allocator;
-    mCommands = commands;
-}
+VulkanBlitter::VulkanBlitter(VkPhysicalDevice physicalDevice, VulkanCommands* commands) noexcept
+    : mPhysicalDevice(physicalDevice),
+      mCommands(commands) {}
 
 void VulkanBlitter::resolve(VulkanAttachment dst, VulkanAttachment src) {
 

--- a/filament/backend/src/vulkan/VulkanBlitter.h
+++ b/filament/backend/src/vulkan/VulkanBlitter.h
@@ -32,10 +32,7 @@ struct VulkanProgram;
 
 class VulkanBlitter {
 public:
-    VulkanBlitter() noexcept;
-
-    void initialize(VkPhysicalDevice physicalDevice, VkDevice device,
-            VmaAllocator allocator, VulkanCommands* commands) noexcept;
+    VulkanBlitter(VkPhysicalDevice physicalDevice, VulkanCommands* commands) noexcept;
 
     void blit(VkFilter filter,
             VulkanAttachment dst, const VkOffset3D* dstRectPair,
@@ -47,8 +44,6 @@ public:
 
 private:
     UTILS_UNUSED VkPhysicalDevice mPhysicalDevice;
-    VkDevice mDevice;
-    VmaAllocator mAllocator;
     VulkanCommands* mCommands;
 };
 

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -155,7 +155,7 @@ VulkanCommands::VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFam
 #endif
 }
 
-VulkanCommands::~VulkanCommands() {
+void VulkanCommands::terminate() {
     wait();
     gc();
     vkDestroyCommandPool(mDevice, mPool, VKALLOC);

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -139,71 +139,72 @@ public:
 //    - We do this because vkGetFenceStatus must be called from the rendering thread.
 //
 class VulkanCommands {
-    public:
-        VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
-                VulkanContext* context, VulkanResourceAllocator* allocator);
-        ~VulkanCommands();
+public:
+    VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+            VulkanContext* context, VulkanResourceAllocator* allocator);
 
-        // Creates a "current" command buffer if none exists, otherwise returns the current one.
-        VulkanCommandBuffer& get();
+    void terminate();
 
-        // Submits the current command buffer if it exists, then sets "current" to null.
-        // If there are no outstanding commands then nothing happens and this returns false.
-        bool flush();
+    // Creates a "current" command buffer if none exists, otherwise returns the current one.
+    VulkanCommandBuffer& get();
 
-        // Returns the "rendering finished" semaphore for the most recent flush and removes
-        // it from the existing dependency chain. This is especially useful for setting up
-        // vkQueuePresentKHR.
-        VkSemaphore acquireFinishedSignal();
+    // Submits the current command buffer if it exists, then sets "current" to null.
+    // If there are no outstanding commands then nothing happens and this returns false.
+    bool flush();
 
-        // Takes a semaphore that signals when the next flush can occur. Only one injected
-        // semaphore is allowed per flush. Useful after calling vkAcquireNextImageKHR.
-        void injectDependency(VkSemaphore next);
+    // Returns the "rendering finished" semaphore for the most recent flush and removes
+    // it from the existing dependency chain. This is especially useful for setting up
+    // vkQueuePresentKHR.
+    VkSemaphore acquireFinishedSignal();
 
-        // Destroys all command buffers that are no longer in use.
-        void gc();
+    // Takes a semaphore that signals when the next flush can occur. Only one injected
+    // semaphore is allowed per flush. Useful after calling vkAcquireNextImageKHR.
+    void injectDependency(VkSemaphore next);
 
-        // Waits for all outstanding command buffers to finish.
-        void wait();
+    // Destroys all command buffers that are no longer in use.
+    void gc();
 
-        // Updates the atomic "status" variable in every extant fence.
-        void updateFences();
+    // Waits for all outstanding command buffers to finish.
+    void wait();
 
-        // Sets an observer who is notified every time a new command buffer has been made "current".
-        // The observer's event handler can only be called during get().
-        void setObserver(CommandBufferObserver* observer) { mObserver = observer; }
+    // Updates the atomic "status" variable in every extant fence.
+    void updateFences();
+
+    // Sets an observer who is notified every time a new command buffer has been made "current".
+    // The observer's event handler can only be called during get().
+    void setObserver(CommandBufferObserver* observer) { mObserver = observer; }
 
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
-        void pushGroupMarker(char const* str, VulkanGroupMarkers::Timestamp timestamp = {});
+    void pushGroupMarker(char const* str, VulkanGroupMarkers::Timestamp timestamp = {});
 
-        void popGroupMarker();
+    void popGroupMarker();
 
-        void insertEventMarker(char const* string, uint32_t len);
+    void insertEventMarker(char const* string, uint32_t len);
 
-        std::string getTopGroupMarker() const;
+    std::string getTopGroupMarker() const;
 #endif
 
-    private:
-        static constexpr int CAPACITY = FVK_MAX_COMMAND_BUFFERS;
-        VkDevice const mDevice;
-        VkQueue const mQueue;
-        VkCommandPool const mPool;
-        VulkanContext const* mContext;
+private:
+    static constexpr int CAPACITY = FVK_MAX_COMMAND_BUFFERS;
+    VkDevice const mDevice;
+    VkQueue const mQueue;
+    VkCommandPool const mPool;
+    VulkanContext const* mContext;
 
-        // int8 only goes up to 127, therefore capacity must be less than that.
-        static_assert(CAPACITY < 128);
-        int8_t mCurrentCommandBufferIndex = -1;
-        VkSemaphore mSubmissionSignal = {};
-        VkSemaphore mInjectedSignal = {};
-        utils::FixedCapacityVector<std::unique_ptr<VulkanCommandBuffer>> mStorage;
-        VkFence mFences[CAPACITY] = {};
-        VkSemaphore mSubmissionSignals[CAPACITY] = {};
-        uint8_t mAvailableBufferCount = CAPACITY;
-        CommandBufferObserver* mObserver = nullptr;
+    // int8 only goes up to 127, therefore capacity must be less than that.
+    static_assert(CAPACITY < 128);
+    int8_t mCurrentCommandBufferIndex = -1;
+    VkSemaphore mSubmissionSignal = {};
+    VkSemaphore mInjectedSignal = {};
+    utils::FixedCapacityVector<std::unique_ptr<VulkanCommandBuffer>> mStorage;
+    VkFence mFences[CAPACITY] = {};
+    VkSemaphore mSubmissionSignals[CAPACITY] = {};
+    uint8_t mAvailableBufferCount = CAPACITY;
+    CommandBufferObserver* mObserver = nullptr;
 
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
-        std::unique_ptr<VulkanGroupMarkers> mGroupMarkers;
-        std::unique_ptr<VulkanGroupMarkers> mCarriedOverMarkers;
+    std::unique_ptr<VulkanGroupMarkers> mGroupMarkers;
+    std::unique_ptr<VulkanGroupMarkers> mCarriedOverMarkers;
 #endif
 };
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -212,7 +212,13 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform, VulkanContext const& contex
       mResourceAllocator(driverConfig.handleArenaSize),
       mResourceManager(&mResourceAllocator),
       mThreadSafeResourceManager(&mResourceAllocator),
+      mCommands(mPlatform->getDevice(), mPlatform->getGraphicsQueue(),
+              mPlatform->getGraphicsQueueFamilyIndex(), &mContext, &mResourceAllocator),
       mPipelineCache(&mResourceAllocator),
+      mStagePool(mAllocator, &mCommands),
+      mFramebufferCache(mPlatform->getDevice()),
+      mSamplerCache(mPlatform->getDevice()),
+      mBlitter(mPlatform->getPhysicalDevice(), &mCommands),
       mReadPixels(mPlatform->getDevice()),
       mIsSRGBSwapChainSupported(mPlatform->getCustomization().isSRGBSwapChainSupported) {
 
@@ -237,23 +243,16 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform, VulkanContext const& contex
 #endif
 
     mTimestamps = std::make_unique<VulkanTimestamps>(mPlatform->getDevice());
-    mCommands = std::make_unique<VulkanCommands>(mPlatform->getDevice(),
-            mPlatform->getGraphicsQueue(), mPlatform->getGraphicsQueueFamilyIndex(), &mContext,
-            &mResourceAllocator);
-    mCommands->setObserver(&mPipelineCache);
+    mCommands.setObserver(&mPipelineCache);
     mPipelineCache.setDevice(mPlatform->getDevice(), mAllocator);
 
-    // TOOD: move them all to be initialized by constructor
-    mStagePool.initialize(mAllocator, mCommands.get());
-    mFramebufferCache.initialize(mPlatform->getDevice());
-    mSamplerCache.initialize(mPlatform->getDevice());
+    mEmptyTexture = createEmptyTexture(mPlatform->getDevice(), mPlatform->getPhysicalDevice(),
+            mContext, mAllocator, &mCommands, mStagePool);
 
-    mEmptyTexture.reset(createEmptyTexture(mPlatform->getDevice(), mPlatform->getPhysicalDevice(),
-            mContext, mAllocator, mCommands.get(), mStagePool));
+    // Use resource manager to ref-count placeholder resources.
+    mResourceManager.acquire(mEmptyTexture);
 
     mPipelineCache.setDummyTexture(mEmptyTexture->getPrimaryImageView());
-    mBlitter.initialize(mPlatform->getPhysicalDevice(), mPlatform->getDevice(), mAllocator,
-            mCommands.get());
 }
 
 VulkanDriver::~VulkanDriver() noexcept = default;
@@ -316,8 +315,10 @@ ShaderModel VulkanDriver::getShaderModel() const noexcept {
 void VulkanDriver::terminate() {
     // Command buffers should come first since it might have commands depending on resources that
     // are about to be destroyed.
-    mCommands.reset();
-    mEmptyTexture.reset();
+    mCommands.terminate();
+
+    mResourceManager.clear();
+
     mTimestamps.reset();
 
     mBlitter.terminate();
@@ -346,7 +347,7 @@ void VulkanDriver::terminate() {
 }
 
 void VulkanDriver::tick(int) {
-    mCommands->updateFences();
+    mCommands.updateFences();
 }
 
 // Garbage collection should not occur too frequently, only about once per frame. Internally, the
@@ -358,7 +359,7 @@ void VulkanDriver::collectGarbage() {
     FVK_SYSTRACE_START("gc");
     // Command buffers need to be submitted and completed before other resources can be gc'd. And
     // its gc() function carrys out the *wait*.
-    mCommands->gc();
+    mCommands.gc();
     mStagePool.gc();
     mFramebufferCache.gc();
 
@@ -386,7 +387,7 @@ void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 void VulkanDriver::endFrame(uint32_t frameId) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("endframe");
-    mCommands->flush();
+    mCommands.flush();
     collectGarbage();
     FVK_SYSTRACE_END();
 }
@@ -394,7 +395,7 @@ void VulkanDriver::endFrame(uint32_t frameId) {
 void VulkanDriver::flush(int) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("flush");
-    mCommands->flush();
+    mCommands.flush();
     FVK_SYSTRACE_END();
 }
 
@@ -402,8 +403,8 @@ void VulkanDriver::finish(int dummy) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("finish");
 
-    mCommands->flush();
-    mCommands->wait();
+    mCommands.flush();
+    mCommands.wait();
 
     mReadPixels.runUntilComplete();
     FVK_SYSTRACE_END();
@@ -500,7 +501,7 @@ void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage usage) {
     auto vktexture = mResourceAllocator.construct<VulkanTexture>(th, mPlatform->getDevice(),
-            mPlatform->getPhysicalDevice(), mContext, mAllocator, mCommands.get(), target, levels,
+            mPlatform->getPhysicalDevice(), mContext, mAllocator, &mCommands, target, levels,
             format, samples, w, h, depth, usage, mStagePool);
     mResourceManager.acquire(vktexture);
 }
@@ -512,7 +513,7 @@ void VulkanDriver::createTextureSwizzledR(Handle<HwTexture> th, SamplerType targ
     TextureSwizzle swizzleArray[] = {r, g, b, a};
     const VkComponentMapping swizzleMap = getSwizzleMap(swizzleArray);
     auto vktexture = mResourceAllocator.construct<VulkanTexture>(th, mPlatform->getDevice(),
-            mPlatform->getPhysicalDevice(), mContext, mAllocator, mCommands.get(), target, levels,
+            mPlatform->getPhysicalDevice(), mContext, mAllocator, &mCommands, target, levels,
             format, samples, w, h, depth, usage, mStagePool, false /*heap allocated */, swizzleMap);
     mResourceManager.acquire(vktexture);
 }
@@ -607,7 +608,7 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     assert_invariant(tmin.x >= width && tmin.y >= height);
 
     auto renderTarget = mResourceAllocator.construct<VulkanRenderTarget>(rth, mPlatform->getDevice(),
-            mPlatform->getPhysicalDevice(), mContext, mAllocator, mCommands.get(), width, height,
+            mPlatform->getPhysicalDevice(), mContext, mAllocator, &mCommands, width, height,
             samples, colorTargets, depthStencil, mStagePool);
     mResourceManager.acquire(renderTarget);
 }
@@ -625,7 +626,7 @@ void VulkanDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
 }
 
 void VulkanDriver::createFenceR(Handle<HwFence> fh, int) {
-    VulkanCommandBuffer const& commandBuffer = mCommands->get();
+    VulkanCommandBuffer const& commandBuffer = mCommands.get();
     mResourceAllocator.construct<VulkanFence>(fh, commandBuffer.fence);
 }
 
@@ -636,7 +637,7 @@ void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
         flags = flags | ~(backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE);
     }
     auto swapChain = mResourceAllocator.construct<VulkanSwapChain>(sch, mPlatform, mContext,
-            mAllocator, mCommands.get(), mStagePool, nativeWindow, flags);
+            mAllocator, &mCommands, mStagePool, nativeWindow, flags);
     mResourceManager.acquire(swapChain);
 }
 
@@ -649,7 +650,7 @@ void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t wi
     }
     assert_invariant(width > 0 && height > 0 && "Vulkan requires non-zero swap chain dimensions.");
     auto swapChain = mResourceAllocator.construct<VulkanSwapChain>(sch, mPlatform, mContext,
-            mAllocator, mCommands.get(), mStagePool, nullptr, flags, VkExtent2D{width, height});
+            mAllocator, &mCommands, mStagePool, nullptr, flags, VkExtent2D{width, height});
     mResourceManager.acquire(swapChain);
 }
 
@@ -994,7 +995,7 @@ void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t in
 
 void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
-    VulkanCommandBuffer& commands = mCommands->get();
+    VulkanCommandBuffer& commands = mCommands.get();
     auto ib = mResourceAllocator.handle_cast<VulkanIndexBuffer*>(ibh);
     commands.acquire(ib);
     ib->buffer.loadFromCpu(commands.buffer(), p.buffer, byteOffset, p.size);
@@ -1004,7 +1005,7 @@ void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor
 
 void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& bd,
         uint32_t byteOffset) {
-    VulkanCommandBuffer& commands = mCommands->get();
+    VulkanCommandBuffer& commands = mCommands.get();
 
     auto bo = mResourceAllocator.handle_cast<VulkanBufferObject*>(boh);
     commands.acquire(bo);
@@ -1015,7 +1016,7 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
 
 void VulkanDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> boh,
         BufferDescriptor&& bd, uint32_t byteOffset) {
-    VulkanCommandBuffer& commands = mCommands->get();
+    VulkanCommandBuffer& commands = mCommands.get();
     auto bo = mResourceAllocator.handle_cast<VulkanBufferObject*>(boh);
     commands.acquire(bo);
     // TODO: implement unsynchronized version
@@ -1180,7 +1181,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     // If that's the case, we need to change the layout of the texture to DEPTH_SAMPLER, which is a
     // more general layout. Otherwise, we prefer the DEPTH_ATTACHMENT layout, which is optimal for
     // the non-sampling case.
-    VulkanCommandBuffer& commands = mCommands->get();
+    VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer const cmdbuffer = commands.buffer();
 
     UTILS_NOUNROLL
@@ -1307,7 +1308,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 
 // Assign a label to the framebuffer for debugging purposes.
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS | FVK_DEBUG_DEBUG_UTILS)
-    auto const topMarker = mCommands->getTopGroupMarker();
+    auto const topMarker = mCommands.getTopGroupMarker();
     if (!topMarker.empty()) {
         DebugUtils::setName(VK_OBJECT_TYPE_FRAMEBUFFER, reinterpret_cast<uint64_t>(vkfb),
                 topMarker.c_str());
@@ -1396,7 +1397,7 @@ void VulkanDriver::endRenderPass(int) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("endRenderPass");
 
-    VulkanCommandBuffer& commands = mCommands->get();
+    VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer cmdbuffer = commands.buffer();
     vkCmdEndRenderPass(cmdbuffer);
 
@@ -1449,7 +1450,7 @@ void VulkanDriver::nextSubpass(int) {
     assert_invariant(renderTarget);
     assert_invariant(mCurrentRenderPass.params.subpassMask);
 
-    vkCmdNextSubpass(mCommands->get().buffer(), VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdNextSubpass(mCommands.get().buffer(), VK_SUBPASS_CONTENTS_INLINE);
 
     mPipelineCache.bindRenderPass(mCurrentRenderPass.renderPass,
             ++mCurrentRenderPass.currentSubpass);
@@ -1530,14 +1531,14 @@ void VulkanDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
 
 void VulkanDriver::insertEventMarker(char const* string, uint32_t len) {
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
-    mCommands->insertEventMarker(string, len);
+    mCommands.insertEventMarker(string, len);
 #endif
 }
 
 void VulkanDriver::pushGroupMarker(char const* string, uint32_t) {
     // Turns out all the markers are 0-terminated, so we can just pass it without len.
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
-    mCommands->pushGroupMarker(string);
+    mCommands.pushGroupMarker(string);
 #endif
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START(string);
@@ -1545,7 +1546,7 @@ void VulkanDriver::pushGroupMarker(char const* string, uint32_t) {
 
 void VulkanDriver::popGroupMarker(int) {
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
-    mCommands->popGroupMarker();
+    mCommands.popGroupMarker();
 #endif
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_END();
@@ -1558,7 +1559,7 @@ void VulkanDriver::stopCapture(int) {}
 void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y, uint32_t width,
         uint32_t height, PixelBufferDescriptor&& pbd) {
     VulkanRenderTarget* srcTarget = mResourceAllocator.handle_cast<VulkanRenderTarget*>(src);
-    mCommands->flush();
+    mCommands.flush();
     mReadPixels.run(
             srcTarget, x, y, width, height, mPlatform->getGraphicsQueueFamilyIndex(),
             std::move(pbd),
@@ -1715,7 +1716,7 @@ void VulkanDriver::bindPipeline(PipelineState pipelineState) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("draw");
 
-    VulkanCommandBuffer* commands = &mCommands->get();
+    VulkanCommandBuffer* commands = &mCommands.get();
     const VulkanVertexBufferInfo& vbi =
             *mResourceAllocator.handle_cast<VulkanVertexBufferInfo*>(pipelineState.vertexBufferInfo);
 
@@ -1814,7 +1815,7 @@ void VulkanDriver::bindPipeline(PipelineState pipelineState) {
             utils::slog.w << " in material '" << program->name.c_str() << "'";
             utils::slog.w << " at binding point " << +binding << utils::io::endl;
 #endif
-            texture = mEmptyTexture.get();
+            texture = mEmptyTexture;
         }
 
         SamplerParams const& samplerParams = boundSampler->s;
@@ -1861,7 +1862,7 @@ void VulkanDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("bindRenderPrimitive");
 
-    VulkanCommandBuffer* commands = &mCommands->get();
+    VulkanCommandBuffer* commands = &mCommands.get();
     VkCommandBuffer cmdbuffer = commands->buffer();
     const VulkanRenderPrimitive& prim = *mResourceAllocator.handle_cast<VulkanRenderPrimitive*>(rph);
     commands->acquire(prim.indexBuffer);
@@ -1890,8 +1891,8 @@ void VulkanDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t ins
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("draw2");
 
-    VulkanCommandBuffer* commands = &mCommands->get();
-    VkCommandBuffer cmdbuffer = commands->buffer();
+    VulkanCommandBuffer& commands = mCommands.get();
+    VkCommandBuffer cmdbuffer = commands.buffer();
 
     // Bind new descriptor sets if they need to change.
     // If descriptor set allocation failed, skip the draw call and bail. No need to emit an error
@@ -1925,8 +1926,8 @@ void VulkanDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGr
 }
 
 void VulkanDriver::scissor(Viewport scissorBox) {
-    VulkanCommandBuffer* commands = &mCommands->get();
-    VkCommandBuffer cmdbuffer = commands->buffer();
+    VulkanCommandBuffer& commands = mCommands.get();
+    VkCommandBuffer cmdbuffer = commands.buffer();
 
     // Set scissoring.
     // clamp left-bottom to 0,0 and avoid overflows
@@ -1953,12 +1954,12 @@ void VulkanDriver::scissor(Viewport scissorBox) {
 
 void VulkanDriver::beginTimerQuery(Handle<HwTimerQuery> tqh) {
     VulkanTimerQuery* vtq = mResourceAllocator.handle_cast<VulkanTimerQuery*>(tqh);
-    mTimestamps->beginQuery(&(mCommands->get()), vtq);
+    mTimestamps->beginQuery(&(mCommands.get()), vtq);
 }
 
 void VulkanDriver::endTimerQuery(Handle<HwTimerQuery> tqh) {
     VulkanTimerQuery* vtq = mResourceAllocator.handle_cast<VulkanTimerQuery*>(tqh);
-    mTimestamps->endQuery(&(mCommands->get()), vtq);
+    mTimestamps->endQuery(&(mCommands.get()), vtq);
 }
 
 void VulkanDriver::debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept {

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -104,9 +104,9 @@ private:
     void collectGarbage();
 
     VulkanPlatform* mPlatform = nullptr;
-    std::unique_ptr<VulkanCommands> mCommands;
     std::unique_ptr<VulkanTimestamps> mTimestamps;
-    std::unique_ptr<VulkanTexture> mEmptyTexture;
+
+    VulkanTexture* mEmptyTexture;
 
     VulkanSwapChain* mCurrentSwapChain = nullptr;
     VulkanRenderTarget* mDefaultRenderTarget = nullptr;
@@ -122,6 +122,7 @@ private:
     // thread.
     VulkanThreadSafeResourceManager mThreadSafeResourceManager;
 
+    VulkanCommands mCommands;
     VulkanPipelineCache mPipelineCache;
     VulkanStagePool mStagePool;
     VulkanFboCache mFramebufferCache;

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -64,7 +64,8 @@ bool VulkanFboCache::FboKeyEqualFn::operator()(const FboKey& k1, const FboKey& k
     return true;
 }
 
-void VulkanFboCache::initialize(VkDevice device) noexcept { mDevice = device; }
+VulkanFboCache::VulkanFboCache(VkDevice device)
+    : mDevice(device) {}
 
 VulkanFboCache::~VulkanFboCache() {
     ASSERT_POSTCONDITION(mFramebufferCache.empty() && mRenderPassCache.empty(),

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -104,9 +104,8 @@ public:
         bool operator()(const FboKey& k1, const FboKey& k2) const;
     };
 
+    explicit VulkanFboCache(VkDevice device);
     ~VulkanFboCache();
-
-    void initialize(VkDevice device) noexcept;
 
     // Retrieves or creates a VkFramebuffer handle.
     VkFramebuffer getFramebuffer(FboKey config) noexcept;

--- a/filament/backend/src/vulkan/VulkanSamplerCache.cpp
+++ b/filament/backend/src/vulkan/VulkanSamplerCache.cpp
@@ -95,7 +95,8 @@ constexpr inline VkBool32 getCompareEnable(SamplerCompareMode mode) noexcept {
     return mode == SamplerCompareMode::NONE ? VK_FALSE : VK_TRUE;
 }
 
-void VulkanSamplerCache::initialize(VkDevice device) { mDevice = device; }
+VulkanSamplerCache::VulkanSamplerCache(VkDevice device)
+    : mDevice(device) {}
 
 VkSampler VulkanSamplerCache::getSampler(SamplerParams params) noexcept {
     auto iter = mCache.find(params);

--- a/filament/backend/src/vulkan/VulkanSamplerCache.h
+++ b/filament/backend/src/vulkan/VulkanSamplerCache.h
@@ -27,7 +27,7 @@ namespace filament::backend {
 // Simple manager for VkSampler objects.
 class VulkanSamplerCache {
 public:
-    void initialize(VkDevice device);
+    explicit VulkanSamplerCache(VkDevice device);
     VkSampler getSampler(SamplerParams params) noexcept;
     void terminate() noexcept;
 private:

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -26,10 +26,9 @@ static constexpr uint32_t TIME_BEFORE_EVICTION = FVK_MAX_COMMAND_BUFFERS;
 
 namespace filament::backend {
 
-void VulkanStagePool::initialize(VmaAllocator allocator, VulkanCommands* commands) noexcept {
-    mAllocator = allocator;
-    mCommands = commands;
-}
+VulkanStagePool::VulkanStagePool(VmaAllocator allocator, VulkanCommands* commands)
+    : mAllocator(allocator),
+      mCommands(commands) {}
 
 VulkanStage const* VulkanStagePool::acquireStage(uint32_t numBytes) {
     // First check if a stage exists whose capacity is greater than or equal to the requested size.

--- a/filament/backend/src/vulkan/VulkanStagePool.h
+++ b/filament/backend/src/vulkan/VulkanStagePool.h
@@ -45,7 +45,7 @@ struct VulkanStageImage {
 // This class manages two types of host-mappable staging areas: buffer stages and image stages.
 class VulkanStagePool {
 public:
-    void initialize(VmaAllocator allocator, VulkanCommands* commands) noexcept;
+    VulkanStagePool(VmaAllocator allocator, VulkanCommands* commands);
 
     // Finds or creates a stage whose capacity is at least the given number of bytes.
     // The stage is automatically released back to the pool after TIME_BEFORE_EVICTION frames.


### PR DESCRIPTION
Instead of holding pointers to class instances in VulkanDriver, we standardize by making the relevant classes have proper constructors and initialize in VulkanDriver's constructor initializer list.