### PR TITLE
don't rely on FMaterialInstance having a default ctor

### DIFF
--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -290,7 +290,7 @@ private:
     bool mIsDefaultMaterial = false;
     bool mSpecularAntiAliasing = false;
 
-    // reserve some sopce to construct the default material instance
+    // reserve some space to construct the default material instance
     std::aligned_storage<sizeof(FMaterialInstance), alignof(FMaterialInstance)>::type mDefaultInstanceStorage;
     static_assert(sizeof(mDefaultInstanceStorage) >= sizeof(mDefaultInstanceStorage));
 

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -48,6 +48,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <string_view>
 #include <unordered_map>
@@ -104,8 +105,13 @@ public:
 
     BufferInterfaceBlock::FieldInfo const* reflect(std::string_view name) const noexcept;
 
-    FMaterialInstance const* getDefaultInstance() const noexcept { return &mDefaultInstance; }
-    FMaterialInstance* getDefaultInstance() noexcept { return &mDefaultInstance; }
+    FMaterialInstance const* getDefaultInstance() const noexcept {
+        return const_cast<FMaterial*>(this)->getDefaultInstance();
+    }
+
+    FMaterialInstance* getDefaultInstance() noexcept {
+        return std::launder(reinterpret_cast<FMaterialInstance*>(&mDefaultInstanceStorage));
+    }
 
     FEngine& getEngine() const noexcept  { return mEngine; }
 
@@ -284,7 +290,10 @@ private:
     bool mIsDefaultMaterial = false;
     bool mSpecularAntiAliasing = false;
 
-    FMaterialInstance mDefaultInstance;
+    // reserve some sopce to construct the default material instance
+    std::aligned_storage<sizeof(FMaterialInstance), alignof(FMaterialInstance)>::type mDefaultInstanceStorage;
+    static_assert(sizeof(mDefaultInstanceStorage) >= sizeof(mDefaultInstanceStorage));
+
     SamplerInterfaceBlock mSamplerInterfaceBlock;
     BufferInterfaceBlock mUniformInterfaceBlock;
     SubpassInfo mSubpassInfo;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -231,8 +231,8 @@ private:
     void setParameterImpl(std::string_view name,
             FTexture const* texture, TextureSampler const& sampler);
 
-    FMaterialInstance() noexcept;
-    void initDefaultInstance(FEngine& engine, FMaterial const* material);
+    // initialize the default instance
+    FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept;
 
     void commitSlow(FEngine::DriverApi& driver) const;
 


### PR DESCRIPTION
FMaterialInstance needed a default ctor because it is a field of FMaterial but cannot be initialized before FMaterial itself is initialized. So we had a defautl ctor and we'd finish the initialization later. Conceptually the default material instance should have been  new'ed and a pointer to it stored instead. 

That's basically what we do now, but to avoid the extra allocation, we in-place new and delete the default material instance into an aligned_storage inside FMaterial.