### PR TITLE
Add a warning for FRenderableManager

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -807,11 +807,10 @@ void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
             primitives[primitiveIndex].setMaterialInstance(mi);
             AttributeBitset const required = material->getRequiredAttributes();
             AttributeBitset const declared = primitives[primitiveIndex].getEnabledAttributes();
-            if (!primitives[primitiveIndex].getHwHandle()) {
-                slog.w << "[instance=" << instance.asValue() << ", primitive @ " << primitiveIndex
-                       << "] render primitive doesn't exist for material \""
-                       << material->getName().c_str_safe() << "\"" << io::endl;
-            } else if (UTILS_UNLIKELY((declared & required) != required)) {
+            // Print the warning only when the handle is available. Otherwise this may end up
+            // emitting many invalid warnings as the `declared` bitset is not populated yet.
+            bool const isPrimitiveInitialized = !!primitives[primitiveIndex].getHwHandle();
+            if (UTILS_UNLIKELY(isPrimitiveInitialized && (declared & required) != required)) {
                 slog.w << "[instance=" << instance.asValue() << ", primitive @ " << primitiveIndex
                        << "] missing required attributes ("
                        << required << "), declared=" << declared << io::endl;

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -807,7 +807,11 @@ void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
             primitives[primitiveIndex].setMaterialInstance(mi);
             AttributeBitset const required = material->getRequiredAttributes();
             AttributeBitset const declared = primitives[primitiveIndex].getEnabledAttributes();
-            if (UTILS_UNLIKELY((declared & required) != required)) {
+            if (!primitives[primitiveIndex].getHwHandle()) {
+                slog.w << "[instance=" << instance.asValue() << ", primitive @ " << primitiveIndex
+                       << "] render primitive doesn't exist for material \""
+                       << material->getName().c_str_safe() << "\"" << io::endl;
+            } else if (UTILS_UNLIKELY((declared & required) != required)) {
                 slog.w << "[instance=" << instance.asValue() << ", primitive @ " << primitiveIndex
                        << "] missing required attributes ("
                        << required << "), declared=" << declared << io::endl;


### PR DESCRIPTION
In some cases, users set materials first without providing render primitives, which has incurred the attribute mismatching warning. This isn't helpful because users don't know what action they should take to remove the warning.

Emit the warning only when the primitive handle is initialized so the AttributeBitset is properly populated.

BUGS=[372755205]