### PR TITLE
Update combine_multiview_images flag

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -600,7 +600,7 @@ public:
             bool debug_froxel_visualization = false;
         } lighting;
         struct {
-            bool combine_multiview_images = true;
+            bool combine_multiview_images = false;
         } stereo;
         matdbg::DebugServer* server = nullptr;
     } debug;

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -387,6 +387,9 @@ ViewerGui::ViewerGui(filament::Engine* engine, filament::Scene* scene, filament:
     mSettings.view.ssao.enabled = true;
     mSettings.view.bloom.enabled = true;
 
+    DebugRegistry& debug = mEngine->getDebugRegistry();
+    *debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images") = true;
+
     using namespace filament;
     LightManager::Builder(LightManager::Type::SUN)
         .color(mSettings.lighting.sunlightColor)
@@ -1097,11 +1100,12 @@ void ViewerGui::updateUserInterface() {
 #if defined(FILAMENT_SAMPLES_STEREO_TYPE_INSTANCED)                                                \
         || defined(FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
         ImGui::Checkbox("Stereo mode", &mSettings.view.stereoscopicOptions.enabled);
-
-    #if defined(FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
-        *debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images")
-                = mSettings.view.stereoscopicOptions.enabled;
-    #endif
+#if defined(FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
+        ImGui::Indent();
+        ImGui::Checkbox("Combine Multiview Images",
+                debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images"));
+        ImGui::Unindent();
+#endif
 #endif
         ImGui::SliderFloat("Ocular distance", &mSettings.viewer.cameraEyeOcularDistance, 0.0f,
                 1.0f);


### PR DESCRIPTION
Set combine_multiview_images to false by default as it's the desirable setting for most Android devices.

Set the flag to true for GUI by default.

Put the `Combine Multiview Images` checkbox under the `Stereo mode` box for an easier access.