### PR TITLE
Fix ResourceAllocator compile error on Windows

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -16,6 +16,8 @@
 
 #include "details/Engine.h"
 
+#include "ResourceAllocator.h"
+
 #include "details/BufferObject.h"
 #include "details/Camera.h"
 #include "details/Fence.h"

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -16,9 +16,10 @@
 
 #include <filament/Renderer.h>
 
-#include "details/Renderer.h"
+#include "ResourceAllocator.h"
 
 #include "details/Engine.h"
+#include "details/Renderer.h"
 #include "details/View.h"
 
 #include <utils/FixedCapacityVector.h>


### PR DESCRIPTION
This commit 730bc99025a6846dc41764f7f5c7f79f0a192350 introduced a new dependency on ResourceAllocator because of the new field `std::unique_ptr<ResourceAllocator> mResourceAllocator{};` in details/Renderer.h

This requires cpp files including details/Renderer.h to include ResourceAllocator.h as well.

This compile issue only happens on the Windows compiler, Visual Studio.