### PR TITLE
Throw an NSException on Apple platforms when panicking

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -87,6 +87,7 @@ if (LINUX OR ANDROID)
     list(APPEND SRCS src/linux/Path.cpp)
 endif()
 if (APPLE)
+    list(APPEND SRCS src/darwin/Exception.mm)
     list(APPEND SRCS src/darwin/Path.mm)
     list(APPEND SRCS src/darwin/Systrace.cpp)
 endif()
@@ -120,6 +121,10 @@ if (LINUX)
     find_package(Threads REQUIRED)
     target_link_libraries(${TARGET} PRIVATE Threads::Threads)
     target_link_libraries(${TARGET} PRIVATE dl)
+endif()
+
+if (APPLE AND NOT IOS)
+    target_link_libraries(${TARGET} PRIVATE "-framework Cocoa")
 endif()
 
 # ==================================================================================================

--- a/libs/utils/include/utils/Panic.h
+++ b/libs/utils/include/utils/Panic.h
@@ -259,6 +259,18 @@ public:
     virtual const char* what() const noexcept = 0;
 
     /**
+     * Get the reason for the panic.
+     * @return a C string containing the reason for the panic.
+     */
+    virtual const char* getReason() const noexcept = 0;
+
+    /**
+     * Get the type of the panic. When compiled without RTTI, this returns a generic type name.
+     * @return a C string containing the type of the panic.
+     */
+    virtual const char* getType() const noexcept = 0;
+
+    /**
      * Get the function name where the panic was detected
      * @return a C string containing the function name where the panic was detected
      */
@@ -305,6 +317,8 @@ public:
     const char* what() const noexcept override;
 
     // Panic interface
+    const char* getReason() const noexcept override;
+    const char* getType() const noexcept override;
     const char* getFunction() const noexcept override;
     const char* getFile() const noexcept override;
     int getLine() const noexcept override;
@@ -369,7 +383,8 @@ private:
     char const* const m_function = nullptr;
     char const* const m_file = nullptr;
     const int m_line = -1;
-    mutable std::string m_msg;
+    std::string m_msg;
+    std::string m_type;
 };
 
 namespace details {

--- a/libs/utils/include/utils/darwin/Exception.h
+++ b/libs/utils/include/utils/darwin/Exception.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_DARWIN_EXCEPTION_H
+#define TNT_UTILS_DARWIN_EXCEPTION_H
+
+#include <utils/Panic.h>
+#include <utils/compiler.h>
+
+namespace utils::details {
+
+void throwDarwinException(const Panic& exception) UTILS_NORETURN;
+
+}
+
+#endif // TNT_UTILS_DARWIN_EXCEPTION_H

--- a/libs/utils/src/darwin/Exception.mm
+++ b/libs/utils/src/darwin/Exception.mm
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/Panic.h>
+
+#include <Foundation/Foundation.h>
+
+namespace utils::details {
+
+void throwDarwinException(const Panic& exception) {
+    // Turn this exception into an NSException and raise it.
+    // This is allowed even if we're built without Objective-C exceptions (-fno-objc-exceptions).
+    [[NSException exceptionWithName:@(exception.getType())
+                             reason:@(exception.getReason())
+                           userInfo:@{
+                               @"file" : @(exception.getFile()),
+                               @"line" : @(exception.getLine()),
+                               @"function" : @(exception.getFunction())
+                           }] raise];
+}
+
+}


### PR DESCRIPTION
On Apple platforms, we should be throwing an `NSException`, which gives us better crash reporting.