### PR TITLE
vk: add descriptor set/layout types to handles

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1771,14 +1771,13 @@ void VulkanDriver::bindPipeline(PipelineState pipelineState) {
     VulkanTexture* samplerTextures[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {nullptr};
 
     auto const& bindingToSamplerIndex = program->getBindingToSamplerIndex();
-    VulkanPipelineCache::UsageFlags usage = program->getUsage();
+    UsageFlags usage = program->getUsage();
 
 #if FVK_ENABLED_DEBUG_SAMPLER_NAME
     auto const& bindingToName = program->getBindingToName();
 #endif
 
-    UTILS_NOUNROLL
-    for (uint8_t binding = 0; binding < VulkanPipelineCache::SAMPLER_BINDING_COUNT; binding++) {
+    for (auto binding: program->getBindings()) {
         uint16_t const indexPair = bindingToSamplerIndex[binding];
 
         if (indexPair == 0xffff) {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -21,35 +21,172 @@
 #include "DriverBase.h"
 
 #include "VulkanBuffer.h"
-#include "VulkanPipelineCache.h"
 #include "VulkanResources.h"
 #include "VulkanSwapChain.h"
 #include "VulkanTexture.h"
+#include "VulkanUtility.h"
 
 #include "private/backend/SamplerGroup.h"
+#include "utils/FixedCapacityVector.h"
+#include "vulkan/vulkan_core.h"
 
 #include <utils/Mutex.h>
 #include <utils/StructureOfArrays.h>
 
 namespace filament::backend {
 
+using namespace descset;
+
 class VulkanTimestamps;
+
+struct VulkanDescriptorSetLayout : public VulkanResource {
+    static constexpr uint8_t UNIQUE_DESCRIPTOR_SET_COUNT = 3;
+
+    // The bitmask representation of a set layout.
+    struct Bitmask {
+        UniformBufferBitmask ubo = 0;         // 4 bytes
+        UniformBufferBitmask dynamicUbo = 0;  // 4 bytes
+        SamplerBitmask sampler = 0;           // 8 bytes
+        InputAttachmentBitmask inputAttachment = 0; // 1 bytes
+
+        // Because we're using this struct as hash key, must make it's 8-bytes aligned, with no
+        // unaccounted bytes.
+        uint8_t padding0 = 0; // 1 bytes
+        uint16_t padding1 = 0;// 2 bytes
+        uint32_t padding2 = 0;// 4 bytes
+
+        bool operator==(Bitmask const& right) const {
+            return ubo == right.ubo && dynamicUbo == right.dynamicUbo && sampler == right.sampler &&
+                   inputAttachment == right.inputAttachment;
+        }
+
+        static Bitmask fromBackendLayout(descset::DescriptorSetLayout const& layout);
+    };
+
+    // This is a convenience struct to quickly check layout compatibility in terms of descriptor set
+    // pools.
+    struct Count {
+        uint32_t ubo = 0;
+        uint32_t dynamicUbo = 0;
+        uint32_t sampler = 0;
+        uint32_t inputAttachment = 0;
+
+        bool operator==(Count const& right) const noexcept {
+            return ubo == right.ubo && dynamicUbo == right.dynamicUbo && sampler == right.sampler &&
+                   inputAttachment == right.inputAttachment;
+        }
+
+        static inline Count fromLayoutBitmask(Bitmask const& mask) {
+            return {
+                    .ubo = countBits(collapseStages(mask.ubo)),
+                    .dynamicUbo = countBits(collapseStages(mask.dynamicUbo)),
+                    .sampler = countBits(collapseStages(mask.sampler)),
+                    .inputAttachment = countBits(collapseStages(mask.inputAttachment)),
+            };
+        }
+
+        Count operator*(uint16_t mult) const noexcept {
+            // TODO: check for overflow.
+
+            Count ret;
+            ret.ubo = ubo * mult;
+            ret.dynamicUbo = dynamicUbo * mult;
+            ret.sampler = sampler * mult;
+            ret.inputAttachment = inputAttachment * mult;
+            return ret;
+        }
+    };
+
+    static_assert(sizeof(Bitmask) % 8 == 0);
+
+    explicit VulkanDescriptorSetLayout(VkDescriptorSetLayout layout, Bitmask const& bitmask)
+        : VulkanResource(VulkanResourceType::DESCRIPTOR_SET_LAYOUT),
+          vklayout(layout),
+          bitmask(bitmask),
+          bindings(getBindings(bitmask)),
+          count(Count::fromLayoutBitmask(bitmask)) {}
+
+    VkDescriptorSetLayout const vklayout;
+    Bitmask const bitmask;
+
+    // This is a convenience struct so that we don't have to iterate through all the bits of the
+    // bitmask (which correspondings to binding indices).
+    struct _Bindings {
+        utils::FixedCapacityVector<uint8_t> const ubo;
+        utils::FixedCapacityVector<uint8_t> const dynamicUbo;
+        utils::FixedCapacityVector<uint8_t> const sampler;
+        utils::FixedCapacityVector<uint8_t> const inputAttachment;
+    } bindings;
+
+    Count const count;
+
+private:
+
+    template <typename MaskType>
+    utils::FixedCapacityVector<uint8_t> bits(MaskType mask) {
+        utils::FixedCapacityVector<uint8_t> ret =
+                utils::FixedCapacityVector<uint8_t>::with_capacity(countBits(mask));
+        for (uint8_t i = 0; i < sizeof(mask) * 4; ++i) {
+            if (mask & (1 << i)) {
+                ret.push_back(i);
+            }
+        }
+        return ret;
+    }
+
+    _Bindings getBindings(Bitmask const& bitmask) {
+        auto const uboCollapsed = collapseStages(bitmask.ubo);
+        auto const dynamicUboCollapsed = collapseStages(bitmask.dynamicUbo);
+        auto const samplerCollapsed = collapseStages(bitmask.sampler);
+        auto const inputAttachmentCollapsed = collapseStages(bitmask.inputAttachment);
+        return {
+            bits(uboCollapsed),
+            bits(dynamicUboCollapsed),
+            bits(samplerCollapsed),
+            bits(inputAttachmentCollapsed),
+        };
+    }
+};
+
+using VulkanDescriptorSetLayoutList = std::array<Handle<VulkanDescriptorSetLayout>,
+        VulkanDescriptorSetLayout::UNIQUE_DESCRIPTOR_SET_COUNT>;
+
+struct VulkanDescriptorSet : public VulkanResource {
+public:
+    // Because we need to recycle descriptor sets not used, we allow for a callback that the "Pool"
+    // can use to repackage the vk handle.
+    using OnRecycle = std::function<void()>;
+
+    VulkanDescriptorSet(VulkanResourceAllocator* allocator,
+            VkDescriptorSet rawSet, OnRecycle&& onRecycleFn)
+        : VulkanResource(VulkanResourceType::DESCRIPTOR_SET),
+          resources(allocator),
+          vkSet(rawSet),
+          mOnRecycleFn(std::move(onRecycleFn)) {}
+
+    ~VulkanDescriptorSet() {
+        if (mOnRecycleFn) {
+            mOnRecycleFn();
+        }
+    }
+
+    // TODO: maybe change to fixed size for performance.
+    VulkanAcquireOnlyResourceManager resources;
+    VkDescriptorSet const vkSet;
+
+private:
+    OnRecycle mOnRecycleFn;
+};
+
+using VulkanDescriptorSetList = std::array<Handle<VulkanDescriptorSet>,
+        VulkanDescriptorSetLayout::UNIQUE_DESCRIPTOR_SET_COUNT>;
 
 struct VulkanProgram : public HwProgram, VulkanResource {
 
+    using BindingList = CappedArray<uint16_t, MAX_SAMPLER_COUNT>;
+
     VulkanProgram(VkDevice device, Program const& builder) noexcept;
 
-    struct CustomSamplerInfo {
-        uint8_t groupIndex;
-        uint8_t samplerIndex;
-        ShaderStageFlags flags;
-    };
-    using CustomSamplerInfoList = utils::FixedCapacityVector<CustomSamplerInfo>;
-
-    // We allow custom descriptor of the samplers within shaders.  This is needed if we want to use
-    // a program that exists only in the backend - for example, for shader-based bliting.
-    VulkanProgram(VkDevice device, VkShaderModule vs, VkShaderModule fs,
-            CustomSamplerInfoList const& samplerInfo) noexcept;
     ~VulkanProgram();
 
     inline VkShaderModule getVertexShader() const {
@@ -58,11 +195,27 @@ struct VulkanProgram : public HwProgram, VulkanResource {
 
     inline VkShaderModule getFragmentShader() const { return mInfo->shaders[1]; }
 
-    inline VulkanPipelineCache::UsageFlags getUsage() const { return mInfo->usage; }
-
     inline utils::FixedCapacityVector<uint16_t> const& getBindingToSamplerIndex() const {
         return mInfo->bindingToSamplerIndex;
     }
+
+    inline UsageFlags getUsage() const {
+        return mInfo->usage;
+    }
+
+    // Get a list of the sampler binding indices so that we don't have to loop through all possible
+    // samplers.
+    inline BindingList const& getBindings() const { return mInfo->bindings; }
+
+    // TODO: this is currently not used. This will replace getLayoutDescriptionList below.
+    // inline descset::DescriptorSetLayout const& getLayoutDescription() const {
+    //    return mInfo->layout;
+    // }
+    // In the usual case, we would have just one layout per program. But in the current setup, we
+    // have a set/layout for each descriptor type. This will be changed in the future.
+    using LayoutDescriptionList = std::array<descset::DescriptorSetLayout,
+            VulkanDescriptorSetLayout::UNIQUE_DESCRIPTOR_SET_COUNT>;
+    inline LayoutDescriptionList const& getLayoutDescriptionList() const { return mInfo->layouts; }
 
 #if FVK_ENABLED_DEBUG_SAMPLER_NAME
     inline utils::FixedCapacityVector<std::string> const& getBindingToName() const {
@@ -70,26 +223,32 @@ struct VulkanProgram : public HwProgram, VulkanResource {
     }
 #endif
 
-private:
     // TODO: handle compute shaders.
     // The expected order of shaders - from frontend to backend - is vertex, fragment, compute.
     static constexpr uint8_t const MAX_SHADER_MODULES = 2;
 
+private:
     struct PipelineInfo {
         PipelineInfo()
             : bindingToSamplerIndex(MAX_SAMPLER_COUNT, 0xffff)
 #if FVK_ENABLED_DEBUG_SAMPLER_NAME
             , bindingToName(MAX_SAMPLER_COUNT, "")
-#endif              
+#endif
             {}
 
         // This bitset maps to each of the sampler in the sampler groups associated with this
         // program, and whether each sampler is used in which shader (i.e. vert, frag, compute).
-        VulkanPipelineCache::UsageFlags usage;
+        UsageFlags usage;
+
+        BindingList bindings;
 
         // We store the samplerGroupIndex as the top 8-bit and the index within each group as the lower 8-bit.
         utils::FixedCapacityVector<uint16_t> bindingToSamplerIndex;
         VkShaderModule shaders[MAX_SHADER_MODULES] = { VK_NULL_HANDLE };
+
+        // TODO: Use this instead of `layouts` after Filament-side Descriptor Set API is in place.
+        // descset::DescriptorSetLayout layout;
+        LayoutDescriptionList layouts;
 
 #if FVK_ENABLED_DEBUG_SAMPLER_NAME
         // We store the sampler name mapped from binding index (only for debug purposes).

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -34,7 +34,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-static VkShaderStageFlags getShaderStageFlags(VulkanPipelineCache::UsageFlags key, uint16_t binding) {
+static VkShaderStageFlags getShaderStageFlags(UsageFlags key, uint16_t binding) {
     // NOTE: if you modify this function, you also need to modify getUsageFlags.
     assert_invariant(binding < MAX_SAMPLER_COUNT);
     VkShaderStageFlags flags = 0;
@@ -47,24 +47,7 @@ static VkShaderStageFlags getShaderStageFlags(VulkanPipelineCache::UsageFlags ke
     return flags;
 }
 
-VulkanPipelineCache::UsageFlags
-VulkanPipelineCache::getUsageFlags(uint16_t binding, ShaderStageFlags flags, UsageFlags src) {
-    // NOTE: if you modify this function, you also need to modify getShaderStageFlags.
-    assert_invariant(binding < MAX_SAMPLER_COUNT);
-    if (any(flags & ShaderStageFlags::VERTEX)) {
-        src.set(binding);
-    }
-    if (any(flags & ShaderStageFlags::FRAGMENT)) {
-        src.set(MAX_SAMPLER_COUNT + binding);
-    }
-    // TODO: add support for compute by extending SHADER_MODULE_COUNT and ensuring UsageFlags
-    // has 186 bits (MAX_SAMPLER_COUNT * 3)
-    // assert_invariant(!any(flags & ~(ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT)));
-    return src;
-}
-
-VulkanPipelineCache::UsageFlags VulkanPipelineCache::disableUsageFlags(uint16_t binding,
-        UsageFlags src) {
+UsageFlags VulkanPipelineCache::disableUsageFlags(uint16_t binding, UsageFlags src) {
     src.unset(binding);
     src.unset(MAX_SAMPLER_COUNT + binding);
     return src;

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -89,8 +89,6 @@ public:
         VkSpecializationInfo* specializationInfos = nullptr;
     };
 
-    using UsageFlags = utils::bitset128;
-    static UsageFlags getUsageFlags(uint16_t binding, ShaderStageFlags stages, UsageFlags src = {});
     static UsageFlags disableUsageFlags(uint16_t binding, UsageFlags src);
 
     #pragma clang diagnostic push

--- a/filament/backend/src/vulkan/VulkanResources.cpp
+++ b/filament/backend/src/vulkan/VulkanResources.cpp
@@ -17,7 +17,7 @@
 #include "VulkanResources.h"
 #include "VulkanHandles.h"
 #include "VulkanResourceAllocator.h"
-#include "caching/VulkanDescriptorSet.h"
+#include "VulkanPipelineCache.h"
 
 namespace filament::backend {
 
@@ -61,6 +61,9 @@ void deallocateResource(VulkanResourceAllocator* allocator, VulkanResourceType t
             break;
         case VulkanResourceType::RENDER_PRIMITIVE:
             allocator->destruct<VulkanRenderPrimitive>(Handle<VulkanRenderPrimitive>(id));
+            break;
+        case VulkanResourceType::DESCRIPTOR_SET_LAYOUT:
+            allocator->destruct<VulkanDescriptorSetLayout>(Handle<VulkanDescriptorSetLayout>(id));
             break;
         case VulkanResourceType::DESCRIPTOR_SET:
             allocator->destruct<VulkanDescriptorSet>(Handle<VulkanDescriptorSet>(id));

--- a/filament/backend/src/vulkan/VulkanResources.h
+++ b/filament/backend/src/vulkan/VulkanResources.h
@@ -35,24 +35,25 @@ struct VulkanThreadSafeResource;
 
 // Subclasses of VulkanResource must provide this enum in their construction.
 enum class VulkanResourceType : uint8_t {
-    BUFFER_OBJECT,
-    INDEX_BUFFER,
-    PROGRAM,
-    RENDER_TARGET,
-    SAMPLER_GROUP,
-    SWAP_CHAIN,
-    RENDER_PRIMITIVE,
-    TEXTURE,
-    TIMER_QUERY,
-    VERTEX_BUFFER,
-    VERTEX_BUFFER_INFO,
-    DESCRIPTOR_SET,
+    BUFFER_OBJECT = 0,
+    INDEX_BUFFER = 1,
+    PROGRAM = 2,
+    RENDER_TARGET = 3,
+    SAMPLER_GROUP = 4,
+    SWAP_CHAIN = 5,
+    RENDER_PRIMITIVE = 6,
+    TEXTURE = 7,
+    TIMER_QUERY = 8,
+    VERTEX_BUFFER = 9,
+    VERTEX_BUFFER_INFO = 10,
+    DESCRIPTOR_SET_LAYOUT = 11,
+    DESCRIPTOR_SET = 12,
 
     // Below are resources that are managed manually (i.e. not ref counted).
-    FENCE,
-    HEAP_ALLOCATED,
+    FENCE = 13,
+    HEAP_ALLOCATED = 14,
 
-    END_TYPE,  // A placeholder
+    END_TYPE = 15,  // A placeholder
 };
 
 #define IS_HEAP_ALLOC_TYPE(f)                                                                      \

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -655,4 +655,6 @@ uint8_t reduceSampleCount(uint8_t sampleCount, VkSampleCountFlags mask) {
     return mostSignificantBit((sampleCount - 1) & mask);
 }
 
+_BitCountHelper _BitCountHelper::BitCounter = {};
+
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -90,6 +90,9 @@ utils::FixedCapacityVector<OutType> enumerate(
 #undef EXPAND_ENUM_NO_ARGS
 #undef EXPAND_ENUM_ARGS
 
+// Used across pipeline related classes.
+using UsageFlags = utils::bitset128;
+
 // Useful shorthands
 using VkFormatList = utils::FixedCapacityVector<VkFormat>;
 
@@ -122,14 +125,14 @@ public:
         clear();
     }
 
-    inline const_iterator begin() {
+    inline const_iterator begin() const {
         if (mInd == 0) {
             return mArray.cend();
         }
         return mArray.cbegin();
     }
 
-    inline const_iterator end() {
+    inline const_iterator end() const {
         if (mInd > 0 && mInd < CAPACITY) {
             return mArray.begin() + mInd;
         }
@@ -170,7 +173,7 @@ public:
         return mArray[ind];
     }
 
-    inline size_t size() {
+    inline uint32_t size() const {
         return mInd;
     }
 
@@ -181,8 +184,126 @@ private:
     }
 
     FixedSizeArray mArray;
-    size_t mInd = 0;
+    uint32_t mInd = 0;
 };
+
+// TODO: ok to remove once Filament-side API is complete
+namespace descset {
+
+// Used to describe the descriptor binding in shader stages. We assume that the binding index does
+// not exceed 31. We also assume that we have two shader stages - vertex and fragment.  The below
+// types and struct are used across VulkanDescriptorSet and VulkanProgram.
+using UniformBufferBitmask = uint32_t;
+using SamplerBitmask = uint64_t;
+
+// We only have at most one input attachment, so this bitmask exists only to make the code more
+// general.
+using InputAttachmentBitmask = uint8_t;
+
+constexpr UniformBufferBitmask UBO_VERTEX_STAGE = 0x1;
+constexpr UniformBufferBitmask UBO_FRAGMENT_STAGE = (0x1ULL << (sizeof(UniformBufferBitmask) * 4));
+constexpr SamplerBitmask SAMPLER_VERTEX_STAGE = 0x1;
+constexpr SamplerBitmask SAMPLER_FRAGMENT_STAGE = (0x1ULL << (sizeof(SamplerBitmask) * 4));
+constexpr InputAttachmentBitmask INPUT_ATTACHMENT_VERTEX_STAGE = 0x1;
+constexpr InputAttachmentBitmask INPUT_ATTACHMENT_FRAGMENT_STAGE =
+        (0x1ULL << (sizeof(InputAttachmentBitmask) * 4));
+
+template<typename Bitmask>
+static constexpr Bitmask getVertexStage() noexcept {
+    if constexpr (std::is_same_v<Bitmask, UniformBufferBitmask>) {
+        return UBO_VERTEX_STAGE;
+    }
+    if constexpr (std::is_same_v<Bitmask, SamplerBitmask>) {
+        return SAMPLER_VERTEX_STAGE;
+    }
+    if constexpr (std::is_same_v<Bitmask, InputAttachmentBitmask>) {
+        return INPUT_ATTACHMENT_VERTEX_STAGE;
+    }
+}
+
+template<typename Bitmask>
+static constexpr Bitmask getFragmentStage() noexcept {
+    if constexpr (std::is_same_v<Bitmask, UniformBufferBitmask>) {
+        return UBO_FRAGMENT_STAGE;
+    }
+    if constexpr (std::is_same_v<Bitmask, SamplerBitmask>) {
+        return SAMPLER_FRAGMENT_STAGE;
+    }
+    if constexpr (std::is_same_v<Bitmask, InputAttachmentBitmask>) {
+        return INPUT_ATTACHMENT_FRAGMENT_STAGE;
+    }
+}
+
+typedef enum ShaderStageFlags2 : uint8_t {
+    NONE        =    0,
+    VERTEX      =    0x1,
+    FRAGMENT    =    0x2,
+} ShaderStageFlags2;
+
+enum class DescriptorType : uint8_t {
+    UNIFORM_BUFFER,
+    SAMPLER,
+    INPUT_ATTACHMENT,
+};
+
+enum class DescriptorFlags : uint8_t {
+    NONE = 0x00,
+    DYNAMIC_OFFSET = 0x01
+};
+
+struct DescriptorSetLayoutBinding {
+    DescriptorType type;
+    ShaderStageFlags2 stageFlags;
+    uint8_t binding;
+    DescriptorFlags flags;
+    uint16_t count;
+};
+
+struct DescriptorSetLayout {
+    utils::FixedCapacityVector<DescriptorSetLayoutBinding> bindings;
+};
+
+} // namespace descset
+
+// Use constexpr to statically generate a bit count table for 8-bit numbers.
+struct _BitCountHelper {
+    constexpr _BitCountHelper() : data{} {
+        for (uint16_t i = 0; i < 256; ++i) {
+            data[i] = 0;
+            for (auto j = i; j > 0; j /= 2) {
+                if (j & 1) {
+                    data[i]++;
+                }
+            }
+        }
+    }
+
+    template<typename MaskType>
+    constexpr uint8_t count(MaskType num) {
+        uint8_t count = 0;
+        for (uint8_t i = 0; i < sizeof(MaskType) * 8; i+=8) {
+            count += data[(num >> i) & 0xFF];
+        }
+        return count;
+    }
+
+    static _BitCountHelper BitCounter;
+private:
+    uint8_t data[256];
+};
+
+template<typename MaskType>
+inline uint8_t countBits(MaskType num) {
+    return _BitCountHelper::BitCounter.count(num);
+}
+
+// This is useful for counting the total number of descriptors for both vertex and fragment stages.
+template<typename MaskType>
+inline MaskType collapseStages(MaskType mask) {
+    constexpr uint8_t NBITS_DIV_2 = sizeof(MaskType) * 4;
+    // First zero out the top-half and then or the bottom-half against the original top-half.
+    return ((mask << NBITS_DIV_2) >> NBITS_DIV_2) | (mask >> NBITS_DIV_2);
+}
 
 } // namespace filament::backend
 

--- a/filament/backend/src/vulkan/caching/VulkanDescriptorSet.h
+++ b/filament/backend/src/vulkan/caching/VulkanDescriptorSet.h
@@ -32,31 +32,6 @@
 
 namespace filament::backend {
 
-// We need to make this class public to enable allocation on the HandleAllocator.
-struct VulkanDescriptorSet : public VulkanResourceBase {
-public:
-    // Because we need to recycle descriptor set not used, we allow for a callback that the "Pool"
-    // can use to repackage the vk handle.
-    using OnRecycle = std::function<void(VulkanDescriptorSet*)>;
-
-    VulkanDescriptorSet(VulkanResourceAllocator* allocator, VkDescriptorSet rawSet,
-            VkDescriptorSetLayout layout, OnRecycle&& onRecycleFn);
-
-    ~VulkanDescriptorSet();
-
-    static VulkanDescriptorSet* create(VulkanResourceAllocator* allocator, VkDescriptorSet rawSet,
-            VkDescriptorSetLayout layout, OnRecycle&& onRecycleFn);
-
-    // TODO: maybe change to fixed size for performance.
-    VulkanAcquireOnlyResourceManager resources;
-
-    VkDescriptorSet const vkSet;
-    VkDescriptorSetLayout const layout;
-
-private:
-    OnRecycle mOnRecycleFn;
-};
-
 // Abstraction over the pool and the layout cache.
 class VulkanDescriptorSetManager {
 public:

--- a/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
+++ b/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
@@ -24,6 +24,7 @@
 
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 namespace filament::backend {
 
@@ -72,7 +73,7 @@ void workaroundSpecConstant(Program::ShaderBlob const& blob,
         std::vector<uint32_t>& output) {
     using WordMap = std::unordered_map<uint32_t, uint32_t>;
     using SpecValueMap = std::unordered_map<uint32_t, SpecConstantValue>;
-    constexpr size_t const HEADER_SIZE = 5;
+    constexpr size_t HEADER_SIZE = 5;
 
     WordMap varToIdMap;
     SpecValueMap idToValue;
@@ -143,6 +144,63 @@ void workaroundSpecConstant(Program::ShaderBlob const& blob,
         cursor += wordCount;
     }
     output.resize(outputCursor);
+}
+
+std::tuple<uint32_t,uint32_t, uint32_t> getProgramBindings(Program::ShaderBlob const& blob) {
+    std::unordered_map<uint32_t, uint32_t> targetToSet, targetToBinding;
+
+    constexpr size_t HEADER_SIZE = 5;
+
+    size_t const dataSize = blob.size() / 4;
+    uint32_t const* data = (uint32_t*) blob.data();
+
+    for (uint32_t cursor = HEADER_SIZE, cursorEnd = dataSize; cursor < cursorEnd;) {
+        uint32_t const firstWord = data[cursor];
+        uint32_t const wordCount = firstWord >> 16;
+        uint32_t const op = firstWord & 0x0000FFFF;
+
+        switch(op) {
+            case spv::Op::OpDecorate: {
+                if (data[cursor + 2] == spv::Decoration::DecorationDescriptorSet) {
+                    uint32_t const targetVar = data[cursor + 1];
+                    uint32_t const setId = data[cursor + 3];
+                    targetToSet[targetVar] = setId;
+                } else if (data[cursor + 2] == spv::Decoration::DecorationBinding) {
+                    uint32_t const targetVar = data[cursor + 1];
+                    uint32_t const binding = data[cursor + 3];
+                    targetToBinding[targetVar] = binding;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+        cursor += wordCount;
+    }
+
+    constexpr uint32_t UBO = 0;
+    constexpr uint32_t SAMPLER = 1;
+    constexpr uint32_t IATTACHMENT = 2;
+    uint32_t ubo = 0, sampler = 0, inputAttachment = 0;
+
+    for (auto const [target, setId]: targetToSet) {
+        uint32_t const binding = targetToBinding[target];
+        assert_invariant(binding < 32);
+        switch(setId) {
+            case UBO:
+                ubo |= (1 << binding);
+                break;
+            case SAMPLER:
+                sampler |= (1 << binding);
+                break;
+            case IATTACHMENT:
+                inputAttachment |= (1 << binding);
+                break;
+            default:
+                PANIC_POSTCONDITION("unexpected %d", (int) setId);
+        }
+    }
+    return {ubo, sampler, inputAttachment};
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.h
+++ b/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.h
@@ -17,10 +17,11 @@
 #ifndef TNT_FILAMENT_BACKEND_VULKANSPIRVUTILS_H
 #define TNT_FILAMENT_BACKEND_VULKANSPIRVUTILS_H
 
-#include "backend/Program.h"
+#include <backend/Program.h>
 
 #include <utils/FixedCapacityVector.h>
 
+#include <tuple>
 #include <vector>
 
 namespace filament::backend {
@@ -41,6 +42,9 @@ using SpecConstantValue = Program::SpecializationConstant::Type;
 void workaroundSpecConstant(Program::ShaderBlob const& blob,
         utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants,
         std::vector<uint32_t>& output);
+
+// bindings for UBO, samplers, input attachment
+std::tuple<uint32_t, uint32_t, uint32_t> getProgramBindings(Program::ShaderBlob const& blob);
 
 } // namespace filament::backend
 


### PR DESCRIPTION
 - Move VulkanDescriptorSet to VulkanHandles.h
 - Add VulkanDescriptorSetLayout to VulkanHandles.h
 - Add "input" descriptor set types to VulkanUtility.h. These are structs that will be defined in the backend API (shared across all backends) and eventually passed from the front-end to the vk backend.
 - Logic to parse descriptor set layout from the spirv-v shaders.
 - Move UsageFlags type to VulkanUtility.h
 - Just prep work. No effect to current implementations.