### PR TITLE
fix shadow cascade computations

### DIFF
--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -109,19 +109,12 @@ public:
     struct SceneInfo {
 
         SceneInfo() noexcept = default;
-        SceneInfo(FScene const& scene, uint8_t visibleLayers, math::mat4f const& viewMatrix) noexcept;
-
-        // scratch data: The near and far planes, in clip space, to use for this shadow map
-        math::float2 csNearFar = { -1.0f, 1.0f };
+        SceneInfo(FScene const& scene, uint8_t visibleLayers) noexcept;
 
         // scratch data: light's near/far expressed in light-space, calculated from the scene's
         // content assuming the light is at the origin.
         math::float2 lsCastersNearFar;
         math::float2 lsReceiversNearFar;
-
-        // Viewing camera's near/far expressed in view-space, calculated from the
-        // scene's content.
-        math::float2 vsNearFar;
 
         // World-space shadow-casters volume
         Aabb wsShadowCastersVolume;
@@ -262,7 +255,7 @@ private:
             math::mat4f const& LMpMv,
             math::mat4f const& WLMp,
             FrustumBoxIntersection const& lsShadowVolume, size_t vertexCount,
-            filament::CameraInfo const& camera, math::float2 const& csNearFar,
+            filament::CameraInfo const& camera,
             float shadowFar, bool stable) noexcept;
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,
@@ -273,8 +266,7 @@ private:
             SceneInfo const& sceneInfo,
             bool stable, bool focusShadowCasters, bool farUsesShadowCasters) noexcept;
 
-    static Corners computeFrustumCorners(const math::mat4f& projectionInverse,
-            math::float2 csNearFar = { -1.0f, 1.0f }) noexcept;
+    static Corners computeFrustumCorners(const math::mat4f& projectionInverse) noexcept;
 
     static inline math::float2 computeNearFar(math::mat4f const& view,
             math::float3 const* wsVertices, size_t count) noexcept;
@@ -309,7 +301,7 @@ private:
 
     static size_t intersectFrustumWithBox(
             FrustumBoxIntersection& outVertices,
-            math::mat4f const& projection, math::float2 const& csNearFar,
+            math::mat4f const& projection,
             Aabb const& box);
 
     static math::mat4f warpFrustum(float n, float f) noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -39,17 +39,20 @@
 #include <backend/DriverApiForward.h>
 #include <backend/DriverEnums.h>
 
-#include <utils/FixedCapacityVector.h>
-#include <utils/Range.h>
-#include <utils/Slice.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
+#include <utils/FixedCapacityVector.h>
+#include <utils/BitmaskEnum.h>
+#include <utils/Range.h>
+#include <utils/Slice.h>
 
 #include <math/half.h>
 #include <math/mat4.h>
 #include <math/vec4.h>
 #include <math/scalar.h>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <new>
@@ -70,8 +73,8 @@ ShadowMapManager::ShadowMapManager(FEngine& engine) {
     FDebugRegistry& debugRegistry = engine.getDebugRegistry();
     debugRegistry.registerProperty("d.shadowmap.visualize_cascades",
             &engine.debug.shadowmap.visualize_cascades);
-    debugRegistry.registerProperty("d.shadowmap.tightly_bound_scene",
-            &engine.debug.shadowmap.tightly_bound_scene);
+    debugRegistry.registerProperty("d.shadowmap.disable_light_frustum_align",
+            &engine.debug.shadowmap.disable_light_frustum_align);
 }
 
 ShadowMapManager::~ShadowMapManager() {
@@ -150,7 +153,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
     calculateTextureRequirements(engine, view, lightData);
 
     // Compute scene-dependent values shared across all shadow maps
-    ShadowMap::SceneInfo const info{ *view.getScene(), view.getVisibleLayers(), cameraInfo.view };
+    ShadowMap::SceneInfo const info{ *view.getScene(), view.getVisibleLayers() };
 
     shadowTechnique |= updateCascadeShadowMaps(
             engine, view, cameraInfo, renderableData, lightData, info);
@@ -546,65 +549,9 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     FLightManager::ShadowParams const& params = lcm.getShadowParams(directionalLight);
 
     // Adjust the camera's projection for the light's shadowFar
-    cameraInfo.zf = params.options.shadowFar > 0.0f ? params.options.shadowFar : cameraInfo.zf;
     if (UTILS_UNLIKELY(params.options.shadowFar > 0.0f)) {
         cameraInfo.zf = params.options.shadowFar;
-        float const n = cameraInfo.zn;
-        float const f = cameraInfo.zf;
-
-        /*
-         *  Updating a projection matrix near and far planes:
-         *
-         *  We assume that the near and far plane equations are of the form:
-         *           N = { 0, 0,  1,  n }
-         *           F = { 0, 0, -1, -f }
-         *
-         *  We also assume that the lower-left 2x2 of the projection is all 0:
-         *       P =   A   0   C   0
-         *             0   B   D   0
-         *             0   0   E   F
-         *             0   0   G   H
-         *
-         *  It result that we need to calculate E and F while leaving all other parameter unchanged.
-         *
-         *  We know that:
-         *       with N, F the near/far normalized plane equation parameters
-         *            sn, sf arbitrary scale factors (they don't affect the planes)
-         *            m is the transpose of projection (see Frustum.cpp)
-         *
-         *       sn * N == -m[3] - m[2]
-         *       sf * F == -m[3] + m[2]
-         *
-         *       sn * N + sf * F == -2 * m[3]
-         *       sn * N - sf * F == -2 * m[2]
-         *
-         *       sn * N.z + sf * F.z == -2 * m[3].z
-         *       sn * N.w + sf * F.w == -2 * m[3].w
-         *       sn * N.z - sf * F.z == -2 * m[2].z
-         *       sn * N.w - sf * F.w == -2 * m[2].w
-         *
-         *       sn * N.z + sf * F.z == -2 * p[2].w
-         *       sn * N.w + sf * F.w == -2 * p[3].w
-         *       sn * N.z - sf * F.z == -2 * p[2].z
-         *       sn * N.w - sf * F.w == -2 * p[3].z
-         *
-         *  We now need to solve for { p[2].z, p[3].z, sn, sf } :
-         *
-         *       sn == -2 * (p[2].w * F.w - p[3].w * F.z) / (N.z * F.w - N.w * F.z)
-         *       sf == -2 * (p[2].w * N.w - p[3].w * N.z) / (F.z * N.w - F.w * N.z)
-         *   p[2].z == (sf * F.z - sn * N.z) / 2
-         *   p[3].z == (sf * F.w - sn * N.w) / 2
-         */
-        auto& p = cameraInfo.cullingProjection;
-        float4 const N = { 0, 0,  1,  n };  // near plane equation
-        float4 const F = { 0, 0, -1, -f };  // far plane equation
-        // near plane equation scale factor
-        float const sn = -2.0f * (p[2].w * F.w - p[3].w * F.z) / (N.z * F.w - N.w * F.z);
-        // far plane equation scale factor
-        float const sf = -2.0f * (p[2].w * N.w - p[3].w * N.z) / (F.z * N.w - F.w * N.z);
-        // New values for the projection
-        p[2].z = (sf * F.z - sn * N.z) * 0.5f;
-        p[3].z = (sf * F.w - sn * N.w) * 0.5f;
+        updateNearFarPlanes(&cameraInfo.cullingProjection, cameraInfo.zn, cameraInfo.zf);
     }
 
     const ShadowMap::ShadowMapInfo shadowMapInfo{
@@ -653,15 +600,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     uint32_t cascadeHasVisibleShadows = 0;
 
     if (hasVisibleShadows) {
-        // Adjust the near and far planes to tightly bound the scene.
-        float vsNear = -cameraInfo.zn;
-        float vsFar = -cameraInfo.zf;
-        if (engine.debug.shadowmap.tightly_bound_scene && !params.options.stable) {
-            vsNear = std::min(vsNear, sceneInfo.vsNearFar.x);
-            vsFar = std::max(vsFar, sceneInfo.vsNearFar.y);
-        }
-
-        const size_t cascadeCount = cascadedShadowMaps.size();
+        uint32_t const cascadeCount = cascadedShadowMaps.size();
 
         // We divide the camera frustum into N cascades. This gives us N + 1 split positions.
         // The first split position is the near plane; the last split position is the far plane.
@@ -672,9 +611,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         }
 
         const CascadeSplits splits({
-                .proj = cameraInfo.cullingProjection,
-                .near = vsNear,
-                .far = vsFar,
+                .near = -cameraInfo.zn,
+                .far = -cameraInfo.zf,
                 .cascadeCount = cascadeCount,
                 .splitPositions = splitPercentages
         });
@@ -684,10 +622,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         static_assert(CONFIG_MAX_SHADOW_CASCADES <= 5,
                 "At most, a float4 can fit 4 split positions for 5 shadow cascades");
         float4 wsSplitPositionUniform{ -std::numeric_limits<float>::infinity() };
-        std::copy(splits.beginWs() + 1, splits.endWs(), &wsSplitPositionUniform[0]);
-
-        float csSplitPosition[CONFIG_MAX_SHADOW_CASCADES + 1];
-        std::copy(splits.beginCs(), splits.endCs(), csSplitPosition);
+        std::copy(splits.begin() + 1, splits.end(), &wsSplitPositionUniform[0]);
 
         mShadowMappingUniforms.cascadeSplits = wsSplitPositionUniform;
 
@@ -700,7 +635,11 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             ShadowMap& shadowMap = cascadedShadowMaps[i];
             assert_invariant(shadowMap.getLightIndex() == 0);
 
-            sceneInfo.csNearFar = { csSplitPosition[i], csSplitPosition[i + 1] };
+            // update cameraInfo culling projection for the cascade
+            float const* nearFarPlanes = splits.begin();
+            cameraInfo.zn = -nearFarPlanes[i];
+            cameraInfo.zf = -nearFarPlanes[i + 1];
+            updateNearFarPlanes(&cameraInfo.cullingProjection, cameraInfo.zn, cameraInfo.zf);
 
             auto shaderParameters = shadowMap.updateDirectional(engine,
                     lightData, 0, cameraInfo, shadowMapInfo, sceneInfo, USE_DEPTH_CLAMP);
@@ -1074,8 +1013,67 @@ ShadowMapManager::CascadeSplits::CascadeSplits(Params const& params) noexcept
         : mSplitCount(params.cascadeCount + 1) {
     for (size_t s = 0; s < mSplitCount; s++) {
         mSplitsWs[s] = params.near + (params.far - params.near) * params.splitPositions[s];
-        mSplitsCs[s] = mat4f::project(params.proj, float3(0.0f, 0.0f, mSplitsWs[s])).z;
     }
+}
+
+void ShadowMapManager::updateNearFarPlanes(mat4f* projection,
+        float nearDistance, float farDistance) noexcept {
+    float const n = nearDistance;
+    float const f = farDistance;
+
+    /*
+     *  Updating a projection matrix near and far planes:
+     *
+     *  We assume that the near and far plane equations are of the form:
+     *           N = { 0, 0,  1,  n }
+     *           F = { 0, 0, -1, -f }
+     *
+     *  We also assume that the lower-left 2x2 of the projection is all 0:
+     *       P =   A   0   C   0
+     *             0   B   D   0
+     *             0   0   E   F
+     *             0   0   G   H
+     *
+     *  It result that we need to calculate E and F while leaving all other parameter unchanged.
+     *
+     *  We know that:
+     *       with N, F the near/far normalized plane equation parameters
+     *            sn, sf arbitrary scale factors (they don't affect the planes)
+     *            m is the transpose of projection (see Frustum.cpp)
+     *
+     *       sn * N == -m[3] - m[2]
+     *       sf * F == -m[3] + m[2]
+     *
+     *       sn * N + sf * F == -2 * m[3]
+     *       sn * N - sf * F == -2 * m[2]
+     *
+     *       sn * N.z + sf * F.z == -2 * m[3].z
+     *       sn * N.w + sf * F.w == -2 * m[3].w
+     *       sn * N.z - sf * F.z == -2 * m[2].z
+     *       sn * N.w - sf * F.w == -2 * m[2].w
+     *
+     *       sn * N.z + sf * F.z == -2 * p[2].w
+     *       sn * N.w + sf * F.w == -2 * p[3].w
+     *       sn * N.z - sf * F.z == -2 * p[2].z
+     *       sn * N.w - sf * F.w == -2 * p[3].z
+     *
+     *  We now need to solve for { p[2].z, p[3].z, sn, sf } :
+     *
+     *       sn == -2 * (p[2].w * F.w - p[3].w * F.z) / (N.z * F.w - N.w * F.z)
+     *       sf == -2 * (p[2].w * N.w - p[3].w * N.z) / (F.z * N.w - F.w * N.z)
+     *   p[2].z == (sf * F.z - sn * N.z) / 2
+     *   p[3].z == (sf * F.w - sn * N.w) / 2
+     */
+    auto& p = *projection;
+    float4 const N = { 0, 0,  1,  n };  // near plane equation
+    float4 const F = { 0, 0, -1, -f };  // far plane equation
+    // near plane equation scale factor
+    float const sn = -2.0f * (p[2].w * F.w - p[3].w * F.z) / (N.z * F.w - N.w * F.z);
+    // far plane equation scale factor
+    float const sf = -2.0f * (p[2].w * N.w - p[3].w * N.z) / (F.z * N.w - F.w * N.z);
+    // New values for the projection
+    p[2].z = (sf * F.z - sn * N.z) * 0.5f;
+    p[3].z = (sf * F.w - sn * N.w) * 0.5f;
 }
 
 } // namespace filament

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -148,6 +148,9 @@ private:
 
     void terminate(FEngine& engine);
 
+    static void updateNearFarPlanes(math::mat4f* projection,
+            float nearDistance, float farDistance) noexcept;
+
     ShadowMapManager::ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
             FView& view, CameraInfo cameraInfo, FScene::RenderableSoa& renderableData,
             FScene::LightSoa const& lightData, ShadowMap::SceneInfo sceneInfo) noexcept;
@@ -186,27 +189,21 @@ private:
         constexpr static size_t SPLIT_COUNT = CONFIG_MAX_SHADOW_CASCADES + 1;
 
         struct Params {
-            math::mat4f proj;
             float near = 0.0f;
             float far = 0.0f;
-            size_t cascadeCount = 1;
+            uint32_t cascadeCount = 1;
             std::array<float, SPLIT_COUNT> splitPositions = { 0.0f };
         };
 
         explicit CascadeSplits(Params const& params) noexcept;
 
         // Split positions in world-space.
-        const float* beginWs() const { return mSplitsWs; }
-        const float* endWs() const { return mSplitsWs + mSplitCount; }
-
-        // Split positions in clip-space.
-        const float* beginCs() const { return mSplitsCs; }
-        const float* endCs() const { return mSplitsCs + mSplitCount; }
+        const float* begin() const { return mSplitsWs; }
+        const float* end() const { return mSplitsWs + mSplitCount; }
 
     private:
         float mSplitsWs[SPLIT_COUNT];
-        float mSplitsCs[SPLIT_COUNT];
-        size_t mSplitCount;
+        uint32_t mSplitCount;
     };
 
     // Atlas requirements, updated in ShadowMapManager::update(),

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -590,7 +590,8 @@ private:
     Config mConfig;
 
 public:
-    // these are the debug properties used by FDebug. They're accessed directly by modules who need them.
+    // These are the debug properties used by FDebug.
+    // They're accessed directly by modules who need them.
     struct {
         struct {
             bool debug_directional_shadowmap = false;
@@ -598,7 +599,7 @@ public:
             bool far_uses_shadowcasters = true;
             bool focus_shadowcasters = true;
             bool visualize_cascades = false;
-            bool tightly_bound_scene = true;
+            bool disable_light_frustum_align = false;
             float dzn = -1.0f;
             float dzf =  1.0f;
             float display_shadow_texture_scale = 0.25f;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -894,6 +894,8 @@ int main(int argc, char** argv) {
                         debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
                 ImGui::Checkbox("Focus shadow casters",
                         debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
+                ImGui::Checkbox("Disable light frustum alignment",
+                        debug.getPropertyAddress<bool>("d.shadowmap.disable_light_frustum_align"));
 
                 bool debugDirectionalShadowmap;
                 if (debug.getProperty("d.shadowmap.debug_directional_shadowmap",


### PR DESCRIPTION
shadow cascades where not calculated properly because part of the  calculation took the cascade near/far into account, while another part didn't. This resulted in cascades being too large. It didn't create wrong shadows, but reduced (and in some case canceled) the usefulness of the cascade.

We fix the problem by always  using the projection matrix only for describing the cascade's frustum, as opposed to just passing the near/far plane distances.

Now the calculation of each cascade is completely self contained and identical.


We also improve the orientation of the light frustum: We can rotate the light frustum around the light direction axis, so it aligns with the view direction, this generally result in smaller light frustums. This cannot be used in stable mode.