### PR TITLE
Fix memory leak of asset loading for gltf_viewer

### DIFF
--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -549,8 +549,9 @@ static bool checkAsset(const utils::Path& filename) {
 
     // Parse the glTF file and create Filament entities.
     cgltf_options options{};
-    cgltf_data* sourceAsset;
+    cgltf_data* sourceAsset = nullptr;
     cgltf_result result = cgltf_parse(&options, buffer.data(), contentSize, &sourceAsset);
+    cgltf_free(sourceAsset);
     if (result != cgltf_result_success) {
         slog.e << "Unable to parse glTF file." << io::endl;
         return false;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -547,7 +547,7 @@ static bool checkAsset(const utils::Path& filename) {
         return false;
     }
 
-    // Parse the glTF file and create Filament entities.
+    // Try parsing the glTF file to check the validity of the file format.
     cgltf_options options{};
     cgltf_data* sourceAsset = nullptr;
     cgltf_result result = cgltf_parse(&options, buffer.data(), contentSize, &sourceAsset);


### PR DESCRIPTION
When a user drags and drops a gltf file to the gltf_viewer window, it loads the new asset.

While this happens, the function `checkAsset` tries parsing the gltf file, but it doesn't free it. Fix this.