### PR TITLE
matdbg: Fix material collision

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -605,13 +605,10 @@ void FMaterial::createAndCacheProgram(Program&& p, Variant variant) const noexce
     FEngine const& engine = mEngine;
     DriverApi& driverApi = mEngine.getDriverApi();
 
-    bool const isSharedVariant =
-            (mMaterialDomain == MaterialDomain::SURFACE) &&
-            !mIsDefaultMaterial && !mHasCustomDepthShader &&
-            Variant::isValidDepthVariant(variant);
+    bool const isShared = isSharedVariant(variant);
 
     // Check if the default material has this program cached
-    if (isSharedVariant) {
+    if (isShared) {
         FMaterial const* const pDefaultMaterial = engine.getDefaultMaterial();
         if (pDefaultMaterial) {
             auto program = pDefaultMaterial->mCachedPrograms[variant.key];
@@ -630,7 +627,7 @@ void FMaterial::createAndCacheProgram(Program&& p, Variant variant) const noexce
     // If the default material doesn't already have this program cached, and all caching conditions
     // are met (Surface Domain and no custom depth shader), cache it now.
     // New Materials will inherit these program automatically.
-    if (isSharedVariant) {
+    if (isShared) {
         FMaterial const* const pDefaultMaterial = engine.getDefaultMaterial();
         if (pDefaultMaterial && !pDefaultMaterial->mCachedPrograms[variant.key]) {
             // set the tag to the default material name

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -193,8 +193,17 @@ DebugServer::addMaterial(const CString& name, const void* data, size_t size, voi
         return {};
     }
 
-    const uint32_t seed = 42;
-    const MaterialKey key = utils::hash::murmurSlow((const uint8_t*) data, size, seed);
+    // Note that it's possible to have two materials with the exact same content (however wasteful),
+    // but they refer to different instantiation of FMaterial. For that case, we need to make sure
+    // that the key for the hash is different by relying on the user provided pointer. Hence we run
+    // the hash function twice.
+    constexpr uint32_t seed = 42;
+    uint64_t appendedData[2] = {
+        utils::hash::murmurSlow((const uint8_t*) data, size, seed),
+        (uint64_t) userdata,
+    };
+    const uint32_t key =
+            utils::hash::murmurSlow((const uint8_t*) appendedData, sizeof(appendedData), seed);
 
     // Retain a copy of the package to permit queries after the client application has
     // freed up the original material package.

--- a/libs/matdbg/web/app.js
+++ b/libs/matdbg/web/app.js
@@ -662,8 +662,8 @@ class MaterialSidePanel extends LitElement {
                 let name = material.name || kUntitledPlaceholder;
                 if (name in duplicatedLabels) {
                     const index = duplicatedLabels[name];
-                    name = `${name} (${index})`;
                     duplicatedLabels[name] = index + 1;
+                    name = `${name} (${index})`;
                 }
                 return {
                     matid: matid,


### PR DESCRIPTION
Fix 3 bugs wrt matdbg:

1. The numbering scheme for materials with same name was buggy
2. The shared depth variants of the default material should also show up as active material variants.
3. When two instantiation of FMaterial point to the exact same bits, we still need to treat them as two materials. (Otherwise we wouldn't be able to modify one of them in matdbg).