### PR TITLE
fix a couple small bugs when mapping the circular buffer

### DIFF
--- a/filament/backend/src/CircularBuffer.cpp
+++ b/filament/backend/src/CircularBuffer.cpp
@@ -32,10 +32,11 @@
 #    define HAS_MMAP 0
 #endif
 
-#include <stdint.h>
 #include <stddef.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 using namespace utils;
 
@@ -81,6 +82,9 @@ void* CircularBuffer::alloc(size_t size) noexcept {
             // map the circular buffer once...
             vaddr = mmap(reserve_vaddr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
             if (vaddr != MAP_FAILED) {
+                // populate the address space with pages (because this is a circular buffer,
+                // all the pages will be allocated eventually, might as well do it now)
+                memset(vaddr, 0, size);
                 // and map the circular buffer again, behind the previous copy...
                 vaddr_shadow = mmap((char*)vaddr + size, size,
                         PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
@@ -101,7 +105,7 @@ void* CircularBuffer::alloc(size_t size) noexcept {
     if (UTILS_UNLIKELY(mAshmemFd < 0)) {
         // ashmem failed
         if (vaddr_guard != MAP_FAILED) {
-            munmap(vaddr_guard, size);
+            munmap(vaddr_guard, BLOCK_SIZE);
         }
 
         if (vaddr_shadow != MAP_FAILED) {
@@ -119,12 +123,11 @@ void* CircularBuffer::alloc(size_t size) noexcept {
         data = mmap(nullptr, size * 2 + BLOCK_SIZE,
                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-        FILAMENT_CHECK_POSTCONDITION(data) <<
+        FILAMENT_CHECK_POSTCONDITION(data != MAP_FAILED) <<
                 "couldn't allocate " << (size * 2 / 1024) <<
                 " KiB of virtual address space for the command buffer";
 
-        slog.d << "WARNING: Using soft CircularBuffer (" << (size * 2 / 1024) << " KiB)"
-               << io::endl;
+        slog.w << "Using 'soft' CircularBuffer (" << (size * 2 / 1024) << " KiB)" << io::endl;
 
         // guard page at the end
         void* guard = (void*)(uintptr_t(data) + size * 2);


### PR DESCRIPTION
- in case of failure we were munmap'ing the wrong size for the guard page (in practice this never happened)
- the post-condition check was incorrect; it checked for nullptr instead of MAP_FAILED. this also never happened in practice.

Also made a couple of small improvements:

- in case the special circular buffer mapping fails, log a message as warning instead of debug.

- immediately memset (i.e. populate) the pages for the circular buffer since they will all be accessed rather quickly.