### PR TITLE
repair the "no buffer padding case"

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -651,14 +651,19 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
     const bool isProtectedContent =  mSwapChain && mSwapChain->isProtected();
 
+    // Conditions to meet to be able to use the sub-pass rendering path. This is regardless of
+    // whether the backend supports subpasses (or if they are disabled but the debugRegistry)
+    const bool isSubpassPossible =
+             msaaSampleCount <= 1 &&
+             hasColorGrading &&
+             !bloomOptions.enabled && !dofOptions.enabled && !taaOptions.enabled;
+
     // asSubpass is disabled with TAA (although it's supported) because performance was degraded
     // on qualcomm hardware -- we might need a backend dependent toggle at some point
     const PostProcessManager::ColorGradingConfig colorGradingConfig{
             .asSubpass =
-                    msaaSampleCount <= 1 &&
+                    isSubpassPossible &&
                     driver.isFrameBufferFetchSupported() &&
-                    hasColorGrading &&
-                    !bloomOptions.enabled && !dofOptions.enabled && !taaOptions.enabled &&
                     !engine.debug.renderer.disable_subpasses,
             .customResolve =
                     msaaSampleCount > 1 &&
@@ -702,8 +707,8 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     // this case, we would need an extra blit to "resolve" the buffer padding (because there are no
     // other pass that can do it as a side effect). In this case, it is better to skip the padding,
     // which won't be helping much.
-    const bool noBufferPadding
-            = (!hasFXAA && !scaled) || engine.debug.renderer.disable_buffer_padding;
+    const bool noBufferPadding = (isSubpassPossible &&
+            !hasFXAA && !scaled) || engine.debug.renderer.disable_buffer_padding;
 
     // guardBand must be a multiple of 16 to guarantee the same exact rendering up to 4 mip levels.
     float const guardBand = guardBandOptions.enabled ? 16.0f : 0.0f;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -652,7 +652,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     const bool isProtectedContent =  mSwapChain && mSwapChain->isProtected();
 
     // Conditions to meet to be able to use the sub-pass rendering path. This is regardless of
-    // whether the backend supports subpasses (or if they are disabled but the debugRegistry)
+    // whether the backend supports subpasses (or if they are disabled in the debugRegistry).
     const bool isSubpassPossible =
              msaaSampleCount <= 1 &&
              hasColorGrading &&


### PR DESCRIPTION
with a previous change we were too aggressive in falling back to  "no buffer padding", we need to do this only in the case where "as subpass" would have been used if supported by the h/w.