### PR TITLE
performance improvements to JobSystem

### DIFF
--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -26,6 +26,7 @@
 #include <filament/Viewport.h>
 
 #include <utils/BinaryTreeArray.h>
+#include <utils/Log.h>
 #include <utils/Systrace.h>
 #include <utils/debug.h>
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -417,8 +417,7 @@ private:
     void instanceify(FEngine& engine, Arena& arena, int32_t eyeCount) noexcept;
 
     // We choose the command count per job to minimize JobSystem overhead.
-    // On a Pixel 4, 2048 commands is about half a millisecond of processing.
-    static constexpr size_t JOBS_PARALLEL_FOR_COMMANDS_COUNT = 2048;
+    static constexpr size_t JOBS_PARALLEL_FOR_COMMANDS_COUNT = 1024;
     static constexpr size_t JOBS_PARALLEL_FOR_COMMANDS_SIZE  =
             sizeof(Command) * JOBS_PARALLEL_FOR_COMMANDS_COUNT;
 

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -20,12 +20,13 @@
 
 #include "details/Engine.h"
 
-#include <math/fast.h>
-#include <math/scalar.h>
-
-#include <utils/debug.h>
 #include <filament/LightManager.h>
 
+#include <utils/debug.h>
+#include <utils/Log.h>
+
+#include <math/fast.h>
+#include <math/scalar.h>
 
 using namespace filament::math;
 using namespace utils;

--- a/libs/ibl/src/CubemapSH.cpp
+++ b/libs/ibl/src/CubemapSH.cpp
@@ -22,6 +22,7 @@
 
 #include "CubemapUtilsImpl.h"
 
+#include <utils/Log.h>
 #include <utils/JobSystem.h>
 
 #include <math/mat4.h>

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -24,6 +24,7 @@
 
 #include <filamat/Enums.h>
 
+#include <utils/Log.h>
 #include <utils/JobSystem.h>
 
 #include "DirIncluder.h"


### PR DESCRIPTION
- reduce the number of calls to notify_one() and notify_all(). notify_one() is not only called when running a new job, and notify_all() only when a job finishes.

- don't hold the condition lock while calling notify_*(), as it is not strictly needed, and because notify_*() can be very slow, there can be a lot of contention on this lock as a result; blocking the whole jobsystem thread pool.

- add a new version of run() that takes an opaque thread id that can be retrieved from a job's execute function; this is especially intended to be used by parallel_for(); it's just a more efficient version of run() that avoids a hashmap lookup.


Overall these change yield a significant performance boost:
- running + waiting a job: +200%
- running many jobs: +150%
- running many jobs in parallel: +50%