### PR TITLE
vk: fix texture swizzle

### DIFF
--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -88,12 +88,28 @@ VkComponentMapping composeSwizzle(VkComponentMapping const& prev, VkComponentMap
         return out;
     };
 
+    auto const identityToChannel = [](VkComponentSwizzle val, uint8_t channelIndex) {
+        if (val != VK_COMPONENT_SWIZZLE_IDENTITY) {
+            return val;
+        }
+        return IDENTITY[channelIndex];
+    };
+
+    // We make sure all all identities are mapped into respective channels so that actual channel
+    // mapping will be passed onto the output.
+    VkComponentMapping const prevExplicit = {
+            identityToChannel(prev.r, 0),
+            identityToChannel(prev.g, 1),
+            identityToChannel(prev.b, 2),
+            identityToChannel(prev.a, 3),
+    };
+
     // Note that the channel index corresponds to the VkComponentMapping struct layout.
     return {
-        compose(next.r, prev, 0),
-        compose(next.g, prev, 1),
-        compose(next.b, prev, 2),
-        compose(next.a, prev, 3),
+        compose(next.r, prevExplicit, 0),
+        compose(next.g, prevExplicit, 1),
+        compose(next.b, prevExplicit, 2),
+        compose(next.a, prevExplicit, 3),
     };
 }
 


### PR DESCRIPTION
There is a bug in the swizzle composition so that given swizzle mapping

A = [I I I I]
B = [R R 0 0]

and compute B(A) (that is, B composed with A) will yield [I I 0 0]. This is incorrect.  We should expect the result to be [I R 0 0].

This change transforms A to [R G B A] and then carry out the original composition code, which will yield the correct result.