### PR TITLE
improve FrameSkipper when disregarding skipping

### DIFF
--- a/filament/src/FrameSkipper.h
+++ b/filament/src/FrameSkipper.h
@@ -22,6 +22,9 @@
 
 #include <array>
 
+#include <stddef.h>
+#include <stdint.h>
+
 namespace filament {
 
 /*
@@ -60,7 +63,7 @@ public:
 private:
     using Container = std::array<backend::Handle<backend::HwFence>, MAX_FRAME_LATENCY>;
     mutable Container mDelayedFences{};
-    size_t mLast;
+    uint8_t const mLast;
 };
 
 } // namespace filament


### PR DESCRIPTION
It is legal for the app to draw a frame even when FrameSkipper  detects that a frame should be skipped. In that case we used to overwrite the most recent fence, but this wasn't ideal. We now proceed as if the fence had signaled, i.e. we destroy it and move all the fences up, creating a new one at the end of the  delayed array.