### PR TITLE
Fix a shader error

### DIFF
--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -275,7 +275,8 @@ int getEyeIndex() {
 #if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
     return instance_index % CONFIG_STEREO_EYE_COUNT;
 #elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
-    return gl_ViewID_OVR;
+    // gl_ViewID_OVR is of uint type, which needs an explicit conversion.
+    return int(gl_ViewID_OVR);
 #endif
     return 0;
 }


### PR DESCRIPTION
gl_ViewID_OVR is of uint type. Explicitly convert it to int to fix the error.