### PR TITLE
matc: remove access to public functions that should be undefined

### DIFF
--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -660,11 +660,13 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
         CodeGenerator::generateDepthShaderMain(fs, ShaderStage::FRAGMENT);
     } else {
         appendShader(fs, mMaterialFragmentCode, mMaterialLineOffset);
-        if (filament::Variant::isSSRVariant(variant)) {
-            CodeGenerator::generateShaderReflections(fs, ShaderStage::FRAGMENT);
-        } else if (material.isLit) {
-            CodeGenerator::generateShaderLit(fs, ShaderStage::FRAGMENT, variant,
-                    material.shading,material.hasCustomSurfaceShading);
+        if (material.isLit) {
+            if (filament::Variant::isSSRVariant(variant)) {
+                CodeGenerator::generateShaderReflections(fs, ShaderStage::FRAGMENT);
+            } else {
+                CodeGenerator::generateShaderLit(fs, ShaderStage::FRAGMENT, variant,
+                        material.shading,material.hasCustomSurfaceShading);
+            }
         } else {
             CodeGenerator::generateShaderUnlit(fs, ShaderStage::FRAGMENT, variant,
                     material.hasShadowMultiplier);

--- a/shaders/src/common_shading.fs
+++ b/shaders/src/common_shading.fs
@@ -3,6 +3,7 @@
 highp mat3  shading_tangentToWorld;   // TBN matrix
 highp vec3  shading_position;         // position of the fragment in world space
       vec3  shading_view;             // normalized vector from the fragment to the eye
+#if defined(HAS_ATTRIBUTE_TANGENTS)
       vec3  shading_normal;           // normalized transformed normal, in world space
       vec3  shading_geometricNormal;  // normalized geometric normal, in world space
       vec3  shading_reflected;        // reflection of view about normal
@@ -14,6 +15,7 @@ highp vec3  shading_position;         // position of the fragment in world space
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)
       vec3  shading_clearCoatNormal;  // normalized clear coat layer normal, in world space
+#endif
 #endif
 
 highp vec2 shading_normalizedViewportCoord;

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -63,6 +63,8 @@ bool isPerspectiveProjection() {
     return frameUniforms.clipFromViewMatrix[2].w != 0.0;
 }
 
+#if defined(HAS_ATTRIBUTE_TANGENTS)
+
 /** @public-api */
 vec3 getWorldNormalVector() {
     return shading_normal;
@@ -82,6 +84,8 @@ vec3 getWorldReflectedVector() {
 float getNdotV() {
     return shading_NoV;
 }
+
+#endif
 
 highp vec3 getNormalizedPhysicalViewportCoord() {
     // make sure to handle our reversed-z


### PR DESCRIPTION
When tangents are not supplied in a material, all "normals" related public methods become undefined; remove access to them so we get  compile time errors instead of garbage values in the shader.