### PR TITLE
vk: fix initial layout logic in renderpass

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1312,7 +1312,6 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 
     // Create the VkRenderPass or fetch it from cache.
     VulkanFboCache::RenderPassKey rpkey = {
-        .initialColorLayoutMask = 0,
         .initialDepthLayout = currentDepthLayout,
         .depthFormat = depth.getFormat(),
         .clear = clearVal,
@@ -1326,7 +1325,6 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         VulkanAttachment const& info = rt->getColor(i);
         if (info.texture) {
             assert_invariant(info.layerCount == renderTargetLayerCount);
-            rpkey.initialColorLayoutMask |= 1 << i;
             rpkey.colorFormat[i] = info.getFormat();
             if (rpkey.samples > 1 && info.texture->samples == 1) {
                 rpkey.needsResolveMask |= (1 << i);
@@ -1358,9 +1356,15 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 
         if (fbkey.samples == 1) {
             auto const& range = attachment.getSubresourceRange();
-            attachment.texture->transitionLayout(&commands,
-                    range, VulkanLayout::COLOR_ATTACHMENT);
+            auto tex = attachment.texture;
+            if (tex->getLayout(range.baseMipLevel, range.baseArrayLayer) !=
+                            VulkanLayout::COLOR_ATTACHMENT &&
+                    !tex->transitionLayout(&commands, range, VulkanLayout::COLOR_ATTACHMENT)) {
+                // If the layout transition did not emit a barrier, we do it manually here.
+                tex->samplerToAttachmentBarrier(&commands, range);
+            }
             renderPassAttachments.insert(attachment);
+
             fbkey.color[i] = attachment.getImageView();
             fbkey.resolve[i] = VK_NULL_HANDLE;
             assert_invariant(fbkey.color[i]);

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -31,7 +31,6 @@ namespace filament::backend {
 
 bool VulkanFboCache::RenderPassEq::operator()(const RenderPassKey& k1,
         const RenderPassKey& k2) const {
-    if (k1.initialColorLayoutMask != k2.initialColorLayoutMask) return false;
     if (k1.initialDepthLayout != k2.initialDepthLayout) return false;
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         if (k1.colorFormat[i] != k2.colorFormat[i]) return false;
@@ -258,9 +257,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .storeOp = kEnableStore,
             .stencilLoadOp = kDontCare,
             .stencilStoreOp = kDisableStore,
-            .initialLayout = ((!discard && config.initialColorLayoutMask & (1 << i)) || clear)
-                                     ? imgutil::getVkLayout(VulkanLayout::COLOR_ATTACHMENT)
-                                     : imgutil::getVkLayout(VulkanLayout::UNDEFINED),
+            .initialLayout = imgutil::getVkLayout(VulkanLayout::COLOR_ATTACHMENT),
             .finalLayout = imgutil::getVkLayout(FINAL_COLOR_ATTACHMENT_LAYOUT),
         };
     }

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -42,19 +42,8 @@ public:
     // RenderPassKey is a small POD representing the immutable state that is used to construct
     // a VkRenderPass. It is hashed and used as a lookup key.
     struct alignas(8) RenderPassKey {
-        // For each target, we need to know three image layouts: the layout BEFORE the pass, the
-        // layout DURING the pass, and the layout AFTER the pass. Here are the rules:
-        // - For depth, we explicitly specify all three layouts.
-        // - Color targets have their initial image layout specified with a bitmask.
-        // - For each color target, the pre-existing layout is either UNDEFINED (0) or GENERAL (1).
-        // - The render pass and final images layout for color buffers is always
-        //   VulkanLayout::COLOR_ATTACHMENT.
-        uint8_t initialColorLayoutMask;
-
-        // Note that if VulkanLayout grows beyond 16, we'd need to up this.
-        VulkanLayout initialDepthLayout : 8;
-        uint8_t padding0;
-        uint8_t padding1;
+        VulkanLayout initialDepthLayout;
+        uint8_t padding[3] = {};
 
         VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
         VkFormat depthFormat; // 4 bytes
@@ -71,7 +60,6 @@ public:
         uint32_t timestamp;
     };
     static_assert(0 == MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT % 8);
-    static_assert(sizeof(RenderPassKey::initialColorLayoutMask) == MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT / 8);
     static_assert(sizeof(TargetBufferFlags) == 4, "TargetBufferFlags has unexpected size.");
     static_assert(sizeof(VkFormat) == 4, "VkFormat has unexpected size.");
     static_assert(sizeof(RenderPassKey) == 56, "RenderPassKey has unexpected size.");

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -17,6 +17,10 @@
 #include "VulkanHandles.h"
 
 #include "VulkanConstants.h"
+
+// TODO: remove this by moving DebugUtils out of VulkanDriver
+#include "VulkanDriver.h"
+
 #include "VulkanMemory.h"
 #include "VulkanResourceAllocator.h"
 #include "VulkanUtility.h"

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -179,6 +179,9 @@ struct VulkanTexture : public HwTexture, VulkanResource {
     void attachmentToSamplerBarrier(VulkanCommandBuffer* commands,
             VkImageSubresourceRange const& range);
 
+    void samplerToAttachmentBarrier(VulkanCommandBuffer* commands,
+            VkImageSubresourceRange const& range);
+
     // Returns the preferred data plane of interest for all image views.
     // For now this always returns either DEPTH or COLOR.
     VkImageAspectFlags getImageAspect() const;


### PR DESCRIPTION
We have a WRITE_AFTER_READ validation when enabling Camera->DoF.

- The old renderpass code assumes that we need to set the initialLayout of a color attachment to UNITIALIZED if it's being discarded. This is no longer true. Before attachment, the image should already be in the proper attachment layout.
- The transition to color attachment layout might not actually emit a barrier. We explicitly emit a barrier for the case of going from sampler to attachment.
- Fix some debug code