### PR TITLE
Don't use AtomicFreeList to squash TSAN complains

### DIFF
--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -446,7 +446,7 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    utils::Arena<utils::ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
+    utils::Arena<utils::ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
 
     template <typename T>
     using aligned_vector = std::vector<T, utils::STLAlignedAllocator<T>>;


### PR DESCRIPTION
The previous fix attempt didn't work on some test. There are no known bugs with AtomicFreeList other than tripping TSAN, and it's unclear that TSAN isn't at fault.

However, switching to using a mutex works fine and doesn't appear to be slower (it's actually faster with synthetic benchmarks on macOS)

BUGS=[377369108]