### PR TITLE
Improve setFrameScheduled threading

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -138,7 +138,6 @@ DECL_DRIVER_API_N(beginFrame,
 
 DECL_DRIVER_API_N(setFrameScheduledCallback,
         backend::SwapChainHandle, sch,
-        backend::CallbackHandler*, handler,
         backend::FrameScheduledCallback&&, callback)
 
 DECL_DRIVER_API_N(setFrameCompletedCallback,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -138,7 +138,9 @@ DECL_DRIVER_API_N(beginFrame,
 
 DECL_DRIVER_API_N(setFrameScheduledCallback,
         backend::SwapChainHandle, sch,
-        backend::FrameScheduledCallback&&, callback)
+        backend::CallbackHandler*, handler,
+        backend::FrameScheduledCallback&&, callback,
+        uint64_t, flags)
 
 DECL_DRIVER_API_N(setFrameCompletedCallback,
         backend::SwapChainHandle, sch,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -241,9 +241,9 @@ void MetalDriver::beginFrame(int64_t monotonic_clock_ns,
 }
 
 void MetalDriver::setFrameScheduledCallback(
-        Handle<HwSwapChain> sch, CallbackHandler* handler, FrameScheduledCallback&& callback) {
+        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
     auto* swapChain = handle_cast<MetalSwapChain>(sch);
-    swapChain->setFrameScheduledCallback(handler, std::move(callback));
+    swapChain->setFrameScheduledCallback(std::move(callback));
 }
 
 void MetalDriver::setFrameCompletedCallback(

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -19,6 +19,8 @@
 #include "CommandStreamDispatcher.h"
 #include "metal/MetalDriver.h"
 
+#include <filament/SwapChain.h>
+
 #include "MetalBlitter.h"
 #include "MetalBufferPool.h"
 #include "MetalContext.h"
@@ -240,10 +242,14 @@ void MetalDriver::beginFrame(int64_t monotonic_clock_ns,
     }
 }
 
-void MetalDriver::setFrameScheduledCallback(
-        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
+void MetalDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch, CallbackHandler* handler,
+        FrameScheduledCallback&& callback, uint64_t flags) {
+    // Turn off the CALLBACK_DEFAULT_USE_METAL_COMPLETION_HANDLER flag if a custom handler is provided.
+    if (handler) {
+        flags &= ~SwapChain::CALLBACK_DEFAULT_USE_METAL_COMPLETION_HANDLER;
+    }
     auto* swapChain = handle_cast<MetalSwapChain>(sch);
-    swapChain->setFrameScheduledCallback(std::move(callback));
+    swapChain->setFrameScheduledCallback(handler, std::move(callback), flags);
 }
 
 void MetalDriver::setFrameCompletedCallback(

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -73,7 +73,7 @@ public:
 
     void releaseDrawable();
 
-    void setFrameScheduledCallback(CallbackHandler* handler, FrameScheduledCallback&& callback);
+    void setFrameScheduledCallback(FrameScheduledCallback&& callback);
     void setFrameCompletedCallback(
             CallbackHandler* handler, utils::Invocable<void(void)>&& callback);
 
@@ -119,7 +119,6 @@ private:
     // Instead, clients bear the responsibility of presenting the frame by calling the
     // PresentCallable object.
     struct {
-        CallbackHandler* handler = nullptr;
         std::shared_ptr<FrameScheduledCallback> callback = nullptr;
     } frameScheduled;
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -73,7 +73,8 @@ public:
 
     void releaseDrawable();
 
-    void setFrameScheduledCallback(FrameScheduledCallback&& callback);
+    void setFrameScheduledCallback(
+            CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags);
     void setFrameCompletedCallback(
             CallbackHandler* handler, utils::Invocable<void(void)>&& callback);
 
@@ -119,7 +120,9 @@ private:
     // Instead, clients bear the responsibility of presenting the frame by calling the
     // PresentCallable object.
     struct {
+        CallbackHandler* handler = nullptr;
         std::shared_ptr<FrameScheduledCallback> callback = nullptr;
+        uint64_t flags = 0;
     } frameScheduled;
 
     struct {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -232,8 +232,11 @@ void MetalSwapChain::ensureDepthStencilTexture() {
     depthStencilTexture = [context.device newTextureWithDescriptor:descriptor];
 }
 
-void MetalSwapChain::setFrameScheduledCallback(FrameScheduledCallback&& callback) {
+void MetalSwapChain::setFrameScheduledCallback(
+        CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
+    frameScheduled.handler = handler;
     frameScheduled.callback = std::make_shared<FrameScheduledCallback>(std::move(callback));
+    frameScheduled.flags = flags;
 }
 
 void MetalSwapChain::setFrameCompletedCallback(
@@ -262,10 +265,10 @@ public:
     PresentDrawableData& operator=(const PresentDrawableData&) = delete;
 
     static PresentDrawableData* create(id<CAMetalDrawable> drawable,
-            std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver) {
+            std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver, uint64_t flags) {
         assert_invariant(drawableMutex);
         assert_invariant(driver);
-        return new PresentDrawableData(drawable, drawableMutex, driver);
+        return new PresentDrawableData(drawable, drawableMutex, driver, flags);
     }
 
     static void maybePresentAndDestroyAsync(PresentDrawableData* that, bool shouldPresent) {
@@ -273,13 +276,23 @@ public:
            [that->mDrawable present];
         }
 
-        cleanupAndDestroy(that);
+        if (that->mFlags & SwapChain::CALLBACK_DEFAULT_USE_METAL_COMPLETION_HANDLER) {
+            cleanupAndDestroy(that);
+        } else {
+            // mDrawable is acquired on the driver thread. Typically, we would release this object
+            // on the same thread, but after receiving consistent crash reports from within
+            // [CAMetalDrawable dealloc], we suspect this object requires releasing on the main
+            // thread.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                cleanupAndDestroy(that);
+            });
+        }
     }
 
 private:
     PresentDrawableData(id<CAMetalDrawable> drawable, std::shared_ptr<std::mutex> drawableMutex,
-            MetalDriver* driver)
-        : mDrawable(drawable), mDrawableMutex(drawableMutex), mDriver(driver) {}
+            MetalDriver* driver, uint64_t flags)
+        : mDrawable(drawable), mDrawableMutex(drawableMutex), mDriver(driver), mFlags(flags) {}
 
     static void cleanupAndDestroy(PresentDrawableData *that) {
         if (that->mDrawable) {
@@ -294,6 +307,7 @@ private:
     id<CAMetalDrawable> mDrawable;
     std::shared_ptr<std::mutex> mDrawableMutex;
     MetalDriver* mDriver = nullptr;
+    uint64_t mFlags = 0;
 };
 
 void presentDrawable(bool presentFrame, void* user) {
@@ -310,22 +324,35 @@ void MetalSwapChain::scheduleFrameScheduledCallback() {
 
     struct Callback {
         Callback(std::shared_ptr<FrameScheduledCallback> callback, id<CAMetalDrawable> drawable,
-                std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver)
-            : f(callback), data(PresentDrawableData::create(drawable, drawableMutex, driver)) {}
+                 std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver, uint64_t flags)
+            : f(callback), data(PresentDrawableData::create(drawable, drawableMutex, driver, flags)) {}
         std::shared_ptr<FrameScheduledCallback> f;
         // PresentDrawableData* is destroyed by maybePresentAndDestroyAsync() later.
         std::unique_ptr<PresentDrawableData> data;
+        static void func(void* user) {
+            auto* const c = reinterpret_cast<Callback*>(user);
+            PresentDrawableData* presentDrawableData = c->data.release();
+            PresentCallable presentCallable(presentDrawable, presentDrawableData);
+            c->f->operator()(presentCallable);
+            delete c;
+        }
     };
 
     // This callback pointer will be captured by the block. Even if the scheduled handler is never
     // called, the unique_ptr will still ensure we don't leak memory.
+    uint64_t const flags = frameScheduled.flags;
     __block auto callback = std::make_unique<Callback>(
-            frameScheduled.callback, drawable, layerDrawableMutex, context.driver);
+            frameScheduled.callback, drawable, layerDrawableMutex, context.driver, flags);
 
+    backend::CallbackHandler* handler = frameScheduled.handler;
+    MetalDriver* driver = context.driver;
     [getPendingCommandBuffer(&context) addScheduledHandler:^(id<MTLCommandBuffer> cb) {
-        PresentDrawableData* presentDrawableData = callback->data.release();
-        PresentCallable presentCallable(presentDrawable, presentDrawableData);
-        callback->f->operator()(presentCallable);
+        Callback* user = callback.release();
+        if (flags & SwapChain::CALLBACK_DEFAULT_USE_METAL_COMPLETION_HANDLER) {
+            Callback::func(user);
+        } else {
+            driver->scheduleCallback(handler, user, &Callback::func);
+        }
     }];
 }
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -53,8 +53,8 @@ void NoopDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
 }
 
-void NoopDriver::setFrameScheduledCallback(
-        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
+void NoopDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
+        CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
 
 }
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -53,8 +53,8 @@ void NoopDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
 }
 
-void NoopDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
-        CallbackHandler* handler, FrameScheduledCallback&& callback) {
+void NoopDriver::setFrameScheduledCallback(
+        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
 
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3528,8 +3528,8 @@ void OpenGLDriver::beginFrame(
     }
 }
 
-void OpenGLDriver::setFrameScheduledCallback(
-        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
+void OpenGLDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch, CallbackHandler* handler,
+        FrameScheduledCallback&& callback, uint64_t flags) {
     DEBUG_MARKER()
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3528,8 +3528,8 @@ void OpenGLDriver::beginFrame(
     }
 }
 
-void OpenGLDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
-        CallbackHandler* handler, FrameScheduledCallback&& callback) {
+void OpenGLDriver::setFrameScheduledCallback(
+        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
     DEBUG_MARKER()
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -403,8 +403,8 @@ void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
     FVK_SYSTRACE_END();
 }
 
-void VulkanDriver::setFrameScheduledCallback(
-        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
+void VulkanDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch, CallbackHandler* handler,
+        FrameScheduledCallback&& callback, uint64_t flags) {
 }
 
 void VulkanDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -403,8 +403,8 @@ void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
     FVK_SYSTRACE_END();
 }
 
-void VulkanDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
-        CallbackHandler* handler, FrameScheduledCallback&& callback) {
+void VulkanDriver::setFrameScheduledCallback(
+        Handle<HwSwapChain> sch, FrameScheduledCallback&& callback) {
 }
 
 void VulkanDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -32,7 +32,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     Handle<HwRenderTarget> renderTarget = api.createDefaultRenderTarget();
 
     int callbackCountA = 0;
-    api.setFrameScheduledCallback(swapChain, [&callbackCountA](PresentCallable callable) {
+    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
         callable();
         callbackCountA++;
     });
@@ -55,7 +55,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
 
     // Now switch out the callback.
     int callbackCountB = 0;
-    api.setFrameScheduledCallback(swapChain, [&callbackCountB](PresentCallable callable) {
+    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountB](PresentCallable callable) {
         callable();
         callbackCountB++;
     });

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -32,7 +32,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     Handle<HwRenderTarget> renderTarget = api.createDefaultRenderTarget();
 
     int callbackCountA = 0;
-    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
+    api.setFrameScheduledCallback(swapChain, [&callbackCountA](PresentCallable callable) {
         callable();
         callbackCountA++;
     });
@@ -55,7 +55,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
 
     // Now switch out the callback.
     int callbackCountB = 0;
-    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountB](PresentCallable callable) {
+    api.setFrameScheduledCallback(swapChain, [&callbackCountB](PresentCallable callable) {
         callable();
         callbackCountB++;
     });

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -35,7 +35,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
         callable();
         callbackCountA++;
-    });
+    }, 0);
 
     // Render the first frame.
     api.makeCurrent(swapChain, swapChain);
@@ -58,7 +58,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountB](PresentCallable callable) {
         callable();
         callbackCountB++;
-    });
+    }, 0);
 
     // Render one final frame.
     api.makeCurrent(swapChain, swapChain);

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -255,6 +255,19 @@ public:
     void* UTILS_NULLABLE getNativeWindow() const noexcept;
 
     /**
+     * If this flag is passed to setFrameScheduledCallback, then the behavior of the default
+     * CallbackHandler (when nullptr is passed as the handler argument) is altered to call the
+     * callback on the Metal completion handler thread (as opposed to the main Filament thread).
+     * This flag also instructs the Metal backend to release the associated CAMetalDrawable on the
+     * completion handler thread.
+     *
+     * This flag has no effect if a custom CallbackHandler is passed.
+     *
+     * @see setFrameScheduledCallback
+     */
+    static constexpr uint64_t CALLBACK_DEFAULT_USE_METAL_COMPLETION_HANDLER = 1;
+
+    /**
      * FrameScheduledCallback is a callback function that notifies an application when Filament has
      * completed processing a frame and that frame is ready to be scheduled for presentation.
      *
@@ -288,9 +301,6 @@ public:
      * Engine::shutdown. This is necessary to ensure the Filament Engine has had a chance to clean
      * up all memory related to frame presentation.
      *
-     * The FrameScheduledCallback is always called on an arbitrary background thread, never on the
-     * main Filament thread.
-     *
      * @param handler     Handler to dispatch the callback or nullptr for the default handler.
      * @param callback    Callback called when the frame is scheduled.
      *
@@ -300,7 +310,8 @@ public:
      * @see CallbackHandler
      * @see PresentCallable
      */
-    void setFrameScheduledCallback(FrameScheduledCallback&& callback = {});
+    void setFrameScheduledCallback(backend::CallbackHandler* UTILS_NULLABLE handler = nullptr,
+            FrameScheduledCallback&& callback = {}, uint64_t flags = 0);
 
     /**
      * Returns whether or not this SwapChain currently has a FrameScheduledCallback set.

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -288,6 +288,9 @@ public:
      * Engine::shutdown. This is necessary to ensure the Filament Engine has had a chance to clean
      * up all memory related to frame presentation.
      *
+     * The FrameScheduledCallback is always called on an arbitrary background thread, never on the
+     * main Filament thread.
+     *
      * @param handler     Handler to dispatch the callback or nullptr for the default handler.
      * @param callback    Callback called when the frame is scheduled.
      *
@@ -297,8 +300,7 @@ public:
      * @see CallbackHandler
      * @see PresentCallable
      */
-    void setFrameScheduledCallback(backend::CallbackHandler* UTILS_NULLABLE handler = nullptr,
-            FrameScheduledCallback&& callback = {});
+    void setFrameScheduledCallback(FrameScheduledCallback&& callback = {});
 
     /**
      * Returns whether or not this SwapChain currently has a FrameScheduledCallback set.

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -28,8 +28,9 @@ void* SwapChain::getNativeWindow() const noexcept {
     return downcast(this)->getNativeWindow();
 }
 
-void SwapChain::setFrameScheduledCallback(FrameScheduledCallback&& callback) {
-    downcast(this)->setFrameScheduledCallback(std::move(callback));
+void SwapChain::setFrameScheduledCallback(
+        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
+    downcast(this)->setFrameScheduledCallback(handler, std::move(callback), flags);
 }
 
 bool SwapChain::isFrameScheduledCallbackSet() const noexcept {

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -28,9 +28,8 @@ void* SwapChain::getNativeWindow() const noexcept {
     return downcast(this)->getNativeWindow();
 }
 
-void SwapChain::setFrameScheduledCallback(
-        backend::CallbackHandler* handler, FrameScheduledCallback&& callback) {
-    downcast(this)->setFrameScheduledCallback(handler, std::move(callback));
+void SwapChain::setFrameScheduledCallback(FrameScheduledCallback&& callback) {
+    downcast(this)->setFrameScheduledCallback(std::move(callback));
 }
 
 bool SwapChain::isFrameScheduledCallbackSet() const noexcept {

--- a/filament/src/details/SwapChain.cpp
+++ b/filament/src/details/SwapChain.cpp
@@ -69,9 +69,11 @@ void FSwapChain::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroySwapChain(mHwSwapChain);
 }
 
-void FSwapChain::setFrameScheduledCallback(FrameScheduledCallback&& callback) {
+void FSwapChain::setFrameScheduledCallback(
+        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
     mFrameScheduledCallbackIsSet = bool(callback);
-    mEngine.getDriverApi().setFrameScheduledCallback(mHwSwapChain, std::move(callback));
+    mEngine.getDriverApi().setFrameScheduledCallback(
+            mHwSwapChain, handler, std::move(callback), flags);
 }
 
 bool FSwapChain::isFrameScheduledCallbackSet() const noexcept {

--- a/filament/src/details/SwapChain.cpp
+++ b/filament/src/details/SwapChain.cpp
@@ -69,10 +69,9 @@ void FSwapChain::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroySwapChain(mHwSwapChain);
 }
 
-void FSwapChain::setFrameScheduledCallback(
-        backend::CallbackHandler* handler, FrameScheduledCallback&& callback) {
+void FSwapChain::setFrameScheduledCallback(FrameScheduledCallback&& callback) {
     mFrameScheduledCallbackIsSet = bool(callback);
-    mEngine.getDriverApi().setFrameScheduledCallback(mHwSwapChain, handler, std::move(callback));
+    mEngine.getDriverApi().setFrameScheduledCallback(mHwSwapChain, std::move(callback));
 }
 
 bool FSwapChain::isFrameScheduledCallbackSet() const noexcept {

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -78,8 +78,7 @@ public:
       return mHwSwapChain;
     }
 
-    void setFrameScheduledCallback(
-            backend::CallbackHandler* handler, FrameScheduledCallback&& callback);
+    void setFrameScheduledCallback(FrameScheduledCallback&& callback);
 
     bool isFrameScheduledCallbackSet() const noexcept;
 

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -78,7 +78,8 @@ public:
       return mHwSwapChain;
     }
 
-    void setFrameScheduledCallback(FrameScheduledCallback&& callback);
+    void setFrameScheduledCallback(
+            backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags);
 
     bool isFrameScheduledCallbackSet() const noexcept;
 


### PR DESCRIPTION
Two improvements:
1. Call present directly on the metal callback thread.
2. Release the drawable immediately in the callback destructor (don't dispatch to main). We still need the mutex to avoid releasing/requesting drawables at the same time.

BUGS=[367044996]