### PR TITLE
GLDescriptorSet: less restrictive size assert

### DIFF
--- a/filament/backend/src/opengl/GLDescriptorSet.h
+++ b/filament/backend/src/opengl/GLDescriptorSet.h
@@ -151,7 +151,7 @@ private:
     DescriptorSetLayoutHandle dslh;                         // 4
     uint8_t dynamicBufferCount = 0;                         // 1
 };
-static_assert(sizeof(GLDescriptorSet) == 32);
+static_assert(sizeof(GLDescriptorSet) <= 32);
 
 } // namespace filament::backend
 


### PR DESCRIPTION
For some platform, the compilation fails because the size of the struct is not exactly 32 bits (but is always less).