### PR TITLE
Export utils::panic function

### DIFF
--- a/libs/utils/include/utils/debug.h
+++ b/libs/utils/include/utils/debug.h
@@ -20,6 +20,7 @@
 #include <utils/compiler.h>
 
 namespace utils {
+UTILS_PUBLIC
 void panic(const char *func, const char * file, int line, const char *assertion) noexcept;
 } // namespace filament
 


### PR DESCRIPTION
We use this in other utils public include files, so I think it should be exported.