### PR TITLE
fix fragment/vertex shader descriptor set layout mismatch

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -242,8 +242,8 @@ struct DescriptorSetLayoutBinding {
     DescriptorType type;
     ShaderStageFlags stageFlags;
     descriptor_binding_t binding;
-    DescriptorFlags flags;
-    uint16_t count;
+    DescriptorFlags flags = DescriptorFlags::NONE;
+    uint16_t count = 0;
 };
 
 struct DescriptorSetLayout {

--- a/filament/src/ds/SsrPassDescriptorSet.cpp
+++ b/filament/src/ds/SsrPassDescriptorSet.cpp
@@ -59,7 +59,7 @@ void SsrPassDescriptorSet::setFrameUniforms(TypedUniformBuffer<PerViewUib>& unif
             uniforms.getUboHandle(), 0, uniforms.getSize());
 
     // This is actually not used for the SSR variants, but the descriptor-set layout needs
-    // to have this UBO because the fragment's shader used is the "generic" one. Both Metal
+    // to have this UBO because the fragment shader used is the "generic" one. Both Metal
     // and GL would be okay without this, but Vulkan's validation layer would complain.
     mDescriptorSet.setBuffer(+PerViewBindingPoints::SHADOWS, mShadowUbh, 0, sizeof(ShadowUib));
 

--- a/filament/src/ds/SsrPassDescriptorSet.cpp
+++ b/filament/src/ds/SsrPassDescriptorSet.cpp
@@ -42,16 +42,26 @@ SsrPassDescriptorSet::SsrPassDescriptorSet() noexcept = default;
 void SsrPassDescriptorSet::init(FEngine& engine) noexcept {
     // create the descriptor-set from the layout
     mDescriptorSet = DescriptorSet{ engine.getPerViewDescriptorSetLayoutSsrVariant() };
+
+    // create a dummy Shadow UBO (see comment in setFrameUniforms() below)
+    mShadowUbh = engine.getDriverApi().createBufferObject(sizeof(ShadowUib),
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
 }
 
 void SsrPassDescriptorSet::terminate(DriverApi& driver) {
     mDescriptorSet.terminate(driver);
+    driver.destroyBufferObject(mShadowUbh);
 }
 
 void SsrPassDescriptorSet::setFrameUniforms(TypedUniformBuffer<PerViewUib>& uniforms) noexcept {
     // initialize the descriptor-set
     mDescriptorSet.setBuffer(+PerViewBindingPoints::FRAME_UNIFORMS,
             uniforms.getUboHandle(), 0, uniforms.getSize());
+
+    // This is actually not used for the SSR variants, but the descriptor-set layout needs
+    // to have this UBO because the fragment's shader used is the "generic" one. Both Metal
+    // and GL would be okay without this, but Vulkan's validation layer would complain.
+    mDescriptorSet.setBuffer(+PerViewBindingPoints::SHADOWS, mShadowUbh, 0, sizeof(ShadowUib));
 
     mUniforms = std::addressof(uniforms);
 }

--- a/filament/src/ds/SsrPassDescriptorSet.h
+++ b/filament/src/ds/SsrPassDescriptorSet.h
@@ -66,6 +66,7 @@ public:
 private:
     TypedUniformBuffer<PerViewUib>* mUniforms = nullptr;
     DescriptorSet mDescriptorSet;
+    backend::BufferObjectHandle mShadowUbh;
 };
 
 } // namespace filament

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -45,16 +45,16 @@ enum class DescriptorSetBindingPoints : uint8_t {
 // binding point for the "per-view" descriptor set
 enum class PerViewBindingPoints : uint8_t  {
     FRAME_UNIFORMS  =  0,   // uniforms updated per view
-    LIGHTS          =  1,   // lights data array
-    SHADOWS         =  2,   // punctual shadow data
+    SHADOWS         =  1,   // punctual shadow data
+    LIGHTS          =  2,   // lights data array
     RECORD_BUFFER   =  3,   // froxel record buffer
     FROXEL_BUFFER   =  4,   // froxel buffer
-    SHADOW_MAP      =  5,   // user defined (1024x1024) DEPTH, array
-    IBL_DFG_LUT     =  6,   // user defined (128x128), RGB16F
-    IBL_SPECULAR    =  7,   // user defined, user defined, CUBEMAP
-    SSAO            =  8,   // variable, RGB8 {AO, [depth]}
-    SSR             =  9,   // variable, RGB_11_11_10, mipmapped
-    STRUCTURE       = 10,   // variable, DEPTH
+    STRUCTURE       =  5,   // variable, DEPTH
+    SHADOW_MAP      =  6,   // user defined (1024x1024) DEPTH, array
+    IBL_DFG_LUT     =  7,   // user defined (128x128), RGB16F
+    IBL_SPECULAR    =  8,   // user defined, user defined, CUBEMAP
+    SSAO            =  9,   // variable, RGB8 {AO, [depth]}
+    SSR             = 10,   // variable, RGB_11_11_10, mipmapped
     FOG             = 11    // variable, user defined, CUBEMAP
 };
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -952,7 +952,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 
                 // Write the variant to a file.
                 if (mSaveRawVariants) {
-                    int variantKey = v.variant.key;
+                    int const variantKey = v.variant.key;
                     auto getExtension = [](backend::ShaderStage stage) {
                         switch (stage) {
                             case backend::ShaderStage::VERTEX:

--- a/libs/filamat/src/MaterialVariants.cpp
+++ b/libs/filamat/src/MaterialVariants.cpp
@@ -16,7 +16,24 @@
 
 #include "MaterialVariants.h"
 
+#include "shaders/ShaderGenerator.h"
+
 #include <private/filament/EngineEnums.h>
+#include <private/filament/Variant.h>
+
+#include <backend/DriverEnums.h>
+
+#include <filament/MaterialEnums.h>
+
+#include <utils/compiler.h>
+#include <utils/Panic.h>
+#include <utils/Log.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <stddef.h>
+#include <stdint.h>
 
 namespace filamat {
 
@@ -36,13 +53,65 @@ std::vector<Variant> determineSurfaceVariants(
         filteredVariant = filament::Variant::filterVariant(
                 filteredVariant, isLit || shadowMultiplier);
 
-        if (filament::Variant::filterVariantVertex(filteredVariant) == variant) {
+        auto const vertexVariant = filament::Variant::filterVariantVertex(filteredVariant);
+        if (vertexVariant == variant) {
             variants.emplace_back(variant, filament::backend::ShaderStage::VERTEX);
         }
 
-        if (filament::Variant::filterVariantFragment(filteredVariant) == variant) {
+        auto const fragmentVariant = filament::Variant::filterVariantFragment(filteredVariant);
+        if (fragmentVariant == variant) {
             variants.emplace_back(variant, filament::backend::ShaderStage::FRAGMENT);
         }
+
+        // Here we make sure that the combination of vertex and fragment variants have compatible
+        // PER_VIEW descriptor-set layouts. This could actually be a static/compile-time check
+        // because it is entirely decided in DescriptorSets.cpp. Unfortunately it's not possible
+        // to write this entirely as a constexpr.
+
+        if (UTILS_UNLIKELY(vertexVariant != fragmentVariant)) {
+            // fragment and vertex variants are different, we need to check the layouts are
+            // compatible.
+            using filament::ReflectionMode;
+            using filament::RefractionMode;
+            using filament::backend::ShaderStage;
+
+            // And we need to do that for all configurations of the "PER_VIEW" descriptor set
+            // layouts (there are eight).
+            // See ShaderGenerator::getPerViewDescriptorSetLayoutWithVariant.
+            for (auto reflection: {
+                    ReflectionMode::SCREEN_SPACE,
+                    ReflectionMode::DEFAULT }) {
+                for (auto refraction: {
+                        RefractionMode::SCREEN_SPACE,
+                        RefractionMode::CUBEMAP,
+                        RefractionMode::NONE }) {
+                    auto const vdsl = ShaderGenerator::getPerViewDescriptorSetLayoutWithVariant(
+                            vertexVariant, userVariantFilter, isLit, reflection, refraction);
+                    auto const fdsl = ShaderGenerator::getPerViewDescriptorSetLayoutWithVariant(
+                            fragmentVariant, userVariantFilter, isLit, reflection, refraction);
+                    // Check that all bindings present in the vertex shader DescriptorSetLayout
+                    // are also present in the fragment shader DescriptorSetLayout.
+                    for (auto const& r: vdsl.bindings) {
+                        if (!hasShaderType(r.stageFlags, ShaderStage::VERTEX)) {
+                            // ignore descriptors that are of the fragment stage only
+                            continue;
+                        }
+                        auto const pos = std::find_if(fdsl.bindings.begin(), fdsl.bindings.end(),
+                                [r](auto const& l) {
+                                    return l.count == r.count && l.type == r.type &&
+                                           l.binding == r.binding && l.flags == r.flags &&
+                                           l.stageFlags == r.stageFlags;
+                                });
+
+                        // A mismatch is fatal. The material is ill-formed. This typically
+                        // mean a bug / inconsistency in DescriptorsSets.cpp
+                        FILAMENT_CHECK_POSTCONDITION(pos != fdsl.bindings.end())
+                                << "Variant " << +k << " has mismatched descriptorset layouts";
+                    }
+                }
+            }
+        }
+
     }
     return variants;
 }

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -606,25 +606,6 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     if (featureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
         assert_invariant(mMaterialDomain == MaterialDomain::SURFACE);
 
-        auto getPerViewDescriptorSetLayoutWithVariant = [](
-                filament::Variant variant,
-                UserVariantFilterMask variantFilter,
-                bool isLit,
-                ReflectionMode reflectionMode,
-                RefractionMode refractionMode) -> backend::DescriptorSetLayout {
-
-            if (filament::Variant::isValidDepthVariant(variant)) {
-                return descriptor_sets::getDepthVariantLayout();
-            }
-            if (filament::Variant::isSSRVariant(variant)) {
-                return descriptor_sets::getSsrVariantLayout();
-            }
-            // We need to filter out all the descriptors not included in the "resolved" layout below
-            return descriptor_sets::getPerViewDescriptorSetLayout(
-                    MaterialDomain::SURFACE, variantFilter,
-                    isLit, reflectionMode, refractionMode);
-        };
-
         auto const perViewDescriptorSetLayout = getPerViewDescriptorSetLayoutWithVariant(
                 variant, variantFilter,
                 material.isLit, material.reflectionMode, material.refractionMode);
@@ -855,6 +836,24 @@ bool ShaderGenerator::hasStereo(
             // HACK(exv): Ignore stereo variant when targeting ESSL 1.0. We should properly build a
             // system in matc which allows the set of included variants to differ per-feature level.
             && featureLevel > MaterialBuilder::FeatureLevel::FEATURE_LEVEL_0;
+}
+
+backend::DescriptorSetLayout ShaderGenerator::getPerViewDescriptorSetLayoutWithVariant(
+        filament::Variant variant,
+        UserVariantFilterMask variantFilter,
+        bool isLit,
+        ReflectionMode reflectionMode,
+        RefractionMode refractionMode) {
+    if (filament::Variant::isValidDepthVariant(variant)) {
+        return descriptor_sets::getDepthVariantLayout();
+    }
+    if (filament::Variant::isSSRVariant(variant)) {
+        return descriptor_sets::getSsrVariantLayout();
+    }
+    // We need to filter out all the descriptors not included in the "resolved" layout below
+    return descriptor_sets::getPerViewDescriptorSetLayout(
+            MaterialDomain::SURFACE, variantFilter,
+            isLit, reflectionMode, refractionMode);
 }
 
 } // namespace filament

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -88,6 +88,13 @@ public:
             MaterialBuilder::FeatureLevel featureLevel,
             MaterialInfo const& material) noexcept;
 
+    static filament::backend::DescriptorSetLayout getPerViewDescriptorSetLayoutWithVariant(
+            filament::Variant variant,
+            filament::UserVariantFilterMask variantFilter,
+            bool isLit,
+            filament::ReflectionMode reflectionMode,
+            filament::RefractionMode refractionMode);
+
 private:
     static void generateVertexDomainDefines(utils::io::sstream& out,
             filament::VertexDomain domain) noexcept;


### PR DESCRIPTION
The SSR variant uses a custom fragment shader but the generic vertex shader. For this reason their descriptor set layout for the "per view" set end-up being different (the fragment shader one has less descriptors in it and the descriptor itself is create from the SSR variant data).  In the end, we end up with a descriptor set that's too small for the vertex shader and Metal was rightly complaining.

We fix this by:
- removing the descriptors unused in the vertex shader in the generic case
- adding the remaining descriptors in the SSR version of the layout

In practice this only adds one UBO (for shadows). That UBO is actually not even used in the SSR variants, but the (generic) vertex shader  layout has it, so it must be provided. WE do this by providing a dummy UBO, which will never be used anyways.

In addition, we add a check to matc which will make sure such mismatch won't happen again.