### PR TITLE
decoding meshoptimized gltf just once

### DIFF
--- a/libs/gltfio/src/extended/AssetLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.cpp
@@ -527,8 +527,10 @@ bool AssetLoaderExtended::createPrimitive(Input* input, Output* out,
 
     if (!mCgltfBuffersLoaded) {
         mCgltfBuffersLoaded = utility::loadCgltfBuffers(gltf, mGltfPath.c_str(), mUriDataCache);
+        if (!mCgltfBuffersLoaded) {
+            return false;
+        }
         utility::decodeMeshoptCompression(gltf);
-        if (!mCgltfBuffersLoaded) return false;
     }
 
     utility::decodeDracoMeshes(gltf, prim, input->dracoCache);

--- a/libs/gltfio/src/extended/AssetLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.cpp
@@ -527,11 +527,11 @@ bool AssetLoaderExtended::createPrimitive(Input* input, Output* out,
 
     if (!mCgltfBuffersLoaded) {
         mCgltfBuffersLoaded = utility::loadCgltfBuffers(gltf, mGltfPath.c_str(), mUriDataCache);
+        utility::decodeMeshoptCompression(gltf);
         if (!mCgltfBuffersLoaded) return false;
     }
 
     utility::decodeDracoMeshes(gltf, prim, input->dracoCache);
-    utility::decodeMeshoptCompression(gltf);
 
     auto slots = computeGeometries(prim, jobType, attributesMap, morphTargets, out->uvmap, mEngine);
 


### PR DESCRIPTION
Decoding the mesh optimized gltf in a loop slows down the extended algo drastically & crashes the app with larger primitives 