### PR TITLE
improve GL backend debug markers

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -81,7 +81,7 @@ public:
             const Platform::DriverConfig& driverConfig) noexcept;
 
     class DebugMarker {
-        OpenGLDriver& driver;
+        UTILS_UNUSED OpenGLDriver& driver;
     public:
         DebugMarker(OpenGLDriver& driver, const char* string) noexcept;
         ~DebugMarker() noexcept;


### PR DESCRIPTION
we now have two levels of debug markers. Those that come from the "user" (i.e. filament itself) are now always enabled and generate both  systrace and gl markers. the 2nd level is internal and always disabled by default. Of enabled at compile time it'll emit markers for each driver API method.