### PR TITLE
Solve the bug: filament error: first argument in call to 'memcpy' is …

### DIFF
--- a/filament/src/ds/DescriptorSet.cpp
+++ b/filament/src/ds/DescriptorSet.cpp
@@ -149,7 +149,7 @@ void DescriptorSet::setSampler(
 
 DescriptorSet DescriptorSet::duplicate(DescriptorSetLayout const& layout) const noexcept {
     DescriptorSet set{layout};
-    memcpy(set.mDescriptors.data(), mDescriptors.data(), mDescriptors.size() * sizeof(Desc));
+    set.mDescriptors = mDescriptors; // Use the vector's assignment operator
     set.mDirty = mDirty;
     set.mValid = mValid;
     return set;


### PR DESCRIPTION
…a pointer to non-trivially copyable type 'value_type' (aka 'filament::DescriptorSet::Desc') [-Werror,-Wnontrivial-memcall]

  152 |     memcpy(set.mDescriptors.data(), mDescriptors.data(), mDescriptors.size() * sizeof(Desc));