### PR TITLE
Pick transparent renderables

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -823,7 +823,8 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
 
                 // FIXME: should writeDepthForShadowCasters take precedence over mi->getDepthWrite()?
                 cmd.info.rasterState.depthWrite = (1 // only keep bit 0
-                        & (mi->isDepthWriteEnabled() | (mode == TransparencyMode::TWO_PASSES_ONE_SIDE))
+                        & (mi->isDepthWriteEnabled() | (mode == TransparencyMode::TWO_PASSES_ONE_SIDE)
+                                                     | Variant::isPickingVariant(variant))
                                                    & !(filterTranslucentObjects & translucent)
                                                    & !(depthFilterAlphaMaskedObjects & rs.alphaToCoverage))
                                                   | writeDepthForShadowCasters;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -817,6 +817,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
                 const BlendingMode blendingMode = ma->getBlendingMode();
                 const bool translucent = (blendingMode != BlendingMode::OPAQUE
                         && blendingMode != BlendingMode::MASKED);
+                const bool isPickingVariant = Variant::isPickingVariant(variant);
 
                 cmd.key |= mi->getSortingKey(); // already all set-up for direct or'ing
                 cmd.info.rasterState.culling = mi->getCullingMode();
@@ -824,7 +825,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(RenderPass::CommandTypeFla
                 // FIXME: should writeDepthForShadowCasters take precedence over mi->getDepthWrite()?
                 cmd.info.rasterState.depthWrite = (1 // only keep bit 0
                         & (mi->isDepthWriteEnabled() | (mode == TransparencyMode::TWO_PASSES_ONE_SIDE)
-                                                     | Variant::isPickingVariant(variant))
+                                                     | isPickingVariant)
                                                    & !(filterTranslucentObjects & translucent)
                                                    & !(depthFilterAlphaMaskedObjects & rs.alphaToCoverage))
                                                   | writeDepthForShadowCasters;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -971,7 +971,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
             .picking = view.hasPicking() && !view.isTransparentPickable()
     });
     auto picking = picking_;
-    
+
     if (view.hasPicking()) {
         if (view.isTransparentPickable()) {
             struct PickingRenderPassData {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -534,7 +534,7 @@ private:
     Viewport mViewport;
     bool mCulling = true;
     bool mFrontFaceWindingInverted = false;
-    bool mIsTransparentPickable = true;
+    bool mIsTransparentPickable = false;
 
     FRenderTarget* mRenderTarget = nullptr;
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -133,6 +133,9 @@ public:
     void setFrontFaceWindingInverted(bool inverted) noexcept { mFrontFaceWindingInverted = inverted; }
     bool isFrontFaceWindingInverted() const noexcept { return mFrontFaceWindingInverted; }
 
+    void setIsTransparentPickable(bool pickable) noexcept { mIsTransparentPickable = pickable; }
+    bool isTransparentPickable() const noexcept { return mIsTransparentPickable; }
+
 
     void setVisibleLayers(uint8_t select, uint8_t values) noexcept;
     uint8_t getVisibleLayers() const noexcept {
@@ -531,6 +534,7 @@ private:
     Viewport mViewport;
     bool mCulling = true;
     bool mFrontFaceWindingInverted = false;
+    bool mIsTransparentPickable = true;
 
     FRenderTarget* mRenderTarget = nullptr;
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -133,8 +133,8 @@ public:
     void setFrontFaceWindingInverted(bool inverted) noexcept { mFrontFaceWindingInverted = inverted; }
     bool isFrontFaceWindingInverted() const noexcept { return mFrontFaceWindingInverted; }
 
-    void setIsTransparentPickable(bool pickable) noexcept { mIsTransparentPickable = pickable; }
-    bool isTransparentPickable() const noexcept { return mIsTransparentPickable; }
+    void setTransparentPickingEnabled(bool enabled) noexcept { mIsTransparentPickingEnabled = enabled; }
+    bool isTransparentPickingEnabled() const noexcept { return mIsTransparentPickingEnabled; }
 
 
     void setVisibleLayers(uint8_t select, uint8_t values) noexcept;
@@ -534,7 +534,7 @@ private:
     Viewport mViewport;
     bool mCulling = true;
     bool mFrontFaceWindingInverted = false;
-    bool mIsTransparentPickable = false;
+    bool mIsTransparentPickingEnabled = true;
 
     FRenderTarget* mRenderTarget = nullptr;
 


### PR DESCRIPTION
Based on #6633 by @grassydragon, I continue to finish the requirements by @pixelflinger:

> This is what I would like to see:
> 
> * have an option to include or not the transparents. I think there is value to not include the transparents in picking.
> * reuse the structure pass in the case transparents are not included (each extra pass costs about the same as a shadow pass, it's not insignificant). Thanks to the framegraph design this can be done pretty easily: keep the old code, keep the new code and just select which "picking" resource you want to use based on wether transparents should be included -- the framegraph will take care of removing the pass that's not needed.

Here's what I did: 
- Add a boolean in `FView` to select whether to pick transparent entities
- Use structure pass when the boolean is false, otherwise use a separate `Picking Render Pass`

Related issue: https://github.com/google/filament/issues/6614