### PR TITLE
Fix potential crash when a descriptor set is destroyed but not unbound

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -540,6 +540,8 @@ if (APPLE AND NOT IOS)
 
 add_executable(metal_utils_test test/MetalTest.mm)
 
+target_compile_options(metal_utils_test PRIVATE "-fobjc-arc")
+
 target_link_libraries(metal_utils_test PRIVATE
         backend
         getopt

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -442,7 +442,7 @@ public:
 
 private:
     static_assert(N <= 8);
-    std::array<__unsafe_unretained id<MTLBuffer>, N> mBuffers = { nil };
+    std::array<__weak id<MTLBuffer>, N> mBuffers = { nil };
     std::array<NSUInteger, N> mOffsets = { 0 };
     utils::bitset8 mDirtyBuffers;
     utils::bitset8 mDirtyOffsets;


### PR DESCRIPTION
When a descriptor set is destroyed, its `id<MTLBuffer>`s are still bound within `vertexDescriptorBindings` and `fragmentDescriptorBindings` using `__unsafe_unretained` pointers . This is a problem because those pointers will be garbage after the descriptor set is destroyed. At the next render pass, if a new descriptor set is not bound, we'll attempt to pass the garbage values to `setVertexBuffer:offset:atIndex`.

Consider the following contrived repro case inside of a backend_test:
Some complications: the destruction of a descriptor set is delayed until the current command buffer completes AND the enclosing `@autoreleasepool` is drained. So, we need to insert a `api.finish(0)` and wrap every command around a `mDriver.execute` [inside CommandStream.cpp](https://github.com/google/filament/blob/20cc4a4d5535ef5c6b2ba1a91ac64c62a9a02983/filament/backend/src/CommandStream.cpp#L95-L101).

In production these conditions should be periodically met naturally, leading to spurious crashes.

```
...
api.destroyDescriptorSet(descSet);
api.finish(0);  // this *actually* destroys descSet and all of its id<MTLBuffer>s

api.beginFrame(0, 0, 1);
api.beginRenderPass(defaultRenderTarget, params);   // this attempts to bind a deallocated id<MTLBuffer>
...
```

Instead, by using a `__weak` reference, pointers will be automatically `nil`-ed when a descriptor set is destroyed. It's valid to pass `nil` to `setVertexBuffer:offset:atIndex`.

BUGS=[374286912]