### PR TITLE
Disable transparent picking by default

### DIFF
--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -534,7 +534,7 @@ private:
     Viewport mViewport;
     bool mCulling = true;
     bool mFrontFaceWindingInverted = false;
-    bool mIsTransparentPickingEnabled = true;
+    bool mIsTransparentPickingEnabled = false;
 
     FRenderTarget* mRenderTarget = nullptr;
 


### PR DESCRIPTION
To fix the [crash](https://github.com/google/filament/issues/8282) for short term, will investigate the root cause of this crash.