### PR TITLE
Fix ES2/anisotropy bug in updateSamplerGroup

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,6 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- engine: Fix bug causing certain sampler parameters to not be applied correctly in GLES 2.0 and on
+  certain GLES 3.0 drivers.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2341,6 +2341,15 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
             GLTexture const* const t = handle_cast<const GLTexture*>(th);
             assert_invariant(t);
 
+            if (UTILS_UNLIKELY(es2)
+#if defined(GL_EXT_texture_filter_anisotropic)
+                    || UTILS_UNLIKELY(anisotropyWorkaround)
+ #endif
+                    ) {
+                // We must set texture parameters on the texture itself.
+                bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
+            }
+
             SamplerParams params = pSamplers[i].s;
             if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
                 // From OES_EGL_image_external spec:


### PR DESCRIPTION
This function attempts to set texture parameters in these two cases, but the texture is not guaranteed to be bound. Perhaps it once was, but the assumption broke at some point.