### PR TITLE
The type of geometry of a renderable can now be specified

### DIFF
--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -106,6 +106,14 @@ Java_com_google_android_filament_RenderableManager_nBuilderGeometry__JIIJJIIII(J
 
 extern "C"
 JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderGeometryType(JNIEnv*, jclass,
+        jlong nativeBuilder, int type) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->geometryType((RenderableManager::Builder::GeometryType)type);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
 Java_com_google_android_filament_RenderableManager_nBuilderMaterial(JNIEnv*, jclass,
         jlong nativeBuilder, jint index, jlong nativeMaterialInstance) {
     RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -176,6 +176,32 @@ public class RenderableManager {
         }
 
         /**
+         * Type of geometry for a Renderable
+         */
+        public enum GeometryType {
+            /** dynamic gemoetry has no restriction */
+            DYNAMIC,
+            /** bounds and world space transform are immutable */
+            STATIC_BOUNDS,
+            /** skinning/morphing not allowed and Vertex/IndexBuffer immutables */
+            STATIC
+        }
+
+        /**
+         * Specify whether this renderable has static bounds. In this context his means that
+         * the renderable's bounding box cannot change and that the renderable's transform is
+         * assumed immutable. Changing the renderable's transform via the TransformManager
+         * can lead to corrupted graphics. Note that skinning and morphing are not forbidden.
+         * Disabled by default.
+         * @param enable whether this renderable has static bounds. false by default.
+         */
+        @NonNull
+        public Builder geometryType(GeometryType type) {
+            nBuilderGeometryType(mNativeBuilder, type.ordinal());
+            return this;
+        }
+
+        /**
          * Binds a material instance to the specified primitive.
          *
          * <p>If no material is specified for a given primitive, Filament will fall back to a basic
@@ -964,6 +990,7 @@ public class RenderableManager {
     private static native void nBuilderGeometry(long nativeBuilder, int index, int value, long nativeVertexBuffer, long nativeIndexBuffer);
     private static native void nBuilderGeometry(long nativeBuilder, int index, int value, long nativeVertexBuffer, long nativeIndexBuffer, int offset, int count);
     private static native void nBuilderGeometry(long nativeBuilder, int index, int value, long nativeVertexBuffer, long nativeIndexBuffer, int offset, int minIndex, int maxIndex, int count);
+    private static native void nBuilderGeometryType(long nativeBuilder, int type);
     private static native void nBuilderMaterial(long nativeBuilder, int index, long nativeMaterialInstance);
     private static native void nBuilderBlendOrder(long nativeBuilder, int index, int blendOrder);
     private static native void nBuilderGlobalBlendOrderEnabled(long nativeBuilder, int index, boolean enabled);

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -157,6 +157,15 @@ public:
         static constexpr uint8_t DEFAULT_CHANNEL = 2u;
 
         /**
+         * Type of geometry for a Renderable
+         */
+        enum class GeometryType : uint8_t {
+            DYNAMIC,        //!< dynamic gemoetry has no restriction
+            STATIC_BOUNDS,  //!< bounds and world space transform are immutable
+            STATIC          //!< skinning/morphing not allowed and Vertex/IndexBuffer immutables
+        };
+
+        /**
          * Creates a builder for renderable components.
          *
          * @param count the number of primitives that will be supplied to the builder
@@ -203,6 +212,17 @@ public:
         Builder& geometry(size_t index, PrimitiveType type,
                 VertexBuffer* UTILS_NONNULL vertices,
                 IndexBuffer* UTILS_NONNULL indices) noexcept; //!< \overload
+
+
+        /**
+         * Specify the type of geometry for this renderable. DYNAMIC geometry has no restriction,
+         * STATIC_BOUNDS geometry means that both the bounds and the world-space transform of the
+         * the renderable are immutable.
+         * STATIC geometry has the same restrictions as STATIC_BOUNDS, but in addition disallows
+         * skinning, morphing and changing the VertexBuffer or IndexBuffer in any way.
+         * @param enable whether this renderable has static bounds. false by default.
+         */
+        Builder& geometryType(GeometryType type) noexcept;
 
         /**
          * Binds a material instance to the specified primitive.
@@ -603,11 +623,12 @@ public:
 
     /**
      * Changes the bounding box used for frustum culling.
+     * The renderable must not have staticGeometry enabled.
      *
      * \see Builder::boundingBox()
      * \see RenderableManager::getAxisAlignedBoundingBox()
      */
-    void setAxisAlignedBoundingBox(Instance instance, const Box& aabb) noexcept;
+    void setAxisAlignedBoundingBox(Instance instance, const Box& aabb);
 
     /**
      * Changes the visibility bits.

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -56,7 +56,7 @@ void RenderableManager::destroy(utils::Entity e) noexcept {
     return downcast(this)->destroy(e);
 }
 
-void RenderableManager::setAxisAlignedBoundingBox(Instance instance, const Box& aabb) noexcept {
+void RenderableManager::setAxisAlignedBoundingBox(Instance instance, const Box& aabb) {
     downcast(this)->setAxisAlignedBoundingBox(instance, aabb);
 }
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -938,6 +938,10 @@ class_<RenderableBuilder>("RenderableManager$Builder")
             size_t count), {
         return &builder->geometry(index, type, vertices, indices, offset, minIndex, maxIndex, count); })
 
+    .BUILDER_FUNCTION("geometryType", RenderableBuilder, (RenderableBuilder* builder,
+            RenderableManager::Builder::GeometryType type), {
+        return &builder->geometryType(type); })
+
     .BUILDER_FUNCTION("material", RenderableBuilder, (RenderableBuilder* builder,
             size_t index, MaterialInstance* mi), {
         return &builder->material(index, mi); })


### PR DESCRIPTION
- dynamic (default) no restriction apply
- static bounds: bounds and world transform can't be changed
- static: additionaly morphing/skinning and vertex/index buffers are
  immutable.

This will allow some optimizations in the future. Currently, we just
store the type but don't do anything with it.