### PR TITLE
Fix inconsistency between jumpToBookmark and getCurrentBookmark in FreeFlightManipulator

### DIFF
--- a/libs/camutils/src/FreeFlightManipulator.h
+++ b/libs/camutils/src/FreeFlightManipulator.h
@@ -226,6 +226,8 @@ public:
 
     void jumpToBookmark(const Bookmark& bookmark) override {
         Base::mEye = bookmark.flight.position;
+        mTargetEuler.x = bookmark.flight.pitch;
+        mTargetEuler.y = bookmark.flight.yaw;
         updateTarget(bookmark.flight.pitch, bookmark.flight.yaw);
     }
 


### PR DESCRIPTION
This PR addresses an issue in the FreeFlightManipulator class where getCurrentBookmark did not accurately reflect the camera state after calling jumpToBookmark. The fix updates the mTargetEuler values in jumpToBookmark to ensure consistency with getCurrentBookmark.

Changes:
- Modified jumpToBookmark in FreeFlightManipulator to update mTargetEuler.x and mTargetEuler.y
- This ensures that subsequent calls to getCurrentBookmark will return the correct pitch and yaw values
- Resolves the issue of incorrect bookmark state after jumping to a bookmark