### PR TITLE
fix a few issues with shadowing

### DIFF
--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -154,7 +154,8 @@ public:
             const FScene::LightSoa& lightData, size_t index,
             filament::CameraInfo const& camera,
             ShadowMapInfo const& shadowMapInfo,
-            SceneInfo const& sceneInfo) noexcept;
+            SceneInfo const& sceneInfo,
+            bool useDepthClamp) noexcept;
 
     ShaderParameters updateSpot(FEngine& engine,
             const FScene::LightSoa& lightData, size_t index,
@@ -244,7 +245,8 @@ private:
             math::float3 direction,
             FLightManager::ShadowParams params,
             filament::CameraInfo const& camera,
-            SceneInfo const& sceneInfo) noexcept;
+            SceneInfo const& sceneInfo,
+            bool useDepthClamp) noexcept;
 
     static math::mat4f applyLISPSM(math::mat4f& Wp,
             filament::CameraInfo const& camera, FLightManager::ShadowParams const& params,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -63,6 +63,9 @@ namespace filament {
 using namespace backend;
 using namespace math;
 
+// do this only if depth-clamp is available
+static constexpr bool USE_DEPTH_CLAMP = false;
+
 ShadowMapManager::ShadowMapManager(FEngine& engine) {
     FDebugRegistry& debugRegistry = engine.getDebugRegistry();
     debugRegistry.registerProperty("d.shadowmap.visualize_cascades",
@@ -631,8 +634,10 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         // Compute scene-dependent values shared across all cascades
         ShadowMap::updateSceneInfoDirectional(MvAtOrigin, *scene, sceneInfo);
 
+        // we always do culling without depth clamp, because objects behind the camera
+        // must be rendered regardless
         shadowMap.updateDirectional(engine,
-                lightData, 0, cameraInfo, shadowMapInfo, sceneInfo);
+                lightData, 0, cameraInfo, shadowMapInfo, sceneInfo, false);
 
         hasVisibleShadows = shadowMap.hasVisibleShadows();
 
@@ -698,7 +703,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             sceneInfo.csNearFar = { csSplitPosition[i], csSplitPosition[i + 1] };
 
             auto shaderParameters = shadowMap.updateDirectional(engine,
-                    lightData, 0, cameraInfo, shadowMapInfo, sceneInfo);
+                    lightData, 0, cameraInfo, shadowMapInfo, sceneInfo, USE_DEPTH_CLAMP);
 
             if (shadowMap.hasVisibleShadows()) {
                 const size_t shadowIndex = shadowMap.getShadowIndex();


### PR DESCRIPTION
A recent change broken the optional "depth clamp" as well as the  computation of the far plane of the light frustum. There was also a case where DEBUG builds could assert.

- The far plane was no longer being "optimized" (i.e. moved as close as possible), which resulted in less optimal use of the shadow texture. the far plane can be moved as close as the farthest visible shadow  caster.

- After the camera/light frustums intersection we now see of the 2D bounds seen from the light are empty and if so we bail, which prevents an assertion later.

- finally, the "DEPTH_CLAMP" option is also updated for the new code structure.