### PR TITLE
fix a GL backend crash when shutting down

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -253,6 +253,12 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform) noexcept
 }
 
 OpenGLContext::~OpenGLContext() noexcept {
+    // note: this is called from the main thread. Can't do any GL calls.
+    delete mTimerQueryFactory;
+}
+
+void OpenGLContext::terminate() noexcept {
+    // note: this is called from the backend thread
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     if (!isES2()) {
         for (auto& item: mSamplerMap) {
@@ -262,7 +268,6 @@ OpenGLContext::~OpenGLContext() noexcept {
         mSamplerMap.clear();
     }
 #endif
-    delete mTimerQueryFactory;
 }
 
 void OpenGLContext::destroyWithContext(

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -92,7 +92,10 @@ public:
     static bool queryOpenGLVersion(GLint* major, GLint* minor) noexcept;
 
     explicit OpenGLContext(OpenGLPlatform& platform) noexcept;
+
     ~OpenGLContext() noexcept final;
+
+    void terminate() noexcept;
 
     // TimerQueryInterface ------------------------------------------------------------------------
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -232,6 +232,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfi
 }
 
 OpenGLDriver::~OpenGLDriver() noexcept { // NOLINT(modernize-use-equals-default)
+    // this is called from the main thread. Can't call GL.
 }
 
 Dispatcher OpenGLDriver::getDispatcher() const noexcept {
@@ -263,6 +264,8 @@ void OpenGLDriver::terminate() {
     // because we called glFinish(), all callbacks should have been executed
     assert_invariant(mGpuCommandCompleteOps.empty());
 #endif
+
+    mContext.terminate();
 
     mPlatform.terminate();
 }


### PR DESCRIPTION
the gl backend did some of its cleanup in the its destructor, including calling into OpenGL, however, the destructor is called from the main thread, not the GL thread, so these calls would be no-ops at best, and crashes in the worst case.