### PR TITLE
Make PBR Neutral invertible

### DIFF
--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -253,7 +253,7 @@ float3 PBRNeutralToneMapper::operator()(math::float3 color) const noexcept {
     color *= newPeak / peak;
 
     float g = 1.0f - 1.0f / (desaturation * (peak - newPeak) + 1.0f);
-    return mix(color, float3(1.0f), g);
+    return mix(color, float3(newPeak), g);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Based on model-viewer's change at https://github.com/google/model-viewer/pull/4716

The change has barely any visible impact, but it allows the resulting equation to be
more trivially invertible (which we will likely want at some point).