### PR TITLE
Add ability to disable panning in the OrbitManipulator

### DIFF
--- a/android/filament-utils-android/src/main/cpp/Manipulator.cpp
+++ b/android/filament-utils-android/src/main/cpp/Manipulator.cpp
@@ -125,7 +125,7 @@ extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBu
     builder->groundPlane(a, b, c, d);
 }
 
-extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderpanning(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderPanning(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
     Builder* builder = (Builder*) nativeBuilder;
     builder->panning(enabled);
 }

--- a/android/filament-utils-android/src/main/cpp/Manipulator.cpp
+++ b/android/filament-utils-android/src/main/cpp/Manipulator.cpp
@@ -125,9 +125,9 @@ extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBu
     builder->groundPlane(a, b, c, d);
 }
 
-extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderpanDisabled(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderPanning(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
     Builder* builder = (Builder*) nativeBuilder;
-    builder->panDisabled(enabled);
+    builder->panning(enabled);
 }
 
 extern "C" JNIEXPORT long Java_com_google_android_filament_utils_Manipulator_nBuilderBuild(JNIEnv*, jclass, jlong nativeBuilder, jint mode) {

--- a/android/filament-utils-android/src/main/cpp/Manipulator.cpp
+++ b/android/filament-utils-android/src/main/cpp/Manipulator.cpp
@@ -125,6 +125,11 @@ extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBu
     builder->groundPlane(a, b, c, d);
 }
 
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderpanDisabled(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->panDisabled(enabled);
+}
+
 extern "C" JNIEXPORT long Java_com_google_android_filament_utils_Manipulator_nBuilderBuild(JNIEnv*, jclass, jlong nativeBuilder, jint mode) {
     Builder* builder = (Builder*) nativeBuilder;
     return (jlong) builder->build((Mode) mode);

--- a/android/filament-utils-android/src/main/cpp/Manipulator.cpp
+++ b/android/filament-utils-android/src/main/cpp/Manipulator.cpp
@@ -125,7 +125,7 @@ extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBu
     builder->groundPlane(a, b, c, d);
 }
 
-extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderPanning(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderpanning(JNIEnv*, jclass, jlong nativeBuilder, jboolean enabled) {
     Builder* builder = (Builder*) nativeBuilder;
     builder->panning(enabled);
 }

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
@@ -280,8 +280,8 @@ public class Manipulator {
          * @return this <code>Builder</code> object for chaining calls
          */
         @NonNull
-        public Builder panDisabled(Boolean enabled) {
-            nBuilderpanDisabled(mNativeBuilder, enabled);
+        public Builder panning(Boolean enabled) {
+            nBuilderpanning(mNativeBuilder, enabled);
             return this;
         }
 
@@ -494,7 +494,7 @@ public class Manipulator {
     private static native void nBuilderFlightPanSpeed(long nativeBuilder, float x, float y);
     private static native void nBuilderFlightMoveDamping(long nativeBuilder, float damping);
     private static native void nBuilderGroundPlane(long nativeBuilder, float a, float b, float c, float d);
-    private static native void nBuilderpanDisabled(long nativeBuilder, Boolean enabled);
+    private static native void nBuilderPanning(long nativeBuilder, Boolean enabled);
     private static native long nBuilderBuild(long nativeBuilder, int mode);
 
     private static native void nDestroyManipulator(long nativeManip);

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
@@ -281,7 +281,7 @@ public class Manipulator {
          */
         @NonNull
         public Builder panning(Boolean enabled) {
-            nBuilderpanning(mNativeBuilder, enabled);
+            nBuilderPanning(mNativeBuilder, enabled);
             return this;
         }
 

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
@@ -275,6 +275,17 @@ public class Manipulator {
         }
 
         /**
+         * Sets whether panning is enabled in the manipulator.
+         *
+         * @return this <code>Builder</code> object for chaining calls
+         */
+        @NonNull
+        public Builder panDisabled(Boolean enabled) {
+            nBuilderpanDisabled(mNativeBuilder, enabled);
+            return this;
+        }
+
+        /**
          * Creates and returns the <code>Manipulator</code> object.
          *
          * @return the newly created <code>Manipulator</code> object
@@ -483,6 +494,7 @@ public class Manipulator {
     private static native void nBuilderFlightPanSpeed(long nativeBuilder, float x, float y);
     private static native void nBuilderFlightMoveDamping(long nativeBuilder, float damping);
     private static native void nBuilderGroundPlane(long nativeBuilder, float a, float b, float c, float d);
+    private static native void nBuilderpanDisabled(long nativeBuilder, Boolean enabled);
     private static native long nBuilderBuild(long nativeBuilder, int mode);
 
     private static native void nDestroyManipulator(long nativeManip);

--- a/libs/camutils/include/camutils/Manipulator.h
+++ b/libs/camutils/include/camutils/Manipulator.h
@@ -109,7 +109,7 @@ public:
         vec4 groundPlane;
         RayCallback raycastCallback;
         void* raycastUserdata;
-        bool panDisabled;
+        bool panning = true;
     };
 
     struct Builder {
@@ -144,7 +144,7 @@ public:
         Builder& groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d);  //! Plane equation used as a raycast fallback
         Builder& raycastCallback(RayCallback cb, void* userdata);  //! Raycast function for accurate grab-and-pan
 
-        Builder& panDisabled(bool enabled);  //! Sets whether panning is enabled
+        Builder& panning(bool enabled);  //! Sets whether panning is enabled
 
         /**
          * Creates a new camera manipulator, either ORBIT, MAP, or FREE_FLIGHT.

--- a/libs/camutils/include/camutils/Manipulator.h
+++ b/libs/camutils/include/camutils/Manipulator.h
@@ -109,6 +109,7 @@ public:
         vec4 groundPlane;
         RayCallback raycastCallback;
         void* raycastUserdata;
+        bool panDisabled;
     };
 
     struct Builder {
@@ -142,6 +143,8 @@ public:
         // Raycast properties
         Builder& groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d);  //! Plane equation used as a raycast fallback
         Builder& raycastCallback(RayCallback cb, void* userdata);  //! Raycast function for accurate grab-and-pan
+
+        Builder& panDisabled(bool enabled);  //! Sets whether panning with two fingers is enabled
 
         /**
          * Creates a new camera manipulator, either ORBIT, MAP, or FREE_FLIGHT.

--- a/libs/camutils/include/camutils/Manipulator.h
+++ b/libs/camutils/include/camutils/Manipulator.h
@@ -144,7 +144,7 @@ public:
         Builder& groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d);  //! Plane equation used as a raycast fallback
         Builder& raycastCallback(RayCallback cb, void* userdata);  //! Raycast function for accurate grab-and-pan
 
-        Builder& panDisabled(bool enabled);  //! Sets whether panning with two fingers is enabled
+        Builder& panDisabled(bool enabled);  //! Sets whether panning is enabled
 
         /**
          * Creates a new camera manipulator, either ORBIT, MAP, or FREE_FLIGHT.

--- a/libs/camutils/src/Manipulator.cpp
+++ b/libs/camutils/src/Manipulator.cpp
@@ -144,6 +144,14 @@ Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::raycastCallback(RayCal
     return *this;
 }
 
+
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::panDisabled(bool enabled) {
+    details.panDisabled = enabled;
+    return *this;
+}
+
 template <typename FLOAT>
 Manipulator<FLOAT>* Manipulator<FLOAT>::Builder::build(Mode mode) {
     switch (mode) {

--- a/libs/camutils/src/Manipulator.cpp
+++ b/libs/camutils/src/Manipulator.cpp
@@ -147,8 +147,8 @@ Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::raycastCallback(RayCal
 
 
 template <typename FLOAT> typename
-Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::panDisabled(bool enabled) {
-    details.panDisabled = enabled;
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::panning(bool enabled) {
+    details.panning = enabled;
     return *this;
 }
 

--- a/libs/camutils/src/OrbitManipulator.h
+++ b/libs/camutils/src/OrbitManipulator.h
@@ -69,7 +69,7 @@ public:
     }
 
     void grabBegin(int x, int y, bool strafe) override {
-        mGrabState = strafe ? PANNING : ORBITING;
+        mGrabState = strafe && !Base::mProps.panDisabled ? PANNING : ORBITING;
         mGrabPivot = mPivot;
         mGrabEye = Base::mEye;
         mGrabTarget = Base::mTarget;

--- a/libs/camutils/src/OrbitManipulator.h
+++ b/libs/camutils/src/OrbitManipulator.h
@@ -69,7 +69,7 @@ public:
     }
 
     void grabBegin(int x, int y, bool strafe) override {
-        mGrabState = strafe && !Base::mProps.panDisabled ? PANNING : ORBITING;
+        mGrabState = strafe && Base::mProps.panning ? PANNING : ORBITING;
         mGrabPivot = mPivot;
         mGrabEye = Base::mEye;
         mGrabTarget = Base::mTarget;


### PR DESCRIPTION
It's useful when you want to have the ability to rotate the camera, but want to limit panning.