### PR TITLE
Renames Vulkan platform's destroy function to destroySwapChain

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -228,7 +228,7 @@ public:
      * Destroy the swapchain.
      * @param handle    The handle returned by createSwapChain()
      */
-    virtual void destroy(SwapChainPtr handle);
+    virtual void destroySwapChain(SwapChainPtr handle);
 
     /**
      * Clean up any resources owned by the Platform. For example, if the Vulkan instance handle was

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -51,7 +51,7 @@ VulkanSwapChain::~VulkanSwapChain() {
     mCommands->flush();
     mCommands->wait();
 
-    mPlatform->destroy(swapChain);
+    mPlatform->destroySwapChain(swapChain);
 }
 
 void VulkanSwapChain::update() {

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -789,7 +789,7 @@ VkResult VulkanPlatform::recreate(SwapChainPtr handle) {
     SWAPCHAIN_RET_FUNC(recreate, handle, )
 }
 
-void VulkanPlatform::destroy(SwapChainPtr handle) {
+void VulkanPlatform::destroySwapChain(SwapChainPtr handle) {
     if (mImpl->mSurfaceSwapChains.erase(handle)) {
         delete static_cast<VulkanPlatformSurfaceSwapChain*>(handle);
     } else if (mImpl->mHeadlessSwapChains.erase(handle)) {


### PR DESCRIPTION
FIXES=[349602983]
Renames Vulkan platform's "destroy" function, which destroys the SwapChain, to "destroySwapChain" to mimic the other platforms.