### PR TITLE
Add warning for the incompatibility of stereo type

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- materials: add a new `stereoscopicType` material parameter. [⚠️ **New Material Version**]

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -354,6 +354,12 @@ bool MaterialParser::getSpecularAntiAliasingThreshold(float* value) const noexce
     return mImpl.getFromSimpleChunk(ChunkType::MaterialSpecularAntiAliasingThreshold, value);
 }
 
+bool MaterialParser::getStereoscopicType(backend::StereoscopicType* value) const noexcept {
+    static_assert(sizeof(StereoscopicType) == sizeof(uint8_t),
+            "StereoscopicType expected size is wrong");
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialStereoscopicType, reinterpret_cast<uint8_t*>(value));
+}
+
 bool MaterialParser::getRequiredAttributes(AttributeBitset* value) const noexcept {
     uint32_t rawAttributes = 0;
     if (!mImpl.getFromSimpleChunk(ChunkType::MaterialRequiredAttributes, &rawAttributes)) {

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -122,6 +122,7 @@ public:
     bool hasSpecularAntiAliasing(bool* value) const noexcept;
     bool getSpecularAntiAliasingVariance(float* value) const noexcept;
     bool getSpecularAntiAliasingThreshold(float* value) const noexcept;
+    bool getStereoscopicType(backend::StereoscopicType*) const noexcept;
 
     bool getShader(filaflat::ShaderContent& shader, backend::ShaderModel shaderModel,
             Variant variant, backend::ShaderStage stage) noexcept;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -192,6 +192,22 @@ Material* Material::Builder::build(Engine& engine) {
         return nullptr;
     }
 
+    MaterialDomain materialDomain;
+    materialParser->getMaterialDomain(&materialDomain);
+    if (materialDomain == MaterialDomain::SURFACE) {
+        StereoscopicType const engineStereoscopicType = engine.getConfig().stereoscopicType;
+        StereoscopicType materialStereoscopicType = StereoscopicType::NONE;
+        materialParser->getStereoscopicType(&materialStereoscopicType);
+        if (materialStereoscopicType != engineStereoscopicType) {
+            CString name;
+            materialParser->getName(&name);
+            slog.w << "The stereoscopic type in the compiled material '" << name.c_str_safe()
+                    << "' is " << (int)materialStereoscopicType
+                    << ", which is not compatiable with the engine's setting "
+                    << (int)engineStereoscopicType << "." << io::endl;
+        }
+    }
+
     return downcast(engine).createMaterial(*this, std::move(materialParser));
 }
 
@@ -200,8 +216,7 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder,
         : mIsDefaultMaterial(builder->mDefaultMaterial),
           mEngine(engine),
           mMaterialId(engine.getMaterialId()),
-          mMaterialParser(std::move(materialParser))
-{
+          mMaterialParser(std::move(materialParser)) {
     MaterialParser* const parser = mMaterialParser.get();
 
     UTILS_UNUSED_IN_RELEASE bool const nameOk = parser->getName(&mName);

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -92,6 +92,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
 
     MaterialVertexDomain = charTo64bitNum("MAT_VEDO"),
     MaterialInterpolation = charTo64bitNum("MAT_INTR"),
+    MaterialStereoscopicType = charTo64bitNum("MAT_STER"),
 
     DictionaryText = charTo64bitNum("DIC_TEXT"),
     DictionarySpirv = charTo64bitNum("DIC_SPIR"),

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -28,7 +28,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 53;
+static constexpr size_t MATERIAL_VERSION = 54;
 
 /**
  * Supported shading models

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -40,14 +40,20 @@ endif()
 
 file(MAKE_DIRECTORY ${MATERIAL_DIR})
 
+set (MATC_FLAGS ${MATC_BASE_FLAGS})
+if (FILAMENT_SAMPLES_STEREO_TYPE STREQUAL "instanced")
+    set (MATC_FLAGS ${MATC_FLAGS} -PstereoscopicType=instanced)
+elseif (FILAMENT_SAMPLES_STEREO_TYPE STREQUAL "multiview")
+    set (MATC_FLAGS ${MATC_FLAGS} -PstereoscopicType=multiview)
+endif ()
+
 foreach (mat_src ${MATERIAL_SRCS})
     get_filename_component(localname "${mat_src}" NAME_WE)
     get_filename_component(fullname "${mat_src}" ABSOLUTE)
     set(output_path "${MATERIAL_DIR}/${localname}.filamat")
-
     add_custom_command(
             OUTPUT ${output_path}
-            COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${fullname}
+            COMMAND matc ${MATC_FLAGS} -o ${output_path} ${fullname}
             DEPENDS ${mat_src} matc
             COMMENT "Compiling material ${mat_src} to ${output_path}"
     )

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1609,6 +1609,7 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
             }
         }
         container.emplace<uint64_t>(ChunkType::MaterialProperties, properties);
+        container.emplace<uint8_t>(ChunkType::MaterialStereoscopicType, static_cast<uint8_t>(mStereoscopicType));
     }
 
     // create a unique material id


### PR DESCRIPTION
Print a warning in case the stereoscopic type in a compiled package is different than what's in the engine's setting. The application may proceed, but it could end up visual glitches when enabling stereoscopic rendering.

This requires the stereoscopic type to be written into the package, which needs a material version bump.