### PR TITLE
Copy back local values to Java array

### DIFF
--- a/android/filament-android/src/main/cpp/EntityManager.cpp
+++ b/android/filament-android/src/main/cpp/EntityManager.cpp
@@ -38,7 +38,7 @@ Java_com_google_android_filament_EntityManager_nCreateArray(JNIEnv* env, jclass,
     // (which it is), but still.
     em->create((size_t) n, reinterpret_cast<Entity *>(entities));
 
-    env->ReleaseIntArrayElements(entities_, entities, JNI_ABORT);
+    env->ReleaseIntArrayElements(entities_, entities, 0);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/filament-android/src/main/cpp/IndirectLight.cpp
+++ b/android/filament-android/src/main/cpp/IndirectLight.cpp
@@ -167,7 +167,7 @@ Java_com_google_android_filament_IndirectLight_nGetDirectionEstimateStatic(JNIEn
     jfloat *outDirection = env->GetFloatArrayElements(outDirection_, NULL);
     *reinterpret_cast<filament::math::float3*>(outDirection) = IndirectLight::getDirectionEstimate((filament::math::float3*)sh);
     env->ReleaseFloatArrayElements(outDirection_, outDirection, 0);
-    env->ReleaseFloatArrayElements(sh_, sh, JNI_ABORT);
+    env->ReleaseFloatArrayElements(sh_, sh, 0);
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -178,5 +178,5 @@ Java_com_google_android_filament_IndirectLight_nGetColorEstimateStatic(JNIEnv *e
     *reinterpret_cast<filament::math::float4*>(outColor) =
             IndirectLight::getColorEstimate((filament::math::float3*)sh, math::float3{x, y, z});
     env->ReleaseFloatArrayElements(outColor_, outColor, 0);
-    env->ReleaseFloatArrayElements(sh_, sh, JNI_ABORT);
+    env->ReleaseFloatArrayElements(sh_, sh, 0);
 }


### PR DESCRIPTION
When releasing array elements, we need to pass 0 as the last argument if we want to copy local chnages back to the Java array. JNI_ABORT should only be used when we don't want the copy, i.e. when the array is read-only.

Fixes issue #8278.