### PR TITLE
PlatformEGL::createSwapChain never returns a nullptr anymore

### DIFF
--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -89,7 +89,7 @@ public:
      * @return              The driver's SwapChain object.
      *
      */
-    virtual SwapChain* UTILS_NONNULL createSwapChain(
+    virtual SwapChain* UTILS_NULLABLE createSwapChain(
             void* UTILS_NULLABLE nativeWindow, uint64_t flags) noexcept = 0;
 
     /**

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1461,6 +1461,8 @@ void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
     sc->swapChain = mPlatform.createSwapChain(nativeWindow, flags);
+
+    // note: in practice this should never happen on Android
     ASSERT_POSTCONDITION(sc->swapChain,
             "createSwapChain(%p, 0x%lx) failed. See logs for details.",
             nativeWindow, flags);
@@ -1478,6 +1480,8 @@ void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
     sc->swapChain = mPlatform.createSwapChain(width, height, flags);
+
+    // note: in practice this should never happen on Android
     ASSERT_POSTCONDITION(sc->swapChain,
             "createSwapChainHeadless(%u, %u, 0x%lx) failed. See logs for details.",
             width, height, flags);


### PR DESCRIPTION
in case the swapchain creation fails, it will now return a swapchain with an EGL_NO_SURFACE handle. this will avoid having to nullptr check the pointer in various places and will revert to the previous behavior on failure.

FIXES=[329659681]