### PR TITLE
Fix a crash for IBL resource loading

### DIFF
--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -163,7 +163,7 @@ public:
     // call this immediately before "swap buffers"
     void endFrame(backend::DriverApi& driver) noexcept;
 
-    details::FrameInfo const getLastFrameInfo() const noexcept {
+    details::FrameInfo getLastFrameInfo() const noexcept {
         // if pFront is not set yet, return FrameInfo(). But the `valid` field will be false in this case.
         return pFront ? *pFront : details::FrameInfo();
     }

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -165,7 +165,7 @@ public:
 
     details::FrameInfo getLastFrameInfo() const noexcept {
         // if pFront is not set yet, return FrameInfo(). But the `valid` field will be false in this case.
-        return pFront ? *pFront : details::FrameInfo();
+        return pFront ? *pFront : details::FrameInfo{};
     }
 
     utils::FixedCapacityVector<Renderer::FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept;

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -163,9 +163,9 @@ public:
     // call this immediately before "swap buffers"
     void endFrame(backend::DriverApi& driver) noexcept;
 
-    details::FrameInfo const& getLastFrameInfo() const noexcept {
-        // if pFront is not set yet, return front() but in this case front().valid will be false
-        return pFront ? *pFront : mFrameTimeHistory.front();
+    details::FrameInfo const getLastFrameInfo() const noexcept {
+        // if pFront is not set yet, return FrameInfo(). But the `valid` field will be false in this case.
+        return pFront ? *pFront : details::FrameInfo();
     }
 
     utils::FixedCapacityVector<Renderer::FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -525,7 +525,15 @@ void FRenderer::renderStandaloneView(FView const* view) {
                         1'000'000'000.0 / mDisplayInfo.refreshRate),
                 mFrameId);
 
+        // This need to occur after the backend beginFrame() because some backends need to start
+        // a command buffer before creating a fence.
+        mFrameInfoManager.beginFrame(driver, {
+                .historySize = mFrameRateOptions.history
+        }, mFrameId);
+
         renderInternal(view);
+
+        mFrameInfoManager.endFrame(driver);
 
         driver.endFrame(mFrameId);
     }

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -525,15 +525,7 @@ void FRenderer::renderStandaloneView(FView const* view) {
                         1'000'000'000.0 / mDisplayInfo.refreshRate),
                 mFrameId);
 
-        // This need to occur after the backend beginFrame() because some backends need to start
-        // a command buffer before creating a fence.
-        mFrameInfoManager.beginFrame(driver, {
-                .historySize = mFrameRateOptions.history
-        }, mFrameId);
-
         renderInternal(view);
-
-        mFrameInfoManager.endFrame(driver);
 
         driver.endFrame(mFrameId);
     }


### PR DESCRIPTION
This fixes a crash introduced by a8ace2891d2d83e8b9dd7d06a01591d3ff53c764

The refactored FrameInfoManager is now required to be called properly within the renderStandaloneView method, which is mainly being called by IBLPrefilterContext.

Also fix a null pointer reference bug for OpenGLTimer::State, which happenes when the renderer for IBLPrefilterContext is destroyed.