### PR TITLE
vk: workaround a renderStandaloneView issue

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -536,6 +536,12 @@ void FRenderer::renderStandaloneView(FView const* view) {
         renderInternal(view);
 
         driver.endFrame(mFrameId);
+
+        // This is a workaround for internal bug b/361822355.
+        // TODO: properly address the bug and remove this workaround.
+        if (engine.getBackend() == backend::Backend::VULKAN) {
+            engine.flushAndWait();
+        }
     }
 }
 


### PR DESCRIPTION
Found through testing that renderStandaloneView+vk+swiftshader seems to cause synchronization issues, which results in incorrect rendering. Here we workaround the issue by forcibly flush and wait per renderStandaloneView call.

BUG=361822355