### PR TITLE
fix ES2 support

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3382,7 +3382,9 @@ void OpenGLDriver::executeGpuCommandsCompleteOps() noexcept {
 
 void OpenGLDriver::tick(int) {
     DEBUG_MARKER()
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     executeGpuCommandsCompleteOps();
+#endif
     executeEveryNowAndThenOps();
     getShaderCompilerService().tick();
 }

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -341,19 +341,22 @@ void PostProcessManager::init() noexcept {
         }
     }
 
-    mStarburstTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
-            TextureFormat::R8, 1, 256, 1, 1, TextureUsage::DEFAULT);
+    if (engine.hasFeatureLevel(FeatureLevel::FEATURE_LEVEL_1)) {
+        mStarburstTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
+                TextureFormat::R8, 1, 256, 1, 1, TextureUsage::DEFAULT);
 
-    PixelBufferDescriptor dataStarburst(driver.allocate(256), 256, PixelDataFormat::R, PixelDataType::UBYTE);
-    std::generate_n((uint8_t*)dataStarburst.buffer, 256,
-            [&dist = mUniformDistribution, &gen = mEngine.getRandomEngine()]() {
-        float const r = 0.5f + 0.5f * dist(gen);
-        return uint8_t(r * 255.0f);
-    });
+        PixelBufferDescriptor dataStarburst(driver.allocate(256), 256,
+                PixelDataFormat::R, PixelDataType::UBYTE);
+        std::generate_n((uint8_t*)dataStarburst.buffer, 256,
+                [&dist = mUniformDistribution, &gen = mEngine.getRandomEngine()]() {
+                    float const r = 0.5f + 0.5f * dist(gen);
+                    return uint8_t(r * 255.0f);
+                });
 
-    driver.update3DImage(mStarburstTexture,
-            0, 0, 0, 0, 256, 1, 1,
-            std::move(dataStarburst));
+        driver.update3DImage(mStarburstTexture,
+                0, 0, 0, 0, 256, 1, 1,
+                std::move(dataStarburst));
+    }
 }
 
 void PostProcessManager::terminate(DriverApi& driver) noexcept {


### PR DESCRIPTION
- make sure we can build with ES2 headers only
- make sure to not use ES3 features when in ES2 mode (post processing was accidentally creating an R8 texture,  which is not supported)