### PR TITLE
Fix precondition check when creating static geometry.

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -443,10 +443,10 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
             << ") instances when supplying transforms via an InstanceBuffer.";
 
     if (mImpl->mGeometryType == GeometryType::STATIC) {
-        FILAMENT_CHECK_PRECONDITION(mImpl->mSkinningBoneCount > 0)
+        FILAMENT_CHECK_PRECONDITION(mImpl->mSkinningBoneCount == 0)
                 << "Skinning can't be used with STATIC geometry";
 
-        FILAMENT_CHECK_PRECONDITION(mImpl->mMorphTargetCount > 0)
+        FILAMENT_CHECK_PRECONDITION(mImpl->mMorphTargetCount == 0)
                 << "Morphing can't be used with STATIC geometry";
     }
 


### PR DESCRIPTION
These 2 preconditions checks are currently incorrect and cause a crash when trying to create static geometry through `RenderableManager`:

https://github.com/google/filament/blob/ef9bbece2af9730af633f002a58680033b0ab410/filament/src/components/RenderableManager.cpp#L446-L450

Since skinning and morphing is not possible, they should ensure that counts are 0, not higher than 0.