### PR TITLE
IBL drag & drop support for desktop gltf_viewer

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- Add drag and drop support for IBL files for desktop gltf_viewer.

--- a/libs/filamentapp/include/filamentapp/FilamentApp.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp.h
@@ -104,6 +104,8 @@ public:
 
     size_t getSkippedFrameCount() const { return mSkippedFrames; }
 
+    void loadIBL(std::string_view path);
+
     FilamentApp(const FilamentApp& rhs) = delete;
     FilamentApp(FilamentApp&& rhs) = delete;
     FilamentApp& operator=(const FilamentApp& rhs) = delete;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -58,6 +58,7 @@
 
 #include <cgltf.h>
 
+#include <algorithm>
 #include <array>
 #include <fstream>
 #include <iostream>
@@ -520,14 +521,8 @@ static utils::Path getPathForIBLAsset(std::string_view string) {
     }
 
     if (filename.isDirectory()) {
-        bool found = false;
-        for (const auto& file: filename.listContents()) {
-            if (isIBL(file)) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
+        std::vector<Path> files = filename.listContents();
+        if (std::none_of(files.cbegin(), files.cend(), isIBL)) {
             return {};
         }
     } else if (!isIBL(filename)) {
@@ -549,15 +544,12 @@ static utils::Path getPathForGLTFAsset(std::string_view string) {
     }
 
     if (filename.isDirectory()) {
-        for (const auto& file: filename.listContents()) {
-            if (isGLTF(file)) {
-                filename = file;
-                break;
-            }
-        }
-        if (filename.isDirectory()) {
+        std::vector<Path> files = filename.listContents();
+        auto it = std::find_if(files.cbegin(), files.cend(), isGLTF);
+        if (it == files.end()) {
             return {};
         }
+        filename = *it;
     } else if (!isGLTF(filename)) {
         return {};
     }


### PR DESCRIPTION
Users now can drag and drop IBL files for desktop gltf_viewer.

It attempts to load gltf files first then tries to load IBL files.