### PR TITLE
try to workaround a tsan warning

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -275,6 +275,9 @@ public:
     AtomicFreeList(const AtomicFreeList& rhs) = delete;
     AtomicFreeList& operator=(const AtomicFreeList& rhs) = delete;
 
+    // TSAN complains about a race on the memory used by the atomic mHead and the user
+    // (see b/377369108). There is a race, but it is handled below.
+    UTILS_NO_SANITIZE_THREAD
     void* pop() noexcept {
         Node* const pStorage = mStorage;
 


### PR DESCRIPTION
tsan detects a race that probably exists but is specifically handled but the code.

BUGS=[377369108]