### PR TITLE
fix a logic bug when updating the lod range of a texture

### DIFF
--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -130,7 +130,13 @@ private:
         uint8_t first = 0;  // first lod
         uint8_t last = 0;   // 1 past last lod
         bool empty() const noexcept { return first == last; }
+        size_t size() const noexcept { return last - first; }
     };
+
+    bool hasAllLods(LodRange const range) const noexcept {
+        return range.first == 0 && range.last == mLevelCount;
+    }
+
     void updateLodRange(uint8_t baseLevel, uint8_t levelCount) noexcept;
     void setHandles(backend::Handle<backend::HwTexture> handle) noexcept;
     backend::Handle<backend::HwTexture> setHandleForSampling(


### PR DESCRIPTION
once we reach the full range of lods, we were resetting the lod range to {0,0}, which means "default, all lods" (which is the initial state of the texture). However this broken the LOD-expanding code.

instead, we now keep the lod range, but we check in in  getHandleForSampling() wether the range is full or default.