### PR TITLE
make scissor() work the same way on all backends

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2909,6 +2909,9 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     GLuint const fbo = gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
     CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 
+    // each render-pass starts with a disabled scissor
+    gl.disable(GL_SCISSOR_TEST);
+
     if (gl.ext.EXT_discard_framebuffer
             && !gl.bugs.disable_invalidate_framebuffer) {
         AttachmentArray attachments; // NOLINT
@@ -2921,7 +2924,6 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         // It's important to clear the framebuffer before drawing, as it resets
         // the fb to a known state (resets fb compression and possibly other things).
         // So we use glClear instead of glInvalidateFramebuffer
-        gl.disable(GL_SCISSOR_TEST);
         clearWithRasterPipe(discardFlags & ~clearFlags, { 0.0f }, 0.0f, 0);
     }
 
@@ -2937,7 +2939,6 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     }
 
     if (any(clearFlags)) {
-        gl.disable(GL_SCISSOR_TEST);
         clearWithRasterPipe(clearFlags,
                 params.clearColor, (GLfloat)params.clearDepth, (GLint)params.clearStencil);
     }
@@ -2956,7 +2957,6 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
 
 #ifndef NDEBUG
     // clear the discarded (but not the cleared ones) buffers in debug builds
-    gl.disable(GL_SCISSOR_TEST);
     clearWithRasterPipe(discardFlags & ~clearFlags,
             { 1, 0, 0, 1 }, 1.0, 0);
 #endif

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -157,7 +157,6 @@ private:
         using AttachmentArray = CappedArray<VulkanAttachment, MAX_RENDERTARGET_ATTACHMENT_TEXTURES>;
         AttachmentArray attachments;
         bool hasColorResolve = false;
-        bool hasScissorSet = false;
     } mRenderPassFboInfo = {};
 
     bool const mIsSRGBSwapChainSupported;


### PR DESCRIPTION
scissor() works like on metal now, that is, it is disabled when a render pass starts.

The GL backend already assumed this in debug mode. We cannot really run into issues at the moment because every time we get a new MaterialInstance we set the scissor -- we do this both for the color pass and the post-process passes. With this change we will be able to skip setting the scissor altogether in a lot of cases.