### PR TITLE
Null out pending edits once latched

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -661,7 +661,7 @@ bool FMaterial::hasPendingEdits() noexcept {
 
 void FMaterial::latchPendingEdits() noexcept {
     std::lock_guard const lock(mPendingEditsLock);
-    std::swap(mPendingEdits, mMaterialParser);
+    mMaterialParser.reset(mPendingEdits.release());
 }
 
 /**


### PR DESCRIPTION
Otherwise, we'd keep swapping between the edited version and the original, causing matdbg to not work.