### PR TITLE
A new stream-based Panic API

### DIFF
--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -173,8 +173,8 @@ public:
                 uint8_t const age = (tag & HANDLE_AGE_MASK) >> HANDLE_AGE_SHIFT;
                 auto const pNode = static_cast<typename Allocator::Node*>(p);
                 uint8_t const expectedAge = pNode[-1].age;
-                ASSERT_POSTCONDITION(expectedAge == age,
-                        "use-after-free of Handle with id=%d", handle.getId());
+                FILAMENT_CHECK_POSTCONDITION(expectedAge == age) <<
+                        "use-after-free of Handle with id=" << handle.getId();
             }
         }
 
@@ -240,8 +240,8 @@ private:
             Node* const pNode = static_cast<Node*>(p);
             uint8_t& expectedAge = pNode[-1].age;
             if (UTILS_UNLIKELY(!mUseAfterFreeCheckDisabled)) {
-                ASSERT_POSTCONDITION(expectedAge == age,
-                        "double-free of Handle of size %d at %p", size, p);
+                FILAMENT_CHECK_POSTCONDITION(expectedAge == age) <<
+                        "double-free of Handle of size " << size << " at " << p;
             }
             expectedAge = (expectedAge + 1) & 0xF; // fixme
 

--- a/filament/backend/src/CircularBuffer.cpp
+++ b/filament/backend/src/CircularBuffer.cpp
@@ -119,9 +119,9 @@ void* CircularBuffer::alloc(size_t size) noexcept {
         data = mmap(nullptr, size * 2 + BLOCK_SIZE,
                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-        ASSERT_POSTCONDITION(data,
-                "couldn't allocate %u KiB of virtual address space for the command buffer",
-                (size * 2 / 1024));
+        FILAMENT_CHECK_POSTCONDITION(data) <<
+                "couldn't allocate " << (size * 2 / 1024) <<
+                " KiB of virtual address space for the command buffer";
 
         slog.d << "WARNING: Using soft CircularBuffer (" << (size * 2 / 1024) << " KiB)"
                << io::endl;

--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -113,9 +113,9 @@ HandleBase::HandleId HandleAllocator<P0, P1, P2>::allocateHandleSlow(size_t size
 
     HandleBase::HandleId id = (++mId) | HANDLE_HEAP_FLAG;
 
-    ASSERT_POSTCONDITION(mId < HANDLE_HEAP_FLAG,
+    FILAMENT_CHECK_POSTCONDITION(mId < HANDLE_HEAP_FLAG) <<
             "No more Handle ids available! This can happen if HandleAllocator arena has been full"
-            " for a while. Please increase FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB");
+            " for a while. Please increase FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB";
 
     mOverflowMap.emplace(id, p);
     lock.unlock();

--- a/libs/utils/include/utils/Panic.h
+++ b/libs/utils/include/utils/Panic.h
@@ -17,14 +17,28 @@
 #ifndef TNT_UTILS_PANIC_H
 #define TNT_UTILS_PANIC_H
 
+#ifdef FILAMENT_PANIC_USES_ABSL
+#   if FILAMENT_PANIC_USES_ABSL
+#       include "absl/log/log.h"
+#       define  FILAMENT_CHECK_PRECONDITION      CHECK
+#       define  FILAMENT_CHECK_POSTCONDITION     CHECK
+#       define  FILAMENT_CHECK_ARITHMETIC        CHECK
+#   endif
+#endif
+
 #include <utils/CallStack.h>
 #include <utils/compiler.h>
+#include <utils/sstream.h>
 
 #include <string>
+#include <string_view>
 
 #ifdef __EXCEPTIONS
 #   define UTILS_EXCEPTIONS 1
 #else
+#   ifdef UTILS_EXCEPTIONS
+#       error  UTILS_EXCEPTIONS is already defined!
+#   endif
 #endif
 
 /**
@@ -281,13 +295,20 @@ public:
     virtual const char* what() const noexcept = 0;
 
     /**
+     * Get the type of the panic (e.g. "Precondition")
+     * @return a C string containing the type of panic
+     */
+    virtual const char* getType() const noexcept = 0;
+
+    /**
      * Get the reason string for the panic
      * @return a C string containing the reason for the panic
      */
     virtual const char* getReason() const noexcept = 0;
 
     /**
-     * You know who you are.
+     * Get a version of the reason string that is guaranteed to be constructed from literal
+     * strings only; it will contain no runtime information.
      */
     virtual const char* getReasonLiteral() const noexcept = 0;
 
@@ -339,6 +360,7 @@ public:
     const char* what() const noexcept override;
 
     // Panic interface
+    const char* getType() const noexcept override;
     const char* getReason() const noexcept override;
     const char* getReasonLiteral() const noexcept override;
     const char* getFunction() const noexcept override;
@@ -354,13 +376,14 @@ public:
      * @param function the name of the function where the error was detected
      * @param file the file where the above function in implemented
      * @param line the line in the above file where the error was detected
+     * @param literal a literal version of the error message
      * @param format printf style string describing the error
      * @see ASSERT_PRECONDITION, ASSERT_POSTCONDITION, ASSERT_ARITHMETIC
      * @see PANIC_PRECONDITION, PANIC_POSTCONDITION, PANIC_ARITHMETIC
      * @see setMode()
      */
-    static void panic(char const* function, char const* file, int line, const char* format, ...)
-        UTILS_NORETURN;
+    static void panic(char const* function, char const* file, int line, char const* literal,
+            const char* format, ...) UTILS_NORETURN;
 
     /**
      * Depending on the mode set, either throws an exception of type T with the given reason plus
@@ -369,15 +392,15 @@ public:
      * @param function the name of the function where the error was detected
      * @param file the file where the above function in implemented
      * @param line the line in the above file where the error was detected
-     * @param s std::string describing the error
+     * @param literal a literal version of the error message
+     * @param reason std::string describing the error
      * @see ASSERT_PRECONDITION, ASSERT_POSTCONDITION, ASSERT_ARITHMETIC
      * @see PANIC_PRECONDITION, PANIC_POSTCONDITION, PANIC_ARITHMETIC
      * @see setMode()
      */
-    static inline void panic(char const* function, char const* file, int line, const std::string& s)
-        UTILS_NORETURN {
-        panic(function, file, line, s.c_str());
-    }
+    static inline void panic(
+            char const* function, char const* file, int line, char const* literal,
+            std::string reason) UTILS_NORETURN;
 
 protected:
 
@@ -386,23 +409,24 @@ protected:
      * @param function the name of the function where the error was detected
      * @param file the file where the above function in implemented
      * @param line the line in the above file where the error was detected
+     * @param literal a literal version of the error message
      * @param reason a description of the cause of the error
      */
-    TPanic(char const* function, char const* file, int line,
-            std::string reason, std::string reasonLiteral);
+    TPanic(char const* function, char const* file, int line, char const* literal,
+            std::string reason);
 
     ~TPanic() override;
 
 private:
     void buildMessage();
 
-    CallStack m_callstack;
-    std::string m_reason;
-    std::string m_reason_literal;
-    char const* const m_function = nullptr;
-    char const* const m_file = nullptr;
-    const int m_line = -1;
-    mutable std::string m_msg;
+    char const* const mFile = nullptr;      // file where the panic happened
+    char const* const mFunction = nullptr;  // function where the panic happened
+    int const mLine = -1;                   // line where the panic happened
+    std::string mLiteral;                   // reason for the panic, built only from literals
+    std::string mReason;                    // reason for the panic
+    mutable std::string mWhat;              // fully formatted reason
+    CallStack mCallstack;
 };
 
 namespace details {
@@ -424,6 +448,7 @@ class UTILS_PUBLIC PreconditionPanic : public TPanic<PreconditionPanic> {
     // e.g.: invalid arguments
     using TPanic<PreconditionPanic>::TPanic;
     friend class TPanic<PreconditionPanic>;
+    constexpr static auto type = "Precondition";
 };
 
 /**
@@ -437,6 +462,7 @@ class UTILS_PUBLIC PostconditionPanic : public TPanic<PostconditionPanic> {
     // e.g.: dead-lock would occur, arithmetic errors
     using TPanic<PostconditionPanic>::TPanic;
     friend class TPanic<PostconditionPanic>;
+    constexpr static auto type = "Postcondition";
 };
 
 /**
@@ -450,7 +476,73 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
     // e.g.: underflow, overflow, internal computations errors
     using TPanic<ArithmeticPanic>::TPanic;
     friend class TPanic<ArithmeticPanic>;
+    constexpr static auto type = "Arithmetic";
 };
+
+namespace details {
+
+struct Voidify final {
+    template<typename T>
+    void operator&&(const T&) const&& {}
+};
+
+class PanicStream {
+public:
+    PanicStream(
+            char const* function,
+            char const* file,
+            int line,
+            char const* message) noexcept;
+
+    ~PanicStream();
+
+    PanicStream& operator<<(short value) noexcept;
+    PanicStream& operator<<(unsigned short value) noexcept;
+
+    PanicStream& operator<<(char value) noexcept;
+    PanicStream& operator<<(unsigned char value) noexcept;
+
+    PanicStream& operator<<(int value) noexcept;
+    PanicStream& operator<<(unsigned int value) noexcept;
+
+    PanicStream& operator<<(long value) noexcept;
+    PanicStream& operator<<(unsigned long value) noexcept;
+
+    PanicStream& operator<<(long long value) noexcept;
+    PanicStream& operator<<(unsigned long long value) noexcept;
+
+    PanicStream& operator<<(float value) noexcept;
+    PanicStream& operator<<(double value) noexcept;
+    PanicStream& operator<<(long double value) noexcept;
+
+    PanicStream& operator<<(bool value) noexcept;
+
+    PanicStream& operator<<(const void* value) noexcept;
+
+    PanicStream& operator<<(const char* string) noexcept;
+    PanicStream& operator<<(const unsigned char* string) noexcept;
+
+    PanicStream& operator<<(std::string const& s) noexcept;
+    PanicStream& operator<<(std::string_view const& s) noexcept;
+
+protected:
+    io::sstream mStream;
+    char const* mFunction;
+    char const* mFile;
+    int mLine;
+    char const* mLiteral;
+};
+
+template<typename T>
+class TPanicStream : public PanicStream {
+public:
+    using PanicStream::PanicStream;
+    ~TPanicStream() noexcept(false) UTILS_NORETURN {
+        T::panic(mFunction, mFile, mLine, mLiteral, mStream.c_str());
+    }
+};
+
+} // namespace details
 
 // -----------------------------------------------------------------------------------------------
 }  // namespace utils
@@ -463,37 +555,70 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
 #   define PANIC_FUNCTION __func__
 #endif
 
+
+#define FILAMENT_CHECK_CONDITION_IMPL(cond)                                                        \
+    switch (0)                                                                                     \
+    case 0:                                                                                        \
+    default:                                                                                       \
+        UTILS_LIKELY(cond) ? (void)0 : ::utils::details::Voidify()&&
+
+#define FILAMENT_PANIC_IMPL(message, TYPE)                                                         \
+        ::utils::details::TPanicStream<::utils::TYPE>(PANIC_FUNCTION, PANIC_FILE(__FILE__), __LINE__, message)
+
+#ifndef FILAMENT_CHECK_PRECONDITION
+#define FILAMENT_CHECK_PRECONDITION(condition)                                                     \
+    FILAMENT_CHECK_CONDITION_IMPL(condition)  FILAMENT_PANIC_IMPL(#condition, PreconditionPanic)
+#endif
+
+#ifndef FILAMENT_CHECK_POSTCONDITION
+#define FILAMENT_CHECK_POSTCONDITION(condition)                                                    \
+    FILAMENT_CHECK_CONDITION_IMPL(condition)  FILAMENT_PANIC_IMPL(#condition, PostconditionPanic)
+#endif
+
+#ifndef FILAMENT_CHECK_ARITHMETIC
+#define FILAMENT_CHECK_ARITHMETIC(condition)                                                       \
+    FILAMENT_CHECK_CONDITION_IMPL(condition)  FILAMENT_PANIC_IMPL(#condition, ArithmeticPanic)
+#endif
+
+#define PANIC_PRECONDITION_IMPL(cond, format, ...)                                                 \
+    ::utils::PreconditionPanic::panic(PANIC_FUNCTION,                                              \
+            PANIC_FILE(__FILE__), __LINE__, #cond, format, format, ##__VA_ARGS__)
+
+#define PANIC_POSTCONDITION_IMPL(cond, format, ...)                                                \
+    ::utils::PostconditionPanic::panic(PANIC_FUNCTION,                                             \
+            PANIC_FILE(__FILE__), __LINE__, #cond, format, format, ##__VA_ARGS__)
+
+#define PANIC_ARITHMETIC_IMPL(cond, format, ...)                                                   \
+    ::utils::ArithmeticPanic::panic(PANIC_FUNCTION,                                                \
+            PANIC_FILE(__FILE__), __LINE__, #cond, format, format, ##__VA_ARGS__)
+
+#define PANIC_LOG_IMPL(cond, format, ...)                                                          \
+    ::utils::details::panicLog(PANIC_FUNCTION,                                                     \
+            PANIC_FILE(__FILE__), __LINE__, #cond, format, format, ##__VA_ARGS__)
+
 /**
  * PANIC_PRECONDITION is a macro that reports a PreconditionPanic
  * @param format printf-style string describing the error in more details
  */
-#define PANIC_PRECONDITION(format, ...)                                                            \
-    ::utils::PreconditionPanic::panic(PANIC_FUNCTION,                                              \
-            PANIC_FILE(__FILE__), __LINE__, format, ##__VA_ARGS__)
+#define PANIC_PRECONDITION(format, ...)     PANIC_PRECONDITION_IMPL(format, format, ##__VA_ARGS__)
 
 /**
  * PANIC_POSTCONDITION is a macro that reports a PostconditionPanic
  * @param format printf-style string describing the error in more details
  */
-#define PANIC_POSTCONDITION(format, ...)                                                           \
-    ::utils::PostconditionPanic::panic(PANIC_FUNCTION,                                             \
-            PANIC_FILE(__FILE__), __LINE__, format, ##__VA_ARGS__)
+#define PANIC_POSTCONDITION(format, ...)    PANIC_POSTCONDITION_IMPL(format, format, ##__VA_ARGS__)
 
 /**
  * PANIC_ARITHMETIC is a macro that reports a ArithmeticPanic
  * @param format printf-style string describing the error in more details
  */
-#define PANIC_ARITHMETIC(format, ...)                                                              \
-    ::utils::ArithmeticPanic::panic(PANIC_FUNCTION,                                                \
-            PANIC_FILE(__FILE__), __LINE__, format, ##__VA_ARGS__)
+#define PANIC_ARITHMETIC(format, ...)       PANIC_ARITHMETIC_IMPL(format, format, ##__VA_ARGS__)
 
 /**
  * PANIC_LOG is a macro that logs a Panic, and continues as usual.
  * @param format printf-style string describing the error in more details
  */
-#define PANIC_LOG(format, ...)                                                                     \
-    ::utils::details::panicLog(PANIC_FUNCTION,                                                     \
-            PANIC_FILE(__FILE__), __LINE__, format, ##__VA_ARGS__)
+#define PANIC_LOG(format, ...)              PANIC_LOG_IMPL(format, format, ##__VA_ARGS__)
 
 /**
  * @ingroup errors
@@ -504,14 +629,14 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
  * @param format printf-style string describing the error in more details
  */
 #define ASSERT_PRECONDITION(cond, format, ...)                                                     \
-    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION(format, ##__VA_ARGS__) : (void)0)
+    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_PRECONDITION_NON_FATAL(cond, format, ...)                                           \
-    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_PRECONDITION_NON_FATAL(cond, format, ...)                                           \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 
@@ -532,14 +657,14 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
  * @endcode
  */
 #define ASSERT_POSTCONDITION(cond, format, ...)                                                    \
-    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION(format, ##__VA_ARGS__) : (void)0)
+    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_POSTCONDITION_NON_FATAL(cond, format, ...)                                          \
-    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_POSTCONDITION_NON_FATAL(cond, format, ...)                                          \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 /**
@@ -560,14 +685,14 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
  * @endcode
  */
 #define ASSERT_ARITHMETIC(cond, format, ...)                                                       \
-    (!(cond) ? PANIC_ARITHMETIC(format, ##__VA_ARGS__) : (void)0)
+    (!(cond) ? PANIC_ARITHMETIC_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_ARITHMETIC_NON_FATAL(cond, format, ...)                                             \
-    (!UTILS_LIKELY(cond) ? PANIC_ARITHMETIC(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_ARITHMETIC_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_ARITHMETIC_NON_FATAL(cond, format, ...)                                             \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG(format, ##__VA_ARGS__), false : true)
+    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 /**
@@ -591,6 +716,7 @@ class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
  *     }
  * @endcode
  */
-#define ASSERT_DESTRUCTOR(cond, format, ...) (!(cond) ? PANIC_LOG(format, ##__VA_ARGS__) : (void)0)
+#define ASSERT_DESTRUCTOR(cond, format, ...)                                                       \
+    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #endif  // TNT_UTILS_PANIC_H

--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -14,22 +14,26 @@
  * limitations under the License.
  */
 
-#include <utils/compiler.h>
 #include <utils/Panic.h>
+
+#include "ostream_.h"
+
+#include <utils/compiler.h>
 #include <utils/Log.h>
 #include <utils/ostream.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
 #include <new>
 #include <string>
+#include <string_view>
 #include <utility>
-
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 namespace utils {
 
@@ -72,9 +76,9 @@ public:
 
 // ------------------------------------------------------------------------------------------------
 
-static std::string formatString(const char* format, va_list args) noexcept {
-    std::string reason;
-
+UTILS_NOINLINE
+static std::string sprintfToString(const char* format, va_list args) noexcept {
+    std::string s;
     va_list tmp;
     va_copy(tmp, args);
     int n = vsnprintf(nullptr, 0, format, tmp);
@@ -85,30 +89,30 @@ static std::string formatString(const char* format, va_list args) noexcept {
         char* const buf = new(std::nothrow) char[n];
         if (buf) {
             vsnprintf(buf, size_t(n), format, args);
-            reason.assign(buf);
+            s.assign(buf);
             delete [] buf;
         }
     }
-    return reason;
+    return s;
 }
 
-static std::string formatString(const char* format, ...) noexcept {
+static inline std::string sprintfToString(const char* format, ...) noexcept {
     va_list args;
     va_start(args, format);
-    std::string s(formatString(format, args));
+    std::string const s{ sprintfToString(format, args) };
     va_end(args);
     return s;
 }
 
-static std::string panicString(
-        const std::string& msg, const char* function, int line,
+static std::string buildPanicString(
+        std::string_view const& msg, const char* function, int line,
         const char* file, const char* reason) {
 #ifndef NDEBUG
-    return formatString("%s\nin %s:%d\nin file %s\nreason: %s",
-            msg.c_str(), function, line, file, reason);
+    return sprintfToString("=%.*s\nin %s:%d\nin file %s\nreason: %s",
+            msg.size(), msg.data(), function, line, file, reason);
 #else
-    return formatString("%s\nin %s:%d\nreason: %s",
-            msg.c_str(), function, line, reason);
+    return sprintfToString("=%.*s\nin %s:%d\nreason: %s",
+            msg.size(), msg.data(), function, line, reason);
 #endif
 }
 
@@ -123,12 +127,15 @@ void Panic::setPanicHandler(PanicHandlerCallback handler, void* user) noexcept {
 // ------------------------------------------------------------------------------------------------
 
 template<typename T>
-TPanic<T>::TPanic(const char* function, const char* file, int line,
-        std::string reason, std::string reasonLiteral)
-        : m_reason(std::move(reason)), m_reason_literal(std::move(reasonLiteral)),
-          m_function(function), m_file(file), m_line(line) {
-    m_callstack.update(1);
-    buildMessage();
+TPanic<T>::TPanic(const char* function, const char* file, int line, char const* literal,
+        std::string reason)
+        : mFile(file),
+          mFunction(function),
+          mLine(line),
+          mLiteral(literal),
+          mReason(std::move(reason)) {
+    mCallstack.update(1);
+    mWhat = buildPanicString(T::type, mFunction, mLine, mFile, mReason.c_str());
 }
 
 template<typename T>
@@ -136,54 +143,48 @@ TPanic<T>::~TPanic() = default;
 
 template<typename T>
 const char* TPanic<T>::what() const noexcept {
-    return m_msg.c_str();
+    return mWhat.c_str();
+}
+
+template<typename T>
+const char* TPanic<T>::getType() const noexcept {
+    return T::type;
 }
 
 template<typename T>
 const char* TPanic<T>::getReason() const noexcept {
-    return m_reason.c_str();
+    return mReason.c_str();
 }
 
 template<typename T>
 const char* TPanic<T>::getReasonLiteral() const noexcept {
-    return m_reason_literal.c_str();
+    return mLiteral.c_str();
 }
 
 template<typename T>
 const char* TPanic<T>::getFunction() const noexcept {
-    return m_function;
+    return mFunction;
 }
 
 template<typename T>
 const char* TPanic<T>::getFile() const noexcept {
-    return m_file;
+    return mFile;
 }
 
 template<typename T>
 int TPanic<T>::getLine() const noexcept {
-    return m_line;
+    return mLine;
 }
 
 template<typename T>
 const CallStack& TPanic<T>::getCallStack() const noexcept {
-    return m_callstack;
+    return mCallstack;
 }
 
 template<typename T>
 void TPanic<T>::log() const noexcept {
     slog.e << what() << io::endl;
-    slog.e << m_callstack << io::endl;
-}
-
-template<typename T>
-void TPanic<T>::buildMessage() {
-    std::string type;
-#if UTILS_HAS_RTTI
-    type = CallStack::demangleTypeName(typeid(T).name()).c_str();
-#else
-    type = "Panic";
-#endif
-    m_msg = panicString(type, m_function, m_line, m_file, m_reason.c_str());
+    slog.e << mCallstack << io::endl;
 }
 
 UTILS_ALWAYS_INLINE
@@ -193,12 +194,25 @@ inline static const char* formatFile(char const* file) noexcept {
 }
 
 template<typename T>
-void TPanic<T>::panic(char const* function, char const* file, int line, const char* format, ...) {
+void TPanic<T>::panic(char const* function, char const* file, int line, char const* literal,
+        const char* format, ...) {
     va_list args;
     va_start(args, format);
-    std::string reason(formatString(format, args));
+    std::string reason{ sprintfToString(format, args) };
     va_end(args);
-    T e(function, formatFile(file), line, std::move(reason), format);
+
+    panic(function, file, line, literal, std::move(reason));
+}
+
+template<typename T>
+void TPanic<T>::panic(char const* function, char const* file, int line, char const* literal,
+        std::string reason) {
+
+    if (reason.empty()) {
+        reason = literal;
+    }
+
+    T e(function, formatFile(file), line, literal, std::move(reason));
 
     // always log the Panic at the point it is detected
     e.log();
@@ -222,14 +236,119 @@ namespace details {
 void panicLog(char const* function, char const* file, int line, const char* format, ...) noexcept {
     va_list args;
     va_start(args, format);
-    std::string const reason(formatString(format, args));
+    std::string const reason{ sprintfToString(format, args) };
     va_end(args);
 
-    const std::string msg = panicString("" /* no extra message */,
+    std::string const msg = buildPanicString("PanicLog",
             function, line, file, reason.c_str());
 
     slog.e << msg << io::endl;
     slog.e << CallStack::unwind(1) << io::endl;
+}
+
+PanicStream::PanicStream(
+        char const* function,
+        char const* file,
+        int line,
+        char const* condition) noexcept
+        : mFunction(function), mFile(file), mLine(line), mLiteral(condition) {
+}
+
+PanicStream::~PanicStream() = default;
+
+PanicStream& PanicStream::operator<<(short value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned short value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(char value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned char value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(int value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned int value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(long value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned long value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(long long int value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned long long int value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(float value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(double value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(long double value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(bool value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(void const* value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(char const* value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(unsigned char const* value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(std::string const& value) noexcept {
+    mStream << value;
+    return *this;
+}
+
+PanicStream& PanicStream::operator<<(std::string_view const& value) noexcept {
+    mStream << value;
+    return *this;
 }
 
 } // namespace details

--- a/libs/utils/src/sstream.cpp
+++ b/libs/utils/src/sstream.cpp
@@ -15,6 +15,9 @@
  */
 
 #include <utils/sstream.h>
+#include <utils/ostream.h>
+
+#include "ostream_.h"
 
 namespace utils::io {
 


### PR DESCRIPTION
going forward, instead of using the printf style syntax for panics we use the c++ stream syntax

The new macros that replace ASSERT_*CONDITON are

FILAMENT_CHECK_PRECONDITON
FILAMENT_CHECK_POSTCONDITION
FILAMENT_CHECK_ARITIHMETIC

Example usage:

FILAMENT_CHECK_PRECONDITON(condition) << "Message";

The effect is exactly the same as before, but it'll let clients use Abseil's logging facilities.