### PR TITLE
Throw an exception when failing to build a Metal render pipeline state.

### DIFF
--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -90,9 +90,15 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
     NSError* error = nullptr;
     id<MTLRenderPipelineState> pipeline = [device newRenderPipelineStateWithDescriptor:descriptor
                                                                                  error:&error];
-    if (error) {
-        auto description = [error.localizedDescription cStringUsingEncoding:NSUTF8StringEncoding];
+    if (UTILS_UNLIKELY(pipeline == nil)) {
+        NSString *errorMessage =
+            [NSString stringWithFormat:@"Could not create Metal pipeline state: %@",
+                error ? error.localizedDescription : @"unknown error"];
+        auto description = [errorMessage cStringUsingEncoding:NSUTF8StringEncoding];
         utils::slog.e << description << utils::io::endl;
+        [[NSException exceptionWithName:@"MetalRenderPipelineFailure"
+                                 reason:errorMessage
+                               userInfo:nil] raise];
     }
     ASSERT_POSTCONDITION(error == nil, "Could not create Metal pipeline state.");
 


### PR DESCRIPTION
Currently, if `newRenderPipelineStateWithDescriptor` fails, we log the error message to stderr (which doesn't get captured by most iOS crash reporting systems) and then crash in a postcondition assert. By including the error message in an exception reason and throwing an ObjC exception, we get better discoverability of error causes.

(Building a render pipeline state from shaders is usually what triggers jitting a shader from LLVM IR to GPU-specific code, so if we accidentally used a feature that's not available on the local GPU, we'll find out about it here.)