### PR TITLE
make the default MaterialInstance just a regular one

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -298,8 +298,11 @@ public:
     void createLight(const LightManager::Builder& builder, utils::Entity entity);
 
     FRenderer* createRenderer() noexcept;
+
     FMaterialInstance* createMaterialInstance(const FMaterial* material,
             const FMaterialInstance* other, const char* name) noexcept;
+
+    FMaterialInstance* createMaterialInstance(const FMaterial* material) noexcept;
 
     FScene* createScene() noexcept;
     FView* createView() noexcept;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -127,9 +127,7 @@ public:
         return const_cast<FMaterial*>(this)->getDefaultInstance();
     }
 
-    FMaterialInstance* getDefaultInstance() noexcept {
-        return std::launder(reinterpret_cast<FMaterialInstance*>(&mDefaultInstanceStorage));
-    }
+    FMaterialInstance* getDefaultInstance() noexcept;
 
     FEngine& getEngine() const noexcept  { return mEngine; }
 
@@ -328,8 +326,7 @@ private:
     bool mSpecularAntiAliasing = false;
 
     // reserve some space to construct the default material instance
-    std::aligned_storage<sizeof(FMaterialInstance), alignof(FMaterialInstance)>::type mDefaultInstanceStorage;
-    static_assert(sizeof(mDefaultInstanceStorage) >= sizeof(FMaterialInstance));
+    mutable FMaterialInstance* mDefaultMaterialInstance = nullptr;
 
     SamplerInterfaceBlock mSamplerInterfaceBlock;
     BufferInterfaceBlock mUniformInterfaceBlock;

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -65,6 +65,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material)
           mDepthWrite(false),
           mHasScissor(false),
           mIsDoubleSided(false),
+          mIsDefaultInstance(false),
           mTransparencyMode(TransparencyMode::DEFAULT) {
 
     FEngine::DriverApi& driver = engine.getDriverApi();
@@ -128,6 +129,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
           mDepthWrite(other->mDepthWrite),
           mHasScissor(false),
           mIsDoubleSided(other->mIsDoubleSided),
+          mIsDefaultInstance(false),
           mScissorRect(other->mScissorRect),
           mName(name ? CString(name) : other->mName) {
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -53,6 +53,7 @@ class FTexture;
 
 class FMaterialInstance : public MaterialInstance {
 public:
+    FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept;
     FMaterialInstance(FEngine& engine, FMaterialInstance const* other, const char* name);
     FMaterialInstance(const FMaterialInstance& rhs) = delete;
     FMaterialInstance& operator=(const FMaterialInstance& rhs) = delete;
@@ -208,6 +209,14 @@ public:
         }
     }
 
+    void setDefaultInstance(bool value) noexcept {
+        mIsDefaultInstance = value;
+    }
+
+    bool isDefaultInstance() const noexcept {
+        return mIsDefaultInstance;
+    }
+
     // Called by the engine to ensure that unset samplers are initialized with placedholders.
     void fixMissingSamplers() const;
 
@@ -240,9 +249,6 @@ private:
     template<typename T>
     T getParameterImpl(std::string_view name) const;
 
-    // initialize the default instance
-    FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept;
-
     // keep these grouped, they're accessed together in the render-loop
     FMaterial const* mMaterial = nullptr;
 
@@ -269,6 +275,7 @@ private:
     bool mDepthWrite : 1;
     bool mHasScissor : 1;
     bool mIsDoubleSided : 1;
+    bool mIsDefaultInstance : 1;
     TransparencyMode mTransparencyMode : 2;
 
     uint64_t mMaterialSortingKey = 0;


### PR DESCRIPTION
The default MaterialInstance is not special anymore. It's not even created until getDefaultInstance() is called.
Material just keeps a pointer to it after that and it's tracked by Engine just like any other instance.