### PR TITLE
renderdiff: fix llvm-18 dep problem

### DIFF
--- a/test/utils/get_mesa.sh
+++ b/test/utils/get_mesa.sh
@@ -17,7 +17,20 @@
 set -e
 set -x
 
+CLANG_VERSION=`clang --version | head -n 1 | awk '{ print $4 }' | python3 -c "import sys; print(sys.stdin.read().split('.')[0])"`
+
 sudo apt-get -y build-dep mesa
+
+# Uninstall llvm-18 (and above) as they conflict with the mesa version we are compiling.
+sudo apt -y remove llvm-18 llvm-18-*
+
+sudo apt -y install clang-${CLANG_VERSION} \
+     libc++-${CLANG_VERSION}-dev \
+     libc++abi-${CLANG_VERSION}-dev \
+     llvm-${CLANG_VERSION} \
+     llvm-${CLANG_VERSION}-{dev,tools,runtime}
+
+export CXX=`which clang++` && export CC=`which clang`
 
 git clone https://gitlab.freedesktop.org/mesa/mesa.git
 


### PR DESCRIPTION
The public dep for mesa has moved on to beyond llvm-18, but the version we're compiling against is not supported by this change. We workaround by ensuring that the llvm dep is less than 18 but consistent with the clang version.