### PR TITLE
Add support for an Atlas allocator for shadow maps

### DIFF
--- a/filament/src/AtlasAllocator.cpp
+++ b/filament/src/AtlasAllocator.cpp
@@ -151,6 +151,17 @@ AtlasAllocator::NodeId AtlasAllocator::allocateInLayer(size_t maxHeight) noexcep
             }
         } else if (candidate.l < int8_t(QuadTree::height())) {
             // we need to create the hierarchy down to the level we need
+
+            if (candidate.l > 0) {
+                // first thing to do is to update our parent's children count (the first node
+                // doesn't have a parent).
+                size_t const pi = QuadTreeUtils::parent(candidate.l, candidate.code);
+                Node& parentNode = mQuadTree[pi];
+                assert_invariant(!parentNode.isAllocated());
+                assert_invariant(!parentNode.hasAllChildren());
+                parentNode.children++;
+            }
+
             NodeId found{ -1, 0 };
             QuadTree::traverse(candidate.l, candidate.code,
                     [this, n, &found](NodeId const& curr) -> QuadTree::TraversalResult {

--- a/filament/src/AtlasAllocator.h
+++ b/filament/src/AtlasAllocator.h
@@ -23,6 +23,9 @@
 
 #include <private/filament/EngineEnums.h>
 
+#include <stdint.h>
+#include <stddef.h>
+
 class AtlasAllocator_AllocateFirstLevel_Test;
 class AtlasAllocator_AllocateSecondLevel_Test;
 class AtlasAllocator_AllocateMixed0_Test;
@@ -45,11 +48,11 @@ class AtlasAllocator {
      * track which children though.
      */
     struct Node {
-        // whether this node is allocated. Implies no children.
+        // Whether this node is allocated. Implies no children.
         constexpr bool isAllocated() const noexcept { return allocated; }
-        // whether this node has children. Implies it's not allocated.
+        // Whether this node has children. Implies it's not allocated.
         constexpr bool hasChildren() const noexcept { return children != 0; }
-        // whether this node has all four children. Implies hasChildren().
+        // Whether this node has all four children. Implies hasChildren().
         constexpr bool hasAllChildren() const noexcept { return children == 4; }
         bool allocated      : 1;    // true / false
         uint8_t children    : 3;    // 0, 1, 2, 3, 4

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -340,7 +340,7 @@ private:
             { 2, 6, 7, 3 },  // top
     };
 
-    mutable ShadowMapDescriptorSet mPerShadowMapUniforms;                     // 4
+    mutable ShadowMapDescriptorSet mPerShadowMapUniforms;                   // 48
 
     FCamera* mCamera = nullptr;                                             //  8
     FCamera* mDebugCamera = nullptr;                                        //  8
@@ -352,9 +352,10 @@ private:
     uint16_t mShadowIndex = 0;  // our index in the shadowMap vector        // 2
     uint8_t mLayer = 0;         // our layer in the shadowMap texture       // 1
     ShadowType mShadowType  : 2;                                            // :2
-    bool mHasVisibleShadows : 2;                                            // :2
+    bool mHasVisibleShadows : 1;                                            // :1
     uint8_t mFace           : 3;                                            // :3
     math::ushort2 mOffset{};                                                // 4
+    UTILS_UNUSED uint8_t reserved[4];                                       // 4
 };
 
 } // namespace filament

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -179,7 +179,8 @@ public:
     LightManager::ShadowOptions const* getShadowOptions() const noexcept { return mOptions; }
     size_t getLightIndex() const { return mLightIndex; }
     uint16_t getShadowIndex() const { return mShadowIndex; }
-    void setLayer(uint8_t layer) noexcept { mLayer = layer; }
+    void setAllocation(uint8_t layer, backend::Viewport viewport) noexcept;
+
     uint8_t getLayer() const noexcept { return mLayer; }
     backend::Viewport getViewport() const noexcept;
     backend::Viewport getScissor() const noexcept;
@@ -353,6 +354,7 @@ private:
     ShadowType mShadowType  : 2;                                            // :2
     bool mHasVisibleShadows : 2;                                            // :2
     uint8_t mFace           : 3;                                            // :3
+    math::ushort2 mOffset{};                                                // 4
 };
 
 } // namespace filament

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -979,13 +979,13 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
         auto const& options = shadowMap.getShadowOptions();
         maxDimension = std::max(maxDimension, options->mapSize);
         elvsm = elvsm || options->vsm.elvsm;
-        shadowMap.setLayer(layer++);
+        shadowMap.setAllocation(layer++, {});
     }
     for (ShadowMap& shadowMap : getSpotShadowMaps()) {
         auto const& options = shadowMap.getShadowOptions();
         maxDimension = std::max(maxDimension, options->mapSize);
         elvsm = elvsm || options->vsm.elvsm;
-        shadowMap.setLayer(layer++);
+        shadowMap.setAllocation(layer++, {});
     }
 
     const uint8_t layersNeeded = layer;
@@ -1003,17 +1003,9 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
     TextureFormat format = TextureFormat::DEPTH16;
     if (view.hasVSM()) {
         if (vsmShadowOptions.highPrecision) {
-            if (elvsm) {
-                format = TextureFormat::RGBA32F;
-            } else {
-                format = TextureFormat::RG32F;
-            }
+            format = elvsm ? TextureFormat::RGBA32F : TextureFormat::RG32F;
         } else {
-            if (elvsm) {
-                format = TextureFormat::RGBA16F;
-            } else {
-                format = TextureFormat::RG16F;
-            }
+            format = elvsm ? TextureFormat::RGBA16F : TextureFormat::RG16F;
         }
     }
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ShadowMapManager.h"
+#include "AtlasAllocator.h"
 #include "RenderPass.h"
 #include "ShadowMap.h"
 
@@ -22,6 +23,7 @@
 #include <filament/LightManager.h>
 #include <filament/Options.h>
 
+#include <iterator>
 #include <private/filament/EngineEnums.h>
 
 #include "components/RenderableManager.h"
@@ -54,6 +56,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <new>
 #include <memory>
@@ -75,6 +78,8 @@ ShadowMapManager::ShadowMapManager(FEngine& engine)
             &engine.debug.shadowmap.disable_light_frustum_align);
     debugRegistry.registerProperty("d.shadowmap.depth_clamp",
             &engine.debug.shadowmap.depth_clamp);
+
+    mFeatureShadowAllocator = engine.features.engine.shadows.use_shadow_atlas;
 }
 
 ShadowMapManager::~ShadowMapManager() {
@@ -99,6 +104,10 @@ void ShadowMapManager::terminate(FEngine& engine,
     if (shadowMapManager) {
         shadowMapManager->terminate(engine);
     }
+}
+
+size_t ShadowMapManager::getMaxShadowMapCount() const noexcept {
+    return mFeatureShadowAllocator ? CONFIG_MAX_SHADOWMAPS : CONFIG_MAX_SHADOW_LAYERS;
 }
 
 void ShadowMapManager::terminate(FEngine& engine) {
@@ -232,7 +241,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
     // -------------------------------------------------------------------------------------------
 
     struct PrepareShadowPassData {
-        struct ShadowPass {
+        struct ShadowPass {  // 112 bytes
             mutable RenderPass::Executor executor;
             ShadowMap* shadowMap;
             utils::Range<uint32_t> range;
@@ -248,7 +257,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
 
     auto& prepareShadowPass = fg.addPass<PrepareShadowPassData>("Prepare Shadow Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
-                data.passList.reserve(CONFIG_MAX_SHADOWMAPS);
+                data.passList.reserve(getMaxShadowMapCount());
                 data.shadows = builder.createTexture("Shadowmap", {
                         .width = textureRequirements.size, .height = textureRequirements.size,
                         .depth = textureRequirements.layers,
@@ -308,7 +317,18 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     }
                 }
 
-                assert_invariant(passList.size() <= textureRequirements.layers);
+                assert_invariant(mFeatureShadowAllocator ||
+                    passList.size() <= textureRequirements.layers);
+
+                if (mFeatureShadowAllocator) {
+                    // sort shadow passes by layer so that we can update all the shadow maps of
+                    // a layer in one render pass.
+                    std::sort(passList.begin(), passList.end(), [](
+                            PrepareShadowPassData::ShadowPass const& lhs,
+                            PrepareShadowPassData::ShadowPass const& rhs) {
+                        return lhs.shadowMap->getLayer() < rhs.shadowMap->getLayer();
+                    });
+                }
 
                 // This pass must be declared as having a side effect because it never gets a
                 // "read" from one of its resource (only writes), so the FrameGraph culls it.
@@ -336,7 +356,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     //       same command buffer for all shadow map, but then we'd generate
                     //       a lot of unneeded draw calls.
                     //       To do this efficiently, we'd need a way to cull draw calls already
-                    //       recorded in the command buffer, per shadow map.
+                    //       recorded in the command buffer, per shadow map. Maybe this could
+                    //       be done with indirect draw calls.
 
                     // Note: the output of culling below is stored in scene->getRenderableData()
 
@@ -429,13 +450,26 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
     };
 
     auto const& passList = prepareShadowPass.getData().passList;
-    for (auto const& entry: passList) {
+    auto first = passList.begin();
+    while (first != passList.end()) {
+        auto const& entry = *first;
+
         const uint8_t layer = entry.shadowMap->getLayer();
         const auto* options = entry.shadowMap->getShadowOptions();
         const auto msaaSamples = textureRequirements.msaaSamples;
         const bool blur = entry.shadowMap->hasVisibleShadows() &&
                 view.hasVSM() && options->vsm.blurWidth > 0.0f;
 
+        auto last = first;
+        // loop over each shadow pass to find its layer range
+        while (last != passList.end() && last->shadowMap->getLayer() == layer) {
+            ++last;
+        }
+
+        assert_invariant(mFeatureShadowAllocator ||
+            std::distance(first, last) == 1);
+
+        // And render all shadow pass of a given layer as a single render pass
         auto& shadowPass = fg.addPass<ShadowPassData>("Shadow Pass",
                 [&](FrameGraph::Builder& builder, auto& data) {
 
@@ -507,7 +541,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     // blurring.
                     data.rt = blur ? data.rt : rt;
                 },
-                [=, &engine, &entry](FrameGraphResources const& resources,
+                [=, &engine](FrameGraphResources const& resources,
                         auto const& data, DriverApi& driver) {
 
                     // Note: we capture entry by reference here. That's actually okay because
@@ -520,21 +554,30 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     auto rt = resources.getRenderPassInfo(data.rt);
 
                     driver.beginRenderPass(rt.target, rt.params);
-                    // if we know there are no visible shadows, we can skip rendering, but
-                    // we need the render-pass to clear/initialize the shadow-map
-                    // Note: this is always true for directional/cascade shadows.
-                    if (entry.shadowMap->hasVisibleShadows()) {
-                        entry.shadowMap->bind(driver);
-                        entry.executor.overrideScissor(entry.shadowMap->getScissor());
-                        entry.executor.execute(engine, driver);
+
+                    for (auto curr = first; curr != last; curr++) {
+                        // if we know there are no visible shadows, we can skip rendering, but
+                        // we need the render-pass to clear/initialize the shadow-map
+                        // Note: this is always true for directional/cascade shadows.
+                        if (curr->shadowMap->hasVisibleShadows()) {
+                            curr->shadowMap->bind(driver);
+                            curr->executor.overrideScissor(curr->shadowMap->getScissor());
+                            curr->executor.execute(engine, driver);
+                        }
                     }
+
                     driver.endRenderPass();
                 });
 
+        first = last;
 
         // now emit the blurring passes if needed
         if (UTILS_UNLIKELY(blur)) {
             auto& ppm = engine.getPostProcessManager();
+
+            // FIXME: this `options` is for the first shadowmap in the list, but it applies to
+            //        the whole layer. Blurring should happen per shadowmap, not for the whole
+            //        layer.
 
             const float blurWidth = options->vsm.blurWidth;
             if (blurWidth > 0.0f) {
@@ -546,6 +589,9 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                         shadowPass->output,
                         false, kernelWidth, sigma);
             }
+
+            // FIXME: mipmapping here is broken because it'll access texels from adjacent
+            //        shadow maps.
 
             // If the shadow texture has more than one level, mipmapping was requested, either directly
             // or indirectly via anisotropic filtering.
@@ -968,32 +1014,59 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
 void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view,
         FScene::LightSoa const&) noexcept {
 
-    // Lay out the shadow maps. For now, we take the largest requested dimension and allocate a
-    // texture of that size. Each cascade / shadow map gets its own layer in the array texture.
-    // The directional shadow cascades start on layer 0, followed by spotlights.
-    uint8_t layer = 0;
     uint32_t maxDimension = 0;
     bool elvsm = false;
-    for (ShadowMap& shadowMap : getCascadedShadowMap()) {
+
+    for (ShadowMap const& shadowMap : getCascadedShadowMap()) {
         // Shadow map size should be the same for all cascades.
         auto const& options = shadowMap.getShadowOptions();
         maxDimension = std::max(maxDimension, options->mapSize);
         elvsm = elvsm || options->vsm.elvsm;
-        shadowMap.setAllocation(layer++, {});
     }
-    for (ShadowMap& shadowMap : getSpotShadowMaps()) {
+
+    for (ShadowMap const& shadowMap : getSpotShadowMaps()) {
         auto const& options = shadowMap.getShadowOptions();
         maxDimension = std::max(maxDimension, options->mapSize);
         elvsm = elvsm || options->vsm.elvsm;
-        shadowMap.setAllocation(layer++, {});
     }
 
-    const uint8_t layersNeeded = layer;
+    uint8_t layersNeeded = 0;
+
+    std::function const allocateFromAtlas =
+            [&layersNeeded, allocator = AtlasAllocator{ maxDimension }](
+        ShadowMap* pShadowMap) mutable {
+        // Allocate shadowmap from our Atlas Allocator
+        auto const& options = pShadowMap->getShadowOptions();
+        auto [layer, pos] = allocator.allocate(options->mapSize);
+        assert_invariant(layer >= 0);
+        assert_invariant(!pos.empty());
+        pShadowMap->setAllocation(layer, pos);
+        layersNeeded = std::max(uint8_t(layer + 1), layersNeeded);
+    };
+
+    std::function const allocateFromTextureArray =
+            [&layersNeeded, layer = 0](ShadowMap* pShadowMap) mutable {
+        // Layout the shadow maps. For now, we take the largest requested dimension and allocate a
+        // texture of that size. Each cascade / shadow map gets its own layer in the array texture.
+        // The directional shadow cascades start on layer 0, followed by spotlights.
+        pShadowMap->setAllocation(layer, {});
+        layersNeeded = ++layer;
+    };
+
+    auto& allocateShadowmapTexture = mFeatureShadowAllocator ?
+        allocateFromAtlas : allocateFromTextureArray;
+
+    for (ShadowMap& shadowMap : getCascadedShadowMap()) {
+        allocateShadowmapTexture(&shadowMap);
+    }
+    for (ShadowMap& shadowMap : getSpotShadowMaps()) {
+        allocateShadowmapTexture(&shadowMap);
+    }
 
     // Generate mipmaps for VSM when anisotropy is enabled or when requested
     auto const& vsmShadowOptions = view.getVsmShadowOptions();
     const bool useMipmapping = view.hasVSM() &&
-                               ((vsmShadowOptions.anisotropy > 0) || vsmShadowOptions.mipmapping);
+            ((vsmShadowOptions.anisotropy > 0) || vsmShadowOptions.mipmapping);
 
     uint8_t msaaSamples = vsmShadowOptions.msaaSamples;
     if (engine.getDriverApi().isWorkaroundNeeded(Workaround::DISABLE_BLIT_INTO_TEXTURE_ARRAY)) {

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -119,6 +119,8 @@ public:
     static void terminate(FEngine& engine,
             std::unique_ptr<ShadowMapManager>& shadowMapManager);
 
+    size_t getMaxShadowMapCount() const noexcept;
+
     // Updates all the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
     ShadowMapManager::ShadowTechnique update(Builder const& builder,
@@ -227,17 +229,18 @@ private:
 
     // Inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
     // Because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.
-    // Each ShadowMap is currently 40 bytes (total of 2.5KB for 64 shadow maps)
-    using ShadowMapStorage = std::aligned_storage<sizeof(ShadowMap), alignof(ShadowMap)>::type;
+    // Each ShadowMap is currently 88 bytes (total of ~12KB for 128 shadow maps)
+    using ShadowMapStorage = std::aligned_storage<sizeof(ShadowMap)>::type;
     using ShadowMapCacheContainer = std::array<ShadowMapStorage, CONFIG_MAX_SHADOWMAPS>;
     ShadowMapCacheContainer mShadowMapCache;
     uint32_t mDirectionalShadowMapCount = 0;
     uint32_t mSpotShadowMapCount = 0;
     bool const mIsDepthClampSupported;
     bool mInitialized = false;
+    bool mFeatureShadowAllocator = false;
 
     ShadowMap& getShadowMap(size_t index) noexcept {
-        assert_invariant(index < CONFIG_MAX_SHADOWMAPS);
+        assert_invariant(index < mShadowMapCache.size());
         return *std::launder(reinterpret_cast<ShadowMap*>(&mShadowMapCache[index]));
     }
 

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -17,12 +17,13 @@
 #ifndef TNT_FILAMENT_DETAILS_SHADOWMAPMANAGER_H
 #define TNT_FILAMENT_DETAILS_SHADOWMAPMANAGER_H
 
-#include "Culler.h"
+#include "AtlasAllocator.h"
 #include "ShadowMap.h"
 #include "ds/TypedBuffer.h"
 
 #include <filament/LightManager.h>
 #include <filament/Options.h>
+#include <filament/Viewport.h>
 
 #include <private/filament/EngineEnums.h>
 #include <private/filament/UibStructs.h>

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -39,6 +39,7 @@
 #include <filament/MaterialEnums.h>
 
 #include <private/filament/DescriptorSets.h>
+#include <private/filament/EngineEnums.h>
 
 #include <private/backend/PlatformFactory.h>
 
@@ -1304,6 +1305,11 @@ size_t FEngine::getTextureCount() const noexcept { return mTextures.size(); }
 size_t FEngine::getSkyboxeCount() const noexcept { return mSkyboxes.size(); }
 size_t FEngine::getColorGradingCount() const noexcept { return mColorGradings.size(); }
 size_t FEngine::getRenderTargetCount() const noexcept { return mRenderTargets.size(); }
+
+size_t FEngine::getMaxShadowMapCount() const noexcept {
+    return features.engine.shadows.use_shadow_atlas ?
+        CONFIG_MAX_SHADOWMAPS : CONFIG_MAX_SHADOW_LAYERS;
+}
 
 void* FEngine::streamAlloc(size_t size, size_t alignment) noexcept {
     // we allow this only for small allocations

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -247,6 +247,8 @@ public:
         return mPlatform;
     }
 
+    size_t getMaxShadowMapCount() const noexcept;
+
     // Return a vector of shader languages, in order of preference.
     utils::FixedCapacityVector<backend::ShaderLanguage> getShaderLanguage() const noexcept {
         switch (mBackend) {
@@ -679,6 +681,11 @@ public:
     struct {
         struct {
             struct {
+                bool use_shadow_atlas = false;
+            } shadows;
+        } engine;
+        struct {
+            struct {
                 bool assert_native_window_is_valid = false;
             } opengl;
             bool disable_parallel_shader_compile = false;
@@ -686,7 +693,7 @@ public:
         } backend;
     } features;
 
-    std::array<Engine::FeatureFlag, sizeof(features)> const mFeatures{{
+    std::array<FeatureFlag, sizeof(features)> const mFeatures{{
             { "backend.disable_parallel_shader_compile",
               "Disable parallel shader compilation in GL and Metal backends.",
               &features.backend.disable_parallel_shader_compile, true },
@@ -695,10 +702,13 @@ public:
               &features.backend.disable_handle_use_after_free_check, true },
             { "backend.opengl.assert_native_window_is_valid",
               "Asserts that the ANativeWindow is valid when rendering starts.",
-              &features.backend.opengl.assert_native_window_is_valid, true }
+              &features.backend.opengl.assert_native_window_is_valid, true },
+            { "engine.shadows.use_shadow_atlas",
+              "Uses an array of atlases to store shadow maps.",
+              &features.engine.shadows.use_shadow_atlas, true }
     }};
 
-    utils::Slice<const Engine::FeatureFlag> getFeatureFlags() const noexcept {
+    utils::Slice<const FeatureFlag> getFeatureFlags() const noexcept {
         return { mFeatures.data(), mFeatures.size() };
     }
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -364,21 +364,23 @@ void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableD
         if (UTILS_LIKELY(!lcm.isShadowCaster(li))) {
             // Because we early exit here, we need to make sure we mark the light as non-casting.
             // See `ShadowMapManager::updateSpotShadowMaps` for const_cast<> justification.
-            const_cast<FScene::ShadowInfo&>(
-                    lightData.elementAt<FScene::SHADOW_INFO>(l)).castsShadows = false;
+            auto& shadowInfo = const_cast<FScene::ShadowInfo&>(
+                lightData.elementAt<FScene::SHADOW_INFO>(l));
+            shadowInfo.castsShadows = false;
             continue; // doesn't cast shadows
         }
 
         const bool spotLight = lcm.isSpotLight(li);
 
+        const size_t maxShadowMapCount = engine.getMaxShadowMapCount();
         const size_t shadowMapCountNeeded = spotLight ? 1 : 6;
-        if (shadowMapCount + shadowMapCountNeeded <= CONFIG_MAX_SHADOWMAPS) {
+        if (shadowMapCount + shadowMapCountNeeded <= maxShadowMapCount) {
             shadowMapCount += shadowMapCountNeeded;
             const auto& shadowOptions = lcm.getShadowOptions(li);
             builder.shadowMap(l, spotLight, &shadowOptions);
         }
 
-        if (shadowMapCount >= CONFIG_MAX_SHADOWMAPS) {
+        if (shadowMapCount >= maxShadowMapCount) {
             break; // we ran out of spotlight shadow casting
         }
     }

--- a/filament/test/filament_AtlasAllocator_test.cpp
+++ b/filament/test/filament_AtlasAllocator_test.cpp
@@ -117,6 +117,32 @@ TEST(AtlasAllocator, AllocateMixed2) {
     EXPECT_TRUE(c7.l == 2 && c7.code == 15);
 }
 
+TEST(AtlasAllocator, AllocateFourCascades_Test) {
+    Viewport vp(0,0,1024,1024);
+    AtlasAllocator allocator(1024);
+    auto e0 = allocator.allocate(1024);
+    EXPECT_EQ(e0.viewport, vp);
+    EXPECT_EQ(e0.layer, 0);
+
+    auto e1 = allocator.allocate(1024);
+    EXPECT_EQ(e1.viewport, vp);
+    EXPECT_EQ(e1.layer, 1);
+
+    auto e2 = allocator.allocate(1024);
+    EXPECT_EQ(e2.viewport, vp);
+    EXPECT_EQ(e2.layer, 2);
+
+    auto e3 = allocator.allocate(1024);
+    EXPECT_EQ(e3.viewport, vp);
+    EXPECT_EQ(e3.layer, 3);
+
+    auto e4 = allocator.allocate(128);
+    EXPECT_EQ(e4.layer, 4);
+
+    auto e5 = allocator.allocate(128);
+    EXPECT_EQ(e5.layer, 4);
+}
+
 TEST(AtlasAllocator, AllocateBySize) {
     AtlasAllocator allocator(256);
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -100,11 +100,11 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // Updating this value necessitates a material version bump.
 constexpr size_t CONFIG_MAX_RESERVED_SPEC_CONSTANTS = 16;
 
-// The maximum number of shadowmaps.
-// There is currently a maximum limit of 128 shadowmaps.
+// The maximum number of shadow maps possible.
+// There is currently a maximum limit of 128 shadow maps.
 // Factors contributing to this limit:
 // - minspec for UBOs is 16KiB, which currently can hold a maximum of 128 entries
-constexpr size_t CONFIG_MAX_SHADOWMAPS = 64;
+constexpr size_t CONFIG_MAX_SHADOWMAPS = 128;
 
 // The maximum number of shadow layers.
 // There is currently a maximum limit of 255 layers.
@@ -112,7 +112,8 @@ constexpr size_t CONFIG_MAX_SHADOWMAPS = 64;
 // - minspec for 2d texture arrays layer is 256
 // - we're using uint8_t to store the number of layers (255 max)
 // - nonsensical to be larger than the number of shadowmaps
-constexpr size_t CONFIG_MAX_SHADOW_LAYERS = CONFIG_MAX_SHADOWMAPS;
+// - AtlasAllocator depth limits it to 64
+constexpr size_t CONFIG_MAX_SHADOW_LAYERS = 64;
 
 // The maximum number of shadow cascades that can be used for directional lights.
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;

--- a/libs/utils/include/utils/QuadTree.h
+++ b/libs/utils/include/utils/QuadTree.h
@@ -80,6 +80,9 @@ static_assert(size(1) == 1);
 static_assert(size(2) == 5);
 static_assert(size(3) == 21);
 static_assert(size(4) == 85);
+static_assert(size(5) == 341);
+static_assert(size(6) == 1365);
+static_assert(size(7) == 5461);
 
 } // namespace QuadTreeUtils
 
@@ -114,11 +117,14 @@ class QuadTreeArray : public std::array<T, QuadTreeUtils::size(HEIGHT)> {
     };
 
 public:
-    using code_t = uint8_t;
+    // code_t needs to be able to encode the # of entries for the largest level supported
+    // the tree. With 7 levels, the largest one as 4096 entries, 0 to 4095 so 12 bits suffice.
+    using code_t = uint16_t;
 
     struct NodeId {
-        int8_t l;       // height of the node or -1 if invalid
-        code_t code;    // morton code of the node
+        int8_t l      :  4;     // height of the node or -1 if invalid
+        code_t   code : 12;     // morton code of the node
+        static_assert(12 >= (HEIGHT - 1) * 2);
     };
 
     enum class TraversalResult {


### PR DESCRIPTION
This feature is controled by a feature flag and is turned off at this point.
This CL shouldn't change the existing behavior of shadowmap allocation as
long as the atlas feature is not enanled.

When enabled, shadowmap allocations are not limited to layers of the
shadowmap texture, instead, an atlas is used meaning a layer can
be shared by multiple shadowmaps. At the very least this can save
a lot of memory as smaller shadowmaps can be packed together.

Currently this feature breaks some VSM features:
- mipmapping
- blurring