### PR TITLE
renderdiff: allow for explicit (compile-time) linking of osmesa

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
@@ -64,10 +64,14 @@ public:
                 break;
             }
         }
-        FILAMENT_CHECK_PRECONDITION(mLib)
-                << "Unable to dlopen libOSMesa to create a software GL context";
+        if (mLib) {
+            OSMesaGetProcAddress = (GetProcAddressFunc) dlsym(mLib, "OSMesaGetProcAddress");
+        } else {
+            OSMesaGetProcAddress = (GetProcAddressFunc) dlsym(RTLD_LOCAL, "OSMesaGetProcAddress");
+        }
 
-        OSMesaGetProcAddress = (GetProcAddressFunc) dlsym(mLib, "OSMesaGetProcAddress");
+        FILAMENT_CHECK_PRECONDITION(OSMesaGetProcAddress)
+                << "Unable to against libOSMesa to create a software GL context";
 
         OSMesaCreateContext = (CreateContextFunc) OSMesaGetProcAddress("OSMesaCreateContext");
         OSMesaDestroyContext =
@@ -76,7 +80,9 @@ public:
     }
 
     ~OSMesaAPI() {
-        dlclose(mLib);
+        if (mLib) {
+            dlclose(mLib);
+        }
     }
 private:
     void* mLib = nullptr;

--- a/libs/bluegl/src/BlueGLLinuxOSMesa.cpp
+++ b/libs/bluegl/src/BlueGLLinuxOSMesa.cpp
@@ -38,11 +38,12 @@ bool initBinder() {
         }
     }
     if (!g_driver.library) {
-        return false;
+        // The library has been linked explicitly during compile.
+        g_driver.OSMesaGetProcAddress = (ProcAddressFunc) dlsym(RTLD_LOCAL, "OSMesaGetProcAddress");
+    } else {
+        g_driver.OSMesaGetProcAddress =
+                (ProcAddressFunc) dlsym(g_driver.library, "OSMesaGetProcAddress");
     }
-
-    g_driver.OSMesaGetProcAddress = (ProcAddressFunc)
-            dlsym(g_driver.library, "OSMesaGetProcAddress");
 
     return g_driver.OSMesaGetProcAddress;
 }
@@ -52,7 +53,9 @@ void* loadFunction(const char* name) {
 }
 
 void shutdownBinder() {
-    dlclose(g_driver.library);
+    if (g_driver.library) {
+        dlclose(g_driver.library);
+    }
     memset(&g_driver, 0, sizeof(g_driver));
 }
 


### PR DESCRIPTION
If the shared osmesa lib is not found, then we assume that the library has been compile-time linked via the linker.  This is to accommodate build frameworks where compile-time linking is preferred.