### PR TITLE
ostream buffer growth was broken

### DIFF
--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -95,11 +95,11 @@ protected:
         size_t length() const noexcept;
 
     private:
-        void reserve(size_t newSize) noexcept;
+        void reserve(size_t newCapacity) noexcept;
 
         char* buffer = nullptr;     // buffer address
         char* curr = nullptr;       // current pointer
-        size_t size = 0;            // size remaining
+        size_t sizeRemaining = 0;            // size remaining
         size_t capacity = 0;        // total capacity of the buffer
     };
 


### PR DESCRIPTION
It only grew by 3/2 of the needed size instead of the needed capacity, which could be extremely slow when growing by a constant amount many times.