### PR TITLE
Fix issue where material instance name cannot be set without creating a default instance

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -827,7 +827,7 @@ FRenderer* FEngine::createRenderer() noexcept {
 
 FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
         const FMaterialInstance* other, const char* name) noexcept {
-        FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, other, name);
+    FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, other, name);
     if (UTILS_UNLIKELY(p)) { // should never happen
         auto pos = mMaterialInstances.emplace(material, "MaterialInstance");
         pos.first->second.insert(p);
@@ -837,8 +837,7 @@ FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
 
 FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
                                                    const char* name) noexcept {
-  FMaterialInstance* p =
-      mHeapAllocator.make<FMaterialInstance>(*this, material, name);
+    FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, material, name);
     if (UTILS_UNLIKELY(p)) { // should never happen
         auto pos = mMaterialInstances.emplace(material, "MaterialInstance");
         pos.first->second.insert(p);

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -827,7 +827,7 @@ FRenderer* FEngine::createRenderer() noexcept {
 
 FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
         const FMaterialInstance* other, const char* name) noexcept {
-    FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, other, name);
+        FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, other, name);
     if (UTILS_UNLIKELY(p)) { // should never happen
         auto pos = mMaterialInstances.emplace(material, "MaterialInstance");
         pos.first->second.insert(p);

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -835,8 +835,10 @@ FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
     return p;
 }
 
-FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material) noexcept {
-    FMaterialInstance* p = mHeapAllocator.make<FMaterialInstance>(*this, material);
+FMaterialInstance* FEngine::createMaterialInstance(const FMaterial* material,
+                                                   const char* name) noexcept {
+  FMaterialInstance* p =
+      mHeapAllocator.make<FMaterialInstance>(*this, material, name);
     if (UTILS_UNLIKELY(p)) { // should never happen
         auto pos = mMaterialInstances.emplace(material, "MaterialInstance");
         pos.first->second.insert(p);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -303,7 +303,8 @@ public:
     FMaterialInstance* createMaterialInstance(const FMaterial* material,
             const FMaterialInstance* other, const char* name) noexcept;
 
-    FMaterialInstance* createMaterialInstance(const FMaterial* material) noexcept;
+    FMaterialInstance* createMaterialInstance(const FMaterial* material,
+                                              const char* name) noexcept;
 
     FScene* createScene() noexcept;
     FView* createView() noexcept;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -462,13 +462,13 @@ FMaterialInstance* FMaterial::createInstance(const char* name) const noexcept {
         return FMaterialInstance::duplicate(mDefaultMaterialInstance, name);
     } else {
         // but if we don't, just create an instance with all the default parameters
-        return mEngine.createMaterialInstance(this);
+        return mEngine.createMaterialInstance(this, name);
     }
 }
 
 FMaterialInstance* FMaterial::getDefaultInstance() noexcept {
     if (UTILS_UNLIKELY(!mDefaultMaterialInstance)) {
-        mDefaultMaterialInstance = mEngine.createMaterialInstance(this);
+        mDefaultMaterialInstance = mEngine.createMaterialInstance(this, mName.c_str());
         mDefaultMaterialInstance->setDefaultInstance(true);
     }
     return mDefaultMaterialInstance;

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -56,7 +56,8 @@ namespace filament {
 
 using namespace backend;
 
-FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept
+FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material,
+                                     const char* name) noexcept
         : mMaterial(material),
           mDescriptorSet(material->getDescriptorSetLayout()),
           mCulling(CullingMode::BACK),
@@ -66,7 +67,8 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material)
           mHasScissor(false),
           mIsDoubleSided(false),
           mIsDefaultInstance(false),
-          mTransparencyMode(TransparencyMode::DEFAULT) {
+          mTransparencyMode(TransparencyMode::DEFAULT),
+          mName(name ? CString(name) : material->getName()) {
 
     FEngine::DriverApi& driver = engine.getDriverApi();
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -54,7 +54,7 @@ class FTexture;
 class FMaterialInstance : public MaterialInstance {
 public:
     FMaterialInstance(FEngine& engine, FMaterial const* material,
-                    const char* name) noexcept;
+                      const char* name) noexcept;
     FMaterialInstance(FEngine& engine, FMaterialInstance const* other, const char* name);
     FMaterialInstance(const FMaterialInstance& rhs) = delete;
     FMaterialInstance& operator=(const FMaterialInstance& rhs) = delete;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -53,7 +53,7 @@ class FTexture;
 
 class FMaterialInstance : public MaterialInstance {
 public:
-  FMaterialInstance(FEngine& engine, FMaterial const* material,
+    FMaterialInstance(FEngine& engine, FMaterial const* material,
                     const char* name) noexcept;
     FMaterialInstance(FEngine& engine, FMaterialInstance const* other, const char* name);
     FMaterialInstance(const FMaterialInstance& rhs) = delete;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -53,7 +53,8 @@ class FTexture;
 
 class FMaterialInstance : public MaterialInstance {
 public:
-    FMaterialInstance(FEngine& engine, FMaterial const* material) noexcept;
+  FMaterialInstance(FEngine& engine, FMaterial const* material,
+                    const char* name) noexcept;
     FMaterialInstance(FEngine& engine, FMaterialInstance const* other, const char* name);
     FMaterialInstance(const FMaterialInstance& rhs) = delete;
     FMaterialInstance& operator=(const FMaterialInstance& rhs) = delete;


### PR DESCRIPTION
This PR is related to [PR #8147](https://github.com/google/filament/pull/8147)

After applying PR #8147, FMaterial::createInstance has an issue where it ignores the name passed as a parameter when mDefaultMaterialInstance is not set.

By applying this PR, a material instance can be assigned a name even if mDefaultMaterialInstance is not set.