### PR TITLE
depth clamp cannot work with VSM

### DIFF
--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -371,7 +371,13 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     if (view.isFrontFaceWindingInverted()) {
                         renderPassFlags |= RenderPass::HAS_INVERSE_FRONT_FACES;
                     }
-                    if (mIsDepthClampSupported && engine.debug.shadowmap.depth_clamp) {
+
+                    bool const canUseDepthClamp =
+                            !view.hasVSM() &&
+                            mIsDepthClampSupported &&
+                            engine.debug.shadowmap.depth_clamp;
+
+                    if (canUseDepthClamp) {
                         renderPassFlags |= RenderPass::HAS_DEPTH_CLAMP;
                     }
 
@@ -650,9 +656,14 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             cameraInfo.zf = -nearFarPlanes[i + 1];
             updateNearFarPlanes(&cameraInfo.cullingProjection, cameraInfo.zn, cameraInfo.zf);
 
+            bool const canUseDepthClamp =
+                    !view.hasVSM() &&
+                    mIsDepthClampSupported &&
+                    engine.debug.shadowmap.depth_clamp;
+
             auto shaderParameters = shadowMap.updateDirectional(engine,
                     lightData, 0, cameraInfo, shadowMapInfo, sceneInfo,
-                    mIsDepthClampSupported && engine.debug.shadowmap.depth_clamp);
+                    canUseDepthClamp);
 
             if (shadowMap.hasVisibleShadows()) {
                 const size_t shadowIndex = shadowMap.getShadowIndex();


### PR DESCRIPTION
This is because the shadowmap doesn't store depth values so it doesn't  work to "flatten" all casters behind de camera to the near plane. The bulk of shadowing works but the filtering/edges don't always.

Disable depth-clamping when VSM is enabled.