### PR TITLE
Ignore another warning for vk_mem_alloc.h 

### DIFF
--- a/filament/backend/src/vulkan/VulkanMemory.cpp
+++ b/filament/backend/src/vulkan/VulkanMemory.cpp
@@ -31,6 +31,7 @@
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
 
 static const PFN_vkGetInstanceProcAddr& vkGetInstanceProcAddr = bluevk::vkGetInstanceProcAddr;
 static const PFN_vkGetDeviceProcAddr& vkGetDeviceProcAddr = bluevk::vkGetDeviceProcAddr;


### PR DESCRIPTION
Allows Filament to compile cleanly with -Wthread-safety enabled.