### PR TITLE
Initialize bool in DescriptorSet.h

### DIFF
--- a/filament/src/ds/DescriptorSet.h
+++ b/filament/src/ds/DescriptorSet.h
@@ -103,7 +103,7 @@ private:
     mutable utils::bitset64 mDirty;                         //  8
     mutable utils::bitset64 mValid;                         //  8
     backend::DescriptorSetHandle mDescriptorSetHandle;      //  4
-    mutable bool mSetAfterCommitWarning;                    //  1
+    mutable bool mSetAfterCommitWarning = false;            //  1
 };
 
 } // namespace filament


### PR DESCRIPTION
This class has a ( = default) constructor and hence should have explicit initialization in its definition.