### PR TITLE
better fix for fixing up missing samplers

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -582,7 +582,6 @@ void FEngine::prepare() {
 
     for (auto& materialInstanceList: mMaterialInstances) {
         materialInstanceList.second.forEach([&driver](FMaterialInstance* item) {
-            item->fixMissingSamplers(driver);
             item->commit(driver);
         });
     }

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -33,6 +33,7 @@
 #include <backend/Handle.h>
 
 #include <utils/BitmaskEnum.h>
+#include <utils/bitset.h>
 #include <utils/CString.h>
 
 #include <tsl/robin_map.h>
@@ -208,7 +209,7 @@ public:
     }
 
     // Called by the engine to ensure that unset samplers are initialized with placedholders.
-    void fixMissingSamplers(FEngine::DriverApi& driver) const;
+    void fixMissingSamplers() const;
 
     const char* getName() const noexcept;
 
@@ -279,6 +280,7 @@ private:
     };
 
     utils::CString mName;
+    mutable utils::bitset64 mMissingSamplerDescriptors{};
     mutable std::once_flag mMissingSamplersFlag;
 };
 


### PR DESCRIPTION
the previous fix prevented "commit" to patch the samplers that use a texture with a volatile handle.

the proper fix is to patch them first, and then see if some are still missing, in which case we use a dummy texture.