### PR TITLE
vk: remove history from DescriptorSetManager

### DIFF
--- a/filament/backend/src/vulkan/caching/VulkanDescriptorSetManager.h
+++ b/filament/backend/src/vulkan/caching/VulkanDescriptorSetManager.h
@@ -74,43 +74,26 @@ public:
     void initVkLayout(VulkanDescriptorSetLayout* layout);
 
 private:
-    class DescriptorSetHistory;
     class DescriptorSetLayoutManager;
     class DescriptorInfinitePool;
 
     void eraseSetFromHistory(VulkanDescriptorSet* set);
 
-    using DescriptorSetHistoryArray =
-            std::array<DescriptorSetHistory*, UNIQUE_DESCRIPTOR_SET_COUNT>;
-
-    struct BoundInfo {
-        VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-        DescriptorSetMask setMask;
-        DescriptorSetHistoryArray boundSets;
-
-        bool operator==(BoundInfo const& info) const {
-            if (pipelineLayout != info.pipelineLayout || setMask != info.setMask) {
-                return false;
-            }
-            bool equal = true;
-            setMask.forEachSetBit([&](size_t i) {
-                if (boundSets[i] != info.boundSets[i]) {
-                    equal = false;
-                }
-            });
-            return equal;
-        }
-    };
+    using DescriptorSetArray =
+            std::array<VulkanDescriptorSet*, UNIQUE_DESCRIPTOR_SET_COUNT>;
 
     VkDevice mDevice;
     VulkanResourceAllocator* mResourceAllocator;
     std::unique_ptr<DescriptorSetLayoutManager> mLayoutManager;
     std::unique_ptr<DescriptorInfinitePool> mDescriptorPool;
     std::pair<VulkanAttachment, VkDescriptorImageInfo> mInputAttachment;
-    std::unordered_map<VulkanDescriptorSet*, std::unique_ptr<DescriptorSetHistory>> mHistory;
-    DescriptorSetHistoryArray mStashedSets = {};
+    DescriptorSetArray mStashedSets = {};
 
-    BoundInfo mLastBoundInfo;
+    struct {
+        VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+        DescriptorSetMask setMask;
+        DescriptorSetArray boundSets;
+    } mLastBoundInfo;
 };
 
 }// namespace filament::backend


### PR DESCRIPTION
"history" is a map from a DescriptorSet pointer to a set of bookkeeping values (we delay "binding" until "commit" so need to keep values until then). Instead of using a map, we can store these values in the DescriptorSet itself so that we save on a map look-up.