### PR TITLE
Remove textureUseAfterFreePoolSize and texture use-after-free

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -68,13 +68,6 @@ public:
          */
         size_t handleArenaSize = 0;
 
-        /**
-         * This number of most-recently destroyed textures will be tracked for use-after-free.
-         * Throws an exception when a texture is freed but still bound to a SamplerGroup and used in
-         * a draw call. 0 disables completely. Currently only respected by the Metal backend.
-         */
-        size_t textureUseAfterFreePoolSize = 0;
-
         size_t metalUploadBufferSizeBytes = 512 * 1024;
 
         /**

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -118,9 +118,6 @@ private:
 };
 
 struct MetalContext {
-    explicit MetalContext(size_t metalFreedTextureListSize)
-        : texturesToDestroy(metalFreedTextureListSize) {}
-
     MetalDriver* driver;
     id<MTLDevice> device = nullptr;
     id<MTLCommandQueue> commandQueue = nullptr;
@@ -186,14 +183,6 @@ struct MetalContext {
 
     // Keeps track of all alive textures.
     tsl::robin_set<MetalTexture*> textures;
-
-    // This circular buffer implements delayed destruction for Metal texture handles. It keeps a
-    // handle to a fixed number of the most recently destroyed texture handles. When we're asked to
-    // destroy a texture handle, we free its texture memory, but keep the MetalTexture object alive,
-    // marking it as "terminated". If we later are asked to use that texture, we can check its
-    // terminated status and throw an Objective-C error instead of crashing, which is helpful for
-    // debugging use-after-free issues in release builds.
-    utils::FixedCircularBuffer<Handle<HwTexture>> texturesToDestroy;
 
     MetalBufferPool* bufferPool;
     MetalBumpAllocator* bumpAllocator;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -267,26 +267,6 @@ public:
 
     MTLPixelFormat devicePixelFormat;
 
-    // Frees memory associated with this texture and marks it as "terminated".
-    // Used to track "use after free" scenario.
-    void terminate() noexcept;
-    bool isTerminated() const noexcept { return terminated; }
-    inline void checkUseAfterFree(const char* samplerGroupDebugName, size_t textureIndex) const {
-        if (UTILS_LIKELY(!isTerminated())) {
-            return;
-        }
-        NSString* reason =
-                [NSString stringWithFormat:
-                                  @"Filament Metal texture use after free, sampler group = "
-                                  @"%s, texture index = %zu",
-                          samplerGroupDebugName, textureIndex];
-        NSException* useAfterFreeException =
-                [NSException exceptionWithName:@"MetalTextureUseAfterFree"
-                                        reason:reason
-                                      userInfo:nil];
-        [useAfterFreeException raise];
-    }
-
 private:
     void loadSlice(uint32_t level, MTLRegion region, uint32_t byteOffset, uint32_t slice,
             PixelBufferDescriptor const& data) noexcept;
@@ -303,8 +283,6 @@ private:
     // Filament swizzling only affects texture reads, so this should not be used when the texture is
     // bound as a render target attachment.
     id<MTLTexture> swizzledTextureView = nil;
-
-    bool terminated = false;
 };
 
 class MetalRenderTarget : public HwRenderTarget {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -648,14 +648,6 @@ MetalTexture::MetalTexture(MetalContext& context, TextureFormat format, uint32_t
     texture = externalImage->getMtlTexture();
 }
 
-void MetalTexture::terminate() noexcept {
-    texture = nil;
-    swizzledTextureView = nil;
-    msaaSidecar = nil;
-    externalImage = nullptr;
-    terminated = true;
-}
-
 id<MTLTexture> MetalTexture::getMtlTextureForRead() const noexcept {
     return swizzledTextureView ? swizzledTextureView : texture;
 }

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -288,16 +288,6 @@ public:
          */
         uint32_t jobSystemThreadCount = 0;
 
-        /*
-         * Number of most-recently destroyed textures to track for use-after-free.
-         *
-         * This will cause the backend to throw an exception when a texture is freed but still bound
-         * to a SamplerGroup and used in a draw call. 0 disables completely.
-         *
-         * Currently only respected by the Metal backend.
-         */
-        size_t textureUseAfterFreePoolSize = 0;
-
         /**
          * When uploading vertex or index data, the Filament Metal backend copies data
          * into a shared staging area before transferring it to the GPU. This setting controls

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -103,7 +103,6 @@ Engine* FEngine::create(Engine::Builder const& builder) {
         }
         DriverConfig const driverConfig{
                 .handleArenaSize = instance->getRequestedDriverHandleArenaSize(),
-                .textureUseAfterFreePoolSize = instance->getConfig().textureUseAfterFreePoolSize,
                 .metalUploadBufferSizeBytes = instance->getConfig().metalUploadBufferSizeBytes,
                 .disableParallelShaderCompile = instance->getConfig().disableParallelShaderCompile,
                 .disableHandleUseAfterFreeCheck = instance->getConfig().disableHandleUseAfterFreeCheck,
@@ -701,7 +700,6 @@ int FEngine::loop() {
 
     DriverConfig const driverConfig {
             .handleArenaSize = getRequestedDriverHandleArenaSize(),
-            .textureUseAfterFreePoolSize = mConfig.textureUseAfterFreePoolSize,
             .metalUploadBufferSizeBytes = mConfig.metalUploadBufferSizeBytes,
             .disableParallelShaderCompile = mConfig.disableParallelShaderCompile,
             .disableHandleUseAfterFreeCheck = mConfig.disableHandleUseAfterFreeCheck,


### PR DESCRIPTION
Remove `textureUseAfterFreePoolSize`, we'll switch to a more generic use-after-free detection for "heap" handles.