### PR TITLE
Fix typo in `Camera` doc comment

### DIFF
--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -61,7 +61,7 @@ namespace filament {
  *  filament::Camera* myCamera = engine->createCamera(myCameraEntity);
  *  myCamera->setProjection(45, 16.0/9.0, 0.1, 1.0);
  *  myCamera->lookAt({0, 1.60, 1}, {0, 0, 0});
- *  engine->destroyCameraComponent(myCamera);
+ *  engine->destroyCameraComponent(myCameraEntity);
  * ~~~~~~~~~~~
  *
  *


### PR DESCRIPTION
As mentioned few lines above:
>  * In Filament, Camera is a component that must be associated with an entity. To do so,
> * use Engine::createCamera(Entity). A Camera component is destroyed using
> * Engine::destroyCameraComponent(Entity).

Entity must be used for creating and destroying `Camera`.
So, this PR propose a fixing typo in code snippet of `Camera` doc comment.