### PR TITLE
Move the ResourceAllocator from Engine to Renderer

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -531,3 +531,11 @@ Java_com_google_android_filament_View_nGetFogEntity(JNIEnv *env, jclass clazz,
     View *view = (View *) nativeView;
     return (jint)view->getFogEntity().getId();
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nClearFrameHistory(JNIEnv *env, jclass clazz,
+        jlong nativeView) {
+    View *view = (View *) nativeView;
+    view->clearFrameHistory();
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1233,6 +1233,18 @@ public class View {
         return nGetFogEntity(getNativeObject());
     }
 
+    /**
+     * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view
+     * keeps an history of previous frame renders associated with the Renderer the view was last
+     * used with. When switching Renderer, it may be necessary to clear that history by calling
+     * this method. Similarly, if the whole content of the screen change, like when a cut-scene
+     * starts, clearing the history might be needed to avoid artifacts due to the previous frame
+     * being very different.
+     */
+    public void clearFrameHistory() {
+        nClearFrameHistory(getNativeObject());
+    }
+
     public long getNativeObject() {
         if (mNativeObject == 0) {
             throw new IllegalStateException("Calling method on destroyed View");
@@ -1294,7 +1306,7 @@ public class View {
     private static native void nSetMaterialGlobal(long nativeView, int index, float x, float y, float z, float w);
     private static native void nGetMaterialGlobal(long nativeView, int index, float[] out);
     private static native int nGetFogEntity(long nativeView);
-
+    private static native void nClearFrameHistory(long nativeView);
 
     /**
      * List of available ambient occlusion techniques.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -878,6 +878,17 @@ public:
      */
     utils::Entity getFogEntity() const noexcept;
 
+
+    /**
+     * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view
+     * keeps an history of previous frame renders associated with the Renderer the view was last
+     * used with. When switching Renderer, it may be necessary to clear that history by calling
+     * this method. Similarly, if the whole content of the screen change, like when a cut-scene
+     * starts, clearing the history might be needed to avoid artifacts due to the previous frame
+     * being very different.
+     */
+    void clearFrameHistory() noexcept;
+
     /**
      * List of available ambient occlusion techniques
      * @deprecated use AmbientOcclusionOptions::enabled instead

--- a/filament/src/FrameHistory.h
+++ b/filament/src/FrameHistory.h
@@ -20,14 +20,24 @@
 #include <fg/FrameGraphId.h>
 #include <fg/FrameGraphTexture.h>
 
+#include <utils/compiler.h>
+
 #include <math/mat4.h>
+#include <math/vec2.h>
+
+#include <memory>
+
+#include <stdint.h>
 
 namespace filament {
+
+class ResourceAllocator;
 
 // This is where we store all the history of a frame
 // when adding things here, please update:
 //      FView::commitFrameHistory()
 struct FrameHistoryEntry {
+    std::weak_ptr<ResourceAllocator> cache;
     struct TemporalAA{
         FrameGraphTexture color;
         FrameGraphTexture::Descriptor desc;
@@ -40,6 +50,9 @@ struct FrameHistoryEntry {
         FrameGraphTexture::Descriptor desc;
         math::mat4 projection;
     } ssr;
+    bool isValid() const noexcept {
+        return !cache.expired();
+    }
 };
 
 /*

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -550,7 +550,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssr(FrameGraph& fg,
     };
 
     auto const& previous = frameHistory.getPrevious().ssr;
-    if (!previous.color.handle) {
+    if (!previous.color.handle || !frameHistory.getPrevious().isValid()) {
         return {};
     }
 
@@ -2629,12 +2629,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
 
     // if we don't have a history yet, just use the current color buffer as history
     FrameGraphId<FrameGraphTexture> colorHistory = input;
-    if (UTILS_LIKELY(previous.color.handle)) {
+    bool const hasHistory = previous.color.handle && !frameHistory.getPrevious().isValid();
+    if (UTILS_LIKELY(hasHistory)) {
         colorHistory = fg.import("TAA history", previous.desc,
                 FrameGraphTexture::Usage::SAMPLEABLE, previous.color);
     }
 
-    mat4 const& historyProjection = previous.color.handle ?
+    mat4 const& historyProjection = hasHistory ?
             previous.projection : current.projection;
 
     struct TAAData {

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -127,6 +127,15 @@ void ResourceAllocator::terminate() noexcept {
     }
 }
 
+std::vector<backend::TextureHandle> ResourceAllocator::getInUseTextures() const noexcept {
+    std::vector<backend::TextureHandle> result;
+    result.reserve(mInUseTextures.size());
+    for (auto const& entry : mInUseTextures) {
+        result.push_back(entry.first);
+    }
+    return result;
+}
+
 RenderTargetHandle ResourceAllocator::createRenderTarget(const char*,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, uint8_t layerCount, MRT color, TargetBufferInfo depth,
@@ -229,12 +238,16 @@ void ResourceAllocator::gc() noexcept {
             ++it;
         }
     }
+
+    dump(true);
 }
 
 UTILS_NOINLINE
 void ResourceAllocator::dump(bool brief) const noexcept {
-    slog.d << "# entries=" << mTextureCache.size() << ", sz=" << mCacheSize / float(1u << 20u)
-           << " MiB" << io::endl;
+    slog.d  << "# entries=" << mTextureCache.size()
+            << ", sz=" << float(mCacheSize) * (1.0f / float(1u << 20u)) << " MiB"
+            << ", inUse=" << mInUseTextures.size()
+            << io::endl;
     if (!brief) {
         for (auto const& it : mTextureCache) {
             auto w = it.first.width;

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -95,6 +95,8 @@ public:
 
     void gc() noexcept;
 
+    std::vector<backend::TextureHandle> getInUseTextures() const noexcept;
+
 private:
     size_t const mCacheMaxAge;
 
@@ -181,6 +183,7 @@ private:
         using value_type = typename Container::value_type::second_type;
 
         size_t size() const { return mContainer.size(); }
+        bool empty() const { return size() == 0; }
         iterator begin() { return mContainer.begin(); }
         const_iterator begin() const { return mContainer.begin(); }
         iterator end() { return mContainer.end(); }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "details/View.h"
+#include "filament/View.h"
+
 
 namespace filament {
 
@@ -310,6 +312,10 @@ math::float4 View::getMaterialGlobal(uint32_t index) const {
 
 utils::Entity View::getFogEntity() const noexcept {
     return downcast(this)->getFogEntity();
+}
+
+void View::clearFrameHistory() noexcept {
+    downcast(this)->clearFrameHistory();
 }
 
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -99,8 +99,6 @@ class FScene;
 class FSwapChain;
 class FView;
 
-class ResourceAllocator;
-
 /*
  * Concrete implementation of the Engine interface. This keeps track of all hardware resources
  * for a given context.
@@ -252,11 +250,6 @@ public:
                 }
                 return { backend::ShaderLanguage::METAL_LIBRARY, backend::ShaderLanguage::MSL };
         }
-    }
-
-    ResourceAllocator& getResourceAllocator() noexcept {
-        assert_invariant(mResourceAllocator);
-        return *mResourceAllocator;
     }
 
     void* streamAlloc(size_t size, size_t alignment) noexcept;
@@ -490,7 +483,6 @@ private:
     FTransformManager mTransformManager;
     FLightManager mLightManager;
     FCameraManager mCameraManager;
-    ResourceAllocator* mResourceAllocator = nullptr;
     HwVertexBufferInfoFactory mHwVertexBufferInfoFactory;
 
     ResourceList<FBufferObject> mBufferObjects{ "BufferObject" };
@@ -561,6 +553,8 @@ private:
     backend::Handle<backend::HwTexture> mDummyZeroTexture;
 
     std::thread::id mMainThreadId{};
+
+    bool mInitialized = false;
 
     // Creation parameters
     Config mConfig;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -46,12 +46,15 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <utility>
 
 #include <stddef.h>
 #include <stdint.h>
 
 namespace filament {
+
+class ResourceAllocator;
 
 namespace backend {
 class Driver;
@@ -206,6 +209,7 @@ private:
     tsl::robin_set<FRenderTarget*> mPreviousRenderTargets;
     std::function<void()> mBeginFrameInternal;
     uint64_t mVsyncSteadyClockTimeNano = 0;
+    std::shared_ptr<ResourceAllocator> mResourceAllocator{};
 };
 
 FILAMENT_DOWNCAST(Renderer)

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -75,6 +75,7 @@ class FEngine;
 class FMaterialInstance;
 class FRenderer;
 class FScene;
+class ResourceAllocator;
 
 // ------------------------------------------------------------------------------------------------
 
@@ -420,7 +421,11 @@ public:
     // Clean-up the oldest frame and save the current frame information.
     // This is typically called after all operations for this View's rendering are complete.
     // (e.g.: after the FrameGraph execution).
-    void commitFrameHistory(FEngine& engine) noexcept;
+    void commitFrameHistory(std::shared_ptr<ResourceAllocator> const& cache) noexcept;
+
+    // Clean-up the whole history, free all resources. This is typically called when the View is
+    // being terminated. Or we're changing Renderer.
+    void clearFrameHistory() noexcept;
 
     // create the picking query
     View::PickingQuery& pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
@@ -484,10 +489,6 @@ private:
             FRenderableManager::Visibility const* visibility,
             Culler::result_type* visibleMask,
             size_t count);
-
-    // Clean-up the whole history, free all resources. This is typically called when the View is
-    // being terminated.
-    void drainFrameHistory(FEngine& engine) noexcept;
 
     // we don't inline this one, because the function is quite large and there is not much to
     // gain from inlining.

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -683,7 +683,8 @@ class_<View>("View")
     .function("isStencilBufferEnabled", &View::isStencilBufferEnabled)
     .function("setMaterialGlobal", &View::setMaterialGlobal)
     .function("getMaterialGlobal", &View::getMaterialGlobal)
-    .function("getFogEntity", &View::getFogEntity);
+    .function("getFogEntity", &View::getFogEntity)
+    .function("clearFrameHistory", &View::clearFrameHistory);
 
 /// Scene ::core class:: Flat container of renderables and lights.
 /// See also the [Engine] methods `createScene` and `destroyScene`.


### PR DESCRIPTION
The ResourceAllocator used to be global and owned by the Engine, this was causing some issues when using several Renderers because each one could cause the eviction of cache data for another.

We now have a ResourceAllocator per Renderer, which makes more sense because most resources are allocated by the FrameGraph. However, there are some textures temporarily owned by Views in their  FrameHistory (e.g.: with SSR or TAA) and because Views can be used by  multiple Renderers, this means that FrameHistory entries can have  resources owned by different ResourceAllocators. 
So we need to handle these cases:

- a Renderer is destroyed before a View that rendered into it: The view won't be able to destroy the resources later, so they are now destroyed when the Renderer is destroyed, effectively making the  handles stale.

- a View is destroyed and has FrameHistory state that belongs to  multiple Renderer and therefore need to be returned to the corresponding ResourceManager

Both cases are handled by storing a weak pointer to the correct ResourceAllocator which each FrameHistory entry. This allows the view to return the resources when it is destroyed AND this allows all parties to check that the FrameEntry is valid and its handles are  usable. In particular Renderer now checks the validity of the history before using its handles (an Entry could have resources belonging to another, destroyed, Renderer).

Finally we add a View::clearFrameHistory() method which can be used when a view is moved from one Renderer to another, or when it is  appropriate to ignore the frame history (e.g.: cut-scene). Generally, it is not a good idea to use the same View with multiple Renderers as it will most certainly mess-up the frame history (At least not if  temporal effects are used).