### PR TITLE
Fix broken ImGui on web

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- filagui: Fix regression which broke WebGL

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -33,6 +33,11 @@ endif()
 set(MATERIAL_SRCS
         src/materials/uiBlit.mat)
 
+if (ANDROID)
+    list(APPEND MATERIAL_SRCS
+            src/materials/uiBlitExternal.mat)
+endif()
+
 file(MAKE_DIRECTORY ${MATERIAL_DIR})
 
 foreach (mat_src ${MATERIAL_SRCS})

--- a/libs/filagui/include/filagui/ImGuiHelper.h
+++ b/libs/filagui/include/filagui/ImGuiHelper.h
@@ -84,12 +84,14 @@ public:
       filament::View* mView; // The view is owned by the client.
       filament::Scene* mScene;
       filament::Material* mMaterial2d = nullptr;
+      std::vector<filament::MaterialInstance*> mMaterial2dInstances;
+#ifdef __ANDROID__
       filament::Material* mMaterialExternal = nullptr;
+      std::vector<filament::MaterialInstance*> mMaterialExternalInstances;
+#endif
       filament::Camera* mCamera = nullptr;
       std::vector<filament::VertexBuffer*> mVertexBuffers;
       std::vector<filament::IndexBuffer*> mIndexBuffers;
-      std::vector<filament::MaterialInstance*> mMaterial2dInstances;
-      std::vector<filament::MaterialInstance*> mMaterialExternalInstances;
       utils::Entity mRenderable;
       utils::Entity mCameraEntity;
       filament::Texture* mTexture = nullptr;

--- a/libs/filagui/src/ImGuiHelper.cpp
+++ b/libs/filagui/src/ImGuiHelper.cpp
@@ -64,10 +64,12 @@ ImGuiHelper::ImGuiHelper(Engine* engine, filament::View* view, const Path& fontP
             .package(FILAGUI_RESOURCES_UIBLIT_DATA, FILAGUI_RESOURCES_UIBLIT_SIZE)
             .constant("external", false)
             .build(*engine);
+#ifdef __ANDROID__
     mMaterialExternal = Material::Builder()
             .package(FILAGUI_RESOURCES_UIBLIT_DATA, FILAGUI_RESOURCES_UIBLIT_SIZE)
             .constant("external", true)
             .build(*engine);
+#endif
 
     // If the given font path is invalid, ImGui will silently fall back to proggy, which is a
     // tiny "pixel art" texture that is compiled into the library.
@@ -134,10 +136,12 @@ ImGuiHelper::~ImGuiHelper() {
         mEngine->destroy(mi);
     }
     mEngine->destroy(mMaterial2d);
+#ifdef __ANDROID__
     for (auto& mi : mMaterialExternalInstances) {
         mEngine->destroy(mi);
     }
     mEngine->destroy(mMaterialExternal);
+#endif
     mEngine->destroy(mTexture);
     for (auto& vb : mVertexBuffers) {
         mEngine->destroy(vb);
@@ -229,13 +233,16 @@ void ImGuiHelper::processImGuiCommands(ImDrawData* commands, const ImGuiIO& io) 
                 auto texture = (Texture const*)pcmd.TextureId;
                 const char* uniformName;
                 MaterialInstance* materialInstance;
+#ifdef __ANDROID__
                 if (texture && texture->getTarget() == Texture::Sampler::SAMPLER_EXTERNAL) {
                     if (materialExternalIndex == mMaterialExternalInstances.size()) {
                         mMaterialExternalInstances.push_back(mMaterialExternal->createInstance());
                     }
                     uniformName = "albedoExternal";
                     materialInstance = mMaterialExternalInstances[materialExternalIndex++];
-                } else {
+                } else
+#endif
+                {
                     if (material2dIndex == mMaterial2dInstances.size()) {
                         mMaterial2dInstances.push_back(mMaterial2d->createInstance());
                     }

--- a/libs/filagui/src/materials/uiBlitExternal.mat
+++ b/libs/filagui/src/materials/uiBlitExternal.mat
@@ -1,8 +1,8 @@
 material {
-    name : uiBlit,
+    name : uiBlitExternal,
     parameters : [
         {
-            type : sampler2d,
+            type : samplerExternal,
             name : albedo
         }
     ],


### PR DESCRIPTION
I was unfortunately naive about the way that Filament handled external textures on non-GLES platforms. This fix restricts the changes to Android (which is the only place this change is required in the first place). Long story short, the change broke WebGL. Desktop seems to be unaffected.