### PR TITLE
Move the ResourceAllocator from Engine to Renderer

### DIFF
--- a/android/filament-android/src/main/cpp/Renderer.cpp
+++ b/android/filament-android/src/main/cpp/Renderer.cpp
@@ -28,6 +28,14 @@
 using namespace filament;
 using namespace backend;
 
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Renderer_nSkipFrame(JNIEnv *, jclass, jlong nativeRenderer,
+        jlong vsyncSteadyClockTimeNano) {
+    Renderer *renderer = (Renderer *) nativeRenderer;
+    renderer->skipFrame(uint64_t(vsyncSteadyClockTimeNano));
+}
+
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_google_android_filament_Renderer_nBeginFrame(JNIEnv *, jclass, jlong nativeRenderer,
         jlong nativeSwapChain, jlong frameTimeNanos) {

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -531,3 +531,12 @@ Java_com_google_android_filament_View_nGetFogEntity(JNIEnv *env, jclass clazz,
     View *view = (View *) nativeView;
     return (jint)view->getFogEntity().getId();
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nClearFrameHistory(JNIEnv *env, jclass clazz,
+        jlong nativeView, jlong nativeEngine) {
+    View *view = (View *) nativeView;
+    Engine *engine = (Engine *) nativeEngine;
+    view->clearFrameHistory(*engine);
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -425,9 +425,12 @@ public class Engine {
         public long resourceAllocatorCacheSizeMB = 64;
 
         /*
-         * This value determines for how many frames are texture entries kept in the cache.
+         * This value determines how many frames texture entries are kept for in the cache. This
+         * is a soft limit, meaning some texture older than this are allowed to stay in the cache.
+         * Typically only one texture is evicted per frame.
+         * The default is 1.
          */
-        public long resourceAllocatorCacheMaxAge = 2;
+        public long resourceAllocatorCacheMaxAge = 1;
 
         /*
          * Disable backend handles use-after-free checks.

--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -298,6 +298,20 @@ public class Renderer {
     }
 
     /**
+     * Call skipFrame when momentarily skipping frames, for instance if the content of the
+     * scene doesn't change.
+     *
+     * @param vsyncSteadyClockTimeNano The time in nanoseconds when the frame started being rendered,
+     *                       in the {@link System#nanoTime()} timebase. Divide this value by 1000000 to
+     *                       convert it to the {@link android.os.SystemClock#uptimeMillis()}
+     *                       time base. This typically comes from
+     *                       {@link android.view.Choreographer.FrameCallback}.
+     */
+    public void skipFrame(long vsyncSteadyClockTimeNano) {
+        nSkipFrame(getNativeObject(), vsyncSteadyClockTimeNano);
+    }
+
+    /**
      * Sets up a frame for this <code>Renderer</code>.
      * <p><code>beginFrame</code> manages frame pacing, and returns whether or not a frame should be
      * drawn. The goal of this is to skip frames when the GPU falls behind in order to keep the frame
@@ -716,6 +730,7 @@ public class Renderer {
 
     private static native void nSetPresentationTime(long nativeObject, long monotonicClockNanos);
     private static native void nSetVsyncTime(long nativeObject, long steadyClockTimeNano);
+    private static native void nSkipFrame(long nativeObject, long vsyncSteadyClockTimeNano);
     private static native boolean nBeginFrame(long nativeRenderer, long nativeSwapChain, long frameTimeNanos);
     private static native void nEndFrame(long nativeRenderer);
     private static native void nRender(long nativeRenderer, long nativeView);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1233,6 +1233,18 @@ public class View {
         return nGetFogEntity(getNativeObject());
     }
 
+    /**
+     * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view
+     * keeps a history of previous frame renders associated with the Renderer the view was last
+     * used with. When switching Renderer, it may be necessary to clear that history by calling
+     * this method. Similarly, if the whole content of the screen change, like when a cut-scene
+     * starts, clearing the history might be needed to avoid artifacts due to the previous frame
+     * being very different.
+     */
+    public void clearFrameHistory(Engine engine) {
+        nClearFrameHistory(getNativeObject(), engine.getNativeObject());
+    }
+
     public long getNativeObject() {
         if (mNativeObject == 0) {
             throw new IllegalStateException("Calling method on destroyed View");
@@ -1294,7 +1306,7 @@ public class View {
     private static native void nSetMaterialGlobal(long nativeView, int index, float x, float y, float z, float w);
     private static native void nGetMaterialGlobal(long nativeView, int index, float[] out);
     private static native int nGetFogEntity(long nativeView);
-
+    private static native void nClearFrameHistory(long nativeView, long nativeEngine);
 
     /**
      * List of available ambient occlusion techniques.

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -350,9 +350,12 @@ public:
         uint32_t resourceAllocatorCacheSizeMB = 64;
 
         /*
-         * This value determines for how many frames are texture entries kept in the cache.
+         * This value determines how many frames texture entries are kept for in the cache. This
+         * is a soft limit, meaning some texture older than this are allowed to stay in the cache.
+         * Typically only one texture is evicted per frame.
+         * The default is 1.
          */
-        uint32_t resourceAllocatorCacheMaxAge = 2;
+        uint32_t resourceAllocatorCacheMaxAge = 1;
 
         /*
          * Disable backend handles use-after-free checks.

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -272,6 +272,14 @@ public:
     void setVsyncTime(uint64_t steadyClockTimeNano) noexcept;
 
     /**
+     * Call skipFrame when momentarily skipping frames, for instance if the content of the
+     * scene doesn't change.
+     *
+     * @param vsyncSteadyClockTimeNano
+     */
+    void skipFrame(uint64_t vsyncSteadyClockTimeNano = 0u);
+
+    /**
      * Set-up a frame for this Renderer.
      *
      * beginFrame() manages frame pacing, and returns whether or not a frame should be drawn. The

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -40,6 +40,7 @@ class CallbackHandler;
 
 class Camera;
 class ColorGrading;
+class Engine;
 class MaterialInstance;
 class RenderTarget;
 class Scene;
@@ -877,6 +878,17 @@ public:
      * @return an Entity representing the large scale fog object.
      */
     utils::Entity getFogEntity() const noexcept;
+
+
+    /**
+     * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view
+     * keeps a history of previous frame renders associated with the Renderer the view was last
+     * used with. When switching Renderer, it may be necessary to clear that history by calling
+     * this method. Similarly, if the whole content of the screen change, like when a cut-scene
+     * starts, clearing the history might be needed to avoid artifacts due to the previous frame
+     * being very different.
+     */
+    void clearFrameHistory(Engine& engine) noexcept;
 
     /**
      * List of available ambient occlusion techniques

--- a/filament/src/FrameHistory.h
+++ b/filament/src/FrameHistory.h
@@ -21,6 +21,9 @@
 #include <fg/FrameGraphTexture.h>
 
 #include <math/mat4.h>
+#include <math/vec2.h>
+
+#include <stdint.h>
 
 namespace filament {
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -45,6 +45,10 @@ void Renderer::setPresentationTime(int64_t monotonic_clock_ns) {
     downcast(this)->setPresentationTime(monotonic_clock_ns);
 }
 
+void Renderer::skipFrame(uint64_t vsyncSteadyClockTimeNano) {
+    downcast(this)->skipFrame(vsyncSteadyClockTimeNano);
+}
+
 bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano) {
     return downcast(this)->beginFrame(downcast(swapChain), vsyncSteadyClockTimeNano);
 }

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -113,7 +113,7 @@ public:
 
     ResourceAllocatorDisposerInterface& getDisposer() noexcept override;
 
-    void gc() noexcept;
+    void gc(bool skippedFrame = false) noexcept;
 
 private:
     size_t const mCacheMaxAge;
@@ -222,6 +222,7 @@ private:
     CacheContainer mTextureCache;
     size_t mAge = 0;
     uint32_t mCacheSize = 0;
+    uint32_t mCacheSizeHiWaterMark = 0;
     static constexpr bool mEnabled = true;
 
     friend class ResourceAllocatorDisposer;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "details/View.h"
+#include "filament/View.h"
+
 
 namespace filament {
 
@@ -310,6 +312,10 @@ math::float4 View::getMaterialGlobal(uint32_t index) const {
 
 utils::Entity View::getFogEntity() const noexcept {
     return downcast(this)->getFogEntity();
+}
+
+void View::clearFrameHistory(Engine& engine) noexcept {
+    downcast(this)->clearFrameHistory(downcast(engine));
 }
 
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -86,6 +86,7 @@ namespace filament {
 
 class Renderer;
 class MaterialParser;
+class ResourceAllocatorDisposer;
 
 namespace backend {
 class Driver;
@@ -254,9 +255,13 @@ public:
         }
     }
 
-    ResourceAllocator& getResourceAllocator() noexcept {
-        assert_invariant(mResourceAllocator);
-        return *mResourceAllocator;
+    ResourceAllocatorDisposer& getResourceAllocatorDisposer() noexcept {
+        assert_invariant(mResourceAllocatorDisposer);
+        return *mResourceAllocatorDisposer;
+    }
+
+    std::shared_ptr<ResourceAllocatorDisposer> const& getSharedResourceAllocatorDisposer() noexcept {
+        return mResourceAllocatorDisposer;
     }
 
     void* streamAlloc(size_t size, size_t alignment) noexcept;
@@ -490,7 +495,7 @@ private:
     FTransformManager mTransformManager;
     FLightManager mLightManager;
     FCameraManager mCameraManager;
-    ResourceAllocator* mResourceAllocator = nullptr;
+    std::shared_ptr<ResourceAllocatorDisposer> mResourceAllocatorDisposer;
     HwVertexBufferInfoFactory mHwVertexBufferInfoFactory;
 
     ResourceList<FBufferObject> mBufferObjects{ "BufferObject" };
@@ -561,6 +566,8 @@ private:
     backend::Handle<backend::HwTexture> mDummyZeroTexture;
 
     std::thread::id mMainThreadId{};
+
+    bool mInitialized = false;
 
     // Creation parameters
     Config mConfig;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -46,12 +46,15 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <utility>
 
 #include <stddef.h>
 #include <stdint.h>
 
 namespace filament {
+
+class ResourceAllocator;
 
 namespace backend {
 class Driver;
@@ -206,6 +209,7 @@ private:
     tsl::robin_set<FRenderTarget*> mPreviousRenderTargets;
     std::function<void()> mBeginFrameInternal;
     uint64_t mVsyncSteadyClockTimeNano = 0;
+    std::unique_ptr<ResourceAllocator> mResourceAllocator{};
 };
 
 FILAMENT_DOWNCAST(Renderer)

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -91,6 +91,9 @@ public:
 
     void setVsyncTime(uint64_t steadyClockTimeNano) noexcept;
 
+    // skip a frame
+    void skipFrame(uint64_t vsyncSteadyClockTimeNano);
+
     // start a frame
     bool beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano);
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -17,6 +17,7 @@
 #include "details/View.h"
 
 #include "Culler.h"
+#include "FrameHistory.h"
 #include "Froxelizer.h"
 #include "RenderPrimitive.h"
 #include "ResourceAllocator.h"
@@ -118,7 +119,7 @@ void FView::terminate(FEngine& engine) {
     DriverApi& driver = engine.getDriverApi();
     driver.destroyBufferObject(mLightUbh);
     driver.destroyBufferObject(mRenderableUbh);
-    drainFrameHistory(engine);
+    clearFrameHistory(engine);
 
     ShadowMapManager::terminate(engine, mShadowMapManager);
     mPerViewUniforms.terminate(driver);
@@ -1007,20 +1008,29 @@ FrameGraphId<FrameGraphTexture> FView::renderShadowMaps(FEngine& engine, FrameGr
 
 void FView::commitFrameHistory(FEngine& engine) noexcept {
     // Here we need to destroy resources in mFrameHistory.back()
+    auto& disposer = engine.getResourceAllocatorDisposer();
     auto& frameHistory = mFrameHistory;
 
     FrameHistoryEntry& last = frameHistory.back();
-    last.taa.color.destroy(engine.getResourceAllocator());
-    last.ssr.color.destroy(engine.getResourceAllocator());
+    disposer.destroy(last.taa.color.handle);
+    disposer.destroy(last.ssr.color.handle);
+    last.taa.color.handle.clear();
+    last.ssr.color.handle.clear();
 
     // and then push the new history entry to the history stack
     frameHistory.commit();
 }
 
-void FView::drainFrameHistory(FEngine& engine) noexcept {
+void FView::clearFrameHistory(FEngine& engine) noexcept {
     // make sure we free all resources in the history
-    for (size_t i = 0; i < mFrameHistory.size(); ++i) {
-        commitFrameHistory(engine);
+    auto& disposer = engine.getResourceAllocatorDisposer();
+    auto& frameHistory = mFrameHistory;
+    for (size_t i = 0; i < frameHistory.size(); ++i) {
+        FrameHistoryEntry& last = frameHistory[i];
+        disposer.destroy(last.taa.color.handle);
+        disposer.destroy(last.ssr.color.handle);
+        last.taa.color.handle.clear();
+        last.ssr.color.handle.clear();
     }
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -422,6 +422,10 @@ public:
     // (e.g.: after the FrameGraph execution).
     void commitFrameHistory(FEngine& engine) noexcept;
 
+    // Clean-up the whole history, free all resources. This is typically called when the View is
+    // being terminated. Or we're changing Renderer.
+    void clearFrameHistory(FEngine& engine) noexcept;
+
     // create the picking query
     View::PickingQuery& pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
             View::PickingQueryResultCallback callback) noexcept;
@@ -484,10 +488,6 @@ private:
             FRenderableManager::Visibility const* visibility,
             Culler::result_type* visibleMask,
             size_t count);
-
-    // Clean-up the whole history, free all resources. This is typically called when the View is
-    // being terminated.
-    void drainFrameHistory(FEngine& engine) noexcept;
 
     // we don't inline this one, because the function is quite large and there is not much to
     // gain from inlining.

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -24,6 +24,7 @@
 #include "FrameGraphPass.h"
 #include "FrameGraphRenderPass.h"
 #include "FrameGraphTexture.h"
+#include "ResourceAllocator.h"
 
 #include "details/Engine.h"
 

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -34,6 +34,10 @@ using namespace backend;
 
 class MockResourceAllocator : public ResourceAllocatorInterface {
     uint32_t handle = 0;
+    struct MockDisposer : public ResourceAllocatorDisposerInterface {
+        void destroy(backend::TextureHandle) noexcept override {}
+    } disposer;
+
 public:
     backend::RenderTargetHandle createRenderTarget(const char* name,
             backend::TargetBufferFlags targetBufferFlags,
@@ -59,6 +63,10 @@ public:
     }
 
     void destroyTexture(backend::TextureHandle h) noexcept override {
+    }
+
+    ResourceAllocatorDisposerInterface& getDisposer() noexcept override {
+        return disposer;
     }
 };
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -627,6 +627,7 @@ class_<Renderer>("Renderer")
     .function("getClearOptions", &Renderer::getClearOptions)
     .function("setPresentationTime", &Renderer::setPresentationTime)
     .function("setVsyncTime", &Renderer::setVsyncTime)
+    .function("skipFrame", &Renderer::skipFrame)
     .function("beginFrame", EMBIND_LAMBDA(bool, (Renderer* self, SwapChain* swapChain), {
         return self->beginFrame(swapChain);
     }), allow_raw_pointers())

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -683,7 +683,8 @@ class_<View>("View")
     .function("isStencilBufferEnabled", &View::isStencilBufferEnabled)
     .function("setMaterialGlobal", &View::setMaterialGlobal)
     .function("getMaterialGlobal", &View::getMaterialGlobal)
-    .function("getFogEntity", &View::getFogEntity);
+    .function("getFogEntity", &View::getFogEntity)
+    .function("clearFrameHistory", &View::clearFrameHistory);
 
 /// Scene ::core class:: Flat container of renderables and lights.
 /// See also the [Engine] methods `createScene` and `destroyScene`.


### PR DESCRIPTION
The ResourceAllocator used to be global and owned by the Engine, this was causing some issues when using several Renderers because each one could cause the eviction of cache data for another.

We now have a ResourceAllocator per Renderer, which makes more sense because most resources are allocated by the FrameGraph.

We also introduce a ResourceAllocatorDisposer class, which is used for checking in and out a texture from the cache, and destroy the texture when it's checked-out. That objet is still global.