### PR TITLE
workaround Mesa glDeleteBuffers() bug

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -190,7 +190,7 @@ public:
     inline void viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void depthRange(GLclampf near, GLclampf far) noexcept;
 
-    void deleteBuffers(GLsizei n, const GLuint* buffers, GLenum target) noexcept;
+    void deleteBuffer(GLuint buffer, GLenum target) noexcept;
     void deleteVertexArray(GLuint vao) noexcept;
 
     void destroyWithContext(size_t index, std::function<void(OpenGLContext&)> const& closure) noexcept;
@@ -316,9 +316,14 @@ public:
         // a glFinish. So we must delay the destruction until we know the GPU is finished.
         bool delay_fbo_destruction;
 
+        // Mesa sometimes clears the generic buffer binding when *another* buffer is destroyed,
+        // if that other buffer is bound on an *indexed* buffer binding.
+        bool rebind_buffer_after_deletion;
+
         // Force feature level 0. Typically used for low end ES3 devices with significant driver
         // bugs or performance issues.
         bool force_feature_level0;
+
 
     } bugs = {};
 
@@ -553,6 +558,9 @@ private:
                     ""},
             {   bugs.delay_fbo_destruction,
                     "delay_fbo_destruction",
+                    ""},
+            {   bugs.rebind_buffer_after_deletion,
+                    "rebind_buffer_after_deletion",
                     ""},
             {   bugs.force_feature_level0,
                     "force_feature_level0",

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1732,7 +1732,7 @@ void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         auto& gl = mContext;
         GLIndexBuffer const* ib = handle_cast<const GLIndexBuffer*>(ibh);
-        gl.deleteBuffers(1, &ib->gl.buffer, GL_ELEMENT_ARRAY_BUFFER);
+        gl.deleteBuffer(ib->gl.buffer, GL_ELEMENT_ARRAY_BUFFER);
         destruct(ibh, ib);
     }
 }
@@ -1745,7 +1745,7 @@ void OpenGLDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
         if (UTILS_UNLIKELY(bo->bindingType == BufferObjectBinding::UNIFORM && gl.isES2())) {
             free(bo->gl.buffer);
         } else {
-            gl.deleteBuffers(1, &bo->gl.id, bo->gl.binding);
+            gl.deleteBuffer(bo->gl.id, bo->gl.binding);
         }
         destruct(boh, bo);
     }


### PR DESCRIPTION
Mesa always clears the generic binding if the buffer deleted is bound to an indexed binding, even if it's not bound to the generic binding.

BUGS=[371324321]