### PR TITLE
Add a workaround for a Windows NVIDIA Vulkan driver bug

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroidLinuxWindows.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroidLinuxWindows.cpp
@@ -195,6 +195,15 @@ VulkanPlatform::SurfaceBundle VulkanPlatform::createVkSurfaceKHR(void* nativeWin
             }
         #endif
     #elif defined(WIN32)
+        // On (at least) NVIDIA drivers, the Vulkan implementation (specifically the call to
+        // vkGetPhysicalDeviceSurfaceCapabilitiesKHR()) does not correctly handle the fact that
+        // each native window has its own DPI_AWARENESS_CONTEXT, and erroneously uses the context
+        // of the calling thread. As a workaround, we set the current thread's DPI_AWARENESS_CONTEXT
+        // to that of the native window we've been given. This isn't a perfect solution, because an
+        // application could create swap chains on multiple native windows with varying DPI-awareness,
+        // but even then, at least one of the windows would be guaranteed to work correctly.
+        SetThreadDpiAwarenessContext(GetWindowDpiAwarenessContext((HWND) nativeWindow));
+
         VkWin32SurfaceCreateInfoKHR const createInfo = {
             .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
             .hinstance = GetModuleHandle(nullptr),


### PR DESCRIPTION
The NVIDIA Vulkan driver bug causes swap chains to be created with incorrect dimensions for native windows created with thread-specific DPI-awareness context.

This is a pretty subtle issue, and only affects processes where the process-wide DPI-awareness context is different from the thread-specific DPI-awareness context that was used to create a given native window. The [Microsoft docs on this](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-improvements-for-desktop-applications) are pretty decent, and are super clear that the DPI-awareness of a HWND is whatever the DPI-awareness of the thread that created it was. The NVIDIA driver appears to be ignoring this. I suspect other drivers do as well.

This workaround has to be submitted into Filament itself because client code has no way to call a function on the Filament renderer thread, and so there's no way for a client to implement this workaround themselves.

I filed an [upstream bug report with NVIDIA](https://forums.developer.nvidia.com/t/bug-vkgetphysicaldevicesurfacecapabilitieskhr-extents-do-not-respect-window-dpi-awareness/310669), but from what I can tell from other similar reports, they are not likely to fix the issue anytime soon.

Happy to answer any questions about this one; I know it's a bit hard to understand because it took me two days of beating my head against the wall to figure out myself.   :D

_(If you're curious why I am the first to see this, it's because my app is unusual in that it is a plugin that runs inside other applications. This is the exact kind of weird edge case that caused Microsoft to introduce the thread-specific DPI-awareness system, because the host application may have different DPI-awareness than the plugins it hosts.)_