### PR TITLE
Fix point/spot shadow rendering bug

### DIFF
--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -160,14 +160,20 @@ private:
 
     void prepareSpotShadowMap(ShadowMap& shadowMap,
             FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
-            FScene::RenderableSoa& renderableData, utils::Range<uint32_t> range,
             FScene::LightSoa& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept;
+
+    static void cullSpotShadowMap(ShadowMap const& map,
+            FEngine& engine, FView& view,
+            FScene::RenderableSoa& renderableData, utils::Range<uint32_t> range,
+            FScene::LightSoa& lightData) noexcept;
 
     void preparePointShadowMap(ShadowMap& map,
             FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
+            FScene::LightSoa& lightData) noexcept;
+
+    static void cullPointShadowMap(ShadowMap const& shadowMap, FView& view,
             FScene::RenderableSoa& renderableData, utils::Range<uint32_t> range,
-            FScene::LightSoa& lightData,
-            ShadowMap::SceneInfo const& sceneInfo) noexcept;
+            FScene::LightSoa& lightData) noexcept;
 
     static void updateSpotVisibilityMasks(
             uint8_t visibleLayers,
@@ -202,8 +208,6 @@ private:
         float mSplitsCs[SPLIT_COUNT];
         size_t mSplitCount;
     };
-
-    FEngine& mEngine;
 
     // Atlas requirements, updated in ShadowMapManager::update(),
     // consumed in ShadowMapManager::render()


### PR DESCRIPTION
We were calculating the shadow visibility of spot/point lights. The visibility was calculated during the "execute" phase of the FrameGraph but it was used/needed during the setup phase. The result was that the visibility was always delayed by one frame (really it was stale  data from the previous calculation).

We are now computing the shadow visibility earlier, during the setup phase. This is also better because we can now skip culling of these shadow maps entirely if we know they're not visible.

Fixes #7715