### PR TITLE
matdbg: fix two memory bugs

### DIFF
--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -198,7 +198,7 @@ DebugServer::addMaterial(const CString& name, const void* data, size_t size, voi
     // material data.
     constexpr uint32_t seed = 42;
     uint64_t dataSpace[2] = {(uint64_t) data, (uint64_t) userdata};
-    uint32_t const key = utils::hash::murmur3((const uint32_t*) dataSpace, sizeof(dataSpace), seed);
+    uint32_t const key = utils::hash::murmurSlow((uint8_t const*) dataSpace, sizeof(dataSpace), seed);
 
     // Retain a copy of the package to permit queries after the client application has
     // freed up the original material package.

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -377,7 +377,7 @@ void BlobIndex::writeChunks(ostream& stream) {
     for (auto& record : mShaderRecords) {
         const auto& src = mDataBlobs[record.dictionaryIndex];
         assert(src.size() % 4 == 0);
-        const uint32_t* ptr = (const uint32_t*) src.data();
+        uint8_t const* ptr = (uint8_t const*) src.data();
         record.dictionaryIndex = blobs.addBlob(vector<uint8_t>(ptr, ptr + src.size()));
     }
 


### PR DESCRIPTION
 - murmur3 expects word size not byte size
 - should use uint8_t in addressing blob source.

both would crash when asan is enabled.