### PR TITLE
Fix stereo variant defines in common_getters

### DIFF
--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -24,13 +24,11 @@ highp mat4 getViewFromClipMatrix() {
 
 /** @public-api */
 highp mat4 getClipFromWorldMatrix() {
-#if defined(VARIANT_HAS_STEREO)
-#if defined(FILAMENT_STEREO_INSTANCED)
+#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
     int eye = instance_index % CONFIG_STEREO_EYE_COUNT;
     return frameUniforms.clipFromWorldMatrix[eye];
-#elif defined(FILAMENT_STEREO_MULTIVIEW)
+#elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
     return frameUniforms.clipFromWorldMatrix[gl_ViewID_OVR];
-#endif
 #else
     return frameUniforms.clipFromWorldMatrix[0];
 #endif


### PR DESCRIPTION
This caused a breakage in shader validation at runtime. Repro:
  - Remove ./out
  - ./build.sh release gltf_viewer
  - run gltf_viewer