### PR TITLE
Allow rendering thread to pause

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- engine: Add experimental APIs `Engine::builder::paused()` and `Engine::setPaused()`

--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -391,6 +391,13 @@ Java_com_google_android_filament_Engine_nFlush(JNIEnv*, jclass,
     engine->flush();
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Engine_nSetPaused(JNIEnv*, jclass,
+        jlong nativeEngine, jboolean paused) {
+    Engine* engine = (Engine*) nativeEngine;
+    engine->setPaused(paused);
+}
+
 // Managers...
 
 extern "C" JNIEXPORT jlong JNICALL
@@ -516,6 +523,12 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
         JNIEnv*, jclass, jlong nativeBuilder, jlong sharedContext) {
     Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
     builder->sharedContext((void*) sharedContext);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBuilderPaused(
+        JNIEnv*, jclass, jlong nativeBuilder, jboolean paused) {
+    Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
+    builder->paused((bool) paused);
 }
 
 extern "C" JNIEXPORT jlong JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -240,6 +240,18 @@ public class Engine {
         }
 
         /**
+         * Sets the initial paused state of the rendering thread.
+         *
+         * @param paused Whether to start the rendering thread paused.
+         * @return A reference to this Builder for chaining calls.
+         * @warning Experimental.
+         */
+        public Builder paused(boolean paused) {
+            nSetBuilderPaused(mNativeBuilder, paused);
+            return this;
+        }
+
+        /**
          * Creates an instance of Engine
          *
          * @return A newly created <code>Engine</code>, or <code>null</code> if the GPU driver couldn't
@@ -1189,6 +1201,13 @@ public class Engine {
         nFlush(getNativeObject());
     }
 
+    /**
+     * Pause or resume the rendering thread.
+     * @warning Experimental.
+     */
+    public void setPaused(boolean paused) {
+        nSetPaused(getNativeObject(), paused);
+    }
 
     @UsedByReflection("TextureHelper.java")
     public long getNativeObject() {
@@ -1263,6 +1282,7 @@ public class Engine {
     private static native void nDestroyEntity(long nativeEngine, int entity);
     private static native void nFlushAndWait(long nativeEngine);
     private static native void nFlush(long nativeEngine);
+    private static native void nSetPaused(long nativeEngine, boolean paused);
     private static native long nGetTransformManager(long nativeEngine);
     private static native long nGetLightManager(long nativeEngine);
     private static native long nGetRenderableManager(long nativeEngine);
@@ -1286,5 +1306,6 @@ public class Engine {
             long resourceAllocatorCacheSizeMB, long resourceAllocatorCacheMaxAge);
     private static native void nSetBuilderFeatureLevel(long nativeBuilder, int ordinal);
     private static native void nSetBuilderSharedContext(long nativeBuilder, long sharedContext);
+    private static native void nSetBuilderPaused(long nativeBuilder, boolean paused);
     private static native long nBuilderBuild(long nativeBuilder);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -242,9 +242,11 @@ public class Engine {
         /**
          * Sets the initial paused state of the rendering thread.
          *
+         * <p>Warning: This is an experimental API. See {@link Engine#setPaused(boolean)} for
+         * caveats.
+         *
          * @param paused Whether to start the rendering thread paused.
          * @return A reference to this Builder for chaining calls.
-         * @warning Experimental.
          */
         public Builder paused(boolean paused) {
             nSetBuilderPaused(mNativeBuilder, paused);
@@ -1203,7 +1205,16 @@ public class Engine {
 
     /**
      * Pause or resume the rendering thread.
-     * @warning Experimental.
+     *
+     * <p>Warning: This is an experimental API. In particular, note the following caveats.
+     *
+     * <ul><li>
+     * Buffer callbacks will never be called as long as the rendering thread is paused.
+     * Do not rely on a buffer callback to unpause the thread.
+     * </li><li>
+     * While the rendering thread is paused, rendering commands will continued to be queued
+     * until the buffer limit is reached. When the limit is reached, the program will abort.
+     * </li></ul>
      */
     public void setPaused(boolean paused) {
         nSetPaused(getNativeObject(), paused);

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -1212,8 +1212,8 @@ public class Engine {
      * Buffer callbacks will never be called as long as the rendering thread is paused.
      * Do not rely on a buffer callback to unpause the thread.
      * </li><li>
-     * While the rendering thread is paused, rendering commands will continued to be queued
-     * until the buffer limit is reached. When the limit is reached, the program will abort.
+     * While the rendering thread is paused, rendering commands will continue to be queued until the
+     * buffer limit is reached. When the limit is reached, the program will abort.
      * </li></ul>
      */
     public void setPaused(boolean paused) {

--- a/filament/backend/include/private/backend/CommandBufferQueue.h
+++ b/filament/backend/include/private/backend/CommandBufferQueue.h
@@ -50,12 +50,13 @@ class CommandBufferQueue {
     size_t mFreeSpace = 0;
     size_t mHighWatermark = 0;
     uint32_t mExitRequested = 0;
+    bool mPaused = false;
 
     static constexpr uint32_t EXIT_REQUESTED = 0x31415926;
 
 public:
     // requiredSize: guaranteed available space after flush()
-    CommandBufferQueue(size_t requiredSize, size_t bufferSize);
+    CommandBufferQueue(size_t requiredSize, size_t bufferSize, bool paused);
     ~CommandBufferQueue();
 
     CircularBuffer& getCircularBuffer() noexcept { return mCircularBuffer; }
@@ -79,6 +80,9 @@ public:
 
     // returns from waitForCommands() immediately.
     void requestExit();
+
+    // suspend or unsuspend the queue.
+    void setPaused(bool paused);
 
     bool isExitRequested() const;
 };

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -51,7 +51,7 @@ void BackendTest::init(Backend backend, bool isMobilePlatform) {
 }
 
 BackendTest::BackendTest() : commandBufferQueue(CONFIG_MIN_COMMAND_BUFFERS_SIZE,
-            CONFIG_COMMAND_BUFFERS_SIZE) {
+        CONFIG_COMMAND_BUFFERS_SIZE, /*mPaused=*/false) {
     initializeDriver();
 }
 

--- a/filament/backend/test/ComputeTest.cpp
+++ b/filament/backend/test/ComputeTest.cpp
@@ -46,7 +46,8 @@ void ComputeTest::init(Backend backend) {
 }
 
 ComputeTest::ComputeTest()
-        : commandBufferQueue(CONFIG_MIN_COMMAND_BUFFERS_SIZE, CONFIG_COMMAND_BUFFERS_SIZE) {
+    : commandBufferQueue(CONFIG_MIN_COMMAND_BUFFERS_SIZE, CONFIG_COMMAND_BUFFERS_SIZE,
+            /*paused=*/false) {
 }
 
 ComputeTest::~ComputeTest() = default;

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -402,6 +402,13 @@ public:
          */
         Builder& featureLevel(FeatureLevel featureLevel) noexcept;
 
+        /**
+         * @param paused Whether to start the rendering thread paused.
+         * @return A reference to this Builder for chaining calls.
+         * @warning Experimental.
+         */
+        Builder& paused(bool paused) noexcept;
+
 #if UTILS_HAS_THREADING
         /**
          * Creates the filament Engine asynchronously.
@@ -826,6 +833,12 @@ public:
      * queue which has a limited size.</p>
       */
     void flush();
+
+    /**
+     * Pause or resume rendering thread.
+     * @warning Experimental.
+     */
+    void setPaused(bool paused);
 
     /**
      * Drains the user callback message queue and immediately execute all pending callbacks.

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -403,9 +403,10 @@ public:
         Builder& featureLevel(FeatureLevel featureLevel) noexcept;
 
         /**
+         * Warning: This is an experimental API. See Engine::setPaused(bool) for caveats.
+         *
          * @param paused Whether to start the rendering thread paused.
          * @return A reference to this Builder for chaining calls.
-         * @warning Experimental.
          */
         Builder& paused(bool paused) noexcept;
 
@@ -836,7 +837,16 @@ public:
 
     /**
      * Pause or resume rendering thread.
-     * @warning Experimental.
+     *
+     * <p>Warning: This is an experimental API. In particular, note the following caveats.
+     *
+     * <ul><li>
+     * Buffer callbacks will never be called as long as the rendering thread is paused.
+     * Do not rely on a buffer callback to unpause the thread.
+     * </li><li>
+     * While the rendering thread is paused, rendering commands will continued to be queued
+     * until the buffer limit is reached. When the limit is reached, the program will abort.
+     * </li></ul>
      */
     void setPaused(bool paused);
 

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -844,8 +844,8 @@ public:
      * Buffer callbacks will never be called as long as the rendering thread is paused.
      * Do not rely on a buffer callback to unpause the thread.
      * </li><li>
-     * While the rendering thread is paused, rendering commands will continued to be queued
-     * until the buffer limit is reached. When the limit is reached, the program will abort.
+     * While the rendering thread is paused, rendering commands will continue to be queued until the
+     * buffer limit is reached. When the limit is reached, the program will abort.
      * </li></ul>
      */
     void setPaused(bool paused);

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -295,6 +295,11 @@ utils::JobSystem& Engine::getJobSystem() noexcept {
     return downcast(this)->getJobSystem();
 }
 
+void Engine::setPaused(bool paused) {
+    ASSERT_PRECONDITION(UTILS_HAS_THREADING, "Pause is meant for multi-threaded platforms.");
+    downcast(this)->setPaused(paused);
+}
+
 DebugRegistry& Engine::getDebugRegistry() noexcept {
     return downcast(this)->getDebugRegistry();
 }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -69,6 +69,7 @@ struct Engine::BuilderDetails {
     Engine::Config mConfig;
     FeatureLevel mFeatureLevel = FeatureLevel::FEATURE_LEVEL_1;
     void* mSharedContext = nullptr;
+    bool mPaused = false;
     static Config validateConfig(const Config* pConfig) noexcept;
 };
 
@@ -200,7 +201,8 @@ FEngine::FEngine(Engine::Builder const& builder) :
         mCameraManager(*this),
         mCommandBufferQueue(
                 builder->mConfig.minCommandBufferSizeMB * MiB,
-                builder->mConfig.commandBufferSizeMB * MiB),
+                builder->mConfig.commandBufferSizeMB * MiB,
+                builder->mPaused),
         mPerRenderPassArena(
                 "FEngine::mPerRenderPassAllocator",
                 builder->mConfig.perRenderPassArenaSizeMB * MiB),
@@ -1194,6 +1196,10 @@ void FEngine::destroy(FEngine* engine) {
     }
 }
 
+void FEngine::setPaused(bool paused) {
+    mCommandBufferQueue.setPaused(paused);
+}
+
 Engine::FeatureLevel FEngine::getSupportedFeatureLevel() const noexcept {
     FEngine::DriverApi& driver = const_cast<FEngine*>(this)->getDriverApi();
     return driver.getFeatureLevel();
@@ -1244,6 +1250,11 @@ Engine::Builder& Engine::Builder::featureLevel(FeatureLevel featureLevel) noexce
 
 Engine::Builder& Engine::Builder::sharedContext(void* sharedContext) noexcept {
     mImpl->mSharedContext = sharedContext;
+    return *this;
+}
+
+Engine::Builder& Engine::Builder::paused(bool paused) noexcept {
+    mImpl->mPaused = paused;
     return *this;
 }
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -340,6 +340,8 @@ public:
 
     void destroy(utils::Entity e);
 
+    void setPaused(bool paused);
+
     void flushAndWait();
 
     // flush the current buffer


### PR DESCRIPTION
This PR adds a new `pause()` option to the `Engine` `Builder` and a new function `setPaused()` to the `Engine`. While paused, the rendering thread will pause indefinitely for commands as if none are available. As soon as the rendering thread is unpaused, the commands are immediately executed.