### PR TITLE
Refactored the handling of usage flags in the VulkanTexture constructor

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -16,7 +16,6 @@
 
 #include "VulkanHandles.h"
 
-#include "VulkanDriver.h"
 #include "VulkanConstants.h"
 #include "VulkanDriver.h"
 #include "VulkanMemory.h"

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -97,13 +97,11 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         imageInfo.extent.depth = 1;
     }
 
-    // Filament expects blit() to work with any texture, so we almost always set these usage flags.
-    // TODO: investigate performance implications of setting these flags.
-    constexpr VkImageUsageFlags blittable = VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-            VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-
-    if (any(usage & (TextureUsage::BLIT_DST | TextureUsage::BLIT_SRC))) {
-        imageInfo.usage |= blittable;
+    if (any(usage & TextureUsage::BLIT_SRC)) {
+        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    }
+    if (any(usage & TextureUsage::BLIT_DST)) {
+        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     }
 
     if (any(usage & TextureUsage::SAMPLEABLE)) {
@@ -121,7 +119,7 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
     }
     if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | blittable;
+        imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
         if (any(usage & TextureUsage::SUBPASS_INPUT)) {
             imageInfo.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
         }
@@ -130,10 +128,9 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     }
     if (any(usage & TextureUsage::UPLOADABLE)) {
-        imageInfo.usage |= blittable;
+        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     }
     if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
-        imageInfo.usage |= blittable;
         imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
         // Depth resolves uses a custom shader and therefore needs to be sampleable.


### PR DESCRIPTION
- Removed the `VK_IMAGE_USAGE_TRANSFER_SRC_BIT` and `VK_IMAGE_USAGE_TRANSFER_DST_BIT` flags that were systematically added to all color and depth attachments.
- Modified the behavior of `TextureUsage::BLIT_SRC`, `TextureUsage::BLIT_DST`, and `TextureUsage::UPLOADABLE`, so that they only raise the corresponding `VkImage` usage flags.
- Note that I shied away from removing `VK_IMAGE_USAGE_SAMPLED_BIT` from depth texture with more than 1 sample, as I am not familiar enough with the custom shader-based resolve. I believe we could move the flag to where the depth sidecar is created (using `TextureUsage::SAMPLEABLE`), but I am not sure 100%.