### PR TITLE
backend tests were broken by a change in TargetBufferInfo

### DIFF
--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -29,17 +29,36 @@ namespace filament::backend {
 //! \privatesection
 
 struct TargetBufferInfo {
+    // note: the parameters of this constructor are not in the order of this structure's fields
+    TargetBufferInfo(Handle<HwTexture> handle, uint8_t level, uint16_t layer, uint8_t baseViewIndex) noexcept
+        : handle(handle), baseViewIndex(baseViewIndex), level(level), layer(layer) {
+    }
+
+    TargetBufferInfo(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
+            : handle(handle), level(level), layer(layer) {
+    }
+
+    TargetBufferInfo(Handle<HwTexture> handle, uint8_t level) noexcept
+            : handle(handle), level(level) {
+    }
+
+    TargetBufferInfo(Handle<HwTexture> handle) noexcept // NOLINT(*-explicit-constructor)
+            : handle(handle) {
+    }
+
+    TargetBufferInfo() noexcept = default;
+
     // texture to be used as render target
     Handle<HwTexture> handle;
 
-    // starting layer index for multiview. This value is only used when the `layerCount` for the
+    // Starting layer index for multiview. This value is only used when the `layerCount` for the
     // render target is greater than 1.
     uint8_t baseViewIndex = 0;
 
     // level to be used
     uint8_t level = 0;
 
-    // for cubemaps and 3D textures. See TextureCubemapFace for the face->layer mapping
+    // For cubemaps and 3D textures. See TextureCubemapFace for the face->layer mapping
     uint16_t layer = 0;
 };
 
@@ -64,7 +83,7 @@ public:
 
     MRT() noexcept = default;
 
-    MRT(TargetBufferInfo const& color) noexcept // NOLINT(hicpp-explicit-conversions)
+    MRT(TargetBufferInfo const& color) noexcept // NOLINT(hicpp-explicit-conversions, *-explicit-constructor)
             : mInfos{ color } {
     }
 
@@ -84,7 +103,7 @@ public:
 
     // this is here for backward compatibility
     MRT(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
-            : mInfos{{ handle, 0, level, layer }} {
+            : mInfos{{ handle, level, layer, 0 }} {
     }
 };
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -894,12 +894,16 @@ void OpenGLContext::unbindTexture(
     // unbind this texture from all the units it might be bound to
     // no need unbind the texture from FBOs because we're not tracking that state (and there is
     // no need to).
-    UTILS_NOUNROLL
-    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
-        if (state.textures.units[unit].id == texture_id) {
-            // if this texture is bound, it should be at the same target
-            assert_invariant(state.textures.units[unit].target == target);
-            unbindTextureUnit(unit);
+    // Never attempt to unbind texture 0. This could happen with external textures w/ streaming if
+    // never populated.
+    if (texture_id) {
+        UTILS_NOUNROLL
+        for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
+            if (state.textures.units[unit].id == texture_id) {
+                // if this texture is bound, it should be at the same target
+                assert_invariant(state.textures.units[unit].target == target);
+                unbindTextureUnit(unit);
+            }
         }
     }
 }

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -410,6 +410,7 @@ io::ostream& operator<<(io::ostream& out, const RasterState& rs) {
 io::ostream& operator<<(io::ostream& out, const TargetBufferInfo& tbi) {
     return out << "TargetBufferInfo{"
     << "handle=" << tbi.handle
+    << ", baseViewIndex=" << tbi.baseViewIndex
     << ", level=" << tbi.level
     << ", layer=" << tbi.layer << "}";
 }

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -265,7 +265,7 @@ TEST_F(BackendTest, FeedbackLoops) {
         for (auto rt : renderTargets)  api.destroyRenderTarget(rt);
     }
 
-    const uint32_t expected = 0xe93a4a07;
+    const uint32_t expected = 0x70695aa1;
     printf("Computed hash is 0x%8.8x, Expected 0x%8.8x\n", sPixelHashResult, expected);
     EXPECT_TRUE(sPixelHashResult == expected);
 }


### PR DESCRIPTION
- a field was added, which broke the layout of the structure. We fix it by adding constructors which will handle the old and new way of initializing this structure.

- one of the test needed a hash update

- OpenGLContext wrongly asserted when trying to unbind texture 0