### PR TITLE
fix potential framegraph textures use-after free 

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -459,10 +459,12 @@ void PerViewUniforms::bind(backend::DriverApi& driver) noexcept {
 
 void PerViewUniforms::unbindSamplers() noexcept {
     auto& samplerGroup = mSamplers;
+    samplerGroup.clearSampler(PerViewSib::SHADOW_MAP);
+    samplerGroup.clearSampler(PerViewSib::IBL_SPECULAR);
     samplerGroup.clearSampler(PerViewSib::SSAO);
     samplerGroup.clearSampler(PerViewSib::SSR);
     samplerGroup.clearSampler(PerViewSib::STRUCTURE);
-    samplerGroup.clearSampler(PerViewSib::SHADOW_MAP);
+    samplerGroup.clearSampler(PerViewSib::FOG);
 }
 
 } // namespace filament

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -143,12 +143,14 @@ void ResourceAllocator::terminate() noexcept {
     }
 }
 
-RenderTargetHandle ResourceAllocator::createRenderTarget(const char*,
+RenderTargetHandle ResourceAllocator::createRenderTarget(const char* name,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, uint8_t layerCount, MRT color, TargetBufferInfo depth,
         TargetBufferInfo stencil) noexcept {
-    return mBackend.createRenderTarget(targetBufferFlags,
+    auto handle = mBackend.createRenderTarget(targetBufferFlags,
             width, height, samples ? samples : 1u, layerCount, color, depth, stencil);
+    mBackend.setDebugTag(handle.getId(), CString{ name });
+    return handle;
 }
 
 void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {
@@ -201,6 +203,7 @@ backend::TextureHandle ResourceAllocator::createTexture(const char* name,
         }
     }
     mDisposer->checkout(handle, key);
+    mBackend.setDebugTag(handle.getId(), CString{ name });
     return handle;
 }
 

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -245,6 +245,8 @@ FTexture::FTexture(FEngine& engine, const Builder& builder) {
     }
     if (auto name = builder.getName(); !name.empty()) {
         driver.setDebugTag(mHandle.getId(), std::move(name));
+    } else {
+        driver.setDebugTag(mHandle.getId(), CString{"FTexture"});
     }
 }
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -1040,10 +1040,8 @@ void FView::commitFrameHistory(FEngine& engine) noexcept {
     auto& frameHistory = mFrameHistory;
 
     FrameHistoryEntry& last = frameHistory.back();
-    disposer.destroy(last.taa.color.handle);
-    disposer.destroy(last.ssr.color.handle);
-    last.taa.color.handle.clear();
-    last.ssr.color.handle.clear();
+    disposer.destroy(std::move(last.taa.color.handle));
+    disposer.destroy(std::move(last.ssr.color.handle));
 
     // and then push the new history entry to the history stack
     frameHistory.commit();
@@ -1055,10 +1053,8 @@ void FView::clearFrameHistory(FEngine& engine) noexcept {
     auto& frameHistory = mFrameHistory;
     for (size_t i = 0; i < frameHistory.size(); ++i) {
         FrameHistoryEntry& last = frameHistory[i];
-        disposer.destroy(last.taa.color.handle);
-        disposer.destroy(last.ssr.color.handle);
-        last.taa.color.handle.clear();
-        last.ssr.color.handle.clear();
+        disposer.destroy(std::move(last.taa.color.handle));
+        disposer.destroy(std::move(last.ssr.color.handle));
     }
 }
 


### PR DESCRIPTION
make sure to unset all textures in the per-view sampler group after
they are used, because the resource could be destroyed after the
pass is finished

- unset the fog and ibl_specular after the color pass
- move that cleanup a bit earlier
- in the case of screen-space reflection the structure pass is
  set, but might not be used in the color pass, so we also need to
  unset it after the SSR pass and before any other passes.