### PR TITLE
don't use thread affinity for the backend thread

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1241,9 +1241,6 @@ enum class Workaround : uint16_t {
     DISABLE_BLIT_INTO_TEXTURE_ARRAY,
     // Multiple workarounds needed for PowerVR GPUs
     POWER_VR_SHADER_WORKAROUNDS,
-    // The driver has some threads pinned, and we can't easily know on which core, it can hurt
-    // performance more if we end-up pinned on the same one.
-    DISABLE_THREAD_AFFINITY
 };
 
 //! The type of technique for stereoscopic rendering

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -526,8 +526,6 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
             bugs->delay_fbo_destruction = true;
             // PowerVR seems to have no problem with this (which is good for us)
             bugs->allow_read_only_ancillary_feedback_loop = true;
-            // PowerVR has a shader compiler thread pinned on the last core
-            bugs->disable_thread_affinity = true;
         } else if (strstr(renderer, "Apple")) {
             // Apple GPU
         } else if (strstr(renderer, "Tegra") ||

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -308,10 +308,6 @@ public:
         // a glFinish. So we must delay the destruction until we know the GPU is finished.
         bool delay_fbo_destruction;
 
-        // The driver has some threads pinned, and we can't easily know on which core, it can hurt
-        // performance more if we end-up pinned on the same one.
-        bool disable_thread_affinity;
-
         // Force feature level 0. Typically used for low end ES3 devices with significant driver
         // bugs or performance issues.
         bool force_feature_level0;
@@ -551,9 +547,6 @@ private:
                     ""},
             {   bugs.delay_fbo_destruction,
                     "delay_fbo_destruction",
-                    ""},
-            {   bugs.disable_thread_affinity,
-                    "disable_thread_affinity",
                     ""},
             {   bugs.force_feature_level0,
                     "force_feature_level0",

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2056,8 +2056,6 @@ bool OpenGLDriver::isWorkaroundNeeded(Workaround workaround) {
             return mContext.bugs.disable_blit_into_texture_array;
         case Workaround::POWER_VR_SHADER_WORKAROUNDS:
             return mContext.bugs.powervr_shader_workarounds;
-        case Workaround::DISABLE_THREAD_AFFINITY:
-            return mContext.bugs.disable_thread_affinity;
         default:
             return false;
     }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -682,18 +682,7 @@ int FEngine::loop() {
         return 0;
     }
 
-    // Set thread affinity for the backend thread.
-    //  see https://developer.android.com/agi/sys-trace/threads-scheduling#cpu_core_affinity
-    // Certain backends already have some threads pinned, and we can't easily know on which core.
-    const bool disableThreadAffinity
-            = mDriver->isWorkaroundNeeded(Workaround::DISABLE_THREAD_AFFINITY);
-
-    uint32_t const id = std::thread::hardware_concurrency() - 1;
     while (true) {
-        // looks like thread affinity needs to be reset regularly (on Android)
-        if (!disableThreadAffinity) {
-            JobSystem::setThreadAffinityById(id);
-        }
         if (!execute()) {
             break;
         }


### PR DESCRIPTION
Originally we did this because we wanted to run on a big core on  android. However setting the thread affinity in this way is fragile, we are not guaranteed to be on a big core, and we don't even know if some thread is pinned to that core already; which was the case with some GL drivers. This can also cause scheduling problems with other threads.

We just remove this logic entirely for now, and we'll figure out  something better later to run on a big core.

Fixes #7748
BUGS=[333949404]