### PR TITLE
Fix shadow cascade calculations

### DIFF
--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -427,7 +427,7 @@ float FLightManager::getSpotLightInnerCone(Instance i) const noexcept {
 
 void LightManager::ShadowCascades::computeUniformSplits(float splitPositions[3], uint8_t cascades) {
     size_t s = 0;
-    cascades = max(cascades, (uint8_t) 4u);
+    cascades = min(cascades, (uint8_t) 4u);
     for (size_t c = 1; c < cascades; c++) {
         splitPositions[s++] = float(c) / float(cascades);
     }
@@ -436,7 +436,7 @@ void LightManager::ShadowCascades::computeUniformSplits(float splitPositions[3],
 void LightManager::ShadowCascades::computeLogSplits(float splitPositions[3], uint8_t cascades,
         float near, float far) {
     size_t s = 0;
-    cascades = max(cascades, (uint8_t) 4u);
+    cascades = min(cascades, (uint8_t) 4u);
     for (size_t c = 1; c < cascades; c++) {
         splitPositions[s++] =
             (near * std::pow(far / near, float(c) / float(cascades)) - near) / (far - near);
@@ -447,7 +447,7 @@ void LightManager::ShadowCascades::computePracticalSplits(float splitPositions[3
         float near, float far, float lambda) {
     float uniformSplits[3];
     float logSplits[3];
-    cascades = max(cascades, (uint8_t) 4u);
+    cascades = min(cascades, (uint8_t) 4u);
     computeUniformSplits(uniformSplits, cascades);
     computeLogSplits(logSplits, cascades, near, far);
     size_t s = 0;


### PR DESCRIPTION
The `ShadowCascade` functions for computing splits all attempted to clamp `cascades` to [0,4] (evidently to avoid out-of-bounds access), but used `max`, instead giving a range of [4, x].

For applications using less than 4 cascades, this results in incorrect split locations and lower quality (much more obvious seam between cascades).

This change just switches to use `min` to ensure `cascades` is in the range [0,4].