### PR TITLE
Fix bug in ResourceAllocator with erasing iterators inside loops

### DIFF
--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -260,7 +260,7 @@ void ResourceAllocator::gc(bool skippedFrame) noexcept {
         if ((ageDiff >= MAX_AGE_SKIPPED_FRAME && skippedFrame) ||
             (ageDiff >= mCacheMaxAge && evictedCount < MAX_EVICTION_COUNT)) {
             evictedCount++;
-            purge(it);
+            it = purge(it);
         } else {
             // build the set of ages present in the cache after eviction
             ages.set(std::min(size_t(31), ageDiff));
@@ -280,7 +280,7 @@ void ResourceAllocator::gc(bool skippedFrame) noexcept {
         for (auto it = textureCache.begin(); it != textureCache.end();) {
             const size_t ageDiff = age - it->second.age;
             if (ageDiff >= maxAge) {
-                purge(it);
+                it = purge(it);
             } else {
                 ++it;
             }
@@ -306,12 +306,13 @@ void ResourceAllocator::dump(bool brief) const noexcept {
     }
 }
 
-void ResourceAllocator::purge(
+ResourceAllocator::CacheContainer::iterator
+ResourceAllocator::purge(
         ResourceAllocator::CacheContainer::iterator const& pos) {
     //slog.d << "purging " << pos->second.handle.getId() << ", age=" << pos->second.age << io::endl;
     mBackend.destroyTexture(pos->second.handle);
     mCacheSize -= pos->second.size;
-    mTextureCache.erase(pos);
+    return mTextureCache.erase(pos);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -215,7 +215,8 @@ private:
 
     using CacheContainer = AssociativeContainer<TextureKey, TextureCachePayload>;
 
-    void purge(ResourceAllocator::CacheContainer::iterator const& pos);
+    ResourceAllocator::CacheContainer::iterator
+    purge(ResourceAllocator::CacheContainer::iterator const& pos);
 
     backend::DriverApi& mBackend;
     std::shared_ptr<ResourceAllocatorDisposer> mDisposer;


### PR DESCRIPTION
This is a fix for #8167, and this allows debug builds under MSVC to work again without crashing in the iterator debug stuff.