### PR TITLE
vk: workaround extension name length = 0 (adreno)

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -176,6 +176,12 @@ ExtensionSet getInstanceExtensions(ExtensionSet const& externallyRequiredExts = 
                     static_cast<char const*>(nullptr) /* pLayerName */);
     for (auto const& extProps: availableExts) {
         utils::CString name { extProps.extensionName };
+
+        // To workaround an Adreno bug where the extension name could be of 0 length.
+        if (name.size() == 0) {
+            continue;
+        }
+
         if (setContains(TARGET_EXTS, name) || setContains(externallyRequiredExts, name)) {
             exts.insert(name);
         }
@@ -200,6 +206,12 @@ ExtensionSet getDeviceExtensions(VkPhysicalDevice device) {
                     static_cast<const char*>(nullptr) /* pLayerName */);
     for (auto const& extension: extensions) {
         utils::CString name { extension.extensionName };
+
+        // To workaround an Adreno bug where the extension name could be of 0 length.
+        if (name.size() == 0) {
+            continue;
+        }
+
         if (setContains(TARGET_EXTS, name)) {
             exts.insert(name);
         }


### PR DESCRIPTION
This was crashing on pixel 4.