### PR TITLE
Add missing include

### DIFF
--- a/libs/utils/include/utils/memalign.h
+++ b/libs/utils/include/utils/memalign.h
@@ -17,6 +17,7 @@
 #ifndef TNT_UTILS_MEMALIGN_H
 #define TNT_UTILS_MEMALIGN_H
 
+#include <cstddef>
 #include <type_traits>
 
 #include <assert.h>


### PR DESCRIPTION
ptrdiff_t was transiently included by type_traits. However, this is not true for some cpp toolchains. Add the header inclusion explicitly.