### PR TITLE
read all valid pending timer queries each frame

### DIFF
--- a/filament/src/FrameInfo.cpp
+++ b/filament/src/FrameInfo.cpp
@@ -25,6 +25,7 @@
 #include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
 #include <utils/ostream.h>
+#include <utils/Systrace.h>
 
 #include <algorithm>
 #include <atomic>
@@ -78,24 +79,32 @@ void FrameInfoManager::beginFrame(DriverApi& driver, Config const& config, uint3
     });
 
     // now is a good time to check the oldest active query
-    uint64_t elapsed = 0;
-    TimerQueryResult const result = driver.getTimerQueryValue(mQueries[mLast].handle, &elapsed);
-    switch (result) {
-        case TimerQueryResult::NOT_READY:
-            // nothing to do
+    while (mLast != mIndex) {
+        uint64_t elapsed = 0;
+        TimerQueryResult const result = driver.getTimerQueryValue(mQueries[mLast].handle, &elapsed);
+        switch (result) {
+            case TimerQueryResult::NOT_READY:
+                // nothing to do
+                break;
+            case TimerQueryResult::ERROR:
+                mLast = (mLast + 1) % POOL_COUNT;
+                break;
+            case TimerQueryResult::AVAILABLE: {
+                SYSTRACE_CONTEXT();
+                SYSTRACE_VALUE32("FrameInfo::elapsed", uint32_t(elapsed));
+                // conversion to our duration happens here
+                pFront = mQueries[mLast].pInfo;
+                pFront->frameTime = std::chrono::duration<uint64_t, std::nano>(elapsed);
+                mLast = (mLast + 1) % POOL_COUNT;
+                denoiseFrameTime(history, config);
+                break;
+            }
+        }
+        if (result != TimerQueryResult::AVAILABLE) {
             break;
-        case TimerQueryResult::ERROR:
-            mLast = (mLast + 1) % POOL_COUNT;
-            break;
-        case TimerQueryResult::AVAILABLE:
-            // conversion to our duration happens here
-            pFront = mQueries[mLast].pInfo;
-            pFront->frameTime = std::chrono::duration<uint64_t, std::nano>(elapsed);
-            mLast = (mLast + 1) % POOL_COUNT;
-            denoiseFrameTime(config);
-            break;
+        }
+        // read the pending timer queries until we find one that's not ready
     }
-
 
     // keep this just for debugging
     if constexpr (false) {
@@ -129,8 +138,7 @@ void FrameInfoManager::endFrame(DriverApi& driver) noexcept {
     mIndex = (mIndex + 1) % POOL_COUNT;
 }
 
-void FrameInfoManager::denoiseFrameTime(Config const& config) noexcept {
-    auto& history = mFrameTimeHistory;
+void FrameInfoManager::denoiseFrameTime(FrameHistoryQueue& history, Config const& config) noexcept {
     assert_invariant(!history.empty());
 
     // find the first slot that has a valid frame duration

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -171,7 +171,8 @@ public:
     utils::FixedCapacityVector<Renderer::FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept;
 
 private:
-    void denoiseFrameTime(Config const& config) noexcept;
+    using FrameHistoryQueue = CircularQueue<FrameInfoImpl, MAX_FRAMETIME_HISTORY>;
+    static void denoiseFrameTime(FrameHistoryQueue& history, Config const& config) noexcept;
     struct Query {
         backend::Handle<backend::HwTimerQuery> handle{};
         FrameInfoImpl* pInfo = nullptr;
@@ -180,7 +181,7 @@ private:
     uint32_t mIndex = 0;                // index of current query
     uint32_t mLast = 0;                 // index of oldest query still active
     FrameInfoImpl* pFront = nullptr;    // the most recent slot with a valid frame time
-    CircularQueue<FrameInfoImpl, MAX_FRAMETIME_HISTORY> mFrameTimeHistory;
+    FrameHistoryQueue mFrameTimeHistory;
 };
 
 


### PR DESCRIPTION
This reduces the latency of the timer query result; with the previous code the latency could only increase, but there is no reason to wait a whole frame for reading the next available result.

We just loop over them until we find one that has not signaled; instead of doing one per frame.