### PR TITLE
Add support for compiling under c++20 on clang-based compilers.

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -607,6 +607,13 @@ else()
             -Wover-aligned
             -Werror
     )
+    if (CMAKE_CXX_STANDARD EQUAL 20)
+        # The lambdas for passes in PostProcessManager.cpp capture this
+        # implicitly in a way that's deprecated in c++20, but can't easily be
+        # fixed in a way that's backwards compatible with c++17:
+        # https://www.nextptr.com/tutorial/ta1430524603/capture-this-in-lambda-expression-timeline-of-change
+        list(APPEND FILAMENT_WARNINGS -Wno-deprecated-this-capture)
+    endif()
 endif()
 
 target_compile_options(${TARGET} PRIVATE

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -197,6 +197,11 @@ if (WEBGL_PTHREADS)
 endif()
 
 set(GLTFIO_WARNINGS -Wall -Werror)
+if (CMAKE_CXX_STANDARD EQUAL 20)
+    # The following things used by AssetLoader.cpp are deprecated in c++20:
+    # wstring_convert and std::codecvt_utf8<char32_t>.
+    list(APPEND GLTFIO_WARNINGS -Wno-deprecated-declarations)
+endif()
 if (NOT MSVC)
     target_compile_options(gltfio_core PRIVATE ${GLTFIO_WARNINGS})
 endif()


### PR DESCRIPTION
The warnings that this change ignores are tricky to fix in the code in a way that is backwards compatible with c++17, but it is possible to do and it would allow these warnings to be reinstated. But for now it seems reasonable to just ignore the warnings if building under c++20, since it compiles and works just fine.

This is useful, for example, if Filament is being used as a CMake submodule inside a project that compiles under c++20.