### PR TITLE
Use xvp for multiview + debug view

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1110,7 +1110,9 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     // FIXME: we probably should take the dynamic scaling into account too
     // if MSAA is enabled, we end-up rendering in an intermediate buffer. This is the only case where
     // "!hasPostProcess" doesn't guarantee rendering into the swapchain.
-    passBuilder.scissorViewport(hasPostProcess || msaaOptions.enabled ? xvp : vp);
+    const bool useIntermediateBuffer = hasPostProcess || msaaOptions.enabled ||
+          (isRenderingMultiview && engine.debug.stereo.combine_multiview_images);
+    passBuilder.scissorViewport(useIntermediateBuffer ? xvp : vp);
 
     // This one doesn't need to be a FrameGraph pass because it always happens by construction
     // (i.e. it won't be culled, unless everything is culled), so no need to complexify things.


### PR DESCRIPTION
When multiview is enabled with the combining debug option toggled on, we use an intermediate buffer that requires us to use the entire area of the buffer as the viewport. Use xvp in this case.