### PR TITLE
Introduce a new precompiled Metal material chunk type

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -158,14 +158,16 @@ static constexpr const char* backendToString(Backend backend) {
 }
 
 /**
- * Defines the shader language. Similar to the above backend enum, but the OpenGL backend can select
- * between two shader languages: ESSL 1.0 and ESSL 3.0.
+ * Defines the shader language. Similar to the above backend enum, with some differences:
+ * - The OpenGL backend can select between two shader languages: ESSL 1.0 and ESSL 3.0.
+ * - The Metal backend can prefer precompiled Metal libraries, while falling back to MSL.
  */
 enum class ShaderLanguage {
     ESSL1 = 0,
     ESSL3 = 1,
     SPIRV = 2,
     MSL = 3,
+    METAL_LIBRARY = 4,
 };
 
 static constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguage) {
@@ -178,6 +180,8 @@ static constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguag
             return "SPIR-V";
         case ShaderLanguage::MSL:
             return "MSL";
+        case ShaderLanguage::METAL_LIBRARY:
+            return "Metal precompiled library";
     }
 }
 

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -65,6 +65,10 @@ MaterialParser::MaterialParserDetails::MaterialParserDetails(ShaderLanguage lang
             mMaterialTag = ChunkType::MaterialSpirv;
             mDictionaryTag = ChunkType::DictionarySpirv;
             break;
+        case ShaderLanguage::METAL_LIBRARY:
+            mMaterialTag = ChunkType::MaterialMetalLibrary;
+            mDictionaryTag = ChunkType::DictionaryMetalLibrary;
+            break;
     }
 }
 

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -45,6 +45,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialEssl1 = charTo64bitNum("MAT_ESS1"),
     MaterialSpirv = charTo64bitNum("MAT_SPIR"),
     MaterialMetal = charTo64bitNum("MAT_METL"),
+    MaterialMetalLibrary = charTo64bitNum("MAT_MLIB"),
     MaterialShaderModels = charTo64bitNum("MAT_SMDL"),
     MaterialSamplerBindings = charTo64bitNum("MAT_SAMP"),
     MaterialUniformBindings = charTo64bitNum("MAT_UNIF"),
@@ -93,6 +94,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
 
     DictionaryText = charTo64bitNum("DIC_TEXT"),
     DictionarySpirv = charTo64bitNum("DIC_SPIR"),
+    DictionaryMetalLibrary = charTo64bitNum("DIC_MLIB"),
 };
 
 } // namespace filamat

--- a/libs/filaflat/include/filaflat/MaterialChunk.h
+++ b/libs/filaflat/include/filaflat/MaterialChunk.h
@@ -74,7 +74,7 @@ private:
             BlobDictionary const& dictionary, ShaderContent& shaderContent,
             ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage);
 
-    bool getSpirvShader(
+    bool getBinaryShader(
             BlobDictionary const& dictionary, ShaderContent& shaderContent,
             ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage);
 };

--- a/libs/filaflat/src/DictionaryReader.cpp
+++ b/libs/filaflat/src/DictionaryReader.cpp
@@ -78,6 +78,25 @@ bool DictionaryReader::unflatten(ChunkContainer const& container,
 
         }
         return true;
+    } else if (dictionaryTag == ChunkType::DictionaryMetalLibrary) {
+        uint32_t blobCount;
+        if (!unflattener.read(&blobCount)) {
+            return false;
+        }
+
+        dictionary.reserve(blobCount);
+        for (uint32_t i = 0; i < blobCount; i++) {
+            unflattener.skipAlignmentPadding();
+
+            const char* data;
+            size_t dataSize;
+            if (!unflattener.read(&data, &dataSize)) {
+                return false;
+            }
+            dictionary.emplace_back(dataSize);
+            memcpy(dictionary.back().data(), data, dictionary.back().size());
+        }
+        return true;
     } else if (dictionaryTag == ChunkType::DictionaryText) {
         uint32_t stringCount = 0;
         if (!unflattener.read(&stringCount)) {

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -153,7 +153,7 @@ bool MaterialChunk::getTextShader(Unflattener unflattener,
     return true;
 }
 
-bool MaterialChunk::getSpirvShader(BlobDictionary const& dictionary,
+bool MaterialChunk::getBinaryShader(BlobDictionary const& dictionary,
         ShaderContent& shaderContent, ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage) {
 
     if (mBase == nullptr) {
@@ -186,7 +186,8 @@ bool MaterialChunk::getShader(ShaderContent& shaderContent, BlobDictionary const
         case filamat::ChunkType::MaterialMetal:
             return getTextShader(mUnflattener, dictionary, shaderContent, shaderModel, variant, stage);
         case filamat::ChunkType::MaterialSpirv:
-            return getSpirvShader(dictionary, shaderContent, shaderModel, variant, stage);
+        case filamat::ChunkType::MaterialMetalLibrary:
+            return getBinaryShader(dictionary, shaderContent, shaderModel, variant, stage);
         default:
             return false;
     }

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -50,6 +50,7 @@ set(PRIVATE_HDRS
         ${COMMON_PRIVATE_HDRS}
         src/eiff/BlobDictionary.h
         src/eiff/DictionarySpirvChunk.h
+        src/eiff/DictionaryMetalLibraryChunk.h
         src/eiff/MaterialBinaryChunk.h
         src/GLSLPostProcessor.h
         src/MetalArgumentBuffer.h
@@ -63,6 +64,7 @@ set(SRCS
         ${COMMON_SRCS}
         src/eiff/BlobDictionary.cpp
         src/eiff/DictionarySpirvChunk.cpp
+        src/eiff/DictionaryMetalLibraryChunk.cpp
         src/eiff/MaterialBinaryChunk.cpp
         src/MetalArgumentBuffer.cpp
         src/sca/ASTHelpers.cpp

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -50,7 +50,7 @@ set(PRIVATE_HDRS
         ${COMMON_PRIVATE_HDRS}
         src/eiff/BlobDictionary.h
         src/eiff/DictionarySpirvChunk.h
-        src/eiff/MaterialSpirvChunk.h
+        src/eiff/MaterialBinaryChunk.h
         src/GLSLPostProcessor.h
         src/MetalArgumentBuffer.h
         src/ShaderMinifier.h
@@ -63,7 +63,7 @@ set(SRCS
         ${COMMON_SRCS}
         src/eiff/BlobDictionary.cpp
         src/eiff/DictionarySpirvChunk.cpp
-        src/eiff/MaterialSpirvChunk.cpp
+        src/eiff/MaterialBinaryChunk.cpp
         src/MetalArgumentBuffer.cpp
         src/sca/ASTHelpers.cpp
         src/sca/GLSLTools.cpp

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -33,7 +33,7 @@
 #include "eiff/LineDictionary.h"
 #include "eiff/MaterialInterfaceBlockChunk.h"
 #include "eiff/MaterialTextChunk.h"
-#include "eiff/MaterialSpirvChunk.h"
+#include "eiff/MaterialBinaryChunk.h"
 #include "eiff/ChunkContainer.h"
 #include "eiff/SimpleFieldChunk.h"
 #include "eiff/DictionaryTextChunk.h"
@@ -1041,11 +1041,11 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 dictionaryChunk.getDictionary(), ChunkType::MaterialEssl1);
     }
 
-    // Emit SPIRV chunks (SpirvDictionaryReader and MaterialSpirvChunk).
+    // Emit SPIRV chunks (SpirvDictionaryReader and MaterialBinaryChunk).
     if (!spirvEntries.empty()) {
         const bool stripInfo = !mGenerateDebugInfo;
         container.push<filamat::DictionarySpirvChunk>(std::move(spirvDictionary), stripInfo);
-        container.push<MaterialSpirvChunk>(std::move(spirvEntries));
+        container.push<MaterialBinaryChunk>(std::move(spirvEntries), ChunkType::MaterialSpirv);
     }
 
     // Emit Metal chunk (MaterialTextChunk).

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -821,7 +821,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
     Mutex entriesLock;
     std::vector<TextEntry> glslEntries;
     std::vector<TextEntry> essl1Entries;
-    std::vector<SpirvEntry> spirvEntries;
+    std::vector<BinaryEntry> spirvEntries;
     std::vector<TextEntry> metalEntries;
     LineDictionary textDictionary;
     BlobDictionary spirvDictionary;
@@ -872,7 +872,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 std::string* pMsl = targetApiNeedsMsl ? &msl : nullptr;
 
                 TextEntry glslEntry{};
-                SpirvEntry spirvEntry{};
+                BinaryEntry spirvEntry{};
                 TextEntry metalEntry{};
 
                 glslEntry.shaderModel  = params.shaderModel;
@@ -966,7 +966,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                     case TargetApi::VULKAN:
                         assert(!spirv.empty());
                         spirvEntry.stage = v.stage;
-                        spirvEntry.spirv = std::move(spirv);
+                        spirvEntry.data = std::move(spirv);
                         spirvEntries.push_back(spirvEntry);
                         break;
                     case TargetApi::METAL:
@@ -1018,7 +1018,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
         textDictionary.addText(s.shader);
     }
     for (auto& s : spirvEntries) {
-        std::vector<uint32_t> spirv = std::move(s.spirv);
+        std::vector<uint32_t> spirv = std::move(s.data);
         s.dictionaryIndex = spirvDictionary.addBlob(spirv);
     }
     for (const auto& s : metalEntries) {

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -38,6 +38,7 @@
 #include "eiff/SimpleFieldChunk.h"
 #include "eiff/DictionaryTextChunk.h"
 #include "eiff/DictionarySpirvChunk.h"
+#include "eiff/DictionaryMetalLibraryChunk.h"
 
 #include <private/filament/BufferInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>

--- a/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DictionaryMetalLibraryChunk.h"
+
+#include <smolv.h>
+
+namespace filamat {
+
+DictionaryMetalLibraryChunk::DictionaryMetalLibraryChunk(BlobDictionary&& dictionary)
+    : Chunk(ChunkType::DictionaryMetalLibrary), mDictionary(std::move(dictionary)) {}
+
+void DictionaryMetalLibraryChunk::flatten(Flattener& f) {
+    f.writeUint32(mDictionary.getBlobCount());
+    for (size_t i = 0 ; i < mDictionary.getBlobCount() ; i++) {
+        std::string_view blob = mDictionary.getBlob(i);
+        f.writeAlignmentPadding();
+        f.writeBlob((const char*) blob.data(), blob.size());
+    }
+}
+
+} // namespace filamat

--- a/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.cpp
@@ -16,8 +16,6 @@
 
 #include "DictionaryMetalLibraryChunk.h"
 
-#include <smolv.h>
-
 namespace filamat {
 
 DictionaryMetalLibraryChunk::DictionaryMetalLibraryChunk(BlobDictionary&& dictionary)

--- a/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.h
+++ b/libs/filamat/src/eiff/DictionaryMetalLibraryChunk.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMAT_DIC_METAL_LIBRARY_CHUNK_H
+#define TNT_FILAMAT_DIC_METAL_LIBRARY_CHUNK_H
+
+#include <stdint.h>
+#include <vector>
+
+#include "Chunk.h"
+#include "Flattener.h"
+#include "BlobDictionary.h"
+
+namespace filamat {
+
+class DictionaryMetalLibraryChunk final : public Chunk {
+public:
+    explicit DictionaryMetalLibraryChunk(BlobDictionary&& dictionary);
+    ~DictionaryMetalLibraryChunk() = default;
+
+private:
+    void flatten(Flattener& f) override;
+
+    BlobDictionary mDictionary;
+    bool mStripDebugInfo;
+};
+
+} // namespace filamat
+
+#endif // TNT_FILAMAT_DIC_METAL_LIBRARY_CHUNK_H

--- a/libs/filamat/src/eiff/MaterialBinaryChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialBinaryChunk.cpp
@@ -14,27 +14,22 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMAT_MATERIAL_SPIRV_CHUNK_H
-#define TNT_FILAMAT_MATERIAL_SPIRV_CHUNK_H
-
-#include "Chunk.h"
-#include "ShaderEntry.h"
-
-#include <vector>
+#include "MaterialBinaryChunk.h"
 
 namespace filamat {
 
-class MaterialSpirvChunk final : public Chunk {
-public:
-    explicit MaterialSpirvChunk(const std::vector<SpirvEntry>&& entries);
-    ~MaterialSpirvChunk() = default;
+MaterialBinaryChunk::MaterialBinaryChunk(
+        const std::vector<SpirvEntry>&& entries, ChunkType chunkType)
+    : Chunk(chunkType), mEntries(entries) {}
 
-private:
-    void flatten(Flattener& f) override;
+void MaterialBinaryChunk::flatten(Flattener &f) {
+    f.writeUint64(mEntries.size());
+    for (const SpirvEntry& entry : mEntries) {
+        f.writeUint8(uint8_t(entry.shaderModel));
+        f.writeUint8(entry.variant.key);
+        f.writeUint8(uint8_t(entry.stage));
+        f.writeUint32(entry.dictionaryIndex);
+    }
+}
 
-    const std::vector<SpirvEntry> mEntries;
-};
-
-} // namespace filamat
-
-#endif // TNT_FILAMAT_MATERIAL_SPIRV_CHUNK_H
+}  // namespace filamat

--- a/libs/filamat/src/eiff/MaterialBinaryChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialBinaryChunk.cpp
@@ -19,12 +19,12 @@
 namespace filamat {
 
 MaterialBinaryChunk::MaterialBinaryChunk(
-        const std::vector<SpirvEntry>&& entries, ChunkType chunkType)
+        const std::vector<BinaryEntry>&& entries, ChunkType chunkType)
     : Chunk(chunkType), mEntries(entries) {}
 
 void MaterialBinaryChunk::flatten(Flattener &f) {
     f.writeUint64(mEntries.size());
-    for (const SpirvEntry& entry : mEntries) {
+    for (const BinaryEntry& entry : mEntries) {
         f.writeUint8(uint8_t(entry.shaderModel));
         f.writeUint8(entry.variant.key);
         f.writeUint8(uint8_t(entry.stage));

--- a/libs/filamat/src/eiff/MaterialBinaryChunk.h
+++ b/libs/filamat/src/eiff/MaterialBinaryChunk.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 The Android Open Source Project
- *DictionaryGlsl
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
-#include "MaterialSpirvChunk.h"
+#ifndef TNT_FILAMAT_MATERIAL_BINARY_CHUNK_H
+#define TNT_FILAMAT_MATERIAL_BINARY_CHUNK_H
+
+#include "Chunk.h"
+#include "ShaderEntry.h"
+
+#include <vector>
 
 namespace filamat {
 
-MaterialSpirvChunk::MaterialSpirvChunk(const std::vector<SpirvEntry>&& entries) :
-        Chunk(ChunkType::MaterialSpirv), mEntries(entries) {}
+class MaterialBinaryChunk final : public Chunk {
+public:
+    explicit MaterialBinaryChunk(const std::vector<SpirvEntry>&& entries, ChunkType type);
+    ~MaterialBinaryChunk() = default;
 
-void MaterialSpirvChunk::flatten(Flattener &f) {
-    f.writeUint64(mEntries.size());
-    for (const SpirvEntry& entry : mEntries) {
-        f.writeUint8(uint8_t(entry.shaderModel));
-        f.writeUint8(entry.variant.key);
-        f.writeUint8(uint8_t(entry.stage));
-        f.writeUint32(entry.dictionaryIndex);
-    }
-}
+private:
+    void flatten(Flattener& f) override;
 
-}  // namespace filamat
+    const std::vector<SpirvEntry> mEntries;
+};
+
+} // namespace filamat
+
+#endif // TNT_FILAMAT_MATERIAL_BINARY_CHUNK_H

--- a/libs/filamat/src/eiff/MaterialBinaryChunk.h
+++ b/libs/filamat/src/eiff/MaterialBinaryChunk.h
@@ -26,13 +26,13 @@ namespace filamat {
 
 class MaterialBinaryChunk final : public Chunk {
 public:
-    explicit MaterialBinaryChunk(const std::vector<SpirvEntry>&& entries, ChunkType type);
+    explicit MaterialBinaryChunk(const std::vector<BinaryEntry>&& entries, ChunkType type);
     ~MaterialBinaryChunk() = default;
 
 private:
     void flatten(Flattener& f) override;
 
-    const std::vector<SpirvEntry> mEntries;
+    const std::vector<BinaryEntry> mEntries;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -34,14 +34,14 @@ struct TextEntry {
     std::string shader;
 };
 
-struct SpirvEntry {
+struct BinaryEntry {
     filament::backend::ShaderModel shaderModel;
     filament::Variant variant;
     filament::backend::ShaderStage stage;
-    size_t dictionaryIndex;
+    size_t dictionaryIndex;  // maps to an index in the blob dictionary
 
-    // temporarily holds this entry's spirv until added to the dictionary
-    std::vector<uint32_t> spirv;
+    // temporarily holds this entry's binary data until added to the dictionary
+    std::vector<uint32_t> data;
 };
 
 }  // namespace filamat

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -53,6 +53,10 @@ ShaderExtractor::ShaderExtractor(backend::ShaderLanguage target, const void* dat
             mMaterialTag = ChunkType::MaterialMetal;
             mDictionaryTag = ChunkType::DictionaryText;
             break;
+        case backend::ShaderLanguage::METAL_LIBRARY:
+            mMaterialTag = ChunkType::MaterialMetalLibrary;
+            mDictionaryTag = ChunkType::DictionaryMetalLibrary;
+            break;
         case backend::ShaderLanguage::SPIRV:
             mMaterialTag = ChunkType::MaterialSpirv;
             mDictionaryTag = ChunkType::DictionarySpirv;

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -35,7 +35,7 @@
 #include "eiff/ChunkContainer.h"
 #include "eiff/DictionarySpirvChunk.h"
 #include "eiff/DictionaryTextChunk.h"
-#include "eiff/MaterialSpirvChunk.h"
+#include "eiff/MaterialBinaryChunk.h"
 #include "eiff/MaterialTextChunk.h"
 #include "eiff/LineDictionary.h"
 
@@ -73,7 +73,7 @@ private:
     vector<TextEntry> mShaderRecords;
 };
 
-// Tiny database of data blobs that can import / export MaterialSpirvChunk and DictionarySpirvChunk.
+// Tiny database of data blobs that can import / export MaterialBinaryChunk and DictionarySpirvChunk.
 // The blobs are stored *after* they have been compressed by SMOL-V.
 class BlobIndex {
 public:
@@ -391,7 +391,7 @@ void BlobIndex::writeChunks(ostream& stream) {
 
     // Apply SMOL-V compression and write out the results.
     filamat::ChunkContainer cc;
-    cc.push<MaterialSpirvChunk>(std::move(mShaderRecords));
+    cc.push<MaterialBinaryChunk>(std::move(mShaderRecords), ChunkType::MaterialSpirv);
     cc.push<DictionarySpirvChunk>(std::move(blobs), false);
 
     Flattener prepass = Flattener::getDryRunner();

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -90,7 +90,7 @@ public:
 private:
     const ChunkType mDictTag;
     const ChunkType mMatTag;
-    vector<SpirvEntry> mShaderRecords;
+    vector<BinaryEntry> mShaderRecords;
     filaflat::BlobDictionary mDataBlobs;
 };
 
@@ -364,7 +364,7 @@ BlobIndex::BlobIndex(ChunkType dictTag, ChunkType matTag, const filaflat::ChunkC
     const auto& offsets = matChunk.getOffsets();
     mShaderRecords.reserve(offsets.size());
     for (auto [key, offset] : offsets) {
-        SpirvEntry info;
+        BinaryEntry info;
         filaflat::MaterialChunk::decodeKey(key, &info.shaderModel, &info.variant, &info.stage);
         info.dictionaryIndex = offset;
         mShaderRecords.emplace_back(info);

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -421,6 +421,9 @@ static bool printShaderInfo(ostream& text, const ChunkContainer& container, Chun
         case ChunkType::MaterialMetal:
             text << "Metal shaders:" << endl;
             break;
+        case ChunkType::MaterialMetalLibrary:
+            text << "Metal precompiled shader libraries:" << endl;
+            break;
         default:
             assert(false && "Invalid shader ChunkType");
             break;
@@ -453,6 +456,9 @@ bool TextWriter::writeMaterialInfo(const filaflat::ChunkContainer& container) {
         return false;
     }
     if (!printShaderInfo(text, container, ChunkType::MaterialMetal)) {
+        return false;
+    }
+    if (!printShaderInfo(text, container, ChunkType::MaterialMetalLibrary)) {
         return false;
     }
 

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -96,7 +96,7 @@ static void printUsage(const char* name) {
             "       Print the Vulkan dictionary\n\n"
             "   --web-server=[port], -w\n"
             "       Serve a web page at the given port (e.g. 8080)\n\n"
-            "   --dump-binary=[index], -b\n"
+            "   --dump-spirv-binary=[index], -b\n"
             "       Dump binary SPIRV for the nth Vulkan shader to 'out.spv'\n\n"
             "   --license\n"
             "       Print copyright and license information\n\n"
@@ -125,20 +125,21 @@ static void license() {
 static int handleArguments(int argc, char* argv[], Config* config) {
     static constexpr const char* OPTSTR = "hla:g:G:s:v:b:m:b:w:Xxyz";
     static const struct option OPTIONS[] = {
-            { "help",            no_argument,       nullptr, 'h' },
-            { "license",         no_argument,       nullptr, 'l' },
-            { "analyze-spirv",   required_argument, nullptr, 'a' },
-            { "print-glsl",      required_argument, nullptr, 'g' },
-            { "print-essl1",      required_argument, nullptr, 'G' },
-            { "print-spirv",     required_argument, nullptr, 's' },
-            { "print-vkglsl",    required_argument, nullptr, 'v' },
-            { "print-metal",     required_argument, nullptr, 'm' },
-            { "print-dic-glsl",  no_argument,       nullptr, 'x' },
-            { "print-dic-essl1", no_argument,       nullptr, 'X' },
-            { "print-dic-metal", no_argument,       nullptr, 'y' },
-            { "print-dic-vk",    no_argument,       nullptr, 'z' },
-            { "dump-binary",     required_argument, nullptr, 'b' },
-            { "web-server",      required_argument, nullptr, 'w' },
+            { "help",               no_argument,       nullptr, 'h' },
+            { "license",            no_argument,       nullptr, 'l' },
+            { "analyze-spirv",      required_argument, nullptr, 'a' },
+            { "print-glsl",         required_argument, nullptr, 'g' },
+            { "print-essl1",        required_argument, nullptr, 'G' },
+            { "print-spirv",        required_argument, nullptr, 's' },
+            { "print-vkglsl",       required_argument, nullptr, 'v' },
+            { "print-metal",        required_argument, nullptr, 'm' },
+            { "print-dic-glsl",     no_argument,       nullptr, 'x' },
+            { "print-dic-essl1",    no_argument,       nullptr, 'X' },
+            { "print-dic-metal",    no_argument,       nullptr, 'y' },
+            { "print-dic-vk",       no_argument,       nullptr, 'z' },
+            { "dump-binary",        required_argument, nullptr, 'b' },  // backwards compatibility
+            { "dump-spirv-binary",  required_argument, nullptr, 'b' },
+            { "web-server",         required_argument, nullptr, 'w' },
             { nullptr, 0, nullptr, 0 }  // termination of the option list
     };
 


### PR DESCRIPTION
This change introduces a new chunk type to material files for precompiled Metal libraries. Previously, SPIR-V was the only binary type, so there's also a couple of refactor commits present here. Nothing is changed in Filament or matc yet.

BUGS=[333547148]