### PR TITLE
Fix mixed up FBO targets in status check code in OpenGLDriver::blit()

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3656,7 +3656,7 @@ void OpenGLDriver::blit(
         case SamplerType::SAMPLER_EXTERNAL:
             break;
     }
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
 
     gl.bindFramebuffer(GL_READ_FRAMEBUFFER, fbo[1]);
     switch (s->target) {
@@ -3682,7 +3682,7 @@ void OpenGLDriver::blit(
         case SamplerType::SAMPLER_EXTERNAL:
             break;
     }
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
 
     gl.disable(GL_SCISSOR_TEST);
     glBlitFramebuffer(


### PR DESCRIPTION
While using Filament with ANGLE on Windows (using D3D11 backend of ANGLE) we noticed getting lots of warnings like this:

```
OpenGL framebuffer error 0x8219 (GL_FRAMEBUFFER_UNDEFINED) in "blit" at line 3581
```

We use Filament v1.50.3 and there the problematic driver calls comes from [here](https://github.com/google/filament/blob/v1.50.3/filament/src/PostProcessManager.cpp#L753). Looking at the implementation of `OpenGLDriver::blit()` it seemed to me there was a bug (fix me if I am wrong). It:

 - binds an FBO **as DRAW** target then attaches images to it
 - checks the completeness of **READ target** FBO (_what if there's no FBO bound as READ target?_)
 - binds another FBO **as READ** target then attaches images to it
 - checks the completeness of **DRAW target** FBO (_this technically works because DRAW target FBO is already configured_)
 
I couldn't reproduce it with gltf_viewer + Windows OpenGL driver but it can be that ANGLE is more chatty on the debug output than the Windows OpenGL driver. And regardless of this, the FBO checks still seem to be mixed up