### PR TITLE
Fix a bug in the OpenGL backend that causes win32 errors not to be logged #8214

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -210,7 +210,7 @@ Platform::SwapChain* PlatformWGL::createSwapChain(void* nativeWindow, uint64_t f
     swapChain->hWnd = (HWND) nativeWindow;
     swapChain->hDc = GetDC(swapChain->hWnd);
     if (!swapChain->hDc) {
-          DWORD dwError = GetLastError();
+        DWORD dwError = GetLastError();
         ASSERT_POSTCONDITION_NON_FATAL(swapChain->hDc,
            "Unable to create the SwapChain (nativeWindow = %p)", nativeWindow);
         reportWindowsError(dwError);

--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -19,8 +19,8 @@
 #include <Wingdi.h>
 
 #ifdef _MSC_VER
-    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this), 
-    // and prevents duplicate definition of OpenGL apis when building this file. 
+    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this),
+    // and prevents duplicate definition of OpenGL apis when building this file.
     // However, GL_GLEXT_PROTOTYPES need to be defined in BlueGL.h when included from other files.
     #define FILAMENT_PLATFORM_WGL
 #endif
@@ -37,9 +37,8 @@
 
 namespace {
 
-void reportLastWindowsError() {
+void reportWindowsError(DWORD dwError) {
     LPSTR lpMessageBuffer = nullptr;
-    DWORD dwError = GetLastError();
 
     if (dwError == 0) {
         return;
@@ -80,6 +79,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext,
         const Platform::DriverConfig& driverConfig) noexcept {
     int result = 0;
     int pixelFormat = 0;
+    DWORD dwError = 0;
 
     mPfd = {
         sizeof(PIXELFORMATDESCRIPTOR),
@@ -105,6 +105,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext,
     mHWnd = CreateWindowA("STATIC", "dummy", 0, 0, 0, 1, 1, NULL, NULL, NULL, NULL);
     HDC whdc = mWhdc = GetDC(mHWnd);
     if (whdc == NULL) {
+        dwError = GetLastError();
         utils::slog.e << "CreateWindowA() failed" << utils::io::endl;
         goto error;
     }
@@ -115,6 +116,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext,
     // We need a tmp context to retrieve and call wglCreateContextAttribsARB.
     tempContext = wglCreateContext(whdc);
     if (!wglMakeCurrent(whdc, tempContext)) {
+        dwError = GetLastError();
         utils::slog.e << "wglMakeCurrent() failed, whdc=" << whdc << ", tempContext=" <<
                 tempContext << utils::io::endl;
         goto error;
@@ -136,6 +138,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext,
         if (mContext) {
             break;
         }
+        dwError = GetLastError();
     }
 
     if (!mContext) {
@@ -148,6 +151,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext,
     tempContext = NULL;
 
     if (!wglMakeCurrent(whdc, mContext)) {
+        dwError = GetLastError();
         utils::slog.e << "wglMakeCurrent() failed, whdc=" << whdc << ", mContext=" <<
                 mContext << utils::io::endl;
         goto error;
@@ -162,7 +166,7 @@ error:
     if (tempContext) {
         wglDeleteContext(tempContext);
     }
-    reportLastWindowsError();
+    reportWindowsError(dwError);
     terminate();
     return NULL;
 }
@@ -205,9 +209,11 @@ Platform::SwapChain* PlatformWGL::createSwapChain(void* nativeWindow, uint64_t f
     // on Windows, the nativeWindow maps to a HWND
     swapChain->hWnd = (HWND) nativeWindow;
     swapChain->hDc = GetDC(swapChain->hWnd);
-    if (!ASSERT_POSTCONDITION_NON_FATAL(swapChain->hDc,
-            "Unable to create the SwapChain (nativeWindow = %p)", nativeWindow)) {
-        reportLastWindowsError();
+    if (!swapChain->hDc) {
+          DWORD dwError = GetLastError();
+        ASSERT_POSTCONDITION_NON_FATAL(swapChain->hDc,
+           "Unable to create the SwapChain (nativeWindow = %p)", nativeWindow);
+        reportWindowsError(dwError);
     }
 
 	// We have to match pixel formats across the HDC and HGLRC (mContext)
@@ -264,8 +270,10 @@ bool PlatformWGL::makeCurrent(ContextType type, SwapChain* drawSwapChain,
     HDC hdc = wglSwapChain->hDc;
     if (hdc != NULL) {
         BOOL success = wglMakeCurrent(hdc, mContext);
-        if (!ASSERT_POSTCONDITION_NON_FATAL(success, "wglMakeCurrent() failed. hdc = %p", hdc)) {
-            reportLastWindowsError();
+        if (!success) {
+            DWORD dwError = GetLastError();
+            ASSERT_POSTCONDITION_NON_FATAL(success, "wglMakeCurrent() failed. hdc = %p", hdc);
+            reportWindowsError(dwError);
             wglMakeCurrent(0, NULL);
         }
     }


### PR DESCRIPTION
As you might imagine, I am submitting this change because I'm debugging a bug in the openGL backend, specifically one that causes PlatformWGL::makeCurrent() to fail if the swap chain is removed and created too many times. I hope that I can figure out the issue there, but if someone more familiar with this code could figure it out, that would be really cool... (If anyone is curious, wglMakeCurrent() is returning win32 error code 6.)