### PR TITLE
github: upgrade runners on release/continuous

### DIFF
--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -8,35 +8,15 @@ on:
       - rc/**
 
 jobs:
-  build-android-armv7:
+  build-android:
     name: build-android-armv7
-    runs-on: macos-14
+    # We intentially use a larger runner here to enable larger disk space
+    # (standard linux runner will fail on disk space and faster build time).
+    runs-on: ubuntu-22.04-32core
 
     steps:
       - uses: actions/checkout@v4.1.6
       - name: Run Android Continuous
         uses: ./.github/actions/android-continuous
         with:
-          build-abi: armeabi-v7a
-
-  build-android-armv8a:
-    name: build-android-armv8a
-    runs-on: macos-14
-
-    steps:
-      - uses: actions/checkout@v4.1.6
-      - name: Run Android Continuous
-        uses: ./.github/actions/android-continuous
-        with:
-          build-abi: arm64-v8a
-
-  build-android-x86_64:
-    name: build-android-x86_64
-    runs-on: macos-14
-
-    steps:
-      - uses: actions/checkout@v4.1.6
-      - name: Run Android Continuous
-        uses: ./.github/actions/android-continuous
-        with:
-          build-abi: x86_64
+          build-abi: armeabi-v7a,arm64-v8a,x86_64

--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-ios:
     name: build-ios
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-linux:
     name: build-linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-16core
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/mac-continuous.yml
+++ b/.github/workflows/mac-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-mac:
     name: build-mac
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-14, ubuntu-22.04]
+        os: [macos-14-xlarge, ubuntu-22.04-32core]
 
     steps:
       - name: Decide Git ref
@@ -65,7 +65,7 @@ jobs:
 
   build-web:
     name: build-web
-    runs-on: macos-14
+    runs-on: ubuntu-22.04-16core
     if: github.event_name == 'release' || github.event.inputs.platform == 'web'
 
     steps:
@@ -98,7 +98,7 @@ jobs:
 
   build-android:
     name: build-android
-    runs-on: macos-14
+    runs-on: ubuntu-22.04-16core
     if: github.event_name == 'release' || github.event.inputs.platform == 'android'
 
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   build-ios:
     name: build-ios
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     if: github.event_name == 'release' || github.event.inputs.platform == 'ios'
 
     steps:
@@ -185,7 +185,7 @@ jobs:
 
   build-windows:
     name: build-windows
-    runs-on: windows-2019
+    runs-on: windows-2019-32core
     if: github.event_name == 'release' || github.event.inputs.platform == 'windows'
 
     steps:

--- a/.github/workflows/web-continuous.yml
+++ b/.github/workflows/web-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-web:
     name: build-web
-    runs-on: macos-14
+    runs-on: ubuntu-22.04-16core
 
     steps:
       - uses: actions/checkout@v4.1.6


### PR DESCRIPTION
 - Previously we also split Android build into 3, but because we get larger disk with large runners, we combine them again.