### PR TITLE
Specify log source for matdbg

### DIFF
--- a/libs/matdbg/src/ApiHandler.cpp
+++ b/libs/matdbg/src/ApiHandler.cpp
@@ -63,7 +63,7 @@ using filamat::ChunkType;
 using utils::FixedCapacityVector;
 
 static auto const error = [](int line, std::string const& uri) {
-    utils::slog.e << "DebugServer: 404 at line " << line << ": " << uri << utils::io::endl;
+    utils::slog.e << "[matdbg] DebugServer: 404 at line " << line << ": " << uri << utils::io::endl;
     return false;
 };
 
@@ -80,7 +80,7 @@ MaterialRecord const* ApiHandler::getMaterialRecord(struct mg_request_info const
 bool ApiHandler::handleGetApiShader(struct mg_connection* conn,
         struct mg_request_info const* request) {
     auto const softError = [conn, request](char const* msg) {
-        utils::slog.e << "DebugServer: " << msg << ": " << request->query_string << utils::io::endl;
+        utils::slog.e << "[matdbg] DebugServer: " << msg << ": " << request->query_string << utils::io::endl;
         mg_printf(conn, kErrorHeader.data(), "application/txt");
         mg_write(conn, msg, strlen(msg));
         return true;
@@ -266,7 +266,7 @@ bool ApiHandler::handlePost(CivetServer* server, struct mg_connection* conn) {
         while (readLen < msgLen) {
             int const res = mg_read(conn, buf, sizeof(buf));
             if (res < 0) {
-                utils::slog.e << "civet error parsing /api/edit body: " << res << utils::io::endl;
+                utils::slog.e << "[matdbg] civet error parsing /api/edit body: " << res << utils::io::endl;
                 break;
             }
             if (res == 0) {

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -115,7 +115,7 @@ public:
             return true;
         }
 #endif
-        slog.e << "DebugServer: bad request at line " <<  __LINE__ << ": " << uri << io::endl;
+        slog.e << "[matdbg] DebugServer: bad request at line " <<  __LINE__ << ": " << uri << io::endl;
         return false;
     }
 private:
@@ -156,7 +156,7 @@ DebugServer::DebugServer(Backend backend, int port) : mBackend(backend) {
     if (!mServer->getContext()) {
         delete mServer;
         mServer = nullptr;
-        slog.e << "Unable to start DebugServer, see civetweb.txt for details." << io::endl;
+        slog.e << "[matdbg] Unable to start DebugServer, see civetweb.txt for details." << io::endl;
         return;
     }
 
@@ -166,7 +166,7 @@ DebugServer::DebugServer(Backend backend, int port) : mBackend(backend) {
     mServer->addHandler("/api", mApiHandler);
     mServer->addHandler("", mFileHandler);
 
-    slog.i << "DebugServer listening at http://localhost:" << port << io::endl;
+    slog.i << "[matdbg] DebugServer listening at http://localhost:" << port << io::endl;
     filamat::GLSLTools::init();
 }
 
@@ -189,7 +189,7 @@ MaterialKey
 DebugServer::addMaterial(const CString& name, const void* data, size_t size, void* userdata) {
     filaflat::ChunkContainer* container = new filaflat::ChunkContainer(data, size);
     if (!container->parse()) {
-        slog.e << "DebugServer: unable to parse material package: " << name.c_str() << io::endl;
+        slog.e << "[matdbg] DebugServer: unable to parse material package: " << name.c_str() << io::endl;
         return {};
     }
 
@@ -236,7 +236,7 @@ void DebugServer::updateActiveVariants() {
 bool DebugServer::handleEditCommand(const MaterialKey& key, backend::Backend api, int shaderIndex,
             const char* source, size_t size) {
     const auto error = [](int line) {
-        slog.e << "DebugServer: Unable to apply shader edit at line " << line << io::endl;
+        slog.e << "[matdbg] DebugServer: Unable to apply shader edit at line " << line << io::endl;
         return false;
     };
 

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -200,7 +200,7 @@ bool ShaderReplacer::replaceSpirv(ShaderModel shaderModel, Variant variant,
                 SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS, &binary, &diagnostic);
         spvContextDestroy(context);
         if (error) {
-            slog.e << "ShaderReplacer spirv-as failed (spv_result_t: " << error << ")" << io::endl;
+            slog.e << "[matdbg] ShaderReplacer spirv-as failed (spv_result_t: " << error << ")" << io::endl;
             spvDiagnosticPrint(diagnostic);
             spvDiagnosticDestroy(diagnostic);
             return false;
@@ -227,7 +227,7 @@ bool ShaderReplacer::replaceSpirv(ShaderModel shaderModel, Variant variant,
 
         const bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
         if (!ok) {
-            slog.e << "ShaderReplacer parse:\n" << tShader.getInfoLog() << io::endl;
+            slog.e << "[matdbg] ShaderReplacer parse:\n" << tShader.getInfoLog() << io::endl;
             return false;
         }
 
@@ -235,7 +235,7 @@ bool ShaderReplacer::replaceSpirv(ShaderModel shaderModel, Variant variant,
         program.addShader(&tShader);
         const bool linkOk = program.link(msg);
         if (!linkOk) {
-            slog.e << "ShaderReplacer link:\n" << program.getInfoLog() << io::endl;
+            slog.e << "[matdbg] ShaderReplacer link:\n" << program.getInfoLog() << io::endl;
             return false;
         }
 
@@ -247,7 +247,7 @@ bool ShaderReplacer::replaceSpirv(ShaderModel shaderModel, Variant variant,
     source = (const char*) spirv.data();
     sourceLength = spirv.size() * 4;
 
-    slog.i << "Success re-generating SPIR-V. (" << sourceLength << " bytes)" << io::endl;
+    slog.i << "[matdbg] Success re-generating SPIR-V. (" << sourceLength << " bytes)" << io::endl;
 
     // Clone all chunks except Dictionary* and Material*.
     filaflat::ChunkContainer const& cc = mOriginalPackage;
@@ -349,7 +349,7 @@ void ShaderIndex::replaceShader(backend::ShaderModel model, Variant variant,
             return;
         }
     }
-    slog.e << "Failed to replace shader." << io::endl;
+    slog.e << "[matdbg] Failed to replace shader." << io::endl;
 }
 
 BlobIndex::BlobIndex(ChunkType dictTag, ChunkType matTag, const filaflat::ChunkContainer& cc) :
@@ -426,7 +426,7 @@ void BlobIndex::replaceShader(ShaderModel model, Variant variant,
             return;
         }
     }
-    slog.e << "Unable to replace shader." << io::endl;
+    slog.e << "[matdbg] Unable to replace shader." << io::endl;
 }
 
 } // namespace filament::matdbg


### PR DESCRIPTION
We will be running an additional debug server for the `fgviewer`. 
To help users identify which server is generating the logs, this PR specifies the log source for `matdbg`.