### PR TITLE
Skybox doesn't need a commit() method

### DIFF
--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -439,11 +439,6 @@ void FScene::updateUBOs(
                 delete weakShared;
             }, weakShared
     }, 0);
-
-    // update skybox
-    if (mSkybox) {
-        mSkybox->commit(driver);
-    }
 }
 
 void FScene::terminate(FEngine&) {

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -17,21 +17,28 @@
 #include "details/Skybox.h"
 
 #include "details/Engine.h"
-#include "details/Texture.h"
-#include "details/VertexBuffer.h"
-#include "details/IndexBuffer.h"
 #include "details/IndirectLight.h"
 #include "details/Material.h"
-#include "details/MaterialInstance.h"
+#include "details/Texture.h"
+#include "details/VertexBuffer.h"
 
 #include "FilamentAPI-impl.h"
 
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+#include <filament/RenderableManager.h>
 #include <filament/TextureSampler.h>
+#include <filament/Skybox.h>
 
 #include <backend/DriverEnums.h>
 
+#include <utils/compiler.h>
+#include <utils/debug.h>
 #include <utils/Panic.h>
-#include <filament/Skybox.h>
+
+#include <math/vec4.h>
+
+#include <stdint.h>
 
 
 #include "generated/resources/materials.h"
@@ -162,10 +169,6 @@ void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
 
 void FSkybox::setColor(math::float4 color) noexcept {
     mSkyboxMaterialInstance->setParameter("color", color);
-}
-
-void FSkybox::commit(backend::DriverApi& driver) noexcept {
-    mSkyboxMaterialInstance->commit(driver);
 }
 
 } // namespace filament

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -53,9 +53,6 @@ public:
 
     void setColor(math::float4 color) noexcept;
 
-    // commits UBOs
-    void commit(backend::DriverApi& driver) noexcept;
-
 private:
     // we don't own these
     FTexture const* mSkyboxTexture = nullptr;


### PR DESCRIPTION
The material parameter changes are committed automatically in Engine::prepare(), no need to do it explicitly for SkyBox.