### PR TITLE
Updates vulkan swapchain synchronization

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -90,6 +90,22 @@ public:
         VkExtent2D extent = {0, 0};
     };
 
+    struct ImageSyncData {
+      static constexpr uint32_t INVALID_IMAGE_INDEX = UINT32_MAX;
+
+      // The index of the next image as returned by vkAcquireNextImage or
+      // equivalent.
+      uint32_t imageIndex = INVALID_IMAGE_INDEX;
+
+      // Semaphore to be signaled once the image is available.
+      VkSemaphore imageReadySemaphore = VK_NULL_HANDLE;
+
+      // A function called right before vkQueueSubmit.
+      // After this call, the image must be available.
+      // This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
+      std::function<void(SwapChainPtr handle)> explicitImageReadyWait = nullptr;
+    };
+
     VulkanPlatform();
 
     ~VulkanPlatform() override;
@@ -127,6 +143,12 @@ public:
          * before recreating the swapchain. Default is true.
          */
         bool flushAndWaitOnWindowResize = true;
+
+        /**
+         * Whether the swapchain image should be transition to a layout suitable
+         * for presentation. Default is true.
+         */
+        bool transitionSwapChainImageLayoutForPresent = true;
     };
 
     /**
@@ -155,13 +177,10 @@ public:
      * corresponding VkImage will be used as the output color attachment. The client should signal
      * the `clientSignal` semaphore when the image is ready to be used by the backend.
      * @param handle         The handle returned by createSwapChain()
-     * @param clientSignal   The semaphore that the client will signal to indicate that the backend
-     *                       may render into the image.
-     * @param index          Pointer to memory that will be filled with the index that corresponding
-     *                       to an image in the `SwapChainBundle.colors` array.
+     * @param outImageSyncData The synchronization data used for image readiness
      * @return               Result of acquire
      */
-    virtual VkResult acquire(SwapChainPtr handle, VkSemaphore clientSignal, uint32_t* index);
+    virtual VkResult acquire(SwapChainPtr handle, ImageSyncData* outImageSyncData);
 
     /**
      * Present the image corresponding to `index` to the display. The client should wait on

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -93,16 +93,14 @@ public:
     struct ImageSyncData {
       static constexpr uint32_t INVALID_IMAGE_INDEX = UINT32_MAX;
 
-      // The index of the next image as returned by vkAcquireNextImage or
-      // equivalent.
+      // The index of the next image as returned by vkAcquireNextImage or equivalent.
       uint32_t imageIndex = INVALID_IMAGE_INDEX;
 
       // Semaphore to be signaled once the image is available.
       VkSemaphore imageReadySemaphore = VK_NULL_HANDLE;
 
-      // A function called right before vkQueueSubmit.
-      // After this call, the image must be available.
-      // This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
+      // A function called right before vkQueueSubmit. After this call, the image must be 
+      // available. This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
       std::function<void(SwapChainPtr handle)> explicitImageReadyWait = nullptr;
     };
 
@@ -145,8 +143,8 @@ public:
         bool flushAndWaitOnWindowResize = true;
 
         /**
-         * Whether the swapchain image should be transition to a layout suitable
-         * for presentation. Default is true.
+         * Whether the swapchain image should be transitioned to a layout suitable for
+         * presentation. Default is true.
          */
         bool transitionSwapChainImageLayoutForPresent = true;
     };

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -91,17 +91,17 @@ public:
     };
 
     struct ImageSyncData {
-      static constexpr uint32_t INVALID_IMAGE_INDEX = UINT32_MAX;
+        static constexpr uint32_t INVALID_IMAGE_INDEX = UINT32_MAX;
 
-      // The index of the next image as returned by vkAcquireNextImage or equivalent.
-      uint32_t imageIndex = INVALID_IMAGE_INDEX;
+        // The index of the next image as returned by vkAcquireNextImage or equivalent.
+        uint32_t imageIndex = INVALID_IMAGE_INDEX;
 
-      // Semaphore to be signaled once the image is available.
-      VkSemaphore imageReadySemaphore = VK_NULL_HANDLE;
+        // Semaphore to be signaled once the image is available.
+        VkSemaphore imageReadySemaphore = VK_NULL_HANDLE;
 
-      // A function called right before vkQueueSubmit. After this call, the image must be 
-      // available. This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
-      std::function<void(SwapChainPtr handle)> explicitImageReadyWait = nullptr;
+        // A function called right before vkQueueSubmit. After this call, the image must be 
+        // available. This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
+        std::function<void(SwapChainPtr handle)> explicitImageReadyWait = nullptr;
     };
 
     VulkanPlatform();

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -36,7 +36,7 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
       mHeadless(extent.width != 0 && extent.height != 0 && !nativeWindow),
       mFlushAndWaitOnResize(platform->getCustomization().flushAndWaitOnWindowResize),
       mTransitionSwapChainImageLayoutForPresent(
-        platform->getCustomization().transitionSwapChainImageLayoutForPresent),
+            platform->getCustomization().transitionSwapChainImageLayoutForPresent),
       mAcquired(false),
       mIsFirstRenderPass(true) {
     swapChain = mPlatform->createSwapChain(nativeWindow, flags, extent);

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -35,28 +35,13 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
       mStagePool(stagePool),
       mHeadless(extent.width != 0 && extent.height != 0 && !nativeWindow),
       mFlushAndWaitOnResize(platform->getCustomization().flushAndWaitOnWindowResize),
-      mCurrentImageReadyIndex(0),
+      mTransitionSwapChainImageLayoutForPresent(
+          platform->getCustomization()
+              .transitionSwapChainImageLayoutForPresent),
       mAcquired(false),
       mIsFirstRenderPass(true) {
     swapChain = mPlatform->createSwapChain(nativeWindow, flags, extent);
     FILAMENT_CHECK_POSTCONDITION(swapChain) << "Unable to create swapchain";
-
-    VkSemaphoreCreateInfo const createInfo = {
-            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
-    };
-
-    // No need to wait on this semaphore before drawing when in Headless mode.
-    if (mHeadless) {
-		// Set all sempahores to VK_NULL_HANDLE
-		memset(mImageReady, 0, sizeof(mImageReady[0]) * IMAGE_READY_SEMAPHORE_COUNT);
-	} else {
-		for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
-			VkResult result =
-					vkCreateSemaphore(mPlatform->getDevice(), &createInfo, nullptr, mImageReady + i);
-                        FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS)
-                                << "Failed to create semaphore";
-                }
-    }
 
     update();
 }
@@ -68,11 +53,6 @@ VulkanSwapChain::~VulkanSwapChain() {
     mCommands->wait();
 
     mPlatform->destroy(swapChain);
-	for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
-		if (mImageReady[i] != VK_NULL_HANDLE) {
-			vkDestroySemaphore(mPlatform->getDevice(), mImageReady[i], VKALLOC);
-		}
-	}
 }
 
 void VulkanSwapChain::update() {
@@ -95,7 +75,7 @@ void VulkanSwapChain::update() {
 }
 
 void VulkanSwapChain::present() {
-    if (!mHeadless) {
+    if (!mHeadless && mTransitionSwapChainImageLayoutForPresent) {
         VkCommandBuffer const cmdbuf = mCommands->get().buffer();
         VkImageSubresourceRange const subresources{
                 .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
@@ -105,11 +85,15 @@ void VulkanSwapChain::present() {
                 .layerCount = 1,
         };
         mColors[mCurrentSwapIndex]->transitionLayout(cmdbuf, subresources, VulkanLayout::PRESENT);
+        mCommands->flush();
     }
-    mCommands->flush();
+    
+    // call the image ready wait function
+    if (mExplicitImageReadyWait != nullptr) {
+        mExplicitImageReadyWait(swapChain);
+    }
 
-    // We only present if it is not headless.  No-op for headless (but note that we still need the
-    // flush() in the above line).
+    // We only present if it is not headless.  No-op for headless.
     if (!mHeadless) {
         VkSemaphore const finishedDrawing = mCommands->acquireFinishedSignal();
         VkResult const result = mPlatform->present(swapChain, mCurrentSwapIndex, finishedDrawing);
@@ -139,13 +123,14 @@ void VulkanSwapChain::acquire(bool& resized) {
         update();
     }
 
-	mCurrentImageReadyIndex = (mCurrentImageReadyIndex + 1) % IMAGE_READY_SEMAPHORE_COUNT;
-	const VkSemaphore imageReady = mImageReady[mCurrentImageReadyIndex];
-    VkResult const result = mPlatform->acquire(swapChain, imageReady, &mCurrentSwapIndex);
+    VulkanPlatform::ImageSyncData imageSyncData;
+    VkResult const result = mPlatform->acquire(swapChain, &imageSyncData);
+    mCurrentSwapIndex = imageSyncData.imageIndex;
+    mExplicitImageReadyWait = imageSyncData.explicitImageReadyWait;
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR)
             << "Cannot acquire in swapchain.";
-    if (imageReady != VK_NULL_HANDLE) {
-        mCommands->injectDependency(imageReady);
+    if (imageSyncData.imageReadySemaphore != VK_NULL_HANDLE) {
+        mCommands->injectDependency(imageSyncData.imageReadySemaphore);
     }
     mAcquired = true;
 }

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -36,8 +36,7 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
       mHeadless(extent.width != 0 && extent.height != 0 && !nativeWindow),
       mFlushAndWaitOnResize(platform->getCustomization().flushAndWaitOnWindowResize),
       mTransitionSwapChainImageLayoutForPresent(
-          platform->getCustomization()
-              .transitionSwapChainImageLayoutForPresent),
+        platform->getCustomization().transitionSwapChainImageLayoutForPresent),
       mAcquired(false),
       mIsFirstRenderPass(true) {
     swapChain = mPlatform->createSwapChain(nativeWindow, flags, extent);
@@ -85,15 +84,16 @@ void VulkanSwapChain::present() {
                 .layerCount = 1,
         };
         mColors[mCurrentSwapIndex]->transitionLayout(cmdbuf, subresources, VulkanLayout::PRESENT);
-        mCommands->flush();
     }
+
+    mCommands->flush();
     
     // call the image ready wait function
     if (mExplicitImageReadyWait != nullptr) {
         mExplicitImageReadyWait(swapChain);
     }
 
-    // We only present if it is not headless.  No-op for headless.
+    // We only present if it is not headless. No-op for headless.
     if (!mHeadless) {
         VkSemaphore const finishedDrawing = mCommands->acquireFinishedSignal();
         VkResult const result = mPlatform->present(swapChain, mCurrentSwapIndex, finishedDrawing);
@@ -127,8 +127,8 @@ void VulkanSwapChain::acquire(bool& resized) {
     VkResult const result = mPlatform->acquire(swapChain, &imageSyncData);
     mCurrentSwapIndex = imageSyncData.imageIndex;
     mExplicitImageReadyWait = imageSyncData.explicitImageReadyWait;
-    FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR)
-            << "Cannot acquire in swapchain.";
+    FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR) 
+        << "Cannot acquire in swapchain.";
     if (imageSyncData.imageReadySemaphore != VK_NULL_HANDLE) {
         mCommands->injectDependency(imageSyncData.imageReadySemaphore);
     }

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -50,8 +50,9 @@ struct VulkanSwapChain : public HwSwapChain, VulkanResource {
     void acquire(bool& reized);
 
     inline VulkanTexture* getCurrentColor() const noexcept {
-        const uint32_t imageIndex = mCurrentSwapIndex;
-        FILAMENT_CHECK_PRECONDITION(imageIndex != VulkanPlatform::ImageSyncData::INVALID_IMAGE_INDEX);
+        uint32_t const imageIndex = mCurrentSwapIndex;
+        FILAMENT_CHECK_PRECONDITION(
+            imageIndex != VulkanPlatform::ImageSyncData::INVALID_IMAGE_INDEX);
         return mColors[imageIndex].get();
     }
 

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -50,7 +50,9 @@ struct VulkanSwapChain : public HwSwapChain, VulkanResource {
     void acquire(bool& reized);
 
     inline VulkanTexture* getCurrentColor() const noexcept {
-        return mColors[mCurrentSwapIndex].get();
+        const uint32_t imageIndex = mCurrentSwapIndex;
+        FILAMENT_CHECK_PRECONDITION(imageIndex != VulkanPlatform::ImageSyncData::INVALID_IMAGE_INDEX);
+        return mColors[imageIndex].get();
     }
 
     inline VulkanTexture* getDepth() const noexcept {
@@ -80,15 +82,15 @@ private:
     VulkanStagePool& mStagePool;
     bool const mHeadless;
     bool const mFlushAndWaitOnResize;
+    bool const mTransitionSwapChainImageLayoutForPresent;
 
     // We create VulkanTextures based on VkImages. VulkanTexture has facilities for doing layout
     // transitions, which are useful here.
     utils::FixedCapacityVector<std::unique_ptr<VulkanTexture>> mColors;
     std::unique_ptr<VulkanTexture> mDepth;
     VkExtent2D mExtent;
-    VkSemaphore mImageReady[IMAGE_READY_SEMAPHORE_COUNT];
-	uint32_t mCurrentImageReadyIndex;
     uint32_t mCurrentSwapIndex;
+    std::function<void(Platform::SwapChain* handle)> mExplicitImageReadyWait = nullptr;
     bool mAcquired;
     bool mIsFirstRenderPass;
 };

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -750,8 +750,8 @@ VulkanPlatform::SwapChainBundle VulkanPlatform::getSwapChainBundle(SwapChainPtr 
     SWAPCHAIN_RET_FUNC(getSwapChainBundle, handle, )
 }
 
-VkResult VulkanPlatform::acquire(SwapChainPtr handle, VkSemaphore clientSignal, uint32_t* index) {
-    SWAPCHAIN_RET_FUNC(acquire, handle, clientSignal, index)
+VkResult VulkanPlatform::acquire(SwapChainPtr handle, ImageSyncData* outImageSyncData) {
+    SWAPCHAIN_RET_FUNC(acquire, handle, outImageSyncData)
 }
 
 VkResult VulkanPlatform::present(SwapChainPtr handle, uint32_t index,

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -329,6 +329,7 @@ void VulkanPlatformSurfaceSwapChain::destroy() {
     for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
         if (mImageReady[i] != VK_NULL_HANDLE) {
             vkDestroySemaphore(mDevice, mImageReady[i], VKALLOC);
+            mImageReady[i] = VK_NULL_HANDLE;
         }
     }
 }

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -324,17 +324,7 @@ VkResult VulkanPlatformSurfaceSwapChain::recreate() {
 }
 
 void VulkanPlatformSurfaceSwapChain::destroy() {
-    if (mSwapChainBundle.depth) {
-        vkDestroyImage(mDevice, mSwapChainBundle.depth, VKALLOC);
-        if (mMemory.find(mSwapChainBundle.depth) != mMemory.end()) {
-            vkFreeMemory(mDevice, mMemory.at(mSwapChainBundle.depth), VKALLOC);
-            mMemory.erase(mSwapChainBundle.depth);
-        }
-    }
-    mSwapChainBundle.depth = VK_NULL_HANDLE;
-
-    // Note: Hardware-backed swapchain images are not owned by us and should not be destroyed.
-    mSwapChainBundle.colors.clear();
+    VulkanPlatformSwapChainImpl::destroy();
 
     for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
         if (mImageReady[i] != VK_NULL_HANDLE) {

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -133,6 +133,7 @@ VulkanPlatformSurfaceSwapChain::VulkanPlatformSurfaceSwapChain(VulkanContext con
 VulkanPlatformSurfaceSwapChain::~VulkanPlatformSurfaceSwapChain() {
     vkDestroySwapchainKHR(mDevice, mSwapchain, VKALLOC);
     vkDestroySurfaceKHR(mInstance, mSurface, VKALLOC);
+    destroy();
 }
 
 VkResult VulkanPlatformSurfaceSwapChain::create() {
@@ -254,17 +255,26 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
            << "depth=" << mSwapChainBundle.depthFormat
            << io::endl;
 
+    VkSemaphoreCreateInfo const semaphoreCreateInfo = {
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+    };
+
+    for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
+        VkResult result = vkCreateSemaphore(mDevice, &semaphoreCreateInfo, nullptr, mImageReady + i);
+        FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Failed to create semaphore";
+    }
+
     return result;
 }
 
-VkResult VulkanPlatformSurfaceSwapChain::acquire(VkSemaphore clientSignal, uint32_t* index) {
-    // This immediately retrieves the index of the next available presentable image, and
-    // asynchronously requests the GPU to trigger the "imageAvailable" semaphore.
-    VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, clientSignal,
-            VK_NULL_HANDLE, index);
+VkResult VulkanPlatformSurfaceSwapChain::acquire(VulkanPlatform::ImageSyncData* outImageSyncData) {
+    mCurrentImageReadyIndex = (mCurrentImageReadyIndex + 1) % IMAGE_READY_SEMAPHORE_COUNT;
+    outImageSyncData->imageReadySemaphore = mImageReady[mCurrentImageReadyIndex];
+    VkResult result = vkAcquireNextImageKHR(
+      mDevice, mSwapchain, UINT64_MAX, outImageSyncData->imageReadySemaphore, VK_NULL_HANDLE, &outImageSyncData->imageIndex);
 
-    // Users should be notified of a suboptimal surface, but it should not cause a cascade of
-    // log messages or a loop of re-creations.
+    // Users should be notified of a suboptimal surface, but it should not cause a
+    // cascade of log messages or a loop of re-creations.
     if (result == VK_SUBOPTIMAL_KHR && !mSuboptimal) {
         slog.w << "Vulkan Driver: Suboptimal swap chain." << io::endl;
         mSuboptimal = true;
@@ -312,6 +322,26 @@ VkResult VulkanPlatformSurfaceSwapChain::recreate() {
     return create();
 }
 
+void VulkanPlatformSurfaceSwapChain::destroy() {
+    if (mSwapChainBundle.depth) {
+        vkDestroyImage(mDevice, mSwapChainBundle.depth, VKALLOC);
+        if (mMemory.find(mSwapChainBundle.depth) != mMemory.end()) {
+            vkFreeMemory(mDevice, mMemory.at(mSwapChainBundle.depth), VKALLOC);
+            mMemory.erase(mSwapChainBundle.depth);
+        }
+    }
+    mSwapChainBundle.depth = VK_NULL_HANDLE;
+
+    // Note: Hardware-backed swapchain images are not owned by us and should not be destroyed.
+    mSwapChainBundle.colors.clear();
+
+    for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
+      if (mImageReady[i] != VK_NULL_HANDLE) {
+        vkDestroySemaphore(mDevice, mImageReady[i], VKALLOC);
+      }
+    }
+}
+
 VulkanPlatformHeadlessSwapChain::VulkanPlatformHeadlessSwapChain(VulkanContext const& context,
         VkDevice device, VkQueue queue, VkExtent2D extent, uint64_t flags)
     : VulkanPlatformSwapChainImpl(context, device, queue),
@@ -343,8 +373,8 @@ VkResult VulkanPlatformHeadlessSwapChain::present(uint32_t index, VkSemaphore fi
     return VK_SUCCESS;
 }
 
-VkResult VulkanPlatformHeadlessSwapChain::acquire(VkSemaphore clientSignal, uint32_t* index) {
-    *index = mCurrentIndex;
+VkResult VulkanPlatformHeadlessSwapChain::acquire(VulkanPlatform::ImageSyncData* outImageSyncData) {
+    outImageSyncData->imageIndex = mCurrentIndex;
     mCurrentIndex = (mCurrentIndex + 1) % HEADLESS_SWAPCHAIN_SIZE;
     return VK_SUCCESS;
 }

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -260,7 +260,8 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
     };
 
     for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
-        VkResult result = vkCreateSemaphore(mDevice, &semaphoreCreateInfo, nullptr, mImageReady + i);
+        VkResult result = vkCreateSemaphore(mDevice, &semaphoreCreateInfo, nullptr,
+                mImageReady + i);
         FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Failed to create semaphore";
     }
 
@@ -270,11 +271,11 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
 VkResult VulkanPlatformSurfaceSwapChain::acquire(VulkanPlatform::ImageSyncData* outImageSyncData) {
     mCurrentImageReadyIndex = (mCurrentImageReadyIndex + 1) % IMAGE_READY_SEMAPHORE_COUNT;
     outImageSyncData->imageReadySemaphore = mImageReady[mCurrentImageReadyIndex];
-    VkResult result = vkAcquireNextImageKHR(
-      mDevice, mSwapchain, UINT64_MAX, outImageSyncData->imageReadySemaphore, VK_NULL_HANDLE, &outImageSyncData->imageIndex);
+    VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX,
+            outImageSyncData->imageReadySemaphore, VK_NULL_HANDLE, &outImageSyncData->imageIndex);
 
-    // Users should be notified of a suboptimal surface, but it should not cause a
-    // cascade of log messages or a loop of re-creations.
+    // Users should be notified of a suboptimal surface, but it should not cause a cascade of
+    // log messages or a loop of re-creations.
     if (result == VK_SUBOPTIMAL_KHR && !mSuboptimal) {
         slog.w << "Vulkan Driver: Suboptimal swap chain." << io::endl;
         mSuboptimal = true;
@@ -336,9 +337,9 @@ void VulkanPlatformSurfaceSwapChain::destroy() {
     mSwapChainBundle.colors.clear();
 
     for (uint32_t i = 0; i < IMAGE_READY_SEMAPHORE_COUNT; ++i) {
-      if (mImageReady[i] != VK_NULL_HANDLE) {
-        vkDestroySemaphore(mDevice, mImageReady[i], VKALLOC);
-      }
+        if (mImageReady[i] != VK_NULL_HANDLE) {
+            vkDestroySemaphore(mDevice, mImageReady[i], VKALLOC);
+        }
     }
 }
 

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
@@ -42,7 +42,7 @@ struct VulkanPlatformSwapChainImpl : public Platform::SwapChain {
     ~VulkanPlatformSwapChainImpl();
 
     // Non-virtual override-able method
-    VkResult acquire(VkSemaphore clientSignal, uint32_t* index) {
+    VkResult acquire(VulkanPlatform::ImageSyncData* outImageSyncData) {
         PANIC_PRECONDITION("Should not be called");
         return VK_ERROR_UNKNOWN;
     }
@@ -86,7 +86,7 @@ struct VulkanPlatformSurfaceSwapChain : public VulkanPlatformSwapChainImpl {
     ~VulkanPlatformSurfaceSwapChain();
 
     // Non-virtual override
-    VkResult acquire(VkSemaphore clientSignal, uint32_t* index);
+    VkResult acquire(VulkanPlatform::ImageSyncData* outImageSyncData);
 
     // Non-virtual override
     VkResult present(uint32_t index, VkSemaphore finished);
@@ -97,7 +97,13 @@ struct VulkanPlatformSurfaceSwapChain : public VulkanPlatformSwapChainImpl {
     // Non-virtual override-able method
     bool hasResized();
 
+protected:
+    // Non-virtual override-able method
+    void destroy();
+
 private:
+    static constexpr int IMAGE_READY_SEMAPHORE_COUNT = FVK_MAX_COMMAND_BUFFERS;
+    
     VkResult create();
 
     VkInstance mInstance;
@@ -106,6 +112,8 @@ private:
     VkSurfaceKHR mSurface;
     VkSwapchainKHR mSwapchain = VK_NULL_HANDLE;
     VkExtent2D const mFallbackExtent;
+    VkSemaphore mImageReady[IMAGE_READY_SEMAPHORE_COUNT];
+    uint32_t mCurrentImageReadyIndex;
 
     bool mUsesRGB = false;
     bool mHasStencil = false;
@@ -121,7 +129,7 @@ struct VulkanPlatformHeadlessSwapChain : public VulkanPlatformSwapChainImpl {
     ~VulkanPlatformHeadlessSwapChain();
 
     // Non-virtual override
-    VkResult acquire(VkSemaphore clientSignal, uint32_t* index);
+    VkResult acquire(VulkanPlatform::ImageSyncData* outImageSyncData);
 
     // Non-virtual override
     VkResult present(uint32_t index, VkSemaphore finished);


### PR DESCRIPTION
FIXES=[338303279]

Abstracts the synchronization of the vulkan swapchain so that it is easier to override during the acquisition and presentation of images. A new structure (ImageSyncData) is created to hold swapchain synchronization data.