### PR TITLE
vk: use std::unordered_map in PipelineLayoutCache

### DIFF
--- a/filament/backend/src/vulkan/caching/VulkanPipelineLayoutCache.cpp
+++ b/filament/backend/src/vulkan/caching/VulkanPipelineLayoutCache.cpp
@@ -32,8 +32,8 @@ VkPipelineLayout VulkanPipelineLayoutCache::getLayout(
     }
 
     // build the push constant layout key
-    uint32_t pushConstantRangeCount = program->getPushConstantRangeCount();
-    auto const& pushConstantRanges = program->getPushConstantRanges();    
+    uint32_t const pushConstantRangeCount = program->getPushConstantRangeCount();
+    auto const& pushConstantRanges = program->getPushConstantRanges();
     if (pushConstantRangeCount > 0) {
         assert_invariant(pushConstantRangeCount <= Program::SHADER_TYPE_COUNT);
         for (uint8_t i = 0; i < pushConstantRangeCount; ++i) {
@@ -52,8 +52,8 @@ VkPipelineLayout VulkanPipelineLayoutCache::getLayout(
         }
     }
 
-    if (PipelineLayoutMap::iterator iter = mPipelineLayouts.find(key); iter != mPipelineLayouts.end()) {
-        PipelineLayoutCacheEntry& entry = iter.value();
+    if (auto iter = mPipelineLayouts.find(key); iter != mPipelineLayouts.end()) {
+        PipelineLayoutCacheEntry& entry = iter->second;
         entry.lastUsed = mTimestamp++;
         return entry.handle;
     }

--- a/filament/backend/src/vulkan/caching/VulkanPipelineLayoutCache.h
+++ b/filament/backend/src/vulkan/caching/VulkanPipelineLayoutCache.h
@@ -22,7 +22,7 @@
 
 #include <utils/Hash.h>
 
-#include <tsl/robin_map.h>
+#include <unordered_map>
 
 namespace filament::backend {
 
@@ -36,8 +36,8 @@ public:
     void terminate() noexcept;
 
     struct PushConstantKey {
-        uint8_t stage;// We have one set of push constant per shader stage (fragment, vertex, etc).
-        uint8_t size;
+        uint8_t stage = 0;// We have one set of push constant per shader stage (fragment, vertex, etc).
+        uint8_t size = 0;
         // Note that there is also an offset parameter for push constants, but
         // we always assume our update range will have the offset 0.
     };
@@ -73,7 +73,7 @@ private:
         }
     };
 
-    using PipelineLayoutMap = tsl::robin_map<PipelineLayoutKey, PipelineLayoutCacheEntry,
+    using PipelineLayoutMap = std::unordered_map<PipelineLayoutKey, PipelineLayoutCacheEntry,
             PipelineLayoutKeyHashFn, PipelineLayoutKeyEqual>;
 
     VkDevice mDevice;
@@ -82,6 +82,6 @@ private:
     PipelineLayoutMap mPipelineLayouts;
 };
 
-}
+} // filament::backend
 
 #endif // TNT_FILAMENT_BACKEND_VULKANPIPELINECACHE_H


### PR DESCRIPTION
This is to address a weird map.find() miss that only happens on ARM in release mode.