### PR TITLE
vk: fix broken gltf renderings

### DIFF
--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -239,7 +239,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .format = config.colorFormat[i],
             .samples = (VkSampleCountFlagBits) config.samples,
             .loadOp = clear ? kClear : (discard ? kDontCare : kKeep),
-            .storeOp = config.samples == 1 ? kEnableStore : kDisableStore,
+            .storeOp = kEnableStore,
             .stencilLoadOp = kDontCare,
             .stencilStoreOp = kDisableStore,
             .initialLayout = ((!discard && config.initialColorLayoutMask & (1 << i)) || clear)


### PR DESCRIPTION
This is due to color attachments being set to store=discard when they are multi-sampled. It's unclear why that condition exists. For now, removing it will fix the rendering issues with transparent object + MSAA. We'll keep it as such until an issue surfaces.

Fixes #7674