### PR TITLE
iOS: fix gltf-viewer crash while destructing ResourceLoader

### DIFF
--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -275,16 +275,16 @@ const float kSensitivity = 100.0f;
 - (void)dealloc {
     [self destroyModel];
 
-    delete _manipulator;
-    delete _stbDecoder;
-    delete _ktxDecoder;
-
     _materialProvider->destroyMaterials();
     delete _materialProvider;
     auto* ncm = _assetLoader->getNames();
     delete ncm;
     AssetLoader::destroy(&_assetLoader);
     delete _resourceLoader;
+
+    delete _manipulator;
+    delete _stbDecoder;
+    delete _ktxDecoder;
 
     _engine->destroy(_swapChain);
     _engine->destroy(_view);

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -93,7 +93,8 @@ public:
     /**
      * Register a plugin that can consume PNG / JPEG content and produce filament::Texture objects.
      *
-     * Destruction of the given provider is the client's responsibility.
+     * Destruction of the given provider is the client's responsibility and must be done after the
+     * destruction of this ResourceLoader.
      */
     void addTextureProvider(const char* mimeType, TextureProvider* provider);
 


### PR DESCRIPTION
Fixes #7672