### PR TITLE
fix FrameSkipper

### DIFF
--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -31,8 +31,7 @@ using namespace utils;
 using namespace backend;
 
 FrameSkipper::FrameSkipper(size_t latency) noexcept
-        : mLast(std::max(latency, MAX_FRAME_LATENCY) - 1) {
-    assert_invariant(latency <= MAX_FRAME_LATENCY);
+        : mLast(std::clamp(latency, size_t(1), MAX_FRAME_LATENCY) - 1) {
 }
 
 FrameSkipper::~FrameSkipper() noexcept = default;

--- a/filament/src/FrameSkipper.h
+++ b/filament/src/FrameSkipper.h
@@ -34,7 +34,7 @@ namespace filament {
 class FrameSkipper {
     /*
      * The maximum frame latency acceptable on ANDROID is 2 because higher latencies will be
-     * throttled anyway is BufferQueueProducer::dequeueBuffer(), because ANDROID is generally
+     * throttled anyway in BufferQueueProducer::dequeueBuffer(), because ANDROID is generally
      * triple-buffered no more; that case is actually pretty bad because the GL thread can block
      * anywhere (usually inside the first draw command that touches the swapchain).
      *

--- a/filament/src/FrameSkipper.h
+++ b/filament/src/FrameSkipper.h
@@ -32,7 +32,18 @@ namespace filament {
  * outrun the GPU.
  */
 class FrameSkipper {
-    static constexpr size_t MAX_FRAME_LATENCY = 3;
+    /*
+     * The maximum frame latency acceptable on ANDROID is 2 because higher latencies will be
+     * throttled anyway is BufferQueueProducer::dequeueBuffer(), because ANDROID is generally
+     * triple-buffered no more; that case is actually pretty bad because the GL thread can block
+     * anywhere (usually inside the first draw command that touches the swapchain).
+     *
+     * A frame latency of 1 has the benefit of reducing render latency,
+     * but the drawback of preventing CPU / GPU overlap.
+     *
+     * Generally a frame latency of 2 is the best compromise.
+     */
+    static constexpr size_t MAX_FRAME_LATENCY = 2;
 public:
     /*
      * The latency parameter defines how many unfinished frames we want to accept before we start


### PR DESCRIPTION
FrameSkipper was recently broken because of a typo resulting in  the frame latency being always 3 instead of the default of 2.

This change also makes the maximum latency 2 instead of 3, because on ANDROID, 3 can cause CPU throttling at seemingly random places on the GL thread.