### PR TITLE
matdbg: enable source formatting

### DIFF
--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -31,6 +31,8 @@ set(SRCS
     src/ShaderReplacer.cpp
     src/ShaderExtractor.cpp
     src/ShaderInfo.cpp
+    src/SourceFormatter.cpp
+    src/SourceFormatter.h
     src/TextWriter.cpp
 )
 

--- a/libs/matdbg/src/ApiHandler.h
+++ b/libs/matdbg/src/ApiHandler.h
@@ -17,6 +17,8 @@
 #ifndef MATDBG_APIHANDLER_H
 #define MATDBG_APIHANDLER_H
 
+#include "SourceFormatter.h"
+
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
@@ -63,6 +65,8 @@ private:
     // will always block until statusMaterialId is updated again. The client is expected to keep
     // calling /api/status (a constant "pull" to simulate a push).
     std::atomic<uint64_t> mCurrentStatus = 0;
+
+    SourceFormatter mFormatter;
 };
 
 } // filament::matdbg

--- a/libs/matdbg/src/SourceFormatter.cpp
+++ b/libs/matdbg/src/SourceFormatter.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SourceFormatter.h"
+
+#include <utils/Log.h>
+
+#include <cstdio>
+#include <sstream>
+
+namespace filament::matdbg {
+
+#if defined(__linux__) || defined(__APPLE__)
+std::string SourceFormatter::format(char const* source) {
+    std::string const TMP_FILENAME = "/tmp/matdbg-tmp-src.cpp";
+
+    std::string original(source);
+    FILE* fp;
+    fp = fopen(TMP_FILENAME.c_str(), "w");
+    if (!fp) {
+        return original;
+    }
+    fputs(original.c_str(), fp);
+    fflush(fp);
+    pclose(fp);
+
+    std::string const CLANG_FORMAT_OPTIONS =
+            "-style='{"
+            "BasedOnStyle: Google, "
+            "IndentWidth: 4, "
+            "MaxEmptyLinesToKeep: 2"
+            "}'";
+
+    fp = popen(("clang-format " + CLANG_FORMAT_OPTIONS + "< " + TMP_FILENAME).c_str(), "r");
+
+    if (!fp) {
+        std::call_once(mClangWarningFlag, []() {
+            utils::slog.w << "[matdbg] unable to run clang-format to format shader file. "
+                          << "Please make sure it's installed.";
+        });
+        return original;
+    }
+
+    char output[1024];
+    std::stringstream outStream;
+    while (fgets(output, 1024, fp) != NULL) {
+        outStream << output;
+    }
+
+    int status = pclose(fp);
+    if (WEXITSTATUS(status)) {
+        utils::slog.w << "[matdbg] clang-format failed with code=" << WEXITSTATUS(status)
+                      << utils::io::endl;
+    }
+    return outStream.str();
+}
+#else
+std::string SourceFormatter::format(char const* source) {
+    std::call_once(mClangWarningFlag, []() {    
+        utils::slog.w <<"[matdbg]: source formatting is not available on this platform" <<
+                utils::io::endl;
+    });
+    return "";
+}
+#endif
+
+} // filament::matdbg

--- a/libs/matdbg/src/SourceFormatter.h
+++ b/libs/matdbg/src/SourceFormatter.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MATDBG_SOURCE_FORMATTER_H
+#define MATDBG_SOURCE_FORMATTER_H
+
+#include <mutex>
+
+namespace filament::matdbg {
+
+class SourceFormatter {
+public:
+    SourceFormatter() = default;
+    ~SourceFormatter() = default;
+    std::string format(char const* source);
+
+private:
+
+    std::once_flag mClangWarningFlag;
+};
+
+} // filament::matdbg
+
+#endif // MATDBG_SOURCE_FORMATTER_H


### PR DESCRIPTION
We use clang-format to format the shader files. Since we assume clang is necessary for compilation, installing clang-format should not be too much of an overhead in terms of adding dependency.

Currently, we only support posix systems (macOS, linux).