### PR TITLE
Expose getShadowType on View.

### DIFF
--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -571,6 +571,13 @@ public:
     void setShadowType(ShadowType shadow) noexcept;
 
     /**
+     * Returns the shadow mapping technique used by this View.
+     *
+     * @return value set by setShadowType().
+     */
+    ShadowType getShadowType() const noexcept;
+
+    /**
      * Sets VSM shadowing options that apply across the entire View.
      *
      * Additional light-specific VSM options can be set with LightManager::setShadowOptions.

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -193,6 +193,10 @@ void View::setShadowType(View::ShadowType shadow) noexcept {
     downcast(this)->setShadowType(shadow);
 }
 
+View::ShadowType View::getShadowType() const noexcept {
+    return downcast(this)->getShadowType();
+}
+
 void View::setVsmShadowOptions(VsmShadowOptions const& options) noexcept {
     downcast(this)->setVsmShadowOptions(options);
 }


### PR DESCRIPTION
While this method exists on FView, it is missing from View and thus not accessible for filament users. This adds a pass-through method on View.