### PR TITLE
Improve multiview shader replacement

### DIFF
--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -145,7 +145,7 @@ public:
 
     uint64_t getCacheId() const noexcept { return mCacheId; }
 
-    bool getMultiview() const noexcept { return mMultiview; }
+    bool isMultiview() const noexcept { return mMultiview; }
 
     CompilerPriorityQueue getPriorityQueue() const noexcept { return mPriorityQueue; }
 

--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -116,6 +116,8 @@ public:
 
     Program& cacheId(uint64_t cacheId) noexcept;
 
+    Program& multiview(bool multiview) noexcept;
+
     ShaderSource const& getShadersSource() const noexcept { return mShadersSource; }
     ShaderSource& getShadersSource() noexcept { return mShadersSource; }
 
@@ -143,6 +145,8 @@ public:
 
     uint64_t getCacheId() const noexcept { return mCacheId; }
 
+    bool getMultiview() const noexcept { return mMultiview; }
+
     CompilerPriorityQueue getPriorityQueue() const noexcept { return mPriorityQueue; }
 
 private:
@@ -158,6 +162,11 @@ private:
     utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> mAttributes;
     std::array<UniformInfo, Program::UNIFORM_BINDING_COUNT> mBindingUniformInfo;
     CompilerPriorityQueue mPriorityQueue = CompilerPriorityQueue::HIGH;
+    // Indicates the current engine was initialized with multiview stereo, and the variant for this
+    // program contains STE flag. This will be referred later for the OpenGL shader compiler to
+    // determine whether shader code replacement for the num_views should be performed.
+    // This variable could be promoted as a more generic variable later if other similar needs occur.
+    bool mMultiview = false;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -91,6 +91,11 @@ Program& Program::cacheId(uint64_t cacheId) noexcept {
     return *this;
 }
 
+Program& Program::multiview(bool multiview) noexcept {
+    mMultiview = multiview;
+    return *this;
+}
+
 io::ostream& operator<<(io::ostream& out, const Program& builder) {
     out << "Program{";
     builder.mLogger(out);

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -263,7 +263,9 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
                     // compile the shaders
                     std::array<GLuint, Program::SHADER_TYPE_COUNT> shaders{};
                     compileShaders(gl,
-                            program,
+                            std::move(program.getShadersSource()),
+                            program.getSpecializationConstants(),
+                            program.getMultiview(),
                             shaders,
                             token->shaderSourceCode);
 
@@ -297,7 +299,9 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
         // this cannot fail because we check compilation status after linking the program
         // shaders[] is filled with id of shader stages present.
         compileShaders(gl,
-                program,
+                std::move(program.getShadersSource()),
+                program.getSpecializationConstants(),
+                program.getMultiview(),
                 token->gl.shaders,
                 token->shaderSourceCode);
 
@@ -497,15 +501,14 @@ GLuint ShaderCompilerService::initialize(program_token_t& token) noexcept {
  * checked until after the program is linked.
  * This always returns the GL shader IDs or zero a shader stage is not present.
  */
-void ShaderCompilerService::compileShaders(OpenGLContext& context, Program& program,
+void ShaderCompilerService::compileShaders(OpenGLContext& context,
+        Program::ShaderSource shadersSource,
+        utils::FixedCapacityVector<Program::SpecializationConstant> const& specializationConstants,
+        bool multiview,
         std::array<GLuint, Program::SHADER_TYPE_COUNT>& outShaders,
         UTILS_UNUSED_IN_RELEASE std::array<CString, Program::SHADER_TYPE_COUNT>& outShaderSourceCode) noexcept {
 
     SYSTRACE_CALL();
-
-    Program::ShaderSource shadersSource = std::move(program.getShadersSource());
-    utils::FixedCapacityVector<Program::SpecializationConstant> const& specializationConstants =
-            program.getSpecializationConstants();
 
     auto appendSpecConstantString = +[](std::string& s, Program::SpecializationConstant const& sc) {
         s += "#define SPIRV_CROSS_CONSTANT_ID_" + std::to_string(sc.id) + ' ';
@@ -560,7 +563,7 @@ void ShaderCompilerService::compileShaders(OpenGLContext& context, Program& prog
             process_GOOGLE_cpp_style_line_directive(context, shader_src, shader_len);
 
             // replace the value of layout(num_views = X) for multiview extension
-            if (program.getMultiview() && stage == ShaderStage::VERTEX) {
+            if (multiview && stage == ShaderStage::VERTEX) {
                 process_OVR_multiview2(context, numViews, shader_src, shader_len);
             }
 

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -265,7 +265,7 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
                     compileShaders(gl,
                             std::move(program.getShadersSource()),
                             program.getSpecializationConstants(),
-                            program.getMultiview(),
+                            program.isMultiview(),
                             shaders,
                             token->shaderSourceCode);
 
@@ -301,7 +301,7 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
         compileShaders(gl,
                 std::move(program.getShadersSource()),
                 program.getSpecializationConstants(),
-                program.getMultiview(),
+                program.isMultiview(),
                 token->gl.shaders,
                 token->shaderSourceCode);
 

--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -132,8 +132,7 @@ private:
 
     static void compileShaders(
             OpenGLContext& context,
-            Program::ShaderSource shadersSource,
-            utils::FixedCapacityVector<Program::SpecializationConstant> const& specializationConstants,
+            Program& program,
             std::array<GLuint, Program::SHADER_TYPE_COUNT>& outShaders,
             std::array<utils::CString, Program::SHADER_TYPE_COUNT>& outShaderSourceCode) noexcept;
 

--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -132,7 +132,9 @@ private:
 
     static void compileShaders(
             OpenGLContext& context,
-            Program& program,
+            Program::ShaderSource shadersSource,
+            utils::FixedCapacityVector<Program::SpecializationConstant> const& specializationConstants,
+            bool multiview,
             std::array<GLuint, Program::SHADER_TYPE_COUNT>& outShaders,
             std::array<utils::CString, Program::SHADER_TYPE_COUNT>& outShaderSourceCode) noexcept;
 

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -641,6 +641,9 @@ void FMaterial::getSurfaceProgramSlow(Variant variant,
 
     Program pb{ getProgramWithVariants(variant, vertexVariant, fragmentVariant) };
     pb.priorityQueue(priorityQueue);
+    pb.multiview(
+            mEngine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW &&
+            Variant::isStereoVariant(variant));
     createAndCacheProgram(std::move(pb), variant);
 }
 


### PR DESCRIPTION
Replace the num_views for OpenGL multiviwe only when
- The engine is initialized with multiview stereo
- The variant for the material contains STE flag
- The program is for surface
- It's vertex shader (this is already in)