### PR TITLE
Do not fix missing samplers for textures with mutable handles

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -582,7 +582,6 @@ void FEngine::prepare() {
 
     for (auto& materialInstanceList: mMaterialInstances) {
         materialInstanceList.second.forEach([&driver](FMaterialInstance* item) {
-            item->fixMissingSamplers(driver);
             item->commit(driver);
         });
     }

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -207,9 +207,6 @@ public:
         }
     }
 
-    // Called by the engine to ensure that unset samplers are initialized with placedholders.
-    void fixMissingSamplers(FEngine::DriverApi& driver) const;
-
     const char* getName() const noexcept;
 
     void setParameter(std::string_view name,
@@ -242,6 +239,9 @@ private:
     // initialize the default instance
     FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept;
 
+    // To ensure that unset samplers are initialized with placedholders.
+    void fixMissingSamplers(FEngine::DriverApi& driver) const;
+
     // keep these grouped, they're accessed together in the render-loop
     FMaterial const* mMaterial = nullptr;
 
@@ -253,6 +253,7 @@ private:
     backend::Handle<backend::HwBufferObject> mUbHandle;
     tsl::robin_map<backend::descriptor_binding_t, TextureParameter> mTextureParameters;
     mutable filament::DescriptorSet mDescriptorSet;
+    mutable utils::bitset64 mMissingSamplerDescriptors;
     UniformBuffer mUniforms;
 
     backend::PolygonOffset mPolygonOffset{};


### PR DESCRIPTION
Because these textures are not going to be present when the sampler "fixup" occurs.