### PR TITLE
Revert "Release Filament 1.55.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.android.filament:filament-android:1.55.0'
+    implementation 'com.google.android.filament:filament-android:1.54.5'
 }
 ```
 
@@ -51,7 +51,7 @@ Here are all the libraries available in the group `com.google.android.filament`:
 iOS projects can use CocoaPods to install the latest release:
 
 ```shell
-pod 'Filament', '~> 1.55.0'
+pod 'Filament', '~> 1.54.5'
 ```
 
 ## Documentation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,9 +7,6 @@ A new header is inserted each time a *tag* is created.
 Instead, if you are authoring a PR for the main branch, add your release note to
 [NEW_RELEASE_NOTES.md](./NEW_RELEASE_NOTES.md).
 
-## v1.55.1
-
-
 ## v1.55.0
 - Add descriptor sets to describe shader resources. [⚠️ **New Material Version**]
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.google.android.filament
-VERSION_NAME=1.55.0
+VERSION_NAME=1.54.5
 
 POM_DESCRIPTION=Real-time physically based rendering engine for Android.
 

--- a/ios/CocoaPods/Filament.podspec
+++ b/ios/CocoaPods/Filament.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = "Filament"
-  spec.version = "1.55.0"
+  spec.version = "1.54.5"
   spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
   spec.homepage = "https://google.github.io/filament"
   spec.authors = "Google LLC."
   spec.summary = "Filament is a real-time physically based rendering engine for Android, iOS, Windows, Linux, macOS, and WASM/WebGL."
   spec.platform = :ios, "11.0"
-  spec.source = { :http => "https://github.com/google/filament/releases/download/v1.55.0/filament-v1.55.0-ios.tgz" }
+  spec.source = { :http => "https://github.com/google/filament/releases/download/v1.54.5/filament-v1.54.5-ios.tgz" }
 
   # Fix linking error with Xcode 12; we do not yet support the simulator on Apple silicon.
   spec.pod_target_xcconfig = {

--- a/web/filament-js/package.json
+++ b/web/filament-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament",
-  "version": "1.55.0",
+  "version": "1.54.5",
   "description": "Real-time physically based rendering engine",
   "main": "filament.js",
   "module": "filament.js",


### PR DESCRIPTION
This reverts commit 4f5369cefa6858e6445281ea3850a6676ddfaa4e.

Reason: Initial attempt to release 1.55.0 failed due to a few
   small bugs.