### PR TITLE
Update hardware Handle

### DIFF
--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -108,7 +108,9 @@ struct Handle : public HandleBase {
     Handle(Handle&& rhs) noexcept = default;
 
     // Explicitly redefine copy/move assignment operators rather than just using default here.
-    // Because it doesn't make a call to the parent's method automatically in certain compilers.
+    // Because it doesn't make a call to the parent's method automatically during the std::move
+    // function call(https://en.cppreference.com/w/cpp/algorithm/move) in certain compilers like
+    // NDK 25.1.8937393 and below (see b/371980551)
     Handle& operator=(Handle const& rhs) noexcept {
         HandleBase::operator=(rhs);
         return *this;

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -106,8 +106,16 @@ struct Handle : public HandleBase {
     Handle(Handle const& rhs) noexcept = default;
     Handle(Handle&& rhs) noexcept = default;
 
-    Handle& operator=(Handle const& rhs) noexcept = default;
-    Handle& operator=(Handle&& rhs) noexcept = default;
+    // Explicitly redefine copy/move assignment operators rather than just using default here.
+    // Because it doesn't make a call to the parent's method automatically in certain compilers.
+    Handle& operator=(Handle const& rhs) noexcept {
+        HandleBase::operator=(rhs);
+        return *this;
+    }
+    Handle& operator=(Handle&& rhs) noexcept {
+        HandleBase::operator=(std::move(rhs));
+        return *this;
+    }
 
     explicit Handle(HandleId id) noexcept : HandleBase(id) { }
 

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -23,6 +23,7 @@
 #include <utils/debug.h>
 
 #include <type_traits> // FIXME: STL headers are not allowed in public headers
+#include <utility>
 
 #include <stdint.h>
 


### PR DESCRIPTION
In certain compilers, the assignment operators defined as default
doesn't automatically make a call to the parent's method if it's
user-defined.

Make this behavior explicit to avoid this edge case.

BUGS=[371980551]
