### PR TITLE
sample: fix two IBL loading crashes

### DIFF
--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -552,6 +552,9 @@ void FilamentApp::loadIBL(std::string_view path) {
         return;
     }
 
+    // Note that IBL holds a skybox, and Scene also holds a reference.  We cannot release IBL's
+    // skybox until after new skybox has been set in the scene.
+    std::unique_ptr<IBL> oldIBL = std::move(mIBL);
     mIBL = std::make_unique<IBL>(*mEngine);
 
     if (!iblPath.isDirectory()) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -671,7 +671,15 @@ int main(int argc, char** argv) {
         buffer.shrink_to_fit();
     };
 
-    auto loadResources = [&app] (const utils::Path& filename) {
+    auto setupIBL = [&app]() {
+        auto ibl = FilamentApp::get().getIBL();
+        if (ibl) {
+            app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
+            app.viewer->getSettings().view.fogSettings.fogColorTexture = ibl->getFogTexture();
+        }
+    };
+
+    auto loadResources = [&app, &setupIBL] (const utils::Path& filename) {
         // Load external textures and buffers.
         std::string const gltfPath = filename.getAbsolutePath();
         ResourceConfiguration configuration = {};
@@ -708,12 +716,7 @@ int main(int argc, char** argv) {
             instances[mi]->setStencilWrite(true);
             instances[mi]->setStencilOpDepthStencilPass(MaterialInstance::StencilOperation::INCR);
         }
-
-        auto ibl = FilamentApp::get().getIBL();
-        if (ibl) {
-            app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
-            app.viewer->getSettings().view.fogSettings.fogColorTexture = ibl->getFogTexture();
-        }
+        setupIBL();
     };
 
     auto setup = [&](Engine* engine, View* view, Scene* scene) {
@@ -1190,7 +1193,7 @@ int main(int argc, char** argv) {
         filename = getPathForIBLAsset(path);
         if (!filename.isEmpty()) {
             FilamentApp::get().loadIBL(path);
-            return;
+            setupIBL();
         }
     });
 


### PR DESCRIPTION
 - Both Scene and IBL are holding on to a skybox reference. We need to make sure the order they are destroyed in right order.
 - Reloading IBL should trigger resetting the indrect light in gltf_viewer.