### PR TITLE
Fix clang c++20 compilation under debug mode as well.

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -391,7 +391,6 @@ else()
     if (CMAKE_CXX_STANDARD EQUAL 20)
         list(APPEND FILAMENT_WARNINGS -Wno-deprecated-this-capture)
     endif()
-
 endif()
 
 if (APPLE)

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -388,6 +388,10 @@ else()
             -Wover-aligned
             -Werror
     )
+    if (CMAKE_CXX_STANDARD EQUAL 20)
+        list(APPEND FILAMENT_WARNINGS -Wno-deprecated-this-capture)
+    endif()
+
 endif()
 
 if (APPLE)


### PR DESCRIPTION
This is an extension of commit 22db1be -- this one only comes up if you compile the project in debug mode in clang, which I hadn't done before.