### PR TITLE
a new Feature Flag API

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -499,6 +499,37 @@ Java_com_google_android_filament_Engine_nGetActiveFeatureLevel(JNIEnv *, jclass,
     return (jint)engine->getActiveFeatureLevel();
 }
 
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_Engine_nHasFeatureFlag(JNIEnv *env, jclass clazz,
+        jlong nativeEngine, jstring name_) {
+    Engine* engine = (Engine*) nativeEngine;
+    const char *name = env->GetStringUTFChars(name_, 0);
+    std::optional<bool> result = engine->getFeatureFlag(name);
+    env->ReleaseStringUTFChars(name_, name);
+    return result.has_value();
+}
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_Engine_nSetFeatureFlag(JNIEnv *env, jclass clazz,
+        jlong nativeEngine, jstring name_, jboolean value) {
+    Engine* engine = (Engine*) nativeEngine;
+    const char *name = env->GetStringUTFChars(name_, 0);
+    jboolean result = engine->setFeatureFlag(name, (bool)value);
+    env->ReleaseStringUTFChars(name_, name);
+    return result;
+}
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_Engine_nGetFeatureFlag(JNIEnv *env, jclass clazz,
+        jlong nativeEngine, jstring name_) {
+    Engine* engine = (Engine*) nativeEngine;
+    const char *name = env->GetStringUTFChars(name_, 0);
+    std::optional<bool> result = engine->getFeatureFlag(name);
+    env->ReleaseStringUTFChars(name_, name);
+    return result.value_or(false); // we should never fail here
+}
+
 extern "C" JNIEXPORT jlong JNICALL Java_com_google_android_filament_Engine_nCreateBuilder(JNIEnv*,
         jclass) {
     Engine::Builder* builder = new Engine::Builder{};
@@ -563,6 +594,16 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
         JNIEnv*, jclass, jlong nativeBuilder, jboolean paused) {
     Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
     builder->paused((bool) paused);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_Engine_nSetBuilderFeature(JNIEnv *env, jclass clazz,
+        jlong nativeBuilder, jstring name_, jboolean value) {
+    Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
+    const char *name = env->GetStringUTFChars(name_, 0);
+    builder->feature(name, (bool)value);
+    env->ReleaseStringUTFChars(name_, name);
 }
 
 extern "C" JNIEXPORT jlong JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -259,6 +259,17 @@ public class Engine {
         }
 
         /**
+         * Set a feature flag value. This is the only way to set constant feature flags.
+         * @param name feature name
+         * @param value true to enable, false to disable
+         * @return A reference to this Builder for chaining calls.
+         */
+        public Builder feature(@NonNull String name, boolean value) {
+            nSetBuilderFeature(mNativeBuilder, name, value);
+            return this;
+        }
+
+        /**
          * Creates an instance of Engine
          *
          * @return A newly created <code>Engine</code>, or <code>null</code> if the GPU driver couldn't
@@ -393,6 +404,7 @@ public class Engine {
         /**
          * Set to `true` to forcibly disable parallel shader compilation in the backend.
          * Currently only honored by the GL backend.
+         * @Deprecated use "backend.disable_parallel_shader_compile" feature flag instead
          */
         public boolean disableParallelShaderCompile = false;
 
@@ -433,6 +445,7 @@ public class Engine {
 
         /**
          * Disable backend handles use-after-free checks.
+         * @Deprecated use "backend.disable_handle_use_after_free_check" feature flag instead
          */
         public boolean disableHandleUseAfterFreeCheck = false;
 
@@ -469,6 +482,7 @@ public class Engine {
          * Assert the native window associated to a SwapChain is valid when calling makeCurrent().
          * This is only supported for:
          *      - PlatformEGLAndroid
+         * @Deprecated use "backend.opengl.assert_native_window_is_valid" feature flag instead
          */
         public boolean assertNativeWindowIsValid = false;
     }
@@ -693,11 +707,11 @@ public class Engine {
 
     /**
      * Returns the maximum number of stereoscopic eyes supported by Filament. The actual number of
-     * eyes rendered is set at Engine creation time with the {@link
-     * Engine#Config#stereoscopicEyeCount} setting.
+     * eyes rendered is set at Engine creation time with the {@link Config#stereoscopicEyeCount}
+     * setting.
      *
      * @return the max number of stereoscopic eyes supported
-     * @see Engine#Config#stereoscopicEyeCount
+     * @see Config#stereoscopicEyeCount
      */
     public long getMaxStereoscopicEyes() {
         return nGetMaxStereoscopicEyes(getNativeObject());
@@ -894,7 +908,8 @@ public class Engine {
 
     /**
      * Returns whether the object is valid.
-     * @param object Object to check for validity
+     * @param ma Material
+     * @param mi MaterialInstance to check for validity
      * @return returns true if the specified object is valid.
      */
     public boolean isValidMaterialInstance(@NonNull Material ma, MaterialInstance mi) {
@@ -1316,6 +1331,39 @@ public class Engine {
      */
     public static native long getSteadyClockTimeNano();
 
+
+    /**
+     * Checks if a feature flag exists
+     * @param name name of the feature flag to check
+     * @return true if it exists false otherwise
+     */
+    public boolean hasFeatureFlag(@NonNull String name) {
+        return nHasFeatureFlag(mNativeObject, name);
+    }
+
+    /**
+     * Set the value of a non-constant feature flag.
+     * @param name name of the feature flag to set
+     * @param value value to set
+     * @return true if the value was set, false if the feature flag is constant or doesn't exist.
+     */
+    public boolean setFeatureFlag(@NonNull String name, boolean value) {
+        return nSetFeatureFlag(mNativeObject, name, value);
+    }
+
+    /**
+     * Retrieves the value of any feature flag.
+     * @param name name of the feature flag
+     * @return the value of the flag if it exists
+     * @exception IllegalArgumentException is thrown if the feature flag doesn't exist
+     */
+    public boolean getFeatureFlag(@NonNull String name) {
+        if (!hasFeatureFlag(name)) {
+            throw new IllegalArgumentException("The feature flag \"" + name + "\" doesn't exist");
+        }
+        return nGetFeatureFlag(mNativeObject, name);
+    }
+
     @UsedByReflection("TextureHelper.java")
     public long getNativeObject() {
         if (mNativeObject == 0) {
@@ -1405,6 +1453,9 @@ public class Engine {
     private static native int nGetSupportedFeatureLevel(long nativeEngine);
     private static native int nSetActiveFeatureLevel(long nativeEngine, int ordinal);
     private static native int nGetActiveFeatureLevel(long nativeEngine);
+    private static native boolean nHasFeatureFlag(long nativeEngine, String name);
+    private static native boolean nSetFeatureFlag(long nativeEngine, String name, boolean value);
+    private static native boolean nGetFeatureFlag(long nativeEngine, String name);
 
     private static native long nCreateBuilder();
     private static native void nDestroyBuilder(long nativeBuilder);
@@ -1420,5 +1471,6 @@ public class Engine {
     private static native void nSetBuilderFeatureLevel(long nativeBuilder, int ordinal);
     private static native void nSetBuilderSharedContext(long nativeBuilder, long sharedContext);
     private static native void nSetBuilderPaused(long nativeBuilder, boolean paused);
+    private static native void nSetBuilderFeature(long nativeBuilder, String name, boolean value);
     private static native long nBuilderBuild(long nativeBuilder);
 }

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -40,6 +40,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Panic.h>
+#include <utils/Slice.h>
 
 #include <chrono>
 
@@ -440,6 +441,22 @@ size_t Engine::getMaxStereoscopicEyes() noexcept {
 
 uint64_t Engine::getSteadyClockTimeNano() noexcept {
     return std::chrono::steady_clock::now().time_since_epoch().count();
+}
+
+utils::Slice<const Engine::FeatureFlag> Engine::getFeatureFlags() const noexcept {
+    return downcast(this)->getFeatureFlags();
+}
+
+bool Engine::setFeatureFlag(char const* name, bool value) noexcept {
+    return downcast(this)->setFeatureFlag(name, value);
+}
+
+std::optional<bool> Engine::getFeatureFlag(char const* name) const noexcept {
+    return downcast(this)->getFeatureFlag(name);
+}
+
+bool* Engine::getFeatureFlagPtr(char const* UTILS_NONNULL name) const noexcept {
+    return downcast(this)->getFeatureFlagPtr(name);
 }
 
 #if defined(__EMSCRIPTEN__)

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -56,21 +56,24 @@
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
 #include <filament/Material.h>
-#include <filament/MaterialEnums.h>
 #include <filament/Skybox.h>
 #include <filament/Stream.h>
 #include <filament/Texture.h>
 #include <filament/VertexBuffer.h>
 
 #include <utils/Allocator.h>
+#include <utils/compiler.h>
 #include <utils/CountDownLatch.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/JobSystem.h>
-#include <utils/compiler.h>
+#include <utils/Slice.h>
 
+#include <array>
 #include <chrono>
 #include <memory>
 #include <new>
+#include <optional>
+#include <string_view>
 #include <random>
 #include <thread>
 #include <type_traits>
@@ -672,6 +675,36 @@ public:
         } stereo;
         matdbg::DebugServer* server = nullptr;
     } debug;
+
+    struct {
+        struct {
+            struct {
+                bool assert_native_window_is_valid = false;
+            } opengl;
+            bool disable_parallel_shader_compile = false;
+            bool disable_handle_use_after_free_check = false;
+        } backend;
+    } features;
+
+    std::array<Engine::FeatureFlag, sizeof(features)> const mFeatures{{
+            { "backend.disable_parallel_shader_compile",
+              "Disable parallel shader compilation in GL and Metal backends.",
+              &features.backend.disable_parallel_shader_compile, true },
+            { "backend.disable_handle_use_after_free_check",
+              "Disable Handle<> use-after-free checks.",
+              &features.backend.disable_handle_use_after_free_check, true },
+            { "backend.opengl.assert_native_window_is_valid",
+              "Asserts that the ANativeWindow is valid when rendering starts.",
+              &features.backend.opengl.assert_native_window_is_valid, true }
+    }};
+
+    utils::Slice<const Engine::FeatureFlag> getFeatureFlags() const noexcept {
+        return { mFeatures.data(), mFeatures.size() };
+    }
+
+    bool setFeatureFlag(char const* name, bool value) noexcept;
+    std::optional<bool> getFeatureFlag(char const* name) const noexcept;
+    bool* getFeatureFlagPtr(std::string_view name, bool allowConstant = false) const noexcept;
 };
 
 FILAMENT_DOWNCAST(Engine)


### PR DESCRIPTION
Feature flags are intended to be used when a new feature is added to  filament and have generally two purposes:

1) during feature development, the feature can be implemented but
   disabled which can help developing large features. This way the
   feature can be tested by stakeholders while it's being developed
   without impacting other clients.

2) once a feature is ready, its flag can be enabled by default, but 
   in case the feature breaks something or has unintended consequence,
   clients have the option to turn it off.

Feature flags are intended to have a relatively short life span, i.e. once a feature is stable, the flag fill be removed.

There two types of feature flags. Constant feature flags can only be set during Engine initialization via Engine::Builder. Non-constant feature flags can be set at any time. 

Feature flags SHOULD NOT be used as configuration or settings.


Feature flags are designed with a few ideas in mind:
- they are very cheap to check inside the engine
- non-constant flags can easily be toggled using ImGUI