### PR TITLE
Trace

### DIFF
--- a/filament/backend/src/SystraceProfile.h
+++ b/filament/backend/src/SystraceProfile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filament/backend/src/SystraceProfile.h
+++ b/filament/backend/src/SystraceProfile.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
+#define TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
+
+#ifdef NDEBUG
+#define ENABLE_BACKEND_PROFILE
+#endif
+
+#if defined(ENABLE_BACKEND_PROFILE)
+#   define PROFILE_SCOPE(marker)   SYSTRACE_NAME(marker)
+#else
+#   define PROFILE_SCOPE(marker)
+#endif
+
+#define PROFILE_BEGINFRAME()    PROFILE_SCOPE("backend::beginFrame")
+#define PROFILE_ENDFRAME()      PROFILE_SCOPE("backend::endFrame")
+
+#endif // TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
+

--- a/filament/backend/src/SystraceProfile.h
+++ b/filament/backend/src/SystraceProfile.h
@@ -17,18 +17,12 @@
 #ifndef TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
 #define TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
 
-#ifdef NDEBUG
-#define ENABLE_BACKEND_PROFILE
-#endif
+#include <utils/Systrace.h>
 
-#if defined(ENABLE_BACKEND_PROFILE)
-#   define PROFILE_SCOPE(marker)   SYSTRACE_NAME(marker)
-#else
-#   define PROFILE_SCOPE(marker)
-#endif
+#define PROFILE_SCOPE(marker)       SYSTRACE_NAME(marker)
 
-#define PROFILE_BEGINFRAME()    PROFILE_SCOPE("backend::beginFrame")
-#define PROFILE_ENDFRAME()      PROFILE_SCOPE("backend::endFrame")
+#define PROFILE_NAME_BEGINFRAME    "backend::beginFrame"
+#define PROFILE_NAME_ENDFRAME      "backend::endFrame"
 
 #endif // TNT_FILAMENT_BACKEND_SYSTRACEPROFILE_H
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -101,7 +101,7 @@
 #define DEBUG_MARKER_ALL              (0xFF & ~DEBUG_MARKER_PROFILE) // all markers
 
 // set to the desired debug marker level (for user markers [default: All])
-#define DEBUG_GROUP_MARKER_LEVEL      DEBUG_GROUP_MARKER_NONE
+#define DEBUG_GROUP_MARKER_LEVEL      DEBUG_GROUP_MARKER_ALL
 
 // set to the desired debug level (for internal debugging [Default: None])
 #define DEBUG_MARKER_LEVEL            DEBUG_MARKER_NONE

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -106,7 +106,8 @@
 
 #if DEBUG_MARKER_LEVEL > DEBUG_MARKER_NONE
 #   define DEBUG_MARKER() \
-        DebugMarker _debug_marker(*this, __func__);
+        const std::string _debug_marker_name = std::string("backend") + __func__; \
+        DebugMarker _debug_marker(*this, _debug_marker_name.c_str());
 #else
 #   define DEBUG_MARKER()
 #endif

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -23,6 +23,7 @@
 #include "OpenGLDriverFactory.h"
 #include "OpenGLProgram.h"
 #include "OpenGLTimerQuery.h"
+#include "SystraceProfile.h"
 #include "gl_headers.h"
 
 #include <backend/platforms/OpenGLPlatform.h>
@@ -3454,6 +3455,7 @@ void OpenGLDriver::beginFrame(
         UTILS_UNUSED int64_t monotonic_clock_ns,
         UTILS_UNUSED int64_t refreshIntervalNs,
         UTILS_UNUSED uint32_t frameId) {
+    PROFILE_BEGINFRAME();
     DEBUG_MARKER()
     auto& gl = mContext;
     insertEventMarker("beginFrame");
@@ -3489,6 +3491,7 @@ void OpenGLDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void OpenGLDriver::endFrame(UTILS_UNUSED uint32_t frameId) {
+    PROFILE_ENDFRAME();
     DEBUG_MARKER()
 #if defined(__EMSCRIPTEN__)
     // WebGL builds are single-threaded so users might manipulate various GL state after we're

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -106,7 +106,7 @@
 
 #if DEBUG_MARKER_LEVEL > DEBUG_MARKER_NONE
 #   define DEBUG_MARKER() \
-        const std::string _debug_marker_name = std::string("backend") + __func__; \
+        const std::string _debug_marker_name = std::string("backend::") + __func__; \
         DebugMarker _debug_marker(*this, _debug_marker_name.c_str());
 #else
 #   define DEBUG_MARKER()

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -106,8 +106,13 @@
 
 #if DEBUG_MARKER_LEVEL > DEBUG_MARKER_NONE
 #   define DEBUG_MARKER() \
-        const std::string _debug_marker_name = std::string("backend::") + __func__; \
-        DebugMarker _debug_marker(*this, _debug_marker_name.c_str());
+        const char* _debug_marker_header = "backend::"; \
+        const size_t _debug_marker_header_len = strlen(_debug_marker_header); \
+        char _debug_marker_name[256] = {0}; \
+        constexpr size_t _debug_marker_name_max_len = sizeof(_debug_marker_name); \
+        strncpy(_debug_marker_name, _debug_marker_header, _debug_marker_name_max_len - 1); \
+        strncpy(_debug_marker_name + _debug_marker_header_len, __func__, _debug_marker_name_max_len - _debug_marker_header_len - 1); \
+        DebugMarker _debug_marker(*this, _debug_marker_name);
 #else
 #   define DEBUG_MARKER()
 #endif

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -108,7 +108,7 @@
 
 #if DEBUG_MARKER_LEVEL == DEBUG_MARKER_PROFILE
 #   define DEBUG_MARKER()
-#   define PROFILE_MARKER(marker) PROFILE_SCOPE(marker)
+#   define PROFILE_MARKER(marker) PROFILE_SCOPE(marker);
 #elif DEBUG_MARKER_LEVEL > DEBUG_MARKER_NONE
 #   define DEBUG_MARKER() DebugMarker _debug_marker(*this, __func__);
 #   define PROFILE_MARKER(marker) DEBUG_MARKER()

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -101,7 +101,7 @@
 #define DEBUG_MARKER_ALL              (0xFF & ~DEBUG_MARKER_PROFILE) // all markers
 
 // set to the desired debug marker level (for user markers [default: All])
-#define DEBUG_GROUP_MARKER_LEVEL      DEBUG_GROUP_MARKER_ALL
+#define DEBUG_GROUP_MARKER_LEVEL      DEBUG_GROUP_MARKER_NONE
 
 // set to the desired debug level (for internal debugging [Default: None])
 #define DEBUG_MARKER_LEVEL            DEBUG_MARKER_NONE
@@ -109,6 +109,9 @@
 #if DEBUG_MARKER_LEVEL == DEBUG_MARKER_PROFILE
 #   define DEBUG_MARKER()
 #   define PROFILE_MARKER(marker) PROFILE_SCOPE(marker);
+#   if DEBUG_GROUP_MARKER_LEVEL != DEBUG_GROUP_MARKER_NONE
+#       error PROFILING is exclusive; group markers must be disabled.
+#   endif
 #elif DEBUG_MARKER_LEVEL > DEBUG_MARKER_NONE
 #   define DEBUG_MARKER() DebugMarker _debug_marker(*this, __func__);
 #   define PROFILE_MARKER(marker) DEBUG_MARKER()

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -128,12 +128,18 @@ static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 #include <utils/Systrace.h>
 
 #define FVK_SYSTRACE_CONTEXT()      SYSTRACE_CONTEXT()
-#define FVK_SYSTRACE_START(marker)  SYSTRACE_NAME_BEGIN(marker)
+#define FVK_SYSTRACE_START(marker)  \
+    const std::string ___marker_name = std::string("backend::") + marker; \
+    SYSTRACE_NAME_BEGIN(___marker_name.c_str())
 #define FVK_SYSTRACE_END()          SYSTRACE_NAME_END()
+#define FVK_SYSTRACE_CALL()         \
+    const std::string ___marker_name = std::string("backend::") + __func__; \
+    SYSTRACE_NAME(___marker_name.c_str())
 #else
 #define FVK_SYSTRACE_CONTEXT()
 #define FVK_SYSTRACE_START(marker)
 #define FVK_SYSTRACE_END()
+#define FVK_SYSTRACE_CALL()
 #endif
 
 #ifndef FVK_HANDLE_ARENA_SIZE_IN_MB

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -77,8 +77,12 @@
 // order of calls).
 #define FVK_DEBUG_FORCE_LOG_TO_I          0x00020000
 
+// Enable a minimal set of traces to assess the performance of the backend.
+// All other debug features must be disabled.
+#define FVK_DEBUG_PROFILING               0x00040000
+
 // Useful default combinations
-#define FVK_DEBUG_EVERYTHING              0xFFFFFFFF
+#define FVK_DEBUG_EVERYTHING              (0xFFFFFFFF & ~FVK_DEBUG_PROFILING)
 #define FVK_DEBUG_PERFORMANCE     \
     FVK_DEBUG_SYSTRACE
 
@@ -112,6 +116,10 @@ static_assert(FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS));
 static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 #endif
 
+#if FVK_ENABLED(FVK_DEBUG_PROFILING) && FVK_DEBUG_FLAGS != FVK_DEBUG_PROFILING
+#error PROFILING is exclusive; all other debug features must be disabled.
+#endif
+
 // end dependcy checks
 
 // Shorthand for combination of enabled debug flags
@@ -123,23 +131,30 @@ static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 
 // end shorthands
 
-#if FVK_ENABLED(FVK_DEBUG_SYSTRACE)
+#if FVK_DEBUG_FLAGS == FVK_DEBUG_PROFILING
 
-#include <utils/Systrace.h>
+    #define FVK_SYSTRACE_CONTEXT()
+    #define FVK_SYSTRACE_START(marker)
+    #define FVK_SYSTRACE_END()
+    #define FVK_SYSTRACE_SCOPE()
+    #define FVK_PROFILE_MARKER(marker)  PROFILE_SCOPE(marker)
 
-#define FVK_SYSTRACE_CONTEXT()      SYSTRACE_CONTEXT()
-#define FVK_SYSTRACE_START(marker)  \
-    const std::string ___marker_name = std::string("backend::") + marker; \
-    SYSTRACE_NAME_BEGIN(___marker_name.c_str())
-#define FVK_SYSTRACE_END()          SYSTRACE_NAME_END()
-#define FVK_SYSTRACE_CALL()         \
-    const std::string ___marker_name = std::string("backend::") + __func__; \
-    SYSTRACE_NAME(___marker_name.c_str())
+#elif FVK_ENABLED(FVK_DEBUG_SYSTRACE)
+
+    #include <utils/Systrace.h>
+    
+    #define FVK_SYSTRACE_CONTEXT()      SYSTRACE_CONTEXT()
+    #define FVK_SYSTRACE_START(marker)  SYSTRACE_NAME_BEGIN(marker)
+    #define FVK_SYSTRACE_END()          SYSTRACE_NAME_END()
+    #define FVK_SYSTRACE_SCOPE()        SYSTRACE_NAME(__func__)
+    #define FVK_PROFILE_MARKER(marker)  FVK_SYSTRACE_SCOPE()
+
 #else
-#define FVK_SYSTRACE_CONTEXT()
-#define FVK_SYSTRACE_START(marker)
-#define FVK_SYSTRACE_END()
-#define FVK_SYSTRACE_CALL()
+    #define FVK_SYSTRACE_CONTEXT()
+    #define FVK_SYSTRACE_START(marker)
+    #define FVK_SYSTRACE_END()
+    #define FVK_SYSTRACE_SCOPE()
+    #define FVK_PROFILE_MARKER(marker)
 #endif
 
 #ifndef FVK_HANDLE_ARENA_SIZE_IN_MB

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -18,6 +18,7 @@
 
 #include "CommandStreamDispatcher.h"
 #include "DataReshaper.h"
+#include "SystraceProfile.h"
 #include "VulkanBuffer.h"
 #include "VulkanCommands.h"
 #include "VulkanDriverFactory.h"
@@ -104,7 +105,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallback(VkDebugReportFlagsEXT flags,
     FVK_LOGE << utils::io::endl;
     return VK_FALSE;
 }
-#endif // FVK_EANBLED(FVK_DEBUG_VALIDATION)
+#endif // FVK_ENABLED(FVK_DEBUG_VALIDATION)
 
 #if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
 VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
@@ -125,7 +126,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFla
     FVK_LOGE << utils::io::endl;
     return VK_FALSE;
 }
-#endif // FVK_EANBLED(FVK_DEBUG_DEBUG_UTILS)
+#endif // FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
 
 
 }// anonymous namespace
@@ -155,7 +156,7 @@ DebugUtils::DebugUtils(VkInstance instance, VkDevice device, VulkanContext const
         FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS)
                 << "Unable to create Vulkan debug messenger.";
     }
-#endif // FVK_EANBLED(FVK_DEBUG_VALIDATION)
+#endif // FVK_ENABLED(FVK_DEBUG_VALIDATION)
 }
 
 DebugUtils* DebugUtils::get() {
@@ -183,7 +184,7 @@ void DebugUtils::setName(VkObjectType type, uint64_t handle, char const* name) {
     };
     vkSetDebugUtilsObjectNameEXT(impl->mDevice, &info);
 }
-#endif // FVK_EANBLED(FVK_DEBUG_DEBUG_UTILS)
+#endif // FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
 
 Dispatcher VulkanDriver::getDispatcher() const noexcept {
     return ConcreteDispatcher<VulkanDriver>::make();
@@ -358,6 +359,7 @@ void VulkanDriver::collectGarbage() {
 }
 void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
+    PROFILE_BEGINFRAME();
     FVK_SYSTRACE_CALL();
     // Do nothing.
 }
@@ -374,6 +376,7 @@ void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void VulkanDriver::endFrame(uint32_t frameId) {
+    PROFILE_ENDFRAME();
     FVK_SYSTRACE_CALL();
     mCommands.flush();
     collectGarbage();

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -345,7 +345,7 @@ void VulkanDriver::tick(int) {
 // rather than the wall clock, because we must wait 3 frames after a DriverAPI-level resource has
 // been destroyed for safe destruction, due to outstanding command buffers and triple buffering.
 void VulkanDriver::collectGarbage() {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
     // Command buffers need to be submitted and completed before other resources can be gc'd. And
     // its gc() function carrys out the *wait*.
     mCommands.gc();
@@ -359,8 +359,7 @@ void VulkanDriver::collectGarbage() {
 }
 void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
-    PROFILE_BEGINFRAME();
-    FVK_SYSTRACE_CALL();
+    FVK_PROFILE_MARKER(PROFILE_NAME_BEGINFRAME);
     // Do nothing.
 }
 
@@ -376,8 +375,7 @@ void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void VulkanDriver::endFrame(uint32_t frameId) {
-    PROFILE_ENDFRAME();
-    FVK_SYSTRACE_CALL();
+    FVK_PROFILE_MARKER(PROFILE_NAME_ENDFRAME);
     mCommands.flush();
     collectGarbage();
 }
@@ -412,12 +410,12 @@ void VulkanDriver::updateDescriptorSetTexture(
 }
 
 void VulkanDriver::flush(int) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
     mCommands.flush();
 }
 
 void VulkanDriver::finish(int dummy) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     mCommands.flush();
     mCommands.wait();
@@ -1231,7 +1229,7 @@ void VulkanDriver::compilePrograms(CompilerPriorityQueue priority,
 }
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanRenderTarget* const rt = mResourceAllocator.handle_cast<VulkanRenderTarget*>(rth);
     VkExtent2D const& extent = rt->getExtent();
@@ -1378,7 +1376,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 }
 
 void VulkanDriver::endRenderPass(int) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer cmdbuffer = commands.buffer();
@@ -1416,7 +1414,7 @@ void VulkanDriver::nextSubpass(int) {
 }
 
 void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     ASSERT_PRECONDITION_NON_FATAL(drawSch == readSch,
             "Vulkan driver does not support distinct draw/read swap chains.");
@@ -1436,7 +1434,7 @@ void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
 }
 
 void VulkanDriver::commit(Handle<HwSwapChain> sch) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanSwapChain* swapChain = mResourceAllocator.handle_cast<VulkanSwapChain*>(sch);
 
@@ -1503,7 +1501,7 @@ void VulkanDriver::readBufferSubData(backend::BufferObjectHandle boh,
 void VulkanDriver::resolve(
         Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
         Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     FILAMENT_CHECK_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE)
             << "resolve() cannot be invoked inside a render pass.";
@@ -1545,7 +1543,7 @@ void VulkanDriver::blit(
         Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, math::uint2 dstOrigin,
         Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, math::uint2 srcOrigin,
         math::uint2 size) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     FILAMENT_CHECK_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE)
             << "blit() cannot be invoked inside a render pass.";
@@ -1585,7 +1583,7 @@ void VulkanDriver::blitDEPRECATED(TargetBufferFlags buffers,
         Handle<HwRenderTarget> dst, Viewport dstRect,
         Handle<HwRenderTarget> src, Viewport srcRect,
         SamplerMagFilter filter) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     // Note: blitDEPRECATED is only used for Renderer::copyFrame()
 
@@ -1627,7 +1625,7 @@ void VulkanDriver::blitDEPRECATED(TargetBufferFlags buffers,
 }
 
 void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanCommandBuffer* commands = &mCommands.get();
     const VulkanVertexBufferInfo& vbi =
@@ -1706,7 +1704,7 @@ void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
 }
 
 void VulkanDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanCommandBuffer* commands = &mCommands.get();
     VkCommandBuffer cmdbuffer = commands->buffer();
@@ -1740,7 +1738,7 @@ void VulkanDriver::bindDescriptorSet(
 }
 
 void VulkanDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
-    FVK_SYSTRACE_CALL();
+    FVK_SYSTRACE_SCOPE();
 
     VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer cmdbuffer = commands.buffer();

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -344,8 +344,7 @@ void VulkanDriver::tick(int) {
 // rather than the wall clock, because we must wait 3 frames after a DriverAPI-level resource has
 // been destroyed for safe destruction, due to outstanding command buffers and triple buffering.
 void VulkanDriver::collectGarbage() {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("gc");
+    FVK_SYSTRACE_CALL();
     // Command buffers need to be submitted and completed before other resources can be gc'd. And
     // its gc() function carrys out the *wait*.
     mCommands.gc();
@@ -356,15 +355,11 @@ void VulkanDriver::collectGarbage() {
 #if FVK_ENABLED(FVK_DEBUG_RESOURCE_LEAK)
     mResourceAllocator.print();
 #endif
-
-    FVK_SYSTRACE_END();
 }
 void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("beginFrame");
+    FVK_SYSTRACE_CALL();
     // Do nothing.
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch, CallbackHandler* handler,
@@ -379,11 +374,9 @@ void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void VulkanDriver::endFrame(uint32_t frameId) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("endframe");
+    FVK_SYSTRACE_CALL();
     mCommands.flush();
     collectGarbage();
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::updateDescriptorSetBuffer(
@@ -416,21 +409,17 @@ void VulkanDriver::updateDescriptorSetTexture(
 }
 
 void VulkanDriver::flush(int) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("flush");
+    FVK_SYSTRACE_CALL();
     mCommands.flush();
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::finish(int dummy) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("finish");
+    FVK_SYSTRACE_CALL();
 
     mCommands.flush();
     mCommands.wait();
 
     mReadPixels.runUntilComplete();
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
@@ -1239,8 +1228,7 @@ void VulkanDriver::compilePrograms(CompilerPriorityQueue priority,
 }
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("beginRenderPass");
+    FVK_SYSTRACE_CALL();
 
     VulkanRenderTarget* const rt = mResourceAllocator.handle_cast<VulkanRenderTarget*>(rth);
     VkExtent2D const& extent = rt->getExtent();
@@ -1384,12 +1372,10 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         .params = params,
         .currentSubpass = 0,
     };
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::endRenderPass(int) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("endRenderPass");
+    FVK_SYSTRACE_CALL();
 
     VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer cmdbuffer = commands.buffer();
@@ -1405,7 +1391,6 @@ void VulkanDriver::endRenderPass(int) {
     mRenderPassFboInfo = {};
     mCurrentRenderPass.renderTarget = nullptr;
     mCurrentRenderPass.renderPass = VK_NULL_HANDLE;
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::nextSubpass(int) {
@@ -1428,8 +1413,7 @@ void VulkanDriver::nextSubpass(int) {
 }
 
 void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("makeCurrent");
+    FVK_SYSTRACE_CALL();
 
     ASSERT_PRECONDITION_NON_FATAL(drawSch == readSch,
             "Vulkan driver does not support distinct draw/read swap chains.");
@@ -1446,19 +1430,15 @@ void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
     if (UTILS_LIKELY(mDefaultRenderTarget)) {
         mDefaultRenderTarget->bindToSwapChain(*swapChain);
     }
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::commit(Handle<HwSwapChain> sch) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("commit");
+    FVK_SYSTRACE_CALL();
 
     VulkanSwapChain* swapChain = mResourceAllocator.handle_cast<VulkanSwapChain*>(sch);
 
     // Present the backbuffer after the most recent command buffer submission has finished.
     swapChain->present();
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::setPushConstant(backend::ShaderStage stage, uint8_t index,
@@ -1520,8 +1500,7 @@ void VulkanDriver::readBufferSubData(backend::BufferObjectHandle boh,
 void VulkanDriver::resolve(
         Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
         Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("resolve");
+    FVK_SYSTRACE_CALL();
 
     FILAMENT_CHECK_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE)
             << "resolve() cannot be invoked inside a render pass.";
@@ -1557,16 +1536,13 @@ void VulkanDriver::resolve(
     mBlitter.resolve(
             { .texture = dstTexture, .level = dstLevel, .layer = dstLayer },
             { .texture = srcTexture, .level = srcLevel, .layer = srcLayer });
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::blit(
         Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, math::uint2 dstOrigin,
         Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, math::uint2 srcOrigin,
         math::uint2 size) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("blit");
+    FVK_SYSTRACE_CALL();
 
     FILAMENT_CHECK_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE)
             << "blit() cannot be invoked inside a render pass.";
@@ -1600,16 +1576,13 @@ void VulkanDriver::blit(
     mBlitter.blit(VK_FILTER_NEAREST,
             { .texture = dstTexture, .level = dstLevel, .layer = dstLayer }, dstOffsets,
             { .texture = srcTexture, .level = srcLevel, .layer = srcLayer }, srcOffsets);
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::blitDEPRECATED(TargetBufferFlags buffers,
         Handle<HwRenderTarget> dst, Viewport dstRect,
         Handle<HwRenderTarget> src, Viewport srcRect,
         SamplerMagFilter filter) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("blitDEPRECATED");
+    FVK_SYSTRACE_CALL();
 
     // Note: blitDEPRECATED is only used for Renderer::copyFrame()
 
@@ -1648,13 +1621,10 @@ void VulkanDriver::blitDEPRECATED(TargetBufferFlags buffers,
     mBlitter.blit(vkfilter,
             dstTarget->getColor0(), dstOffsets,
             srcTarget->getColor0(), srcOffsets);
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("draw");
+    FVK_SYSTRACE_CALL();
 
     VulkanCommandBuffer* commands = &mCommands.get();
     const VulkanVertexBufferInfo& vbi =
@@ -1730,13 +1700,10 @@ void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
 
     mPipelineCache.bindLayout(pipelineLayout);
     mPipelineCache.bindPipeline(commands);
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("bindRenderPrimitive");
+    FVK_SYSTRACE_CALL();
 
     VulkanCommandBuffer* commands = &mCommands.get();
     VkCommandBuffer cmdbuffer = commands->buffer();
@@ -1759,8 +1726,6 @@ void VulkanDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     vkCmdBindVertexBuffers(cmdbuffer, 0, bufferCount, buffers, offsets);
     vkCmdBindIndexBuffer(cmdbuffer, prim.indexBuffer->buffer.getGpuBuffer(), 0,
             prim.indexBuffer->indexType);
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::bindDescriptorSet(
@@ -1772,8 +1737,7 @@ void VulkanDriver::bindDescriptorSet(
 }
 
 void VulkanDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
-    FVK_SYSTRACE_CONTEXT();
-    FVK_SYSTRACE_START("draw2");
+    FVK_SYSTRACE_CALL();
 
     VulkanCommandBuffer& commands = mCommands.get();
     VkCommandBuffer cmdbuffer = commands.buffer();
@@ -1787,8 +1751,6 @@ void VulkanDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t ins
     const uint32_t firstInstId = 0;
 
     vkCmdDrawIndexed(cmdbuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstId);
-
-    FVK_SYSTRACE_END();
 }
 
 void VulkanDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,


### PR DESCRIPTION
This PR introduces a profiling mode for both GLES and Vulkan backends on Android.
The profiling mode relies on systrace to record very few backend events (right now, _beginFrame_ and _endFrame_ only). The name of the events is kept consistant across backend to allow automatic gathering of data through Perfetto metrics.
The profiling mode is made incompatible with other debug features on purpose, to avoid any errors (e.g. enabling debug features with heavy overhead) when profiling the backend performance.