### PR TITLE
Metal re-apply: throw an NSException when attempting to draw with inalid program

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1634,7 +1634,7 @@ void MetalDriver::bindPipeline(PipelineState ps) {
         return;
     }
 
-    ASSERT_PRECONDITION(bool(functions), "Attempting to bind an invalid Metal program.");
+    functions.validate();
 
     auto [fragment, vertex] = functions.getRasterFunctions();
 


### PR DESCRIPTION
This was originally done in #7581, but was reverted due to a refactor.