### PR TITLE
Fix: combine-static-libs.sh in macos universal

### DIFF
--- a/build/linux/combine-static-libs.sh
+++ b/build/linux/combine-static-libs.sh
@@ -131,7 +131,7 @@ if [[ "${has_universal}" == "true" ]]; then
             archives+=("$REPLY")
         done < <(find "$(pwd)/${archs_temp_dir}/${arch}" -iname '*.a' -print0)
 
-        combine_static_libs "$arch_output" "$archives"
+        combine_static_libs "$arch_output" "${archives[@]}"
     done
 
     # Finally, combine the single-architecture archives into a universal binary.


### PR DESCRIPTION
I found that only the first archive is passed as an argument to combine_static_libs, when using macos + universal architecture.

As can be seen from line 146, the bash array should be unrolled using "${archives[@]}".

Up to my knowledge, simply using "$archives" will only pass the first element of the array.