### PR TITLE
Set mCgltfBuffersLoaded in constructor

### DIFF
--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -70,7 +70,8 @@ struct AssetLoaderExtended {
         : mEngine(engine),
           mGltfPath(config.gltfPath),
           mMaterials(materials),
-          mUriDataCache(std::make_shared<UriDataCache>()) {}
+          mUriDataCache(std::make_shared<UriDataCache>()),
+          mCgltfBuffersLoaded(false) {}
 
     ~AssetLoaderExtended() = default;
 


### PR DESCRIPTION
Value of `mCgltfBuffersLoaded` is sometimes retained across creation of FAssetLoader which skips loading the buffer in AssetLoaderExtended#createPrimitive leading to null pointer crash.

I also tried `(*loader)->mLoaderExtended.reset()` in `AssetLoader::destroy` but that doesn't seem to reset the value of `mCgltfBuffersLoaded`


Fixes the issue, https://github.com/google/filament/issues/7997