### PR TITLE
Re-enable DebugRegistry::setProperty for release build

### DIFF
--- a/filament/src/details/DebugRegistry.cpp
+++ b/filament/src/details/DebugRegistry.cpp
@@ -28,12 +28,6 @@
 #include <string_view>
 #include <utility>
 
-#ifndef NDEBUG
-#   define DEBUG_PROPERTIES_WRITABLE true
-#else
-#   define DEBUG_PROPERTIES_WRITABLE false
-#endif
-
 using namespace filament::math;
 using namespace utils;
 
@@ -79,17 +73,15 @@ bool FDebugRegistry::hasProperty(const char* name) const noexcept {
 
 template<typename T>
 bool FDebugRegistry::setProperty(const char* name, T v) noexcept {
-    if constexpr (DEBUG_PROPERTIES_WRITABLE) {
-        auto info = getPropertyInfo(name);
-        T* const addr = static_cast<T*>(info.first);
-        if (addr) {
-            auto old = *addr;
-            *addr = v;
-            if (info.second && old != v) {
-                info.second();
-            }
-            return true;
+    auto info = getPropertyInfo(name);
+    T* const addr = static_cast<T*>(info.first);
+    if (addr) {
+        auto old = *addr;
+        *addr = v;
+        if (info.second && old != v) {
+            info.second();
         }
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
`DebugRegistry::setProperty` is no longer just applicable to debug builds.

This change was previously added in 6c0bd36 but then reverted in a7317e7. We re-enable it and separate it from the shadow changes in this commit.