### PR TITLE
Fix ARC objects leak in MetalShaderCompiler thread

### DIFF
--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -226,9 +226,11 @@ MetalShaderCompiler::program_token_t MetalShaderCompiler::createProgram(
             CompilerPriorityQueue const priorityQueue = program.getPriorityQueue();
             mCompilerThreadPool.queue(priorityQueue, token,
                     [this, name, device = mDevice, program = std::move(program), token]() {
-                        MetalFunctionBundle compiledProgram = compileProgram(program, device);
-                        token->set(compiledProgram);
-                        mCallbackManager.put(token->handle);
+                        @autoreleasepool {
+                            MetalFunctionBundle compiledProgram = compileProgram(program, device);
+                            token->set(compiledProgram);
+                            mCallbackManager.put(token->handle);
+                        }
                     });
 
             break;


### PR DESCRIPTION
When using async shader compilation, the compiler thread pool is a  standard pthread and not an NSThread. Therefore, it needs a manual @autorelease pool, otherwise ARC objects never get truly released.   BUGS=[383167935]