### PR TITLE
Only sets the layercount if the view has stereo and the stereoscopic type is multiview

### DIFF
--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -172,7 +172,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
 
                 data.color = builder.write(data.color, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 data.depth = builder.write(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
-                if (engine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW) {
+                if (view.hasStereo() && engine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW) {
                     layerCount = engine.getConfig().stereoscopicEyeCount;
                 }
 


### PR DESCRIPTION
FIXES=[354756389]
Only sets the layer count of the color pass target to the stereoscopic eye count if view.hasStereo() and the stereoscopic type is multiview. This aligns RenderUtils.cpp with Renderer.cpp, where the color buffer descriptor's depth is set to the stereoscopic eye count only when view.hasStereo() and the stereoscopic type is multiview.