### PR TITLE
feat: support installing and finding filament via find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # ==================================================================================================
 # Project declaration
 # ==================================================================================================
-project(TNT)
+project(filament VERSION 1.56.0)
 
 # ==================================================================================================
 # Options
@@ -46,6 +46,8 @@ option(FILAMENT_ENABLE_FEATURE_LEVEL_0 "Enable Feature Level 0" ON)
 option(FILAMENT_ENABLE_MULTIVIEW "Enable multiview for Filament" OFF)
 
 option(FILAMENT_SUPPORTS_OSMESA "Enable OSMesa (headless GL context) for Filament" OFF)
+
+option(FILAMENT_INSTALL_RULES "Enable Filament's install rules" ON)
 
 set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
@@ -829,7 +831,53 @@ if (IS_HOST_PLATFORM)
     add_subdirectory(${TOOLS}/uberz)
 endif()
 
-# Generate exported executables for cross-compiled builds (Android, WebGL, and iOS)
-if (NOT CMAKE_CROSSCOMPILING)
-    export(TARGETS matc cmgen filamesh mipgen resgen uberz glslminifier FILE ${IMPORT_EXECUTABLES})
+if(FILAMENT_INSTALL_RULES)
+    # version file
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+    write_basic_package_version_file("${CMAKE_BINARY_DIR}/filamentConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
+    install(FILES "${CMAKE_BINARY_DIR}/filamentConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/filament
+        COMPONENT filament)
+
+    # public header dependencies
+    set(HEADER_DEPS cgltf jsmn SPIRV-Headers)
+    foreach(_dep ${HEADER_DEPS})
+        get_target_property(_dep_include ${_dep} INTERFACE_INCLUDE_DIRECTORIES)
+        set_target_properties(${_dep} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+            "$<BUILD_INTERFACE:${_dep_include}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+        )
+    endforeach()
+    install(TARGETS ${HEADER_DEPS} EXPORT filament-targets COMPONENT filament-dependencies)
+    export(TARGETS ${HEADER_DEPS}
+        NAMESPACE filament::
+        FILE "${CMAKE_BINARY_DIR}/filamentTargets-Dependencies.cmake")
+
+    # config file
+    set(PACKAGE_VERSION ${PROJECT_VERSION})
+    configure_package_config_file("${CMAKE_CURRENT_LIST_DIR}/filamentConfig.cmake.in"
+        "${CMAKE_BINARY_DIR}/filamentConfig.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/filament)
+    install(FILES "${CMAKE_BINARY_DIR}/filamentConfig.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/filament
+        COMPONENT filament)
+
+    # targets file
+    set(TARGETS camutils filabridge filaflat filagui filameshio uberarchive gltfio_core gltfio ibl ibl-lite filament-iblprefilter
+        image ktxreader math mathio uberzlib utils viewer backend backend_headers vkshaders backend_test_linux filament
+        shaders geometry filamat matdbg_resources matdbg bluevk bluegl imageio cmgen cso-lut filamesh glslminifier matlang
+        matc matinfo matedit mipgen normal-blending resgen rgb-to-lmsr roughness-prefilter specular-color uberz
+        getopt smol-v vkmemalloc)
+    install(TARGETS ${TARGETS} EXPORT filament-targets COMPONENT filament)
+    export(TARGETS ${TARGETS}
+        NAMESPACE filament::
+        FILE "${CMAKE_BINARY_DIR}/filamentTargets.cmake")
+    export(PACKAGE filament)
+    install(EXPORT filament-targets
+        NAMESPACE filament::
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/filament
+        FILE "filamentTargets.cmake"
+        COMPONENT filament)
 endif()

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -540,7 +540,10 @@ include_directories(src)
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS} ${DATA_BINS})
 
 # specify where the public headers of this library are
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 
 # add this subproject to the Filament folder
 set_target_properties(${TARGET} PROPERTIES FOLDER Filament)

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -254,7 +254,10 @@ include_directories(${GENERATION_ROOT})
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 # specify where the public headers of this library are
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 
 # add this subproject to the Filament folder
 set_target_properties(${TARGET} PROPERTIES FOLDER Filament)
@@ -264,7 +267,10 @@ set_target_properties(${TARGET} PROPERTIES FOLDER Filament)
 # ==================================================================================================
 
 add_library(${TARGET}_headers INTERFACE)
-target_include_directories(${TARGET}_headers INTERFACE ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET}_headers INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 
 # ==================================================================================================
 # Build SPIRV snippets used by the Vulkan backend.

--- a/filamentConfig.cmake.in
+++ b/filamentConfig.cmake.in
@@ -1,0 +1,9 @@
+set(filament_VERSION @PACKAGE_VERSION@)
+
+@PACKAGE_INIT@
+
+@PACKAGE_DEPENDENCIES@
+
+include("${CMAKE_CURRENT_LIST_DIR}/filamentTargets.cmake")
+
+@INCLUDED_CONTENT@

--- a/libs/bluegl/CMakeLists.txt
+++ b/libs/bluegl/CMakeLists.txt
@@ -53,7 +53,10 @@ include_directories(${PUBLIC_HDR_DIR})
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 # specify where the public headers of this library are
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 if (WIN32)

--- a/libs/bluevk/CMakeLists.txt
+++ b/libs/bluevk/CMakeLists.txt
@@ -25,7 +25,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} utils math)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # test_bluevk is not supported on mobile or Windows

--- a/libs/camutils/CMakeLists.txt
+++ b/libs/camutils/CMakeLists.txt
@@ -30,7 +30,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} PUBLIC math)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/filabridge/CMakeLists.txt
+++ b/libs/filabridge/CMakeLists.txt
@@ -22,7 +22,10 @@ set(SRCS
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+        $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 target_link_libraries(${TARGET} utils)

--- a/libs/filaflat/CMakeLists.txt
+++ b/libs/filaflat/CMakeLists.txt
@@ -21,7 +21,10 @@ set(SRCS
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} ${HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 target_link_libraries(${TARGET} filabridge utils)

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -94,7 +94,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS} ${RESGEN_SOURCE})
 
 target_link_libraries(${TARGET} PUBLIC imgui filament)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -81,7 +81,10 @@ include_directories(${CMAKE_BINARY_DIR})
 
 # Filamat
 add_library(${TARGET} STATIC ${HDRS} ${PRIVATE_HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET} backend_headers shaders filabridge utils smol-v)
 

--- a/libs/filamentapp/CMakeLists.txt
+++ b/libs/filamentapp/CMakeLists.txt
@@ -143,7 +143,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} PUBLIC ${LIBS} filamentapp-resources)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_include_directories(${TARGET} PRIVATE ${GENERATION_ROOT})
 

--- a/libs/filameshio/CMakeLists.txt
+++ b/libs/filameshio/CMakeLists.txt
@@ -20,7 +20,10 @@ set(SRCS src/MeshReader.cpp)
 # ==================================================================================================
 include_directories(${PUBLIC_HDR_DIR})
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET}
     PRIVATE meshoptimizer

--- a/libs/geometry/CMakeLists.txt
+++ b/libs/geometry/CMakeLists.txt
@@ -35,7 +35,10 @@ set(GEOMETRY_DEPS
 target_link_libraries(${TARGET} PUBLIC math utils)
 target_link_libraries(${TARGET} PRIVATE ${GEOMETRY_DEPS})
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -174,7 +174,10 @@ set(DUMMY_SRC "${RESOURCE_DIR}/dummy.c")
 add_custom_command(OUTPUT ${DUMMY_SRC} COMMAND echo "//" > ${DUMMY_SRC})
 
 add_library(uberarchive ${DUMMY_SRC} ${RESGEN_SOURCE})
-target_include_directories(uberarchive PUBLIC ${RESOURCE_DIR})
+target_include_directories(uberarchive PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(uberarchive PROPERTIES FOLDER Libs)
 
 # ==================================================================================================
@@ -186,7 +189,10 @@ link_libraries(math utils filament cgltf stb ktxreader geometry tsl uberzlib)
 
 add_library(gltfio_core STATIC ${PUBLIC_HDRS} ${SRCS})
 
-target_include_directories(gltfio_core PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(gltfio_core PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(gltfio_core PROPERTIES FOLDER Libs)
 
 target_compile_definitions(gltfio_core PUBLIC -DGLTFIO_DRACO_SUPPORTED=1)
@@ -213,7 +219,10 @@ if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
     # ==================================================================================================
     add_library(${TARGET} STATIC ${PUBLIC_HDRS} src/JitShaderProvider.cpp)
     target_link_libraries(${TARGET} PUBLIC filamat gltfio_core)
-    target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+    target_include_directories(${TARGET} PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+        $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+    )
     set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
     if (NOT MSVC)
         target_compile_options(${TARGET} PRIVATE -Wno-deprecated-register)

--- a/libs/ibl/CMakeLists.txt
+++ b/libs/ibl/CMakeLists.txt
@@ -34,13 +34,19 @@ set(SRCS
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} ${PUBLIC_HDRS} ${PRIVATE_HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET} math utils)
 
 add_library(${TARGET}-lite ${PUBLIC_HDRS} ${PRIVATE_HDRS} ${SRCS})
 target_compile_definitions(${TARGET}-lite PUBLIC -DFILAMENT_IBL_LITE=1)
-target_include_directories(${TARGET}-lite PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET}-lite PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET}-lite PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET}-lite math utils)
 

--- a/libs/iblprefilter/CMakeLists.txt
+++ b/libs/iblprefilter/CMakeLists.txt
@@ -87,7 +87,10 @@ include_directories(src)
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 # specify where the public headers of this library are
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/image/CMakeLists.txt
+++ b/libs/image/CMakeLists.txt
@@ -31,7 +31,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} PUBLIC math utils)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/imageio/CMakeLists.txt
+++ b/libs/imageio/CMakeLists.txt
@@ -30,7 +30,10 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 target_link_libraries(${TARGET} PUBLIC image math png tinyexr utils z basis_encoder)

--- a/libs/ktxreader/CMakeLists.txt
+++ b/libs/ktxreader/CMakeLists.txt
@@ -26,7 +26,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} PUBLIC utils image filament basis_transcoder)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -88,7 +88,10 @@ target_link_libraries(${TARGET} PUBLIC
 
 target_include_directories(${TARGET} PRIVATE ${filamat_SOURCE_DIR}/src)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/math/CMakeLists.txt
+++ b/libs/math/CMakeLists.txt
@@ -41,7 +41,10 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 target_compile_options(${TARGET} PRIVATE ${OPTIMIZATION_FLAGS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/mathio/CMakeLists.txt
+++ b/libs/mathio/CMakeLists.txt
@@ -20,7 +20,10 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 target_compile_options(${TARGET} PRIVATE ${OPTIMIZATION_FLAGS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET} PRIVATE math)
 
@@ -28,4 +31,3 @@ target_link_libraries(${TARGET} PRIVATE math)
 # Installation
 # ==================================================================================================
 install(DIRECTORY ${PUBLIC_HDR_DIR}/mathio DESTINATION include)
-

--- a/libs/uberz/CMakeLists.txt
+++ b/libs/uberz/CMakeLists.txt
@@ -27,7 +27,10 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_link_libraries(${TARGET} PUBLIC math utils filabridge zstd)
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 # ==================================================================================================

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -103,7 +103,10 @@ endif()
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET} PUBLIC tsl)
 

--- a/libs/viewer/CMakeLists.txt
+++ b/libs/viewer/CMakeLists.txt
@@ -31,7 +31,10 @@ set(SRCS
 # ==================================================================================================
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 target_link_libraries(${TARGET} PUBLIC imgui filament gltfio_core filagui jsmn civetweb)
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
 if (FILAMENT_SAMPLES_STEREO_TYPE STREQUAL "instanced")

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -110,7 +110,10 @@ endif()
 # Include and target definitions
 # ==================================================================================================
 add_library(${TARGET} STATIC ${RESGEN_SOURCE})
-target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER Filament/Shaders)
 
 # ==================================================================================================

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -20,5 +20,8 @@ set(SRCS
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
-target_include_directories (${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:${PUBLIC_HDR_DIR}>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER ThirdParty)

--- a/third_party/smol-v/tnt/CMakeLists.txt
+++ b/third_party/smol-v/tnt/CMakeLists.txt
@@ -20,7 +20,10 @@ if (NOT MSVC)
     target_compile_options(${TARGET} PRIVATE -Wno-tautological-unsigned-enum-zero-compare)
 endif()
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC
+    $<BUILD_INTERFACE:${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:source>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER ThirdParty)
 
 install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})

--- a/third_party/vkmemalloc/tnt/CMakeLists.txt
+++ b/third_party/vkmemalloc/tnt/CMakeLists.txt
@@ -10,6 +10,12 @@ set(PUBLIC_HDRS ${PUBLIC_HDR_DIR}/vk_mem_alloc.h)
 include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} INTERFACE)
-target_sources(${TARGET} INTERFACE ${PUBLIC_HDRS})
-target_include_directories(${TARGET} INTERFACE ${PUBLIC_HDR_DIR})
+target_sources(${TARGET} INTERFACE
+    $<BUILD_INTERFACE:${PUBLIC_HDRS}>
+    $<INSTALL_INTERFACE:include/vk_mem_alloc.h>
+)
+target_include_directories(${TARGET} INTERFACE
+    $<BUILD_INTERFACE:${PUBLIC_HDR_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 set_target_properties(${TARGET} PROPERTIES FOLDER ThirdParty)

--- a/tools/matc/CMakeLists.txt
+++ b/tools/matc/CMakeLists.txt
@@ -41,7 +41,10 @@ set(SRCS
 # ==================================================================================================
 add_library(${TARGET} STATIC ${SRCS} ${HDRS})
 
-target_include_directories(${TARGET} PUBLIC src)
+target_include_directories(${TARGET} PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:src>
+)
 target_include_directories(${TARGET} PRIVATE ${filamat_SOURCE_DIR}/src)
 
 target_link_libraries(${TARGET} getopt filamat filabridge utils)


### PR DESCRIPTION
This allows installing the targets of Filament and finding it later via `find_package(filament CONFIG)`. This makes usage of Filament very easy from other CMake projects.

For this to work, I had to differentiate the public include paths during build vs being used when filament is installed.

This is cherry-picked from my PR for allowing filament to be built via vcpkg:
https://github.com/microsoft/vcpkg/pull/41916