### PR TITLE
github: use up-to-date actions/upload-artifact

### DIFF
--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run build script
         run: |
           cd build/ios && printf "y" | ./build.sh continuous
-      - uses: actions/upload-artifact@v1.0.0
+      - uses: actions/upload-artifact@v4
         with:
           name: filament-ios
           path: out/filament-release-ios.tgz

--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run build script
         run: |
           cd build/linux && printf "y" | ./build.sh continuous
-      - uses: actions/upload-artifact@v1.0.0
+      - uses: actions/upload-artifact@v4
         with:
           name: filament-linux
           path: out/filament-release-linux.tgz

--- a/.github/workflows/mac-continuous.yml
+++ b/.github/workflows/mac-continuous.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run build script
         run: |
           cd build/mac && printf "y" | ./build.sh continuous
-      - uses: actions/upload-artifact@v1.0.0
+      - uses: actions/upload-artifact@v4
         with:
           name: filament-mac
           path: out/filament-release-darwin.tgz

--- a/.github/workflows/web-continuous.yml
+++ b/.github/workflows/web-continuous.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run build script
         run: |
           cd build/web && printf "y" | ./build.sh continuous
-      - uses: actions/upload-artifact@v1.0.0
+      - uses: actions/upload-artifact@v4
         with:
           name: filament-web
           path: out/filament-release-web.tgz

--- a/.github/workflows/windows-continuous.yml
+++ b/.github/workflows/windows-continuous.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           build\windows\build-github.bat continuous
         shell: cmd
-      - uses: actions/upload-artifact@v1.0.0
+      - uses: actions/upload-artifact@v4
         with:
           name: filament-windows
           path: out/filament-windows.tgz


### PR DESCRIPTION
v1.0.0 has been deprecated and is causing our builds to fail. We update the action to use v4 (the most current and recommended version).