### PR TITLE
fix a use-after-free of texture handles

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -963,6 +963,11 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
                             uint32_t(float(xvp.width ) * aoOptions.resolution),
                             uint32_t(float(xvp.height) * aoOptions.resolution)});
 
+                // this needs to reset the sampler that are only set in RendererUtils::colorPass(), because
+                // this descriptor-set is also used for ssr/picking/structure and these could be stale
+                // it would be better to use a separate desriptor-set for those two cases so that we don't
+                // have to do this
+                view.unbindSamplers(driver);
                 view.commitUniformsAndSamplers(driver);
             });
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -912,6 +912,10 @@ void FView::commitUniformsAndSamplers(DriverApi& driver) const noexcept {
     mColorPassDescriptorSet.commit(driver);
 }
 
+void FView::unbindSamplers(DriverApi& driver) noexcept {
+    mColorPassDescriptorSet.unbindSamplers(driver);
+}
+
 void FView::commitFroxels(DriverApi& driverApi) const noexcept {
     if (mHasDynamicLighting) {
         mFroxelizer.commit(driverApi);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -174,6 +174,7 @@ public:
 
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;
     void commitUniformsAndSamplers(backend::DriverApi& driver) const noexcept;
+    void unbindSamplers(backend::DriverApi& driver) noexcept;
 
     utils::JobSystem::Job* getFroxelizerSync() const noexcept { return mFroxelizerSync; }
     void setFroxelizerSync(utils::JobSystem::Job* sync) noexcept { mFroxelizerSync = sync; }

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -541,6 +541,17 @@ void ColorPassDescriptorSet::commit(backend::DriverApi& driver) noexcept {
     }
 }
 
+void ColorPassDescriptorSet::unbindSamplers(DriverApi&) noexcept {
+    // this needs to reset the sampler that are only set in RendererUtils::colorPass(), because
+    // this descriptor-set is also used for ssr/picking/structure and these could be stale
+    // it would be better to use a separate descriptor-set for those two cases so that we don't
+    // have to do this
+    setSampler(+PerViewBindingPoints::STRUCTURE, {}, {});
+    setSampler(+PerViewBindingPoints::SHADOW_MAP, {}, {});
+    setSampler(+PerViewBindingPoints::SSAO, {}, {});
+    setSampler(+PerViewBindingPoints::SSR, {}, {});
+}
+
 void ColorPassDescriptorSet::setSampler(backend::descriptor_binding_t binding,
         TextureHandle th, SamplerParams params) noexcept {
     for (size_t i = 0; i < DESCRIPTOR_LAYOUT_COUNT; i++) {

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -158,6 +158,8 @@ public:
     // update local data into GPU UBO
     void commit(backend::DriverApi& driver) noexcept;
 
+    void unbindSamplers(backend::DriverApi& driver) noexcept;
+
     // bind this UBO
     void bind(backend::DriverApi& driver, uint8_t index) const noexcept {
         mDescriptorSet[index].bind(driver, DescriptorSetBindingPoints::PER_VIEW);


### PR DESCRIPTION
Because ColorPassDescriptorSet is used for both the color pass and the picking/ssr/structure passes, the texture it holds can be stale.

In this CL we fix this by reseting the offending textures when preparing the picking/ssr/structure passes. This has a side effect of recreating the descriptor-set internally. A better fix would be to use separate descriptor-sets for these two cases and rely on the texture cache to avoid recreation from a frame to the next.

BUGS=[376705346]