### PR TITLE
Add explicit headers for supporting libstdc++

### DIFF
--- a/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
+++ b/filament/backend/src/vulkan/spirv/VulkanSpirvUtils.cpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <cstring>
 
 namespace filament::backend {
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -52,6 +52,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <thread>
 
 #include "generated/resources/materials.h"
 

--- a/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
+++ b/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <cstring>
 
 namespace filament::gltfio {
 

--- a/libs/matdbg/src/ApiHandler.h
+++ b/libs/matdbg/src/ApiHandler.h
@@ -19,6 +19,7 @@
 
 #include <mutex>
 #include <condition_variable>
+#include <atomic>
 
 #include <CivetServer.h>
 

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -6,6 +6,7 @@
 #include <utils/Log.h>
 
 #include <ostream>
+#include <cstring>
 
 #include "jsonParseUtils.h"
 

--- a/tools/matedit/src/main.cpp
+++ b/tools/matedit/src/main.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstring>
 
 struct Config {
     utils::Path inputFile;


### PR DESCRIPTION
When `USE_STATIC_LIBCXX` is off, some cannot be compiled because of implicit headers.