### PR TITLE
Work around client descriptor set issues

### DIFF
--- a/filament/backend/src/opengl/GLDescriptorSet.h
+++ b/filament/backend/src/opengl/GLDescriptorSet.h
@@ -78,8 +78,12 @@ struct GLDescriptorSet : public HwDescriptorSet {
 private:
     // a Buffer Descriptor such as SSBO or UBO with static offset
     struct Buffer {
-        Buffer() = default;
-        explicit Buffer(GLenum target) noexcept : target(target) { }
+        // Workaround: we cannot define the following as Buffer() = default because one of our
+        // clients has their compiler set up where such declaration (possibly coupled with explicit)
+        // will be considered a deleted constructor.
+        Buffer() {}
+
+        explicit Buffer(GLenum target) noexcept : target(target) {}
         GLenum target;                          // 4
         GLuint id = 0;                          // 4
         uint32_t offset = 0;                    // 4

--- a/filament/src/ds/DescriptorSet.h
+++ b/filament/src/ds/DescriptorSet.h
@@ -103,6 +103,7 @@ private:
     mutable utils::bitset64 mDirty;                         //  8
     mutable utils::bitset64 mValid;                         //  8
     backend::DescriptorSetHandle mDescriptorSetHandle;      //  4
+    mutable bool mSetAfterCommitWarning;                    //  1
 };
 
 } // namespace filament


### PR DESCRIPTION
- We change GLDescriptorSet::Buffer default constructor to workaround a client's compiler set up issue.
- We removed the assert_invariant that checks that ubo/samplers are not changed after committed in DescriptorSet. This caused an existing client's build to crash.