### PR TITLE
Bugfix to allow animations to use a keyframe at exactly time=duration

### DIFF
--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -264,7 +264,7 @@ size_t Animator::getAnimationCount() const {
 
 void Animator::applyAnimation(size_t animationIndex, float time) const {
     const Animation& anim = mImpl->animations[animationIndex];
-    time = fmod(time, anim.duration);
+    time = time == anim.duration ? time : fmod(time, anim.duration);
     TransformManager& transformManager = *mImpl->transformManager;
     transformManager.openLocalTransformTransaction();
     for (const auto& channel : anim.channels) {


### PR DESCRIPTION
Without this change, trying to animate to the exact last keyframe wraps back to the first, which only works for animations that loop.