### PR TITLE
Fix If the width of the image is not a multiple of 4, the rendering r…

### DIFF
--- a/samples/image_viewer.cpp
+++ b/samples/image_viewer.cpp
@@ -246,7 +246,7 @@ static void loadImage(App& app, Engine* engine, const Path& filename) {
             .height(h)
             .levels(0xff)
             .format(channels == 3 ?
-                    Texture::InternalFormat::RGB16F : Texture::InternalFormat::RGBA16F)
+                    Texture::InternalFormat::RGB16F : Texture::InternalFormat::RGBA32F)
             .sampler(Texture::Sampler::SAMPLER_2D)
             .build(*engine);
 


### PR DESCRIPTION
Fix If the width of the image is not a multiple of 4, the rendering result by image_view will be skewed. (#8166)