### PR TITLE
vk: Use-after-free coverage

### DIFF
--- a/filament/backend/src/vulkan/memory/ResourcePointer.h
+++ b/filament/backend/src/vulkan/memory/ResourcePointer.h
@@ -21,6 +21,7 @@
 #include "vulkan/memory/ResourceManager.h"
 
 #include <backend/Handle.h>
+#include <utils/compiler.h>
 
 #include <utility>
 
@@ -59,6 +60,11 @@ public:
     static enabled_resource_ptr<B> cast(ResourceManager* resManager,
             Handle<B> const& handle) noexcept {
         D* ptr = resManager->handle_cast<D*, B>(handle);
+        if (UTILS_UNLIKELY(ptr->isHandleConsideredDestroyed())) {
+            FILAMENT_CHECK_PRECONDITION(!ptr->isHandleConsideredDestroyed())
+                    << "Handle id=" << ptr->id << " (" << getTypeStr(ptr->restype)
+                    << ") is being used after it has been freed";
+        }
         return {ptr};
     }
 
@@ -156,6 +162,8 @@ private:
     // only be used from VulkanDriver.
     inline void dec() {
         assert_invariant(mRef);
+        assert_invariant(!mRef->isHandleConsiderDestroyed());
+        mRef->setHandleConsiderDestroyed();
         mRef->dec();
     }
 

--- a/filament/backend/src/vulkan/memory/ResourcePointer.h
+++ b/filament/backend/src/vulkan/memory/ResourcePointer.h
@@ -60,11 +60,10 @@ public:
     static enabled_resource_ptr<B> cast(ResourceManager* resManager,
             Handle<B> const& handle) noexcept {
         D* ptr = resManager->handle_cast<D*, B>(handle);
-        if (UTILS_UNLIKELY(ptr->isHandleConsideredDestroyed())) {
-            FILAMENT_CHECK_PRECONDITION(!ptr->isHandleConsideredDestroyed())
-                    << "Handle id=" << ptr->id << " (" << getTypeStr(ptr->restype)
-                    << ") is being used after it has been freed";
-        }
+        FILAMENT_CHECK_PRECONDITION(!ptr->isHandleConsideredDestroyed())
+                << "Handle id=" << ptr->id << " (" << getTypeStr(ptr->restype)
+                << ") is being used after it has been freed";
+
         return {ptr};
     }
 


### PR DESCRIPTION
To allow for use-after-free discovery with ref-counting, we keep a bit to indicate whether the handle is considered destroyed by Filament. We assert against "cast"-ing a destroyed handle.