### PR TITLE
Fix broken layerCount for some types of textures

### DIFF
--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -30,10 +30,6 @@ namespace filament::backend {
 
 struct TargetBufferInfo {
     // note: the parameters of this constructor are not in the order of this structure's fields
-    TargetBufferInfo(Handle<HwTexture> handle, uint8_t level, uint16_t layer, uint8_t baseViewIndex) noexcept
-        : handle(handle), baseViewIndex(baseViewIndex), level(level), layer(layer) {
-    }
-
     TargetBufferInfo(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
             : handle(handle), level(level), layer(layer) {
     }
@@ -51,14 +47,15 @@ struct TargetBufferInfo {
     // texture to be used as render target
     Handle<HwTexture> handle;
 
-    // Starting layer index for multiview. This value is only used when the `layerCount` for the
-    // render target is greater than 1.
-    uint8_t baseViewIndex = 0;
-
     // level to be used
     uint8_t level = 0;
 
-    // For cubemaps and 3D textures. See TextureCubemapFace for the face->layer mapping
+    // - For cubemap textures, this indicates the face of the cubemap. See TextureCubemapFace for
+    //   the face->layer mapping)
+    // - For 2d array, cubemap array, and 3d textures, this indicates an index of a single layer of
+    //   them.
+    // - For multiview textures (i.e., layerCount for the RenderTarget is greater than 1), this
+    //   indicates a starting layer index of the current 2d array texture for multiview.
     uint16_t layer = 0;
 };
 
@@ -103,7 +100,7 @@ public:
 
     // this is here for backward compatibility
     MRT(Handle<HwTexture> handle, uint8_t level, uint16_t layer) noexcept
-            : mInfos{{ handle, level, layer, 0 }} {
+            : mInfos{{ handle, level, layer }} {
     }
 };
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1213,7 +1213,7 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
                 if (layerCount > 1) {
                     // if layerCount > 1, it means we use the multiview extension.
                     glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, attachment,
-                        t->gl.id, 0, binfo.baseViewIndex, layerCount);
+                        t->gl.id, 0, binfo.layer, layerCount);
                 } else
 #endif // !defined(__EMSCRIPTEN__) && !defined(IOS)
                 {

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -410,7 +410,6 @@ io::ostream& operator<<(io::ostream& out, const RasterState& rs) {
 io::ostream& operator<<(io::ostream& out, const TargetBufferInfo& tbi) {
     return out << "TargetBufferInfo{"
     << "handle=" << tbi.handle
-    << ", baseViewIndex=" << tbi.baseViewIndex
     << ", level=" << tbi.level
     << ", layer=" << tbi.layer << "}";
 }

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -43,7 +43,6 @@ struct VulkanCommandBuffer;
 struct VulkanAttachment {
     VulkanTexture* texture = nullptr;
     uint8_t level = 0;
-    uint8_t baseViewIndex = 0;
     uint8_t layerCount = 1;
     uint16_t layer = 0;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -595,7 +595,6 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             colorTargets[i] = {
                 .texture = mResourceAllocator.handle_cast<VulkanTexture*>(color[i].handle),
                 .level = color[i].level,
-                .baseViewIndex = color[i].baseViewIndex,
                 .layerCount = layerCount,
                 .layer = color[i].layer,
             };
@@ -611,7 +610,6 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         depthStencil[0] = {
             .texture = mResourceAllocator.handle_cast<VulkanTexture*>(depth.handle),
             .level = depth.level,
-            .baseViewIndex = depth.baseViewIndex,
             .layerCount = layerCount,
             .layer = depth.layer,
         };
@@ -625,7 +623,6 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         depthStencil[1] = {
             .texture = mResourceAllocator.handle_cast<VulkanTexture*>(stencil.handle),
             .level = stencil.level,
-            .baseViewIndex = stencil.baseViewIndex,
             .layerCount = layerCount,
             .layer = stencil.layer,
         };

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -147,10 +147,11 @@ public:
          * This requires COLOR and DEPTH attachments (if set) to be of 2D array textures.
          *
          * @param attachment The attachment point.
+         * @param layerCount The number of layers used for multiview, starting from baseLayer.
          * @param baseLayer The starting index of the 2d array texture.
          * @return A reference to this Builder for chaining calls.
          */
-        Builder& multiview(AttachmentPoint attachment, uint8_t baseLayer = 0) noexcept;
+        Builder& multiview(AttachmentPoint attachment, uint8_t layerCount, uint8_t baseLayer = 0) noexcept;
 
         /**
          * Creates the RenderTarget object and returns a pointer to it.

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -118,7 +118,7 @@ public:
         Builder& mipLevel(AttachmentPoint attachment, uint8_t level) noexcept;
 
         /**
-         * Sets the cubemap face for a given attachment point.
+         * Sets the face for cubemap textures at the given attachment point.
          *
          * @param attachment The attachment point.
          * @param face The associated cubemap face.
@@ -127,13 +127,30 @@ public:
         Builder& face(AttachmentPoint attachment, CubemapFace face) noexcept;
 
         /**
-         * Sets the layer for a given attachment point (for 3D textures).
+         * Sets an index of a single layer for 2d array, cubemap array, and 3d textures at the given
+         * attachment point.
+         *
+         * For cubemap array textures, layer is translated into an array index and face according to
+         *  - index: layer / 6
+         *  - face: layer % 6
          *
          * @param attachment The attachment point.
          * @param layer The associated cubemap layer.
          * @return A reference to this Builder for chaining calls.
          */
         Builder& layer(AttachmentPoint attachment, uint32_t layer) noexcept;
+
+        /**
+         * Sets the starting index of the 2d array textures for multiview at the given attachment
+         * point.
+         *
+         * This requires COLOR and DEPTH attachments (if set) to be of 2D array textures.
+         *
+         * @param attachment The attachment point.
+         * @param baseLayer The starting index of the 2d array texture.
+         * @return A reference to this Builder for chaining calls.
+         */
+        Builder& multiview(AttachmentPoint attachment, uint8_t baseLayer = 0) noexcept;
 
         /**
          * Creates the RenderTarget object and returns a pointer to it.

--- a/filament/src/details/RenderTarget.h
+++ b/filament/src/details/RenderTarget.h
@@ -39,6 +39,9 @@ public:
         uint8_t mipLevel = 0;
         CubemapFace face = RenderTarget::CubemapFace::POSITIVE_X;
         uint32_t layer = 0;
+        // Indicates the number of layers used for multiview, starting from the `layer` (baseIndex).
+        // This means `layer` + `layerCount` cannot exceed the number of depth for the attachment.
+        uint16_t layerCount = 0;
     };
 
     FRenderTarget(FEngine& engine, const Builder& builder);

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -224,8 +224,8 @@ int main(int argc, char** argv) {
         app.stereoRenderTarget = RenderTarget::Builder()
                 .texture(RenderTarget::AttachmentPoint::COLOR, app.stereoColorTexture)
                 .texture(RenderTarget::AttachmentPoint::DEPTH, app.stereoDepthTexture)
-                .multiview(RenderTarget::AttachmentPoint::COLOR, 0)
-                .multiview(RenderTarget::AttachmentPoint::DEPTH, 0)
+                .multiview(RenderTarget::AttachmentPoint::COLOR, eyeCount, 0)
+                .multiview(RenderTarget::AttachmentPoint::DEPTH, eyeCount, 0)
                 .build(*engine);
         app.stereoView->setRenderTarget(app.stereoRenderTarget);
         app.stereoView->setViewport({0, 0, vp.width, vp.height});

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -224,6 +224,8 @@ int main(int argc, char** argv) {
         app.stereoRenderTarget = RenderTarget::Builder()
                 .texture(RenderTarget::AttachmentPoint::COLOR, app.stereoColorTexture)
                 .texture(RenderTarget::AttachmentPoint::DEPTH, app.stereoDepthTexture)
+                .multiview(RenderTarget::AttachmentPoint::COLOR, 0)
+                .multiview(RenderTarget::AttachmentPoint::DEPTH, 0)
                 .build(*engine);
         app.stereoView->setRenderTarget(app.stereoRenderTarget);
         app.stereoView->setViewport({0, 0, vp.width, vp.height});


### PR DESCRIPTION
Currently mLayerCount for RenderTarget is always updated to the number of depth for attachments, which incurs unintended behaviors for some types of textures. i.e., 2d array, cubemap array, and 3d textures.

Fix this by updating mLayerCount only for multiview use case.

BUGS=[369165616]