### PR TITLE
github: Split Android CI to per ABI builds

### DIFF
--- a/.github/actions/android-continuous/action.yml
+++ b/.github/actions/android-continuous/action.yml
@@ -1,0 +1,17 @@
+name: 'Android Continuous'
+inputs:
+  build-abi:
+    description: 'The target platform ABI'
+    required: true
+    default: 'armeabi-v7a'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    - name: Run build script
+      run: |
+        cd build/android && printf "y" | ./build.sh continuous ${{ inputs.build-abi }}
+      shell: bash

--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -8,32 +8,35 @@ on:
       - rc/**
 
 jobs:
-  build-android:
-    name: build-android
+  build-android-armv7:
+    name: build-android-armv7
     runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4.1.6
-      - uses: actions/setup-java@v3
+      - name: Run Android Continuous
+        uses: ./.github/actions/android-continuous
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Run build script
-        run: |
-          cd build/android && printf "y" | ./build.sh continuous
-      - uses: actions/upload-artifact@v1.0.0
+          build-abi: armeabi-v7a
+
+  build-android-armv8a:
+    name: build-android-armv8a
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - name: Run Android Continuous
+        uses: ./.github/actions/android-continuous
         with:
-          name: filament-android
-          path: out/filament-android-release.aar
-      - uses: actions/upload-artifact@v1.0.0
+          build-abi: arm64-v8a
+
+  build-android-x86_64:
+    name: build-android-x86_64
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - name: Run Android Continuous
+        uses: ./.github/actions/android-continuous
         with:
-          name: filamat-android-full
-          path: out/filamat-android-release.aar
-      - uses: actions/upload-artifact@v1.0.0
-        with:
-          name: gltfio-android-release
-          path: out/gltfio-android-release.aar
-      - uses: actions/upload-artifact@v1.0.0
-        with:
-          name: filament-utils-android-release
-          path: out/filament-utils-android-release.aar
+          build-abi: x86_64

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -49,8 +49,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Run build script
+        # Only build 1 64 bit target during presubmit to cut down build times during presubmit
+        # Continuous builds will build everything
         run: |
-          cd build/android && printf "y" | ./build.sh presubmit
+          cd build/android && printf "y" | ./build.sh presubmit arm64-v8a
 
   build-ios:
     name: build-iOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           TAG: ${{ steps.git_ref.outputs.tag }}
         run: |
-          cd build/android && printf "y" | ./build.sh release
+          cd build/android && printf "y" | ./build.sh release armeabi-v7a,arm64-v8a,x86,x86_64
           cd ../..
           mv out/filament-android-release.aar out/filament-${TAG}-android.aar
           mv out/filamat-android-release.aar out/filamat-${TAG}-android.aar

--- a/README.md
+++ b/README.md
@@ -54,16 +54,6 @@ iOS projects can use CocoaPods to install the latest release:
 pod 'Filament', '~> 1.54.1'
 ```
 
-### Snapshots
-
-If you prefer to live on the edge, you can download a continuous build by following the following
-steps:
-
-1. Find the [commit](https://github.com/google/filament/commits/main) you're interested in.
-2. Click the green check mark under the commit message.
-3. Click on the _Details_ link for the platform you're interested in.
-4. On the top left click _Summary_, then in the _Artifacts_ section choose the desired artifact.
-
 ## Documentation
 
 - [Filament](https://google.github.io/filament/Filament.html), an in-depth explanation of


### PR DESCRIPTION
 - Pulled the android continuous workflow into an action
 - Split the android continuous build into 3 ABIs armv7, armv8a,
   and x86_64 (note that x86 is not present).
 - Remove the upload artifacts step from previous workflow.
   Unclear why that was present.
 - Split the android continous into debug build and a release
   build commands, enabling deletion of intermediate output
   directory.