### PR TITLE
github: make windows build use all available cores

### DIFF
--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-android:
-    name: build-android-armv7
+    name: build-android
     # We intentially use a larger runner here to enable larger disk space
     # (standard linux runner will fail on disk space and faster build time).
     runs-on: ubuntu-22.04-32core

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -29,7 +29,7 @@ jobs:
 
   build-windows:
     name: build-windows
-    runs-on: windows-2019-32core
+    runs-on: win-2019-16core
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
           TAG: ${{ steps.git_ref.outputs.tag }}
         run: |
           build\windows\build-github.bat release
+          echo on
           move out\filament-windows.tgz out\filament-%TAG%-windows.tgz
         shell: cmd
       - uses: actions/github-script@v6

--- a/build/windows/build-github.bat
+++ b/build/windows/build-github.bat
@@ -115,17 +115,23 @@ cmake ..\.. ^
     -DFILAMENT_SUPPORTS_VULKAN=ON ^
     || exit /b
 
+set build_flags=-j %NUMBER_OF_PROCESSORS%
+
+@echo on
+
+:: we've upgraded the windows machines, so the following are no longer accurate as of 09/19/24, but
+:: keeping around the comment for record.
+
 :: Attempt to fix "error C1060: compiler is out of heap space" seen on CI.
 :: Some resource libraries require significant heap space to compile, so first compile them serially.
-@echo on
-cmake --build . --target filagui --config %config% || exit /b
-cmake --build . --target uberarchive --config %config% || exit /b
-cmake --build . --target gltf-demo-resources --config %config% || exit /b
-cmake --build . --target filamentapp-resources --config %config% || exit /b
-cmake --build . --target sample-resources --config %config% || exit /b
-cmake --build . --target suzanne-resources --config %config% || exit /b
+:: cmake --build . --target filagui --config %config% %build_flags% || exit /b
+:: cmake --build . --target uberarchive --config %config% %build_flags% || exit /b
+:: cmake --build . --target gltf-demo-resources --config %config% %build_flags% || exit /b
+:: cmake --build . --target filamentapp-resources --config %config% %build_flags% || exit /b
+:: cmake --build . --target sample-resources --config %config% %build_flags% || exit /b
+:: cmake --build . --target suzanne-resources --config %config% %build_flags% || exit /b
 
-cmake --build . %INSTALL% --config %config% -- /m || exit /b
+cmake --build . %INSTALL% --config %config% %build_flags% -- /m || exit /b
 @echo off
 
 echo Disk info after building variant: %variant%


### PR DESCRIPTION
    - Also used a smaller runner as the gains from the 32-core was
      not efficient when comparing output times.
    - Clean-up:
        - Rename the android continuous to a proper name
        - set 'echo on' for the Windows release build so we'll know
          why the output asset does not get "moved" correclty.
