### PR TITLE
fix a potential crash is AssetLoader

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -96,7 +96,8 @@ static std::string getNodeName(cgltf_node const* node, char const* defaultNodeNa
         if (node->mesh && node->mesh->name) return node->mesh->name;
         if (node->light && node->light->name) return node->light->name;
         if (node->camera && node->camera->name) return node->camera->name;
-        return defaultNodeName;
+        if (defaultNodeName) return defaultNodeName;
+        return "<unknown>";
     };
 
     std::string strOrig(getNameImpl());


### PR DESCRIPTION
if it can't find a name for a node, it will revert to the config's defaultNodeName, however, if that is nullptr also, a crash will occur. so we provide a last-resort hardcoded name in that case.