### PR TITLE
vk: increase number of command buffers

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -127,7 +127,7 @@ private:
 };
 
 struct CommandBufferPool {
-    using ActiveBuffers = utils::bitset32;
+    using ActiveBuffers = utils::bitset64;
     static constexpr int8_t INVALID = -1;
 
     CommandBufferPool(VulkanContext* context, VkDevice device, VkQueue queue,
@@ -153,6 +153,11 @@ private:
     static constexpr int CAPACITY = FVK_MAX_COMMAND_BUFFERS;
     // int8 only goes up to 127, therefore capacity must be less than that.
     static_assert(CAPACITY < 128);
+
+    // The number of bits in ActiveBuffers describe the usage of the buffers in the pool, so must be
+    // larger than the size of the pool.
+    static_assert(sizeof(ActiveBuffers) * 8 >= CAPACITY);
+
     using BufferList = utils::FixedCapacityVector<std::unique_ptr<VulkanCommandBuffer>>;
     VkDevice mDevice;
     VkCommandPool mPool;

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -196,14 +196,16 @@ constexpr static const int FVK_REQUIRED_VERSION_MINOR = 1;
 // buffers that have been submitted but have not yet finished rendering. Note that Filament can
 // issue multiple commit calls in a single frame, and that we use a triple buffered swap chain on
 // some platforms.
-constexpr static const int FVK_MAX_COMMAND_BUFFERS = 10;
+//
+// Heuristic: Triple Buffering (3) multiplied by maximum number of renderpasses (15).
+constexpr static const int FVK_MAX_COMMAND_BUFFERS = 3 * 15;
 
 // Number of command buffer submissions that should occur before an unused pipeline is removed
 // from the cache.
 //
 // If this number is low, VkPipeline construction will occur frequently, which can
 // be extremely slow. If this number is high, the memory footprint will be large.
-constexpr static const int FVK_MAX_PIPELINE_AGE = 10;
+constexpr static const int FVK_MAX_PIPELINE_AGE = FVK_MAX_COMMAND_BUFFERS;
 
 // VulkanPipelineCache does not track which command buffers contain references to which pipelines,
 // instead it simply waits for at least FVK_MAX_COMMAND_BUFFERS submissions to occur before


### PR DESCRIPTION
Small number of pre-allocated command buffers can cause unnecessary blocking on the CPU.  We increase this number.