### PR TITLE
vk: fix scissor logic

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -47,21 +47,6 @@ struct VulkanSamplerGroup;
 constexpr uint8_t MAX_RENDERTARGET_ATTACHMENT_TEXTURES =
         MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT * 2 + 1;
 
-// We need to store information about a render pass to enable better barriers at the end of a
-// renderpass.
-struct RenderPassFboBundle {
-    using AttachmentArray =
-            CappedArray<VulkanAttachment, MAX_RENDERTARGET_ATTACHMENT_TEXTURES>;
-
-    AttachmentArray attachments;
-    bool hasColorResolve = false;
-
-    void clear() {
-        attachments.clear();
-        hasColorResolve = false;
-    }
-};
-
 class VulkanDriver final : public DriverBase {
 public:
     static Driver* create(VulkanPlatform* platform, VulkanContext const& context,
@@ -160,13 +145,20 @@ private:
     VulkanDescriptorSetManager mDescriptorSetManager;
 
     // This is necessary for us to write to push constants after binding a pipeline.
-    struct BoundPipeline {
+    struct {
         VulkanProgram* program;
         VkPipelineLayout pipelineLayout;
         DescriptorSetMask descriptorSetMask;
-    };
-    BoundPipeline mBoundPipeline = {};
-    RenderPassFboBundle mRenderPassFboInfo;
+    } mBoundPipeline = {};
+
+    // We need to store information about a render pass to enable better barriers at the end of a
+    // renderpass.
+    struct {
+        using AttachmentArray = CappedArray<VulkanAttachment, MAX_RENDERTARGET_ATTACHMENT_TEXTURES>;
+        AttachmentArray attachments;
+        bool hasColorResolve = false;
+        bool hasScissorSet = false;
+    } mRenderPassFboInfo = {};
 
     bool const mIsSRGBSwapChainSupported;
     backend::StereoscopicType const mStereoscopicType;


### PR DESCRIPTION
In the previous logic, if bindPipeline() is called after scissor(), then the scissor is overwritten with the extent of the rendertarget.  We only want to call scissor if it hasn't been called before in the same renderpass.

BUG=677841839