### PR TITLE
vk: cache descriptor set layout

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -749,7 +749,10 @@ void VulkanDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, int) {
 void VulkanDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh,
         backend::DescriptorSetLayout&& info) {
     VulkanDescriptorSetLayout* layout = mResourceAllocator.construct<VulkanDescriptorSetLayout>(
-            dslh, mPlatform->getDevice(), info);
+            dslh, info);
+
+    // This will create a VkDescriptorSetLayout (which is cached) for this object.
+    mDescriptorSetManager.initVkLayout(layout);
     mResourceManager.acquire(layout);
 }
 
@@ -1830,7 +1833,7 @@ void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
                 }
                 auto layout = mResourceAllocator.handle_cast<VulkanDescriptorSetLayout*>(handle);
                 layoutCount++;
-                return layout->vklayout;
+                return layout->getVkLayout();
             });
     auto pipelineLayout = mPipelineLayoutCache.getLayout(layoutList, program);
 

--- a/filament/backend/src/vulkan/caching/VulkanDescriptorSetManager.h
+++ b/filament/backend/src/vulkan/caching/VulkanDescriptorSetManager.h
@@ -68,6 +68,8 @@ public:
 
     void destroySet(Handle<HwDescriptorSet> handle);
 
+    void initVkLayout(VulkanDescriptorSetLayout* layout);
+
 private:
     class Impl;
     Impl* mImpl;


### PR DESCRIPTION
We need to cache descriptor set layouts because Filament creates new layout objects for the same layout content. Adding to this is that descriptor set's lifetime is tied to the layout that it is created from, and we are trying to recycle used descriptor sets wrt layout. This implies that we need to (unfortunately) separate the vk layout lifetime from the filament layout lifetime.

In this commit, we use a cache so that the same layout content will always map to one vk layout.

Also fixed bugs on bit-shifting and counting.