### PR TITLE
Fix a couple depthClamp issues on metal

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -135,6 +135,7 @@ struct MetalContext {
     bool supportsTextureSwizzling = false;
     bool supportsAutoDepthResolve = false;
     bool supportsMemorylessRenderTargets = false;
+    bool supportsDepthClamp = false;
     uint8_t maxColorRenderTargets = 4;
     struct {
         uint8_t common;


### PR DESCRIPTION
- depthClamp is only supported from iOS 11.0
- reset the depthClamp state at the beginning of the renderpass


BUGS=[379729888]