### PR TITLE
clean-ups to prepare for descriptor set changes

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -163,6 +163,7 @@ set(PRIVATE_HDRS
         src/ResourceList.h
         src/ShadowMap.h
         src/ShadowMapManager.h
+        src/SharedHandle.h
         src/TypedUniformBuffer.h
         src/UniformBuffer.h
         src/components/CameraManager.h

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -19,16 +19,19 @@
 
 #include "Allocators.h"
 
+#include "SharedHandle.h"
+
 #include "details/Camera.h"
 #include "details/Scene.h"
 
 #include "private/filament/Variant.h"
-#include "utils/BitmaskEnum.h"
 
+#include <backend/DriverApiForward.h>
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
 
 #include <utils/Allocator.h>
+#include <utils/BitmaskEnum.h>
 #include <utils/Range.h>
 #include <utils/Slice.h>
 #include <utils/architecture.h>
@@ -243,6 +246,7 @@ public:
         };
         backend::RenderPrimitiveHandle rph;                             // 4 bytes
         backend::VertexBufferInfoHandle vbih;                           // 4 bytes
+        backend::BufferObjectHandle boh;                                // 4 bytes
         uint32_t indexOffset;                                           // 4 bytes
         uint32_t indexCount;                                            // 4 bytes
         uint32_t index = 0;                                             // 4 bytes
@@ -257,10 +261,7 @@ public:
         bool hasMorphing : 1;                                           //              1 bit
         bool hasHybridInstancing : 1;                                   //              1 bit
 
-        uint64_t rfu[2];                                                // 16 bytes
-
-        static const uint16_t USER_INSTANCE_MASK = 0x8000u;
-        static const uint16_t INSTANCE_COUNT_MASK = 0x7fffu;
+        uint32_t rfu[3];                                                // 16 bytes
     };
     static_assert(sizeof(PrimitiveInfo) == 56);
 
@@ -292,11 +293,11 @@ public:
 
     // RenderPass can only be moved
     RenderPass(RenderPass&& rhs) = default;
+    RenderPass& operator=(RenderPass&& rhs) = delete;  // could be supported if needed
 
     // RenderPass can't be copied
     RenderPass(RenderPass const& rhs) = delete;
     RenderPass& operator=(RenderPass const& rhs) = delete;
-    RenderPass& operator=(RenderPass&& rhs) = delete;
 
     // allocated commands ARE NOT freed, they're owned by the Arena
     ~RenderPass() noexcept;
@@ -311,6 +312,17 @@ public:
             backend::Handle<backend::HwRenderTarget> renderTarget,
             backend::RenderPassParams params) noexcept;
 
+
+    class BufferObjectHandleDeleter {
+        std::reference_wrapper<backend::DriverApi> driver;
+    public:
+        explicit BufferObjectHandleDeleter(backend::DriverApi& driver) noexcept : driver(driver) { }
+        void operator()(backend::BufferObjectHandle handle) noexcept;
+    };
+
+    using BufferObjectSharedHandle = SharedHandle<
+            backend::HwBufferObject, BufferObjectHandleDeleter>;
+
     /*
      * Executor holds the range of commands to execute for a given pass
      */
@@ -323,8 +335,7 @@ public:
         FScene::RenderableSoa const* mRenderableSoa = nullptr;
         utils::Slice<Command> mCommands;
         utils::Slice<CustomCommandFn> mCustomCommands;
-        backend::Handle<backend::HwBufferObject> mUboHandle;
-        backend::Handle<backend::HwBufferObject> mInstancedUboHandle;
+        BufferObjectSharedHandle mInstancedUboHandle;
         backend::Viewport mScissorViewport;
 
         backend::Viewport mScissor{};            // value of scissor override
@@ -332,7 +343,8 @@ public:
         bool mPolygonOffsetOverride : 1;         // whether to override the polygon offset setting
         bool mScissorOverride : 1;               // whether to override the polygon offset setting
 
-        Executor(RenderPass const* pass, Command const* b, Command const* e) noexcept;
+        Executor(RenderPass const* pass, Command const* b, Command const* e,
+                BufferObjectSharedHandle instancedUbo) noexcept;
 
         void execute(FEngine& engine, const Command* first, const Command* last) const noexcept;
 
@@ -341,9 +353,16 @@ public:
                 backend::Viewport const& scissor) noexcept;
 
     public:
-        Executor() = default;
-        Executor(Executor const& rhs);
-        Executor& operator=(Executor const& rhs) = default;
+        Executor() noexcept;
+
+        // can't be copied
+        Executor(Executor const& rhs) noexcept = delete;
+        Executor& operator=(Executor const& rhs) noexcept = delete;
+
+        // can be moved
+        Executor(Executor&& rhs) noexcept;
+        Executor& operator=(Executor&& rhs) noexcept;
+
         ~Executor() noexcept;
 
         // if non-null, overrides the material's polygon offset
@@ -358,11 +377,11 @@ public:
 
     // returns a new executor for this pass
     Executor getExecutor() const {
-        return { this, mCommandBegin, mCommandEnd };
+        return getExecutor(mCommandBegin, mCommandEnd);
     }
 
     Executor getExecutor(Command const* b, Command const* e) const {
-        return { this, b, e };
+        return { this, b, e, mInstancedUboHandle };
     }
 
 private:
@@ -373,7 +392,15 @@ private:
     // This is the main function of this class, this appends commands to the pass using
     // the current camera, geometry and flags set. This can be called multiple times if needed.
     void appendCommands(FEngine& engine,
-            utils::Slice<Command> commands, CommandTypeFlags commandTypeFlags) noexcept;
+            utils::Slice<Command> commands,
+            backend::BufferObjectHandle uboHandle,
+            utils::Range<uint32_t> const visibleRenderables,
+            CommandTypeFlags commandTypeFlags,
+            RenderFlags renderFlags,
+            FScene::VisibleMaskType visibilityMask,
+            Variant variant,
+            math::float3 cameraPosition,
+            math::float3 cameraForwardVector) noexcept;
 
     // Appends a custom command.
     void appendCustomCommand(Command* commands,
@@ -399,6 +426,7 @@ private:
 
     static inline void generateCommands(CommandTypeFlags commandTypeFlags, Command* commands,
             FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
+            backend::BufferObjectHandle renderablesUbo,
             Variant variant, RenderFlags renderFlags,
             FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward,
@@ -407,6 +435,7 @@ private:
     template<RenderPass::CommandTypeFlags commandTypeFlags>
     static inline Command* generateCommandsImpl(RenderPass::CommandTypeFlags extraFlags, Command* curr,
             FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
+            backend::BufferObjectHandle renderablesUbo,
             Variant variant, RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward,
             uint8_t instancedStereoEyeCount) noexcept;
@@ -417,23 +446,12 @@ private:
     static void updateSummedPrimitiveCounts(
             FScene::RenderableSoa& renderableData, utils::Range<uint32_t> vr) noexcept;
 
-
     FScene::RenderableSoa const& mRenderableSoa;
-    utils::Range<uint32_t> const mVisibleRenderables;
-    backend::Handle<backend::HwBufferObject> const mUboHandle;
-    math::float3 const mCameraPosition;
-    math::float3 const mCameraForwardVector;
-    RenderFlags const mFlags;
-    Variant const mVariant;
-    FScene::VisibleMaskType const mVisibilityMask;
     backend::Viewport const mScissorViewport;
-
-    // Pointer to the first command
-    Command* mCommandBegin = nullptr;
-    // Pointer to one past the last command
-    Command* mCommandEnd = nullptr;
+    Command* mCommandBegin = nullptr;   // Pointer to the first command
+    Command* mCommandEnd = nullptr;     // Pointer to one past the last command
     // a UBO for instanced primitives
-    backend::Handle<backend::HwBufferObject> mInstancedUboHandle;
+    BufferObjectSharedHandle mInstancedUboHandle;
     // a vector for our custom commands
     using CustomCommandVector = std::vector<Executor::CustomCommandFn,
             utils::STLAllocator<Executor::CustomCommandFn, LinearAllocatorArena>>;

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -266,7 +266,7 @@ public:
 
     struct alignas(8) Command {     // 64 bytes
         CommandKey key = 0;         //  8 bytes
-        PrimitiveInfo primitive;    // 56 bytes
+        PrimitiveInfo info;    // 56 bytes
         bool operator < (Command const& rhs) const noexcept { return key < rhs.key; }
         // placement new declared as "throw" to avoid the compiler's null-check
         inline void* operator new (size_t, void* ptr) {

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -54,7 +54,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
         FrameGraph& fg, const char* name, FEngine& engine, FView const& view,
         FrameGraphTexture::Descriptor const& colorBufferDesc,
         ColorPassConfig const& config, PostProcessManager::ColorGradingConfig colorGradingConfig,
-        RenderPass::Executor const& passExecutor) noexcept {
+        RenderPass::Executor passExecutor) noexcept {
 
     struct ColorPassData {
         FrameGraphId<FrameGraphTexture> shadows;
@@ -200,7 +200,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                         .clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags});
                 blackboard["depth"] = data.depth;
             },
-            [=, &view, &engine](FrameGraphResources const& resources,
+            [=, passExecutor = std::move(passExecutor), &view, &engine](FrameGraphResources const& resources,
                     ColorPassData const& data, DriverApi& driver) {
                 auto out = resources.getRenderPassInfo();
 

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -76,7 +76,7 @@ public:
             FrameGraphTexture::Descriptor const& colorBufferDesc,
             ColorPassConfig const& config,
             PostProcessManager::ColorGradingConfig colorGradingConfig,
-            RenderPass::Executor const& passExecutor) noexcept;
+            RenderPass::Executor passExecutor) noexcept;
 
     static std::pair<FrameGraphId<FrameGraphTexture>, bool> refractionPass(
             FrameGraph& fg, FEngine& engine, FView const& view,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -365,7 +365,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                             .camera(cameraInfo)
                             .visibilityMask(entry.visibilityMask)
                             .geometry(scene->getRenderableData(),
-                                    entry.range, scene->getRenderableUBO())
+                                    entry.range,
+                                    view.getRenderableUBO())
                             .commandTypeFlags(RenderPass::CommandTypeFlags::SHADOW)
                             .build(engine);
 

--- a/filament/src/SharedHandle.h
+++ b/filament/src/SharedHandle.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_SHARED_HANDLE_H
+#define TNT_FILAMENT_SHARED_HANDLE_H
+
+#include <backend/Handle.h>
+
+#include <stdint.h>
+
+namespace filament {
+
+/*
+ * SharedHandle is a bit like shared_ptr<> but for Handle<>, the destruction is
+ * performed by a Deleter functor that needs to be provided. We only support strong
+ * references for now.
+ *
+ * caveat: The current implementation is not thread-safe.
+ */
+template<typename T, typename Deleter>
+struct SharedHandle {
+    SharedHandle() noexcept = default;
+
+    ~SharedHandle() noexcept {
+        dec(mControlBlockPtr);
+    }
+
+    SharedHandle(SharedHandle const& rhs) noexcept
+            : mControlBlockPtr(inc(rhs.mControlBlockPtr)) {
+    }
+
+    SharedHandle(SharedHandle&& rhs) noexcept {
+        std::swap(mControlBlockPtr, rhs.mControlBlockPtr);
+    }
+
+    SharedHandle& operator=(SharedHandle const& rhs) noexcept {
+        if (this != &rhs) {
+            inc(rhs.mControlBlockPtr);  // add a reference to other control block
+            dec(mControlBlockPtr);      // drop a reference from ours (possibly destroying it)
+            mControlBlockPtr = rhs.mControlBlockPtr; // adopt the new control block
+        }
+        return *this;
+    }
+
+    SharedHandle& operator=(SharedHandle&& rhs) noexcept {
+        if (this != &rhs) {
+            std::swap(mControlBlockPtr, rhs.mControlBlockPtr);
+        }
+        return *this;
+    }
+
+    // initialize the SharedHandle and provide a Deleter
+    template<typename ... ARGS>
+    explicit SharedHandle(backend::Handle<T> const& rhs, ARGS&& ... args) noexcept
+            : mControlBlockPtr(new ControlBlock(rhs, std::forward<ARGS>(args)...)) {
+    }
+
+    // initialize the SharedHandle and provide a Deleter
+    template<typename ... ARGS>
+    explicit SharedHandle(backend::Handle<T>&& rhs, ARGS&& ... args) noexcept
+            : mControlBlockPtr(new ControlBlock(rhs, std::forward<ARGS>(args)...)) {
+    }
+
+    // automatically converts to Handle<T>
+    operator backend::Handle<T>() const noexcept { // NOLINT(*-explicit-constructor)
+        return mControlBlockPtr ? mControlBlockPtr->handle : backend::Handle<T>{};
+    }
+
+    explicit operator bool() const noexcept {
+        return mControlBlockPtr ? (bool)mControlBlockPtr->handle : false;
+    }
+
+    void clear() noexcept { dec(mControlBlockPtr); }
+
+private:
+    struct ControlBlock {
+        template<typename ... ARGS>
+        explicit ControlBlock(backend::Handle<T> handle, ARGS&& ... args) noexcept
+                : deleter(std::forward<ARGS>(args)...), handle(std::move(handle)) {
+        }
+        void inc() noexcept {
+            ++count;
+        }
+        void dec() noexcept {
+            if (--count == 0) {
+                deleter(handle);
+                delete this;
+            }
+        }
+        Deleter deleter;
+        int32_t count = 1;
+        backend::Handle<T> handle;
+    };
+
+    ControlBlock* inc(ControlBlock* const ctrlBlk) noexcept {
+        if (ctrlBlk) {
+            ctrlBlk->inc();
+        }
+        return ctrlBlk;
+    }
+
+    void dec(ControlBlock* const ctrlBlk) noexcept {
+        if (ctrlBlk) {
+            ctrlBlk->dec();
+        }
+    }
+
+    ControlBlock* mControlBlockPtr = nullptr;
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_SHARED_HANDLE_H

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -840,7 +840,8 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
     passBuilder.camera(cameraInfo);
     passBuilder.geometry(scene.getRenderableData(),
-            view.getVisibleRenderables(), scene.getRenderableUBO());
+            view.getVisibleRenderables(),
+            view.getRenderableUBO());
 
     // view set-ups that need to happen before rendering
     fg.addTrivialSideEffectPass("Prepare View Uniforms",

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -388,9 +388,6 @@ void FScene::updateUBOs(
     SYSTRACE_CALL();
     FEngine::DriverApi& driver = mEngine.getDriverApi();
 
-    // store the UBO handle
-    mRenderableViewUbh = renderableUbh;
-
     // don't allocate more than 16 KiB directly into the render stream
     static constexpr size_t MAX_STREAM_ALLOCATION_COUNT = 64;   // 16 KiB
     const size_t count = visibleRenderables.size();
@@ -450,8 +447,6 @@ void FScene::updateUBOs(
 }
 
 void FScene::terminate(FEngine&) {
-    // DO NOT destroy this UBO, it's owned by the View
-    mRenderableViewUbh.clear();
 }
 
 void FScene::prepareDynamicLights(const CameraInfo& camera,

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -80,10 +80,6 @@ public:
     void prepareDynamicLights(const CameraInfo& camera,
             backend::Handle<backend::HwBufferObject> lightUbh) noexcept;
 
-    backend::Handle<backend::HwBufferObject> getRenderableUBO() const noexcept {
-        return mRenderableViewUbh;
-    }
-
     /*
      * Storage for per-frame renderable data
      */
@@ -228,7 +224,6 @@ private:
      */
     RenderableSoa mRenderableData;
     LightSoa mLightData;
-    backend::Handle<backend::HwBufferObject> mRenderableViewUbh; // This is actually owned by the view.
     bool mHasContactShadows = false;
 
     // State shared between Scene and driver callbacks.

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -649,7 +649,8 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
                 const size_t count = std::max(size_t(16u), (4u * merged.size() + 2u) / 3u);
                 mRenderableUBOSize = uint32_t(count * sizeof(PerRenderableData));
                 driver.destroyBufferObject(mRenderableUbh);
-                mRenderableUbh = driver.createBufferObject(mRenderableUBOSize + sizeof(PerRenderableUib),
+                mRenderableUbh = driver.createBufferObject(
+                        mRenderableUBOSize + sizeof(PerRenderableUib),
                         BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
             } else {
                 // TODO: should we shrink the underlying UBO at some point?

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -437,8 +437,11 @@ public:
         return mFogEntity;
     }
 
-private:
+    backend::Handle<backend::HwBufferObject> getRenderableUBO() const noexcept {
+        return mRenderableUbh;
+    }
 
+private:
     struct FPickingQuery : public PickingQuery {
     private:
         FPickingQuery(uint32_t x, uint32_t y,


### PR DESCRIPTION
The main goal of this change is to avoid having to select the 
"per renderable" UBO at execution time. Instead we want the
PrimitiveInfo structure to already know which UBO will be used.
Concretely, this means that this determination must be done when
the RenderPass is created.

When automatic instancing is used, the RenderPass creates a temporary
UBO to store the instance info. This UBO's life-time is dictated by both
the life-time of the RenderPass and the Executors that where created
from it. For this reason we introduce SharedHandle<> to correctly 
account for the owner's lifetime. This fixes a potential bugs where
that handle could have been destroyed and used later; in practice this
bug didn't happen however.

A couple other changes:

- RenderPass has a bunch of fields that were actually temporary, so we
removed those.

- The canonical "per-renderable" UBO was owned by View but accessed 
through Scene. This was confusing, it's now accessed through View.