### PR TITLE
backend: zero-cost ES2 draw()

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -336,6 +336,8 @@ private:
 
     void setScissor(Viewport const& scissor) noexcept;
 
+    void draw2GLES2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount);
+
     // ES2 only. Uniform buffer emulation binding points
     GLuint mLastAssignedEmulatedUboId = 0;
 


### PR DESCRIPTION
we use a different hook for the draw() call when on an ES2 context, this eliminates completely the overhead of supporting ES2 for the draw call. draw calls are expected to be the most common calls.