### PR TITLE
Exposes createInstance and createLogicalDevice functions

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -267,6 +267,14 @@ public:
      */
     VkQueue getGraphicsQueue() const noexcept;
 
+   protected:
+    virtual VkDevice createLogicalDevice(
+        VkPhysicalDevice physicalDevice,
+        const VkPhysicalDeviceFeatures& features,
+        uint32_t graphicsQueueFamilyIndex,
+        const ExtensionSet& deviceExtensions);
+    virtual VkInstance createInstance(ExtensionSet const& requiredExts);
+
 private:
     static ExtensionSet getSwapchainInstanceExtensions();
 


### PR DESCRIPTION
FIXES=[349603734]

Exposes createInstance and createLogicalDevice as protected member functions so that they can be overridden.