### PR TITLE
Metal: implement more accurate buffer tracking

### DIFF
--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -65,9 +65,12 @@ private:
     const char* mName;
 };
 
-class TrackedMetalBuffer {
-public:
+#ifndef FILAMENT_METAL_BUFFER_TRACKING
+#define FILAMENT_METAL_BUFFER_TRACKING 0
+#endif
 
+class MetalBufferTracking {
+public:
     static constexpr size_t EXCESS_BUFFER_COUNT = 30000;
 
     enum class Type {
@@ -91,66 +94,58 @@ public:
         }
     }
 
-    TrackedMetalBuffer() noexcept : mBuffer(nil) {}
-    TrackedMetalBuffer(nullptr_t) noexcept : mBuffer(nil) {}
-    TrackedMetalBuffer(id<MTLBuffer> buffer, Type type) : mBuffer(buffer), mType(type) {
+#if FILAMENT_METAL_BUFFER_TRACKING
+    static void initialize() {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            for (size_t i = 0; i < TypeCount; i++) {
+                aliveBuffers[i] = [NSHashTable weakObjectsHashTable];
+            }
+        });
+    }
+
+    static void setPlatform(MetalPlatform* p) { platform = p; }
+
+    static id<MTLBuffer> track(id<MTLBuffer> buffer, Type type) {
         assert_invariant(type != Type::NONE);
-        if (buffer) {
-            aliveBuffers[toIndex(type)]++;
-            mType = type;
-            if (getAliveBuffers() >= EXCESS_BUFFER_COUNT) {
-                if (platform && platform->hasDebugUpdateStatFunc()) {
-                    platform->debugUpdateStat("filament.metal.excess_buffers_allocated",
-                            TrackedMetalBuffer::getAliveBuffers());
-                }
+        if (UTILS_UNLIKELY(getAliveBuffers() >= EXCESS_BUFFER_COUNT)) {
+            if (platform && platform->hasDebugUpdateStatFunc()) {
+                platform->debugUpdateStat("filament.metal.excess_buffers_allocated",
+                        MetalBufferTracking::getAliveBuffers());
             }
         }
+        [aliveBuffers[toIndex(type)] addObject:buffer];
+        return buffer;
     }
-
-    ~TrackedMetalBuffer() {
-        if (mBuffer) {
-            assert_invariant(mType != Type::NONE);
-            aliveBuffers[toIndex(mType)]--;
-        }
-    }
-
-    TrackedMetalBuffer(TrackedMetalBuffer&&) = delete;
-    TrackedMetalBuffer(TrackedMetalBuffer const&) = delete;
-    TrackedMetalBuffer& operator=(TrackedMetalBuffer const&) = delete;
-
-    TrackedMetalBuffer& operator=(TrackedMetalBuffer&& rhs) noexcept {
-        swap(rhs);
-        return *this;
-    }
-
-    id<MTLBuffer> get() const noexcept { return mBuffer; }
-    operator bool() const noexcept { return bool(mBuffer); }
 
     static uint64_t getAliveBuffers() {
         uint64_t sum = 0;
-        for (const auto& v : aliveBuffers) {
-            sum += v;
+        for (size_t i = 1; i < TypeCount; i++) {
+            sum += getAliveBuffers(static_cast<Type>(i));
         }
         return sum;
     }
 
     static uint64_t getAliveBuffers(Type type) {
         assert_invariant(type != Type::NONE);
-        return aliveBuffers[toIndex(type)];
+        NSHashTable* hashTable = aliveBuffers[toIndex(type)];
+        // Caution! We can't simply use hashTable.count here, which is inaccurate.
+        // See http://cocoamine.net/blog/2013/12/13/nsmaptable-and-zeroing-weak-references/
+        return hashTable.objectEnumerator.allObjects.count;
     }
-    static void setPlatform(MetalPlatform* p) { platform = p; }
+#else
+    static void initialize() {}
+    static void setPlatform(MetalPlatform* p) {}
+    static id<MTLBuffer> track(id<MTLBuffer> buffer, Type type) { return buffer; }
+    static uint64_t getAliveBuffers() { return 0; }
+    static uint64_t getAliveBuffers(Type type) { return 0; }
+#endif
 
 private:
-    void swap(TrackedMetalBuffer& other) noexcept {
-        std::swap(mBuffer, other.mBuffer);
-        std::swap(mType, other.mType);
-    }
-
-    id<MTLBuffer> mBuffer;
-    Type mType = Type::NONE;
-
+#if FILAMENT_METAL_BUFFER_TRACKING
+    static std::array<NSHashTable<id<MTLBuffer>>*, TypeCount> aliveBuffers;
     static MetalPlatform* platform;
-    static std::array<uint64_t, TypeCount> aliveBuffers;
+#endif
 };
 
 class MetalBuffer {
@@ -204,7 +199,7 @@ public:
 
 private:
 
-    TrackedMetalBuffer mBuffer;
+    id<MTLBuffer> mBuffer;
     size_t mBufferSize = 0;
     void* mCpuBuffer = nullptr;
     MetalContext& mContext;
@@ -253,9 +248,11 @@ public:
           mBufferOptions(options),
           mSlotSizeBytes(computeSlotSize(layout)),
           mSlotCount(slotCount) {
-        ScopedAllocationTimer timer("ring");
-        mBuffer = { [device newBufferWithLength:mSlotSizeBytes * mSlotCount options:mBufferOptions],
-            TrackedMetalBuffer::Type::RING };
+        {
+            ScopedAllocationTimer timer("ring");
+            mBuffer = [device newBufferWithLength:mSlotSizeBytes * mSlotCount options:mBufferOptions];
+        }
+        MetalBufferTracking::track(mBuffer, MetalBufferTracking::Type::RING);
         assert_invariant(mBuffer);
     }
 
@@ -275,11 +272,11 @@ public:
             // finishes executing.
             {
                 ScopedAllocationTimer timer("ring");
-                mAuxBuffer = { [mDevice newBufferWithLength:mSlotSizeBytes options:mBufferOptions],
-                    TrackedMetalBuffer::Type::RING };
+                mAuxBuffer = [mDevice newBufferWithLength:mSlotSizeBytes options:mBufferOptions];
             }
+            MetalBufferTracking::track(mAuxBuffer, MetalBufferTracking::Type::RING);
             assert_invariant(mAuxBuffer);
-            return { mAuxBuffer.get(), 0 };
+            return { mAuxBuffer, 0 };
         }
         mCurrentSlot = (mCurrentSlot + 1) % mSlotCount;
         mOccupiedSlots->fetch_add(1, std::memory_order_relaxed);
@@ -308,9 +305,9 @@ public:
      */
     std::pair<id<MTLBuffer>, NSUInteger> getCurrentAllocation() const {
         if (UTILS_UNLIKELY(mAuxBuffer)) {
-            return { mAuxBuffer.get(), 0 };
+            return { mAuxBuffer, 0 };
         }
-        return { mBuffer.get(), mCurrentSlot * mSlotSizeBytes };
+        return { mBuffer, mCurrentSlot * mSlotSizeBytes };
     }
 
     bool canAccomodateLayout(MTLSizeAndAlign layout) const {
@@ -319,8 +316,8 @@ public:
 
 private:
     id<MTLDevice> mDevice;
-    TrackedMetalBuffer mBuffer;
-    TrackedMetalBuffer mAuxBuffer;
+    id<MTLBuffer> mBuffer;
+    id<MTLBuffer> mAuxBuffer;
 
     MTLResourceOptions mBufferOptions;
 

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -106,7 +106,7 @@ public:
 
     static void setPlatform(MetalPlatform* p) { platform = p; }
 
-    static id<MTLBuffer> track(id<MTLBuffer> buffer, Type type) {
+    static void track(id<MTLBuffer> buffer, Type type) {
         assert_invariant(type != Type::NONE);
         if (UTILS_UNLIKELY(getAliveBuffers() >= EXCESS_BUFFER_COUNT)) {
             if (platform && platform->hasDebugUpdateStatFunc()) {
@@ -115,7 +115,6 @@ public:
             }
         }
         [aliveBuffers[toIndex(type)] addObject:buffer];
-        return buffer;
     }
 
     static uint64_t getAliveBuffers() {

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -22,9 +22,13 @@
 namespace filament {
 namespace backend {
 
-std::array<uint64_t, TrackedMetalBuffer::TypeCount> TrackedMetalBuffer::aliveBuffers = { 0 };
-MetalPlatform* TrackedMetalBuffer::platform = nullptr;
 MetalPlatform* ScopedAllocationTimer::platform = nullptr;
+
+#if FILAMENT_METAL_BUFFER_TRACKING
+std::array<NSHashTable<id<MTLBuffer>>*, MetalBufferTracking::TypeCount>
+        MetalBufferTracking::aliveBuffers;
+MetalPlatform* MetalBufferTracking::platform = nullptr;
+#endif
 
 MetalBuffer::MetalBuffer(MetalContext& context, BufferObjectBinding bindingType, BufferUsage usage,
         size_t size, bool forceGpuBuffer) : mBufferSize(size), mContext(context) {
@@ -41,9 +45,9 @@ MetalBuffer::MetalBuffer(MetalContext& context, BufferObjectBinding bindingType,
     // Otherwise, we allocate a private GPU buffer.
     {
         ScopedAllocationTimer timer("generic");
-        mBuffer = { [context.device newBufferWithLength:size options:MTLResourceStorageModePrivate],
-            TrackedMetalBuffer::Type::GENERIC };
+        mBuffer = [context.device newBufferWithLength:size options:MTLResourceStorageModePrivate];
     }
+    MetalBufferTracking::track(mBuffer, MetalBufferTracking::Type::GENERIC);
     ASSERT_POSTCONDITION(mBuffer, "Could not allocate Metal buffer of size %zu.", size);
 }
 
@@ -70,7 +74,7 @@ void MetalBuffer::copyIntoBuffer(void* src, size_t size, size_t byteOffset) {
     // Acquire a staging buffer to hold the contents of this update.
     MetalBufferPool* bufferPool = mContext.bufferPool;
     const MetalBufferPoolEntry* const staging = bufferPool->acquireBuffer(size);
-    memcpy(staging->buffer.get().contents, src, size);
+    memcpy(staging->buffer.contents, src, size);
 
     // The blit below requires that byteOffset be a multiple of 4.
     ASSERT_PRECONDITION(!(byteOffset & 0x3u), "byteOffset must be a multiple of 4");
@@ -79,9 +83,9 @@ void MetalBuffer::copyIntoBuffer(void* src, size_t size, size_t byteOffset) {
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(&mContext);
     id<MTLBlitCommandEncoder> blitEncoder = [cmdBuffer blitCommandEncoder];
     blitEncoder.label = @"Buffer upload blit";
-    [blitEncoder copyFromBuffer:staging->buffer.get()
+    [blitEncoder copyFromBuffer:staging->buffer
                    sourceOffset:0
-                       toBuffer:mBuffer.get()
+                       toBuffer:mBuffer
               destinationOffset:byteOffset
                            size:size];
     [blitEncoder endEncoding];
@@ -102,7 +106,7 @@ id<MTLBuffer> MetalBuffer::getGpuBufferForDraw(id<MTLCommandBuffer> cmdBuffer) n
         return nil;
     }
     assert_invariant(mBuffer);
-    return mBuffer.get();
+    return mBuffer;
 }
 
 void MetalBuffer::bindBuffers(id<MTLCommandBuffer> cmdBuffer, id<MTLCommandEncoder> encoder,

--- a/filament/backend/src/metal/MetalBufferPool.h
+++ b/filament/backend/src/metal/MetalBufferPool.h
@@ -32,7 +32,7 @@ struct MetalContext;
 
 // Immutable POD representing a shared CPU-GPU buffer.
 struct MetalBufferPoolEntry {
-    TrackedMetalBuffer buffer;
+    id<MTLBuffer> buffer;
     size_t capacity;
     mutable uint64_t lastAccessed;
     mutable uint32_t referenceCount;

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -48,9 +48,10 @@ MetalBufferPoolEntry const* MetalBufferPool::acquireBuffer(size_t numBytes) {
         buffer = [mContext.device newBufferWithLength:numBytes
                                               options:MTLResourceStorageModeShared];
     }
+    MetalBufferTracking::track(buffer, MetalBufferTracking::Type::STAGING);
     ASSERT_POSTCONDITION(buffer, "Could not allocate Metal staging buffer of size %zu.", numBytes);
     MetalBufferPoolEntry* stage = new MetalBufferPoolEntry {
-        .buffer = { buffer, TrackedMetalBuffer::Type::STAGING },
+        .buffer = buffer,
         .capacity = numBytes,
         .lastAccessed = mCurrentFrame,
         .referenceCount = 1

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -105,8 +105,9 @@ MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& 
                   driverConfig.disableHandleUseAfterFreeCheck) {
     mContext->driver = this;
 
-    TrackedMetalBuffer::setPlatform(platform);
     ScopedAllocationTimer::setPlatform(platform);
+    MetalBufferTracking::initialize();
+    MetalBufferTracking::setPlatform(platform);
 
     mContext->device = mPlatform.createDevice();
     assert_invariant(mContext->device);
@@ -201,7 +202,7 @@ MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& 
 }
 
 MetalDriver::~MetalDriver() noexcept {
-    TrackedMetalBuffer::setPlatform(nullptr);
+    MetalBufferTracking::setPlatform(nullptr);
     ScopedAllocationTimer::setPlatform(nullptr);
     mContext->device = nil;
     mContext->emptyTexture = nil;
@@ -223,13 +224,16 @@ void MetalDriver::beginFrame(int64_t monotonic_clock_ns,
     os_signpost_interval_begin(mContext->log, mContext->signpostId, "Frame encoding", "%{public}d", frameId);
 #endif
     if (mPlatform.hasDebugUpdateStatFunc()) {
-        mPlatform.debugUpdateStat("filament.metal.alive_buffers", TrackedMetalBuffer::getAliveBuffers());
-        mPlatform.debugUpdateStat("filament.metal.alive_buffers.generic",
-                TrackedMetalBuffer::getAliveBuffers(TrackedMetalBuffer::Type::GENERIC));
-        mPlatform.debugUpdateStat("filament.metal.alive_buffers.ring",
-                TrackedMetalBuffer::getAliveBuffers(TrackedMetalBuffer::Type::RING));
-        mPlatform.debugUpdateStat("filament.metal.alive_buffers.staging",
-                TrackedMetalBuffer::getAliveBuffers(TrackedMetalBuffer::Type::STAGING));
+#if FILAMENT_METAL_BUFFER_TRACKING
+        const uint64_t generic = MetalBufferTracking::getAliveBuffers(MetalBufferTracking::Type::GENERIC);
+        const uint64_t ring = MetalBufferTracking::getAliveBuffers(MetalBufferTracking::Type::RING);
+        const uint64_t staging = MetalBufferTracking::getAliveBuffers(MetalBufferTracking::Type::STAGING);
+        const uint64_t total = generic + ring + staging;
+        mPlatform.debugUpdateStat("filament.metal.alive_buffers2", total);
+        mPlatform.debugUpdateStat("filament.metal.alive_buffers2.generic", generic);
+        mPlatform.debugUpdateStat("filament.metal.alive_buffers2.ring", ring);
+        mPlatform.debugUpdateStat("filament.metal.alive_buffers2.staging", staging);
+#endif
     }
 }
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -789,13 +789,13 @@ void MetalTexture::loadWithCopyBuffer(uint32_t level, uint32_t slice, MTLRegion 
         PixelBufferDescriptor const& data, const PixelBufferShape& shape) {
     const size_t stagingBufferSize = shape.totalBytes;
     auto entry = context.bufferPool->acquireBuffer(stagingBufferSize);
-    memcpy(entry->buffer.get().contents,
+    memcpy(entry->buffer.contents,
             static_cast<uint8_t*>(data.buffer) + shape.sourceOffset,
             stagingBufferSize);
     id<MTLCommandBuffer> blitCommandBuffer = getPendingCommandBuffer(&context);
     id<MTLBlitCommandEncoder> blitCommandEncoder = [blitCommandBuffer blitCommandEncoder];
     blitCommandEncoder.label = @"Texture upload buffer blit";
-    [blitCommandEncoder copyFromBuffer:entry->buffer.get()
+    [blitCommandEncoder copyFromBuffer:entry->buffer
                           sourceOffset:0
                      sourceBytesPerRow:shape.bytesPerRow
                    sourceBytesPerImage:shape.bytesPerSlice


### PR DESCRIPTION
This PR updates our Metal buffer tracking logic to use a `NSHashTable` to track alive buffers. `NSHashTable` is configured to hold weak references to the buffers we add to it. When a buffer is deallocated, it is automatically removed from the hash table. By counting the number of buffers in the hash table, we get an accurate count of the number of alive buffers.

The previous implementation had the limitation that once we pass a buffer off to Metal (when a command buffer becomes the sole owner of it, for example), we assume Metal will eventually release it and and decrement our count. In reality, that buffer could stay alive for a frame or two while the command buffer executes. Using the hash table should give us a more accurate tally of the alive buffer count.