### PR TITLE
fix several issue with the debug datasource in View

### DIFF
--- a/filament/src/details/DebugRegistry.cpp
+++ b/filament/src/details/DebugRegistry.cpp
@@ -118,18 +118,31 @@ template bool FDebugRegistry::getProperty<float2>(const char* name, float2* v) c
 template bool FDebugRegistry::getProperty<float3>(const char* name, float3* v) const noexcept;
 template bool FDebugRegistry::getProperty<float4>(const char* name, float4* v) const noexcept;
 
-void FDebugRegistry::registerDataSource(std::string_view name,
+bool FDebugRegistry::registerDataSource(std::string_view name,
         void const* data, size_t count) noexcept {
     auto& dataSourceMap = mDataSourceMap;
-    if (dataSourceMap.find(name) == dataSourceMap.end()) {
+    bool const found = dataSourceMap.find(name) == dataSourceMap.end();
+    if (found) {
         dataSourceMap[name] = { data, count };
     }
+    return found;
 }
 
-void FDebugRegistry::registerDataSource(std::string_view name,
+bool FDebugRegistry::registerDataSource(std::string_view name,
         utils::Invocable<DataSource()>&& creator) noexcept {
-    mDataSourceCreatorMap[name] = std::move(creator);
+    auto& dataSourceCreatorMap = mDataSourceCreatorMap;
+    bool const found = dataSourceCreatorMap.find(name) == dataSourceCreatorMap.end();
+    if (found) {
+        dataSourceCreatorMap[name] = std::move(creator);
+    }
+    return found;
 }
+
+void FDebugRegistry::unregisterDataSource(std::string_view name) noexcept {
+    mDataSourceCreatorMap.erase(name);
+    mDataSourceMap.erase(name);
+}
+
 
 DebugRegistry::DataSource FDebugRegistry::getDataSource(const char* name) const noexcept {
     std::string_view const key{ name };

--- a/filament/src/details/DebugRegistry.h
+++ b/filament/src/details/DebugRegistry.h
@@ -101,11 +101,13 @@ public:
     }
 
     // registers a DataSource directly
-    void registerDataSource(std::string_view name, void const* data, size_t count) noexcept;
+    bool registerDataSource(std::string_view name, void const* data, size_t count) noexcept;
 
     // registers a DataSource lazily
-    void registerDataSource(std::string_view name,
+    bool registerDataSource(std::string_view name,
             utils::Invocable<DataSource()>&& creator) noexcept;
+
+    void unregisterDataSource(std::string_view name) noexcept;
 
 #if !defined(_MSC_VER)
 private:

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -576,7 +576,12 @@ private:
                                                     }};
 
 #ifndef NDEBUG
-    std::unique_ptr<std::array<DebugRegistry::FrameHistory, 5*60>> mDebugFrameHistory;
+    struct DebugState {
+        std::unique_ptr<std::array<DebugRegistry::FrameHistory, 5*60>> debugFrameHistory{};
+        bool owner = false;
+        bool active = false;
+    };
+    std::shared_ptr<DebugState> mDebugState{ new DebugState };
 #endif
 };
 


### PR DESCRIPTION
- the last View created was always overriding previous View's datasource
- because of lazy registering of the data source it was possible that the registering lambda was called after the view was destroyed, leading to crashes
- all view would share the same PID parameters and these would be initialized to default value instead of the user provided value. so debug build would behave differently.

With this change we improve things:
- now only the first view gets to publish its data source. it's still not ideal, but works for our use case with gltf_Viewer
- the view can now unregister itself when it's destroyed
- only the view that successfully registered uses the debug PID values and publishes its data source.
- the normal parameters are used until we query the datasource (from imgui), so by default the behavior is now identical to release builds


This fixes a crash in gltf_viewer when opening the Debug panel.