### PR TITLE
add a cache for DescriptorSetLayout

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRCS
         src/FrameSkipper.cpp
         src/Froxelizer.cpp
         src/Frustum.cpp
+        src/HwDescriptorSetLayoutFactory.cpp
         src/HwRenderPrimitiveFactory.cpp
         src/HwVertexBufferInfoFactory.cpp
         src/IndexBuffer.cpp
@@ -153,6 +154,7 @@ set(PRIVATE_HDRS
         src/FrameInfo.h
         src/FrameSkipper.h
         src/Froxelizer.h
+        src/HwDescriptorSetLayoutFactory.h
         src/HwRenderPrimitiveFactory.h
         src/HwVertexBufferInfoFactory.h
         src/Intersections.h

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -244,6 +244,15 @@ struct DescriptorSetLayoutBinding {
     descriptor_binding_t binding;
     DescriptorFlags flags = DescriptorFlags::NONE;
     uint16_t count = 0;
+
+    friend inline bool operator==(
+            DescriptorSetLayoutBinding const& lhs,
+            DescriptorSetLayoutBinding const& rhs) noexcept {
+        return lhs.type == rhs.type &&
+               lhs.flags == rhs.flags &&
+               lhs.count == rhs.count &&
+               lhs.stageFlags == rhs.stageFlags;
+    }
 };
 
 struct DescriptorSetLayout {

--- a/filament/src/Bimap.h
+++ b/filament/src/Bimap.h
@@ -56,7 +56,12 @@ class Bimap {
         }
     };
 
-    using ForwardMap = tsl::robin_map<KeyDelegate, Value, KeyHasherDelegate>;
+    using ForwardMap = tsl::robin_map<
+            KeyDelegate, Value,
+            KeyHasherDelegate,
+            std::equal_to<KeyDelegate>,
+            std::allocator<std::pair<KeyDelegate, Value>>,
+            true>;
     using BackwardMap = tsl::robin_map<Value, KeyDelegate, ValueHash>;
 
     Allocator mAllocator;

--- a/filament/src/HwDescriptorSetLayoutFactory.cpp
+++ b/filament/src/HwDescriptorSetLayoutFactory.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HwDescriptorSetLayoutFactory.h"
+
+#include <backend/DriverApiForward.h>
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <private/backend/DriverApi.h>
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Hash.h>
+#include <utils/Log.h>
+
+#include <algorithm>
+#include <utility>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace filament {
+
+using namespace utils;
+using namespace backend;
+
+size_t HwDescriptorSetLayoutFactory::Parameters::hash() const noexcept {
+    return utils::hash::murmurSlow(
+            reinterpret_cast<uint8_t const *>(dsl.bindings.data()),
+            dsl.bindings.size() * sizeof(backend::DescriptorSetLayoutBinding),
+            42);
+}
+
+bool operator==(HwDescriptorSetLayoutFactory::Parameters const& lhs,
+        HwDescriptorSetLayoutFactory::Parameters const& rhs) noexcept {
+    return (lhs.dsl.bindings.size() == rhs.dsl.bindings.size()) &&
+           std::equal(
+                   lhs.dsl.bindings.begin(), lhs.dsl.bindings.end(),
+                   rhs.dsl.bindings.begin());
+}
+
+// ------------------------------------------------------------------------------------------------
+
+HwDescriptorSetLayoutFactory::HwDescriptorSetLayoutFactory()
+        : mArena("HwDescriptorSetLayoutFactory::mArena", SET_ARENA_SIZE),
+          mBimap(mArena) {
+    mBimap.reserve(256);
+}
+
+HwDescriptorSetLayoutFactory::~HwDescriptorSetLayoutFactory() noexcept = default;
+
+void HwDescriptorSetLayoutFactory::terminate(DriverApi&) noexcept {
+    assert_invariant(mBimap.empty());
+}
+
+auto HwDescriptorSetLayoutFactory::create(DriverApi& driver,
+        backend::DescriptorSetLayout dsl) noexcept -> Handle {
+
+    std::sort(dsl.bindings.begin(), dsl.bindings.end(),
+            [](auto&& lhs, auto&& rhs) {
+        return lhs.binding < rhs.binding;
+    });
+
+    // see if we already have seen this RenderPrimitive
+    Key const key({ dsl });
+    auto pos = mBimap.find(key);
+
+    // the common case is that we've never seen it (i.e.: no reuse)
+    if (UTILS_LIKELY(pos == mBimap.end())) {
+        auto handle = driver.createDescriptorSetLayout(std::move(dsl));
+        mBimap.insert(key, { handle });
+        return handle;
+    }
+
+    ++(pos->first.pKey->refs);
+
+    return pos->second.handle;
+}
+
+void HwDescriptorSetLayoutFactory::destroy(DriverApi& driver, Handle handle) noexcept {
+    // look for this handle in our map
+    auto pos = mBimap.find(Value{ handle });
+    if (--pos->second.pKey->refs == 0) {
+        mBimap.erase(pos);
+        driver.destroyDescriptorSetLayout(handle);
+    }
+}
+
+} // namespace filament

--- a/filament/src/HwDescriptorSetLayoutFactory.h
+++ b/filament/src/HwDescriptorSetLayoutFactory.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_HWRENDERPRIMITIVEFACTORY_H
-#define TNT_FILAMENT_HWRENDERPRIMITIVEFACTORY_H
+#ifndef TNT_FILAMENT_HWDESCRIPTORSETLAYOUTFACTORY_H
+#define TNT_FILAMENT_HWDESCRIPTORSETLAYOUTFACTORY_H
 
 #include "Bimap.h"
 
@@ -34,38 +34,33 @@ namespace filament {
 
 class FEngine;
 
-class HwRenderPrimitiveFactory {
+class HwDescriptorSetLayoutFactory {
 public:
-    using Handle = backend::RenderPrimitiveHandle;
+    using Handle = backend::DescriptorSetLayoutHandle;
 
-    HwRenderPrimitiveFactory();
-    ~HwRenderPrimitiveFactory() noexcept;
+    HwDescriptorSetLayoutFactory();
+    ~HwDescriptorSetLayoutFactory() noexcept;
 
-    HwRenderPrimitiveFactory(HwRenderPrimitiveFactory const& rhs) = delete;
-    HwRenderPrimitiveFactory(HwRenderPrimitiveFactory&& rhs) noexcept = delete;
-    HwRenderPrimitiveFactory& operator=(HwRenderPrimitiveFactory const& rhs) = delete;
-    HwRenderPrimitiveFactory& operator=(HwRenderPrimitiveFactory&& rhs) noexcept = delete;
+    HwDescriptorSetLayoutFactory(HwDescriptorSetLayoutFactory const& rhs) = delete;
+    HwDescriptorSetLayoutFactory(HwDescriptorSetLayoutFactory&& rhs) noexcept = delete;
+    HwDescriptorSetLayoutFactory& operator=(HwDescriptorSetLayoutFactory const& rhs) = delete;
+    HwDescriptorSetLayoutFactory& operator=(HwDescriptorSetLayoutFactory&& rhs) noexcept = delete;
 
     void terminate(backend::DriverApi& driver) noexcept;
 
-    struct Parameters { // 12 bytes
-        backend::VertexBufferHandle vbh;            // 4
-        backend::IndexBufferHandle ibh;             // 4
-        backend::PrimitiveType type;                // 4
+    struct Parameters { // 16 bytes + heap allocations
+        backend::DescriptorSetLayout dsl;
         size_t hash() const noexcept;
     };
 
     friend bool operator==(Parameters const& lhs, Parameters const& rhs) noexcept;
 
-    Handle create(backend::DriverApi& driver,
-            backend::VertexBufferHandle vbh,
-            backend::IndexBufferHandle ibh,
-            backend::PrimitiveType type) noexcept;
+    Handle create(backend::DriverApi& driver, backend::DescriptorSetLayout dsl) noexcept;
 
     void destroy(backend::DriverApi& driver, Handle handle) noexcept;
 
 private:
-    struct Key { // 16 bytes
+    struct Key { // 24 bytes
         // The key should not be copyable, unfortunately due to how the Bimap works we have
         // to copy-construct it once.
         Key(Key const&) = default;
@@ -100,8 +95,8 @@ private:
     }
 
     // Size of the arena used for the "set" part of the bimap
-    // about ~65K entry before fall back to heap
-    static constexpr size_t SET_ARENA_SIZE = 1 * 1024 * 1024;
+    // about ~1K entries before fall back to heap
+    static constexpr size_t SET_ARENA_SIZE = 24 * 1024;
 
     // Arena for the set<>, using a pool allocator inside a heap area.
     using PoolAllocatorArena = utils::Arena<
@@ -121,4 +116,4 @@ private:
 
 } // namespace filament
 
-#endif // TNT_FILAMENT_HWRENDERPRIMITIVEFACTORY_H
+#endif // TNT_FILAMENT_HWDESCRIPTORSETLAYOUTFACTORY_H

--- a/filament/src/HwVertexBufferInfoFactory.h
+++ b/filament/src/HwVertexBufferInfoFactory.h
@@ -48,7 +48,7 @@ public:
 
     void terminate(backend::DriverApi& driver) noexcept;
 
-    struct Parameters { // 136 bytes
+    struct Parameters { // 132 bytes
         uint8_t bufferCount;
         uint8_t attributeCount;
         uint8_t padding[2] = {};
@@ -66,7 +66,7 @@ public:
     void destroy(backend::DriverApi& driver, Handle handle) noexcept;
 
 private:
-    struct Key { // 140 bytes
+    struct Key { // 136 bytes
         // The key should not be copyable, unfortunately due to how the Bimap works we have
         // to copy-construct it once.
         Key(Key const&) = default;
@@ -101,7 +101,8 @@ private:
     }
 
     // Size of the arena used for the "set" part of the bimap
-    static constexpr size_t SET_ARENA_SIZE = 4 * 1024 * 1024;
+    // about ~15K entry before fall back to heap
+    static constexpr size_t SET_ARENA_SIZE = 2 * 1024 * 1024;
 
     // Arena for the set<>, using a pool allocator inside a heap area.
     using PoolAllocatorArena = utils::Arena<

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -391,7 +391,7 @@ void PostProcessManager::terminate(DriverApi& driver) noexcept {
         ++first;
     }
 
-    mPostProcessDescriptorSet.terminate(driver);
+    mPostProcessDescriptorSet.terminate(engine.getDescriptorSetLayoutFactory(), driver);
     mSsrPassDescriptorSet.terminate(driver);
 }
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -345,14 +345,17 @@ void FEngine::init() {
 
 
     mPerViewDescriptorSetLayoutSsrVariant = {
+            mHwDescriptorSetLayoutFactory,
             driverApi,
             descriptor_sets::getSsrVariantLayout() };
 
     mPerViewDescriptorSetLayoutDepthVariant = {
+            mHwDescriptorSetLayoutFactory,
             driverApi,
             descriptor_sets::getDepthVariantLayout() };
 
     mPerRenderableDescriptorSetLayout = {
+            mHwDescriptorSetLayoutFactory,
             driverApi,
             descriptor_sets::getPerRenderableLayout() };
 
@@ -483,9 +486,9 @@ void FEngine::shutdown() {
     mLightManager.terminate();              // free-up all lights
     mCameraManager.terminate(*this);        // free-up all cameras
 
-    mPerViewDescriptorSetLayoutDepthVariant.terminate(driver);
-    mPerViewDescriptorSetLayoutSsrVariant.terminate(driver);
-    mPerRenderableDescriptorSetLayout.terminate(driver);
+    mPerViewDescriptorSetLayoutDepthVariant.terminate(mHwDescriptorSetLayoutFactory, driver);
+    mPerViewDescriptorSetLayoutSsrVariant.terminate(mHwDescriptorSetLayoutFactory, driver);
+    mPerRenderableDescriptorSetLayout.terminate(mHwDescriptorSetLayoutFactory, driver);
 
     driver.destroyRenderPrimitive(mFullScreenTriangleRph);
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -23,6 +23,7 @@
 #include "DFG.h"
 #include "PostProcessManager.h"
 #include "ResourceList.h"
+#include "HwDescriptorSetLayoutFactory.h"
 #include "HwVertexBufferInfoFactory.h"
 
 #include "components/CameraManager.h"
@@ -447,6 +448,10 @@ public:
         return mHwVertexBufferInfoFactory;
     }
 
+    HwDescriptorSetLayoutFactory& getDescriptorSetLayoutFactory() noexcept {
+        return mHwDescriptorSetLayoutFactory;
+    }
+
     DescriptorSetLayout const& getPerViewDescriptorSetLayoutDepthVariant() const noexcept {
         return mPerViewDescriptorSetLayoutDepthVariant;
     }
@@ -528,6 +533,7 @@ private:
     FCameraManager mCameraManager;
     std::shared_ptr<ResourceAllocatorDisposer> mResourceAllocatorDisposer;
     HwVertexBufferInfoFactory mHwVertexBufferInfoFactory;
+    HwDescriptorSetLayoutFactory mHwDescriptorSetLayoutFactory;
     DescriptorSetLayout mPerViewDescriptorSetLayoutDepthVariant;
     DescriptorSetLayout mPerViewDescriptorSetLayoutSsrVariant;
     DescriptorSetLayout mPerRenderableDescriptorSetLayout;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -409,8 +409,10 @@ void FMaterial::terminate(FEngine& engine) {
 
     getDefaultInstance()->terminate(engine);
 
-    mPerViewDescriptorSetLayout.terminate(engine.getDriverApi());
-    mDescriptorSetLayout.terminate(engine.getDriverApi());
+    mPerViewDescriptorSetLayout.terminate(
+            engine.getDescriptorSetLayoutFactory(), engine.getDriverApi());
+    mDescriptorSetLayout.terminate(
+            engine.getDescriptorSetLayoutFactory(), engine.getDriverApi());
 }
 
 void FMaterial::compile(CompilerPriorityQueue priority,
@@ -1042,9 +1044,13 @@ void FMaterial::processDescriptorSets(FEngine& engine, MaterialParser const* con
     success = parser->getDescriptorSetLayout(&descriptorSetLayout);
     assert_invariant(success);
 
-    mDescriptorSetLayout = { engine.getDriverApi(), std::move(descriptorSetLayout[0]) };
+    mDescriptorSetLayout = {
+            engine.getDescriptorSetLayoutFactory(),
+            engine.getDriverApi(), std::move(descriptorSetLayout[0]) };
 
-    mPerViewDescriptorSetLayout = { engine.getDriverApi(), std::move(descriptorSetLayout[1]) };
+    mPerViewDescriptorSetLayout = {
+            engine.getDescriptorSetLayoutFactory(),
+            engine.getDriverApi(), std::move(descriptorSetLayout[1]) };
 }
 
 backend::descriptor_binding_t FMaterial::getSamplerBinding(

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -142,7 +142,7 @@ void FView::terminate(FEngine& engine) {
 
     ShadowMapManager::terminate(engine, mShadowMapManager);
     mUniforms.terminate(driver);
-    mColorPassDescriptorSet.terminate(driver);
+    mColorPassDescriptorSet.terminate(engine.getDescriptorSetLayoutFactory(), driver);
     mFroxelizer.terminate(driver);
     mCommonRenderableDescriptorSet.terminate(driver);
 

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -17,6 +17,7 @@
 #include "ColorPassDescriptorSet.h"
 
 #include "Froxelizer.h"
+#include "HwDescriptorSetLayoutFactory.h"
 #include "ShadowMapManager.h"
 #include "TypedUniformBuffer.h"
 
@@ -100,6 +101,7 @@ ColorPassDescriptorSet::ColorPassDescriptorSet(FEngine& engine,
             for (bool const fog: { false, true }) {
                 auto index = ColorPassDescriptorSet::getIndex(lit, ssr, fog);
                 mDescriptorSetLayout[index] = {
+                        engine.getDescriptorSetLayoutFactory(),
                         engine.getDriverApi(),
                         descriptor_sets::getPerViewDescriptorSetLayout(
                                 MaterialDomain::SURFACE,
@@ -137,12 +139,12 @@ void ColorPassDescriptorSet::init(
     }
 }
 
-void ColorPassDescriptorSet::terminate(DriverApi& driver) {
+void ColorPassDescriptorSet::terminate(HwDescriptorSetLayoutFactory& factory, DriverApi& driver) {
     for (auto&& entry : mDescriptorSet) {
         entry.terminate(driver);
     }
     for (auto&& entry : mDescriptorSetLayout) {
-        entry.terminate(driver);
+        entry.terminate(factory, driver);
     }
 }
 

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -43,6 +43,7 @@
 namespace filament {
 
 class DescriptorSetLayout;
+class HwDescriptorSetLayoutFactory;
 
 struct AmbientOcclusionOptions;
 struct DynamicResolutionOptions;
@@ -88,7 +89,7 @@ public:
             backend::BufferObjectHandle recordBuffer,
             backend::BufferObjectHandle froxelBuffer) noexcept;
 
-    void terminate(backend::DriverApi& driver);
+    void terminate(HwDescriptorSetLayoutFactory& factory, backend::DriverApi& driver);
 
     void prepareCamera(FEngine& engine, const CameraInfo& camera) noexcept;
     void prepareLodBias(float bias, math::float2 derivativesScale) noexcept;

--- a/filament/src/ds/DescriptorSetLayout.cpp
+++ b/filament/src/ds/DescriptorSetLayout.cpp
@@ -16,6 +16,8 @@
 
 #include "DescriptorSetLayout.h"
 
+#include "HwDescriptorSetLayoutFactory.h"
+
 #include "details/Engine.h"
 
 #include <backend/DriverEnums.h>
@@ -27,7 +29,9 @@ namespace filament {
 
 DescriptorSetLayout::DescriptorSetLayout() noexcept = default;
 
-DescriptorSetLayout::DescriptorSetLayout(backend::DriverApi& driver,
+DescriptorSetLayout::DescriptorSetLayout(
+        HwDescriptorSetLayoutFactory& factory,
+        backend::DriverApi& driver,
         backend::DescriptorSetLayout descriptorSetLayout) noexcept  {
     for (auto&& desc : descriptorSetLayout.bindings) {
         mMaxDescriptorBinding = std::max(mMaxDescriptorBinding, desc.binding);
@@ -35,13 +39,15 @@ DescriptorSetLayout::DescriptorSetLayout(backend::DriverApi& driver,
         mUniformBuffers.set(desc.binding, desc.type == backend::DescriptorType::UNIFORM_BUFFER);
     }
 
-    mDescriptorSetLayoutHandle = driver.createDescriptorSetLayout(
+    mDescriptorSetLayoutHandle = factory.create(driver,
             std::move(descriptorSetLayout));
 }
 
-void DescriptorSetLayout::terminate(backend::DriverApi& driver) noexcept {
+void DescriptorSetLayout::terminate(
+        HwDescriptorSetLayoutFactory& factory,
+        backend::DriverApi& driver) noexcept {
     if (mDescriptorSetLayoutHandle) {
-        driver.destroyDescriptorSetLayout(mDescriptorSetLayoutHandle);
+        factory.destroy(driver, mDescriptorSetLayoutHandle);
     }
 }
 

--- a/filament/src/ds/DescriptorSetLayout.h
+++ b/filament/src/ds/DescriptorSetLayout.h
@@ -29,10 +29,14 @@
 
 namespace filament {
 
+class HwDescriptorSetLayoutFactory;
+
 class DescriptorSetLayout {
 public:
     DescriptorSetLayout() noexcept;
-    DescriptorSetLayout(backend::DriverApi& driver,
+    DescriptorSetLayout(
+            HwDescriptorSetLayoutFactory& factory,
+            backend::DriverApi& driver,
             backend::DescriptorSetLayout descriptorSetLayout) noexcept;
 
     DescriptorSetLayout(DescriptorSetLayout const&) = delete;
@@ -40,7 +44,9 @@ public:
     DescriptorSetLayout& operator=(DescriptorSetLayout const&) = delete;
     DescriptorSetLayout& operator=(DescriptorSetLayout&& rhs) noexcept;
 
-    void terminate(backend::DriverApi& driver) noexcept;
+    void terminate(
+            HwDescriptorSetLayoutFactory& factory,
+            backend::DriverApi& driver) noexcept;
 
     backend::DescriptorSetLayoutHandle getHandle() const noexcept {
         return mDescriptorSetLayoutHandle;

--- a/filament/src/ds/PostProcessDescriptorSet.cpp
+++ b/filament/src/ds/PostProcessDescriptorSet.cpp
@@ -16,6 +16,7 @@
 
 #include "PostProcessDescriptorSet.h"
 
+#include "HwDescriptorSetLayoutFactory.h"
 #include "TypedUniformBuffer.h"
 
 #include "details/Engine.h"
@@ -37,15 +38,16 @@ void PostProcessDescriptorSet::init(FEngine& engine) noexcept {
 
     // create the descriptor-set layout
     mDescriptorSetLayout = filament::DescriptorSetLayout{
+            engine.getDescriptorSetLayoutFactory(),
             engine.getDriverApi(), descriptor_sets::getPostProcessLayout() };
 
     // create the descriptor-set from the layout
     mDescriptorSet = DescriptorSet{ mDescriptorSetLayout };
 }
 
-void PostProcessDescriptorSet::terminate(DriverApi& driver) {
+void PostProcessDescriptorSet::terminate(HwDescriptorSetLayoutFactory& factory, DriverApi& driver) {
     mDescriptorSet.terminate(driver);
-    mDescriptorSetLayout.terminate(driver);
+    mDescriptorSetLayout.terminate(factory, driver);
 }
 
 void PostProcessDescriptorSet::setFrameUniforms(DriverApi& driver,

--- a/filament/src/ds/PostProcessDescriptorSet.h
+++ b/filament/src/ds/PostProcessDescriptorSet.h
@@ -30,6 +30,7 @@
 namespace filament {
 
 class FEngine;
+class HwDescriptorSetLayoutFactory;
 
 class PostProcessDescriptorSet {
 public:
@@ -37,7 +38,7 @@ public:
 
     void init(FEngine& engine) noexcept;
 
-    void terminate(backend::DriverApi& driver);
+    void terminate(HwDescriptorSetLayoutFactory& factory, backend::DriverApi& driver);
 
     void setFrameUniforms(backend::DriverApi& driver,
             TypedUniformBuffer<PerViewUib>& uniforms) noexcept;


### PR DESCRIPTION
The cache gets a lot of hits for the "per view" descriptor set layout because it is provided by the  material itself but in practice there is just a set of 8 of them.

The "per material" descriptor set layout also get a fair number of hits. Probably because many materials have similar layouts.


This will help the vk backend who needs to keep some state per  descriptor set layout. This should also save a bit memory and could help with state changes.