### PR TITLE
large code cleanup

### DIFF
--- a/filament/include/filament/Box.h
+++ b/filament/include/filament/Box.h
@@ -183,7 +183,7 @@ struct UTILS_PUBLIC Aabb {
      * Returns the 8 corner vertices of the AABB.
      */
     Corners getCorners() const {
-        return Aabb::Corners{ .vertices = {
+        return Corners{ .vertices = {
                 { min.x, min.y, min.z },
                 { max.x, min.y, min.z },
                 { min.x, max.y, min.z },

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -73,7 +73,7 @@ public:
 
         /**
          * The binding type for this buffer object. (defaults to VERTEX)
-         * @param BindingType Distinguishes between SSBO, VBO, etc. For now this must be VERTEX.
+         * @param bindingType Distinguishes between SSBO, VBO, etc. For now this must be VERTEX.
          * @return A reference to this Builder for chaining calls.
          */
         Builder& bindingType(BindingType bindingType) noexcept;
@@ -91,7 +91,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the BufferObject and returns a pointer to it. After creation, the buffer

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -400,14 +400,14 @@ public:
      *          engine.getTransformManager().getInstance(camera->getEntity()), model);
      * ~~~~~~~~~~~
      *
-     * @param model The camera position and orientation provided as a rigid transform matrix.
+     * @param modelMatrix The camera position and orientation provided as a rigid transform matrix.
      *
      * @note The Camera "looks" towards its -z axis
      *
      * @warning \p model must be a rigid transform
      */
-    void setModelMatrix(const math::mat4& model) noexcept;
-    void setModelMatrix(const math::mat4f& model) noexcept; //!< @overload
+    void setModelMatrix(const math::mat4& modelMatrix) noexcept;
+    void setModelMatrix(const math::mat4f& modelMatrix) noexcept; //!< @overload
 
     /** Set the position of an eye relative to this Camera (head).
      *

--- a/filament/include/filament/Color.h
+++ b/filament/include/filament/Color.h
@@ -194,7 +194,7 @@ inline sRGBColorA Color::toSRGB<ACCURATE>(LinearColorA const& color) {
 }
 
 inline LinearColor Color::toLinear(RgbType type, math::float3 color) {
-    return (type == RgbType::LINEAR) ? color : Color::toLinear<ACCURATE>(color);
+    return (type == RgbType::LINEAR) ? color : toLinear<ACCURATE>(color);
 }
 
 // converts an RGBA color to linear space
@@ -202,11 +202,11 @@ inline LinearColor Color::toLinear(RgbType type, math::float3 color) {
 inline LinearColorA Color::toLinear(RgbaType type, math::float4 color) {
     switch (type) {
         case RgbaType::sRGB:
-            return Color::toLinear<ACCURATE>(color) * math::float4{color.a, color.a, color.a, 1.0f};
+            return toLinear<ACCURATE>(color) * math::float4{color.a, color.a, color.a, 1.0f};
         case RgbaType::LINEAR:
             return color * math::float4{color.a, color.a, color.a, 1.0f};
         case RgbaType::PREMULTIPLIED_sRGB:
-            return Color::toLinear<ACCURATE>(color);
+            return toLinear<ACCURATE>(color);
         case RgbaType::PREMULTIPLIED_LINEAR:
             return color;
     }

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -537,7 +537,7 @@ public:
             Platform* UTILS_NULLABLE platform = nullptr,
             void* UTILS_NULLABLE sharedContext = nullptr,
             const Config* UTILS_NULLABLE config = nullptr) {
-        return Engine::Builder()
+        return Builder()
                 .backend(backend)
                 .platform(platform)
                 .sharedContext(sharedContext)
@@ -557,7 +557,7 @@ public:
             Platform* UTILS_NULLABLE platform = nullptr,
             void* UTILS_NULLABLE sharedContext = nullptr,
             const Config* UTILS_NULLABLE config = nullptr) {
-        Engine::Builder()
+        Builder()
                 .backend(backend)
                 .platform(platform)
                 .sharedContext(sharedContext)

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -96,7 +96,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the IndexBuffer object and returns a pointer to it. After creation, the index

--- a/filament/include/filament/InstanceBuffer.h
+++ b/filament/include/filament/InstanceBuffer.h
@@ -83,7 +83,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the InstanceBuffer object and returns a pointer to it.

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -118,10 +118,10 @@ public:
         Builder& package(const void* UTILS_NONNULL payload, size_t size);
 
         template<typename T>
-        using is_supported_constant_parameter_t = typename std::enable_if<
-                std::is_same<int32_t, T>::value ||
-                std::is_same<float, T>::value ||
-                std::is_same<bool, T>::value>::type;
+        using is_supported_constant_parameter_t = std::enable_if_t<
+                std::is_same_v<int32_t, T> ||
+                std::is_same_v<float, T> ||
+                std::is_same_v<bool, T>>;
 
         /**
          * Specialize a constant parameter specified in the material definition with a concrete

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -177,7 +177,7 @@ public:
          *            memory or other resources.
          * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
          */
-        Material* UTILS_NULLABLE build(Engine& engine);
+        Material* UTILS_NULLABLE build(Engine& engine) const;
     private:
         friend class FMaterial;
     };

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -56,35 +56,35 @@ class UTILS_PUBLIC MaterialInstance : public FilamentAPI {
     };
 
 public:
-    using CullingMode = filament::backend::CullingMode;
-    using TransparencyMode = filament::TransparencyMode;
-    using DepthFunc = filament::backend::SamplerCompareFunc;
-    using StencilCompareFunc = filament::backend::SamplerCompareFunc;
-    using StencilOperation = filament::backend::StencilOperation;
-    using StencilFace = filament::backend::StencilFace;
+    using CullingMode = backend::CullingMode;
+    using TransparencyMode = TransparencyMode;
+    using DepthFunc = backend::SamplerCompareFunc;
+    using StencilCompareFunc = backend::SamplerCompareFunc;
+    using StencilOperation = backend::StencilOperation;
+    using StencilFace = backend::StencilFace;
 
     template<typename T>
-    using is_supported_parameter_t = typename std::enable_if<
-            std::is_same<float, T>::value ||
-            std::is_same<int32_t, T>::value ||
-            std::is_same<uint32_t, T>::value ||
-            std::is_same<math::int2, T>::value ||
-            std::is_same<math::int3, T>::value ||
-            std::is_same<math::int4, T>::value ||
-            std::is_same<math::uint2, T>::value ||
-            std::is_same<math::uint3, T>::value ||
-            std::is_same<math::uint4, T>::value ||
-            std::is_same<math::float2, T>::value ||
-            std::is_same<math::float3, T>::value ||
-            std::is_same<math::float4, T>::value ||
-            std::is_same<math::mat4f, T>::value ||
+    using is_supported_parameter_t = std::enable_if_t<
+            std::is_same_v<float, T> ||
+            std::is_same_v<int32_t, T> ||
+            std::is_same_v<uint32_t, T> ||
+            std::is_same_v<math::int2, T> ||
+            std::is_same_v<math::int3, T> ||
+            std::is_same_v<math::int4, T> ||
+            std::is_same_v<math::uint2, T> ||
+            std::is_same_v<math::uint3, T> ||
+            std::is_same_v<math::uint4, T> ||
+            std::is_same_v<math::float2, T> ||
+            std::is_same_v<math::float3, T> ||
+            std::is_same_v<math::float4, T> ||
+            std::is_same_v<math::mat4f, T> ||
             // these types are slower as they need a layout conversion
-            std::is_same<bool, T>::value ||
-            std::is_same<math::bool2, T>::value ||
-            std::is_same<math::bool3, T>::value ||
-            std::is_same<math::bool4, T>::value ||
-            std::is_same<math::mat3f, T>::value
-    >::type;
+            std::is_same_v<bool, T> ||
+            std::is_same_v<math::bool2, T> ||
+            std::is_same_v<math::bool3, T> ||
+            std::is_same_v<math::bool4, T> ||
+            std::is_same_v<math::mat3f, T>
+    >;
 
     /**
      * Creates a new MaterialInstance using another MaterialInstance as a template for initialization.
@@ -121,13 +121,13 @@ public:
 
     /** inline helper to provide the name as a null-terminated string literal */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline void setParameter(StringLiteral name, T const& value) {
+    void setParameter(StringLiteral name, T const& value) {
         setParameter<T>(name.data, name.size, value);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline void setParameter(const char* UTILS_NONNULL name, T const& value) {
+    void setParameter(const char* UTILS_NONNULL name, T const& value) {
         setParameter<T>(name, strlen(name), value);
     }
 
@@ -148,14 +148,14 @@ public:
 
     /** inline helper to provide the name as a null-terminated string literal */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline void setParameter(StringLiteral name, const T* UTILS_NONNULL values, size_t count) {
+    void setParameter(StringLiteral name, const T* UTILS_NONNULL values, size_t count) {
         setParameter<T>(name.data, name.size, values, count);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline void setParameter(const char* UTILS_NONNULL name,
-            const T* UTILS_NONNULL values, size_t count) {
+    void setParameter(const char* UTILS_NONNULL name,
+                      const T* UTILS_NONNULL values, size_t count) {
         setParameter<T>(name, strlen(name), values, count);
     }
 
@@ -176,14 +176,14 @@ public:
             Texture const* UTILS_NULLABLE texture, TextureSampler const& sampler);
 
     /** inline helper to provide the name as a null-terminated string literal */
-    inline void setParameter(StringLiteral name,
-            Texture const* UTILS_NULLABLE texture, TextureSampler const& sampler) {
+    void setParameter(StringLiteral name,
+                      Texture const* UTILS_NULLABLE texture, TextureSampler const& sampler) {
         setParameter(name.data, name.size, texture, sampler);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
-    inline void setParameter(const char* UTILS_NONNULL name,
-            Texture const* UTILS_NULLABLE texture, TextureSampler const& sampler) {
+    void setParameter(const char* UTILS_NONNULL name,
+                      Texture const* UTILS_NULLABLE texture, TextureSampler const& sampler) {
         setParameter(name, strlen(name), texture, sampler);
     }
 
@@ -202,12 +202,12 @@ public:
             RgbType type, math::float3 color);
 
     /** inline helper to provide the name as a null-terminated string literal */
-    inline void setParameter(StringLiteral name, RgbType type, math::float3 color) {
+    void setParameter(StringLiteral name, RgbType type, math::float3 color) {
         setParameter(name.data, name.size, type, color);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
-    inline void setParameter(const char* UTILS_NONNULL name, RgbType type, math::float3 color) {
+    void setParameter(const char* UTILS_NONNULL name, RgbType type, math::float3 color) {
         setParameter(name, strlen(name), type, color);
     }
 
@@ -226,12 +226,12 @@ public:
             RgbaType type, math::float4 color);
 
     /** inline helper to provide the name as a null-terminated string literal */
-    inline void setParameter(StringLiteral name, RgbaType type, math::float4 color) {
+    void setParameter(StringLiteral name, RgbaType type, math::float4 color) {
         setParameter(name.data, name.size, type, color);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
-    inline void setParameter(const char* UTILS_NONNULL name, RgbaType type, math::float4 color) {
+    void setParameter(const char* UTILS_NONNULL name, RgbaType type, math::float4 color) {
         setParameter(name, strlen(name), type, color);
     }
 
@@ -251,13 +251,13 @@ public:
 
     /** inline helper to provide the name as a null-terminated C string */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline T getParameter(StringLiteral name) const {
+    T getParameter(StringLiteral name) const {
         return getParameter<T>(name.data, name.size);
     }
 
     /** inline helper to provide the name as a null-terminated C string */
     template<typename T, typename = is_supported_parameter_t<T>>
-    inline T getParameter(const char* UTILS_NONNULL name) const {
+    T getParameter(const char* UTILS_NONNULL name) const {
         return getParameter<T>(name, strlen(name));
     }
 

--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -76,7 +76,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the MorphTargetBuffer object and returns a pointer to it.

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -501,7 +501,7 @@ public:
          * @param primitiveIndex zero-based index of the primitive, must be less than the count passed to Builder constructor
          * @param offset specifies where in the morph target buffer to start reading (expressed as a number of vertices)
          */
-        RenderableManager::Builder& morphing(uint8_t level,
+        Builder& morphing(uint8_t level,
                 size_t primitiveIndex, size_t offset) noexcept;
 
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -220,7 +220,7 @@ public:
          * the renderable are immutable.
          * STATIC geometry has the same restrictions as STATIC_BOUNDS, but in addition disallows
          * skinning, morphing and changing the VertexBuffer or IndexBuffer in any way.
-         * @param enable whether this renderable has static bounds. false by default.
+         * @param type type of geometry.
          */
         Builder& geometryType(GeometryType type) noexcept;
 
@@ -454,7 +454,7 @@ public:
          *
          * @param primitiveIndex zero-based index of the primitive, must be less than the primitive
          *                       count passed to Builder constructor
-         * @param indicesAndWeightsVectors pairs of bone index and bone weight for all vertices of
+         * @param indicesAndWeightsVector pairs of bone index and bone weight for all vertices of
          *                                 the primitive sequentially
          *
          * @return Builder reference for chaining calls.
@@ -852,20 +852,20 @@ public:
     /*! \cond PRIVATE */
     template<typename T>
     struct is_supported_vector_type {
-        using type = typename std::enable_if<
-                std::is_same<math::float4, T>::value ||
-                std::is_same<math::half4,  T>::value ||
-                std::is_same<math::float3, T>::value ||
-                std::is_same<math::half3,  T>::value
-        >::type;
+        using type = std::enable_if_t<
+                std::is_same_v<math::float4, T> ||
+                std::is_same_v<math::half4,  T> ||
+                std::is_same_v<math::float3, T> ||
+                std::is_same_v<math::half3,  T>
+        >;
     };
 
     template<typename T>
     struct is_supported_index_type {
-        using type = typename std::enable_if<
-                std::is_same<uint16_t, T>::value ||
-                std::is_same<uint32_t, T>::value
-        >::type;
+        using type = std::enable_if_t<
+                std::is_same_v<uint16_t, T> ||
+                std::is_same_v<uint32_t, T>
+        >;
     };
     /*! \endcond */
 

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -105,7 +105,7 @@ public:
      * @param historySize requested history size. The returned vector could be smaller.
      * @return A vector of FrameInfo.
      */
-    utils::FixedCapacityVector<Renderer::FrameInfo> getFrameInfoHistory(
+    utils::FixedCapacityVector<FrameInfo> getFrameInfoHistory(
             size_t historySize = 1) const noexcept;
 
     /**

--- a/filament/include/filament/SkinningBuffer.h
+++ b/filament/include/filament/SkinningBuffer.h
@@ -82,7 +82,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the SkinningBuffer object and returns a pointer to it.

--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -149,7 +149,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the Stream object and returns a pointer to it.

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -94,7 +94,7 @@ public:
     /** @return whether a backend supports texture swizzling. */
     static bool isTextureSwizzleSupported(Engine& engine) noexcept;
 
-    static size_t computeTextureDataSize(Texture::Format format, Texture::Type type,
+    static size_t computeTextureDataSize(Format format, Type type,
             size_t stride, size_t height, size_t alignment) noexcept;
 
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -215,7 +215,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-         // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+         Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the Texture object and returns a pointer to it.

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -171,7 +171,7 @@ public:
          * @param len Length of name, should be less than or equal to 128
          * @return This Builder, for chaining calls.
          */
-        // Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept; // inherited
+        Builder& name(const char* UTILS_NONNULL name, size_t len) noexcept;
 
         /**
          * Creates the VertexBuffer object and returns a pointer to it.

--- a/filament/src/AtlasAllocator.cpp
+++ b/filament/src/AtlasAllocator.cpp
@@ -32,12 +32,12 @@ static inline constexpr std::pair<uint8_t, uint8_t> unmorton(uint16_t m) noexcep
 
 AtlasAllocator::AtlasAllocator(size_t maxTextureSize) noexcept {
     // round to power-of-two immediately inferior or equal to the size specified.
-    mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - utils::clz(maxTextureSize);
+    mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - clz(maxTextureSize);
 }
 
 AtlasAllocator::Allocation AtlasAllocator::allocate(size_t textureSize) noexcept {
     Allocation result{};
-    const size_t powerOfTwo = (sizeof(textureSize) * 8 - 1u) - utils::clz(textureSize);
+    const size_t powerOfTwo = (sizeof(textureSize) * 8 - 1u) - clz(textureSize);
 
     // asked for a texture size too large
     if (UTILS_UNLIKELY(powerOfTwo > mMaxTextureSizePot)) {
@@ -69,7 +69,7 @@ AtlasAllocator::Allocation AtlasAllocator::allocate(size_t textureSize) noexcept
 
 void AtlasAllocator::clear(size_t maxTextureSize) noexcept {
     std::fill(mQuadTree.begin(), mQuadTree.end(), Node{});
-    mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - utils::clz(maxTextureSize);
+    mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - clz(maxTextureSize);
 }
 
 AtlasAllocator::NodeId AtlasAllocator::allocateInLayer(size_t maxHeight) noexcept {
@@ -155,7 +155,7 @@ AtlasAllocator::NodeId AtlasAllocator::allocateInLayer(size_t maxHeight) noexcep
             if (candidate.l > 0) {
                 // first thing to do is to update our parent's children count (the first node
                 // doesn't have a parent).
-                size_t const pi = QuadTreeUtils::parent(candidate.l, candidate.code);
+                size_t const pi = parent(candidate.l, candidate.code);
                 Node& parentNode = mQuadTree[pi];
                 assert_invariant(!parentNode.isAllocated());
                 assert_invariant(!parentNode.hasAllChildren());

--- a/filament/src/AtlasAllocator.cpp
+++ b/filament/src/AtlasAllocator.cpp
@@ -22,7 +22,7 @@ namespace filament {
 
 using namespace utils;
 
-static inline constexpr std::pair<uint8_t, uint8_t> unmorton(uint16_t m) noexcept {
+static inline constexpr std::pair<uint8_t, uint8_t> unmorton(uint16_t const m) noexcept {
     uint32_t r = (m | (uint32_t(m) << 15u)) & 0x55555555u;
     r = (r | (r >> 1u)) & 0x33333333u;
     r = (r | (r >> 2u)) & 0x0f0f0f0fu;
@@ -30,12 +30,12 @@ static inline constexpr std::pair<uint8_t, uint8_t> unmorton(uint16_t m) noexcep
     return { uint8_t(r), uint8_t(r >> 16u) };
 }
 
-AtlasAllocator::AtlasAllocator(size_t maxTextureSize) noexcept {
+AtlasAllocator::AtlasAllocator(size_t const maxTextureSize) noexcept {
     // round to power-of-two immediately inferior or equal to the size specified.
     mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - clz(maxTextureSize);
 }
 
-AtlasAllocator::Allocation AtlasAllocator::allocate(size_t textureSize) noexcept {
+AtlasAllocator::Allocation AtlasAllocator::allocate(size_t const textureSize) noexcept {
     Allocation result{};
     const size_t powerOfTwo = (sizeof(textureSize) * 8 - 1u) - clz(textureSize);
 
@@ -67,12 +67,12 @@ AtlasAllocator::Allocation AtlasAllocator::allocate(size_t textureSize) noexcept
     return result;
 }
 
-void AtlasAllocator::clear(size_t maxTextureSize) noexcept {
+void AtlasAllocator::clear(size_t const maxTextureSize) noexcept {
     std::fill(mQuadTree.begin(), mQuadTree.end(), Node{});
     mMaxTextureSizePot = (sizeof(maxTextureSize) * 8 - 1u) - clz(maxTextureSize);
 }
 
-AtlasAllocator::NodeId AtlasAllocator::allocateInLayer(size_t maxHeight) noexcept {
+AtlasAllocator::NodeId AtlasAllocator::allocateInLayer(size_t const maxHeight) noexcept {
     using namespace QuadTreeUtils;
 
     NodeId candidate{ -1, 0 };

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -23,7 +23,7 @@
 namespace filament {
 
 void BufferObject::setBuffer(Engine& engine,
-        BufferDescriptor&& buffer, uint32_t byteOffset) {
+        BufferDescriptor&& buffer, uint32_t const byteOffset) {
     downcast(this)->setBuffer(downcast(engine), std::move(buffer), byteOffset);
 }
 

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -23,7 +23,7 @@
 namespace filament {
 
 void BufferObject::setBuffer(Engine& engine,
-        BufferObject::BufferDescriptor&& buffer, uint32_t byteOffset) {
+        BufferDescriptor&& buffer, uint32_t byteOffset) {
     downcast(this)->setBuffer(downcast(engine), std::move(buffer), byteOffset);
 }
 

--- a/filament/src/BufferPoolAllocator.h
+++ b/filament/src/BufferPoolAllocator.h
@@ -103,7 +103,7 @@ void BufferPoolAllocator<POOL_SIZE, ALIGNMENT, AllocatorPolicy, LockingPolicy>::
 }
 
 template<size_t POOL_SIZE, size_t ALIGNMENT, typename AllocatorPolicy, typename LockingPolicy>
-void* BufferPoolAllocator<POOL_SIZE, ALIGNMENT, AllocatorPolicy, LockingPolicy>::get(size_type size) noexcept {
+void* BufferPoolAllocator<POOL_SIZE, ALIGNMENT, AllocatorPolicy, LockingPolicy>::get(size_type const size) noexcept {
     std::lock_guard<LockingPolicy> guard(mLock);
 
     // if the requested size is larger that our buffers in the pool, we just empty the pool

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -23,7 +23,7 @@ namespace filament {
 using namespace math;
 
 void Camera::setProjection(double fovInDegrees, double aspect, double near, double far,
-        Camera::Fov direction) {
+        Fov direction) {
     setCustomProjection(
             projection(direction, fovInDegrees, aspect, near),
             projection(direction, fovInDegrees, aspect, near, far),
@@ -46,16 +46,16 @@ mat4 Camera::inverseProjection(const mat4& p) noexcept {
     return inverse(p);
 }
 
-void Camera::setEyeModelMatrix(uint8_t eyeId, math::mat4 const& model) {
+void Camera::setEyeModelMatrix(uint8_t eyeId, mat4 const& model) {
     downcast(this)->setEyeModelMatrix(eyeId, model);
 }
 
-void Camera::setCustomEyeProjection(math::mat4 const* projection, size_t count,
-        math::mat4 const& projectionForCulling, double near, double far) {
+void Camera::setCustomEyeProjection(mat4 const* projection, size_t count,
+        mat4 const& projectionForCulling, double near, double far) {
     downcast(this)->setCustomEyeProjection(projection, count, projectionForCulling, near, far);
 }
 
-void Camera::setProjection(Camera::Projection projection, double left, double right, double bottom,
+void Camera::setProjection(Projection projection, double left, double right, double bottom,
         double top, double near, double far) {
     downcast(this)->setProjection(projection, left, right, bottom, top, near, far);
 }
@@ -137,7 +137,7 @@ float3 Camera::getForwardVector() const noexcept {
     return downcast(this)->getForwardVector();
 }
 
-float Camera::getFieldOfViewInDegrees(Camera::Fov direction) const noexcept {
+float Camera::getFieldOfViewInDegrees(Fov direction) const noexcept {
     return downcast(this)->getFieldOfViewInDegrees(direction);
 }
 
@@ -185,12 +185,12 @@ double Camera::computeEffectiveFov(double fovInDegrees, double focusDistance) no
     return FCamera::computeEffectiveFov(fovInDegrees, focusDistance);
 }
 
-math::mat4 Camera::projection(Fov direction, double fovInDegrees,
+mat4 Camera::projection(Fov direction, double fovInDegrees,
         double aspect, double near, double far) {
     return FCamera::projection(direction, fovInDegrees, aspect, near, far);
 }
 
-math::mat4 Camera::projection(double focalLengthInMillimeters,
+mat4 Camera::projection(double focalLengthInMillimeters,
         double aspect, double near, double far) {
     return FCamera::projection(focalLengthInMillimeters, aspect, near, far);
 }

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -22,16 +22,16 @@ namespace filament {
 
 using namespace math;
 
-void Camera::setProjection(double fovInDegrees, double aspect, double near, double far,
-        Fov direction) {
+void Camera::setProjection(double const fovInDegrees, double const aspect, double const near, double const far,
+        Fov const direction) {
     setCustomProjection(
             projection(direction, fovInDegrees, aspect, near),
             projection(direction, fovInDegrees, aspect, near, far),
             near, far);
 }
 
-void Camera::setLensProjection(double focalLengthInMillimeters,
-        double aspect, double near, double far) {
+void Camera::setLensProjection(double const focalLengthInMillimeters,
+        double const aspect, double const near, double const far) {
     setCustomProjection(
             projection(focalLengthInMillimeters, aspect, near),
             projection(focalLengthInMillimeters, aspect, near, far),
@@ -46,38 +46,38 @@ mat4 Camera::inverseProjection(const mat4& p) noexcept {
     return inverse(p);
 }
 
-void Camera::setEyeModelMatrix(uint8_t eyeId, mat4 const& model) {
+void Camera::setEyeModelMatrix(uint8_t const eyeId, mat4 const& model) {
     downcast(this)->setEyeModelMatrix(eyeId, model);
 }
 
-void Camera::setCustomEyeProjection(mat4 const* projection, size_t count,
-        mat4 const& projectionForCulling, double near, double far) {
+void Camera::setCustomEyeProjection(mat4 const* projection, size_t const count,
+        mat4 const& projectionForCulling, double const near, double const far) {
     downcast(this)->setCustomEyeProjection(projection, count, projectionForCulling, near, far);
 }
 
-void Camera::setProjection(Projection projection, double left, double right, double bottom,
-        double top, double near, double far) {
+void Camera::setProjection(Projection const projection, double const left, double const right, double const bottom,
+        double const top, double const near, double const far) {
     downcast(this)->setProjection(projection, left, right, bottom, top, near, far);
 }
 
-void Camera::setCustomProjection(mat4 const& projection, double near, double far) noexcept {
+void Camera::setCustomProjection(mat4 const& projection, double const near, double const far) noexcept {
     downcast(this)->setCustomProjection(projection, near, far);
 }
 
 void Camera::setCustomProjection(mat4 const& projection, mat4 const& projectionForCulling,
-        double near, double far) noexcept {
+        double const near, double const far) noexcept {
     downcast(this)->setCustomProjection(projection, projectionForCulling, near, far);
 }
 
-void Camera::setScaling(double2 scaling) noexcept {
+void Camera::setScaling(double2 const scaling) noexcept {
     downcast(this)->setScaling(scaling);
 }
 
-void Camera::setShift(double2 shift) noexcept {
+void Camera::setShift(double2 const shift) noexcept {
     downcast(this)->setShift(shift);
 }
 
-mat4 Camera::getProjectionMatrix(uint8_t eyeId) const {
+mat4 Camera::getProjectionMatrix(uint8_t const eyeId) const {
     return downcast(this)->getUserProjectionMatrix(eyeId);
 }
 
@@ -137,7 +137,7 @@ float3 Camera::getForwardVector() const noexcept {
     return downcast(this)->getForwardVector();
 }
 
-float Camera::getFieldOfViewInDegrees(Fov direction) const noexcept {
+float Camera::getFieldOfViewInDegrees(Fov const direction) const noexcept {
     return downcast(this)->getFieldOfViewInDegrees(direction);
 }
 
@@ -149,7 +149,7 @@ utils::Entity Camera::getEntity() const noexcept {
     return downcast(this)->getEntity();
 }
 
-void Camera::setExposure(float aperture, float shutterSpeed, float ISO) noexcept {
+void Camera::setExposure(float const aperture, float const shutterSpeed, float const ISO) noexcept {
     downcast(this)->setExposure(aperture, shutterSpeed, ISO);
 }
 
@@ -165,7 +165,7 @@ float Camera::getSensitivity() const noexcept {
     return downcast(this)->getSensitivity();
 }
 
-void Camera::setFocusDistance(float distance) noexcept {
+void Camera::setFocusDistance(float const distance) noexcept {
     downcast(this)->setFocusDistance(distance);
 }
 
@@ -177,21 +177,21 @@ double Camera::getFocalLength() const noexcept {
     return downcast(this)->getFocalLength();
 }
 
-double Camera::computeEffectiveFocalLength(double focalLength, double focusDistance) noexcept {
+double Camera::computeEffectiveFocalLength(double const focalLength, double const focusDistance) noexcept {
     return FCamera::computeEffectiveFocalLength(focalLength, focusDistance);
 }
 
-double Camera::computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept {
+double Camera::computeEffectiveFov(double const fovInDegrees, double const focusDistance) noexcept {
     return FCamera::computeEffectiveFov(fovInDegrees, focusDistance);
 }
 
-mat4 Camera::projection(Fov direction, double fovInDegrees,
-        double aspect, double near, double far) {
+mat4 Camera::projection(Fov const direction, double const fovInDegrees,
+        double const aspect, double const near, double const far) {
     return FCamera::projection(direction, fovInDegrees, aspect, near, far);
 }
 
-mat4 Camera::projection(double focalLengthInMillimeters,
-        double aspect, double near, double far) {
+mat4 Camera::projection(double const focalLengthInMillimeters,
+        double const aspect, double const near, double const far) {
     return FCamera::projection(focalLengthInMillimeters, aspect, near, far);
 }
 

--- a/filament/src/Color.cpp
+++ b/filament/src/Color.cpp
@@ -25,15 +25,15 @@ namespace filament {
 
 using namespace math;
 
-float3 Color::sRGBToLinear(float3 color) noexcept {
+float3 Color::sRGBToLinear(float3 const color) noexcept {
     return EOTF_sRGB(color);
 }
 
-float3 Color::linearToSRGB(float3 color) noexcept {
+float3 Color::linearToSRGB(float3 const color) noexcept {
     return OETF_sRGB(color);
 }
 
-LinearColor Color::cct(float K) {
+LinearColor Color::cct(float const K) {
     // temperature to CIE 1960
     float const K2 = K * K;
     float const u = (0.860117757f + 1.54118254e-4f * K + 1.28641212e-7f * K2) /
@@ -47,7 +47,7 @@ LinearColor Color::cct(float K) {
     return saturate(linear / max(1e-5f, max(linear)));
 }
 
-LinearColor Color::illuminantD(float K) {
+LinearColor Color::illuminantD(float const K) {
     // temperature to xyY
     const float iK = 1.0f / K;
     float const iK2 = iK * iK;
@@ -61,7 +61,7 @@ LinearColor Color::illuminantD(float K) {
     return saturate(linear / max(1e-5f, max(linear)));
 }
 
-LinearColor Color::absorptionAtDistance(LinearColor const& color, float distance) {
+LinearColor Color::absorptionAtDistance(LinearColor const& color, float const distance) {
     return -log(clamp(color, 1e-5f, 1.0f)) / max(1e-5f, distance);
 }
 

--- a/filament/src/ColorSpaceUtils.cpp
+++ b/filament/src/ColorSpaceUtils.cpp
@@ -52,7 +52,7 @@ using namespace math;
 // Finds the maximum saturation possible for a given hue that fits in sRGB
 // Saturation here is defined as S = C/L
 // a and b must be normalized so a^2 + b^2 == 1
-static float compute_max_saturation(float a, float b) noexcept {
+static float compute_max_saturation(float const a, float const b) noexcept {
     // Max saturation will be when one of r, g or b goes below zero.
 
     // Select different coefficients depending on which component goes below zero first
@@ -131,7 +131,7 @@ static float compute_max_saturation(float a, float b) noexcept {
 
 // finds L_cusp and C_cusp for a given hue
 // a and b must be normalized so a^2 + b^2 == 1
-static float2 find_cusp(float a, float b) noexcept {
+static float2 find_cusp(float const a, float const b) noexcept {
     // First, find the maximum saturation (saturation S = C/L)
     float const S_cusp = compute_max_saturation(a, b);
 
@@ -147,7 +147,7 @@ static float2 find_cusp(float a, float b) noexcept {
 // L = L0 * (1 - t) + t * L1;
 // C = t * C1;
 // a and b must be normalized so a^2 + b^2 == 1
-static float find_gamut_intersection(float a, float b, float L1, float C1, float L0) noexcept {
+static float find_gamut_intersection(float const a, float const b, float const L1, float const C1, float const L0) noexcept {
     // Find the cusp of the gamut triangle
     float2 const cusp = find_cusp(a, b);
 
@@ -231,7 +231,7 @@ static float find_gamut_intersection(float a, float b, float L1, float C1, float
     return t;
 }
 
-constexpr float sgn(float x) noexcept {
+constexpr float sgn(float const x) noexcept {
     return (float) (0.f < x) - (float) (x < 0.f);
 }
 
@@ -266,7 +266,7 @@ inline float3 gamut_clip_adaptive_L0_0_5(float3 rgb,
     return OkLab_to_sRGB({L_clipped, C_clipped * a_, C_clipped * b_});
 }
 
-float3 gamutMapping_sRGB(float3 rgb) noexcept {
+float3 gamutMapping_sRGB(float3 const rgb) noexcept {
     return gamut_clip_adaptive_L0_0_5(rgb);
 }
 

--- a/filament/src/ColorSpaceUtils.h
+++ b/filament/src/ColorSpaceUtils.h
@@ -213,7 +213,7 @@ constexpr float MIDDLE_GRAY_ACEScct = 0.4135884f;
 
 // Returns the y chromaticity coordinate in xyY for an illuminant series D,
 // given its x chromaticity coordinate.
-inline constexpr float chromaticityCoordinateIlluminantD(float x) noexcept {
+inline constexpr float chromaticityCoordinateIlluminantD(float const x) noexcept {
     // See http://en.wikipedia.org/wiki/Standard_illuminant#Illuminant_series_D
     return 2.87f * x - 3.0f * x * x - 0.275f;
 }
@@ -222,7 +222,7 @@ inline constexpr float chromaticityCoordinateIlluminantD(float x) noexcept {
 // Color space conversions
 //------------------------------------------------------------------------------
 
-inline constexpr XYZ xyY_to_XYZ(xyY v) noexcept {
+inline constexpr XYZ xyY_to_XYZ(xyY const v) noexcept {
     const float a = v.z / max(v.y, 1e-5f);
     return XYZ{v.x * a, v.z, (1.0f - v.x - v.y) * a};
 }
@@ -231,23 +231,23 @@ inline constexpr xyY XYZ_to_xyY(XYZ v) noexcept {
     return {v.xy / max(v.x + v.y + v.z, 1e-5f), v.y};
 }
 
-inline constexpr float3 pow3(float3 x) noexcept {
+inline constexpr float3 pow3(float3 const x) noexcept {
     return x * x * x;
 }
 
-inline float3 sRGB_to_OkLab(float3 x) noexcept {
+inline float3 sRGB_to_OkLab(float3 const x) noexcept {
     return OkLab_LMS_to_OkLab * cbrt(sRGB_to_OkLab_LMS * x);
 }
 
-inline float3 Rec2020_to_OkLab(float3 x) noexcept {
+inline float3 Rec2020_to_OkLab(float3 const x) noexcept {
     return OkLab_LMS_to_OkLab * cbrt(Rec2020_to_OkLab_LMS * x);
 }
 
-inline float3 OkLab_to_sRGB(float3 x) noexcept {
+inline float3 OkLab_to_sRGB(float3 const x) noexcept {
     return OkLab_LMS_to_sRGB * pow3(OkLab_to_OkLab_LMS * x);
 }
 
-inline float3 OkLab_to_Rec2020(float3 x) noexcept {
+inline float3 OkLab_to_Rec2020(float3 const x) noexcept {
     return OkLab_LMS_to_Rec2020 * pow3(OkLab_to_OkLab_LMS * x);
 }
 
@@ -256,7 +256,7 @@ inline float3 OkLab_to_Rec2020(float3 x) noexcept {
 //------------------------------------------------------------------------------
 
 // Decodes a linear value from LogC using the Alexa LogC EI 1000 curve
-inline float3 LogC_to_linear(float3 x) noexcept {
+inline float3 LogC_to_linear(float3 const x) noexcept {
     const float ia = 1.0f / 5.555556f;
     const float b  = 0.047996f;
     const float ic = 1.0f / 0.244161f;
@@ -265,7 +265,7 @@ inline float3 LogC_to_linear(float3 x) noexcept {
 }
 
 // Encodes a linear value in LogC using the Alexa LogC EI 1000 curve
-inline float3 linear_to_LogC(float3 x) noexcept {
+inline float3 linear_to_LogC(float3 const x) noexcept {
     const float a = 5.555556f;
     const float b = 0.047996f;
     const float c = 0.244161f;
@@ -296,7 +296,7 @@ inline float3 linearAP1_to_ACEScct(float3 x) noexcept {
     return x;
 }
 
-inline float3 OETF_Linear(float3 x) noexcept {
+inline float3 OETF_Linear(float3 const x) noexcept {
     return x;
 }
 

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -64,7 +64,7 @@ void Culler::intersects(
         Frustum const& UTILS_RESTRICT frustum,
         float3 const* UTILS_RESTRICT center,
         float3 const* UTILS_RESTRICT extent,
-        size_t count, size_t bit) noexcept {
+        size_t count, size_t const bit) noexcept {
 
     float4 const * UTILS_RESTRICT const planes = frustum.mPlanes;
 
@@ -127,14 +127,14 @@ void Culler::Test::intersects(
         Frustum const& UTILS_RESTRICT frustum,
         float3 const* UTILS_RESTRICT c,
         float3 const* UTILS_RESTRICT e,
-        size_t count) noexcept {
+        size_t const count) noexcept {
     Culler::intersects(results, frustum, c, e, count, 0);
 }
 
 void Culler::Test::intersects(
         result_type* UTILS_RESTRICT results,
         Frustum const& UTILS_RESTRICT frustum,
-        float4 const* UTILS_RESTRICT b, size_t count) noexcept {
+        float4 const* UTILS_RESTRICT b, size_t const count) noexcept {
     Culler::intersects(results, frustum, b, count);
 }
 

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -101,10 +101,10 @@ bool Culler::intersects(Frustum const& frustum, Box const& box) noexcept {
     // The main intersection routine assumes multiples of 8 items
     float3 centers[MODULO];
     float3 extents[MODULO];
-    Culler::result_type results[MODULO];
+    result_type results[MODULO];
     centers[0] = box.center;
     extents[0] = box.halfExtent;
-    Culler::intersects(results, frustum, centers, extents, MODULO, 0);
+    intersects(results, frustum, centers, extents, MODULO, 0);
     return bool(results[0] & 1);
 }
 
@@ -114,9 +114,9 @@ bool Culler::intersects(Frustum const& frustum, Box const& box) noexcept {
 bool Culler::intersects(Frustum const& frustum, float4 const& sphere) noexcept {
     // The main intersection routine assumes multiples of 8 items
     float4 spheres[MODULO];
-    Culler::result_type results[MODULO];
+    result_type results[MODULO];
     spheres[0] = sphere;
-    Culler::intersects(results, frustum, spheres, MODULO);
+    intersects(results, frustum, spheres, MODULO);
     return bool(results[0] & 1);
 }
 

--- a/filament/src/Culler.h
+++ b/filament/src/Culler.h
@@ -38,7 +38,7 @@ class Culler {
 public:
     // Culler can only process buffers with a size multiple of MODULO
     static constexpr size_t MODULO = 8u;
-    static inline size_t round(size_t count) noexcept {
+    static inline size_t round(size_t const count) noexcept {
         return (count + (MODULO - 1)) & ~(MODULO - 1);
     }
 

--- a/filament/src/DebugRegistry.cpp
+++ b/filament/src/DebugRegistry.cpp
@@ -28,27 +28,27 @@ bool DebugRegistry::hasProperty(const char* name) const noexcept {
     return downcast(this)->hasProperty(name);
 }
 
-bool DebugRegistry::setProperty(const char* name, bool v) noexcept {
+bool DebugRegistry::setProperty(const char* name, bool const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 
-bool DebugRegistry::setProperty(const char* name, int v) noexcept {
+bool DebugRegistry::setProperty(const char* name, int const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 
-bool DebugRegistry::setProperty(const char* name, float v) noexcept {
+bool DebugRegistry::setProperty(const char* name, float const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 
-bool DebugRegistry::setProperty(const char* name, float2 v) noexcept {
+bool DebugRegistry::setProperty(const char* name, float2 const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 
-bool DebugRegistry::setProperty(const char* name, float3 v) noexcept {
+bool DebugRegistry::setProperty(const char* name, float3 const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 
-bool DebugRegistry::setProperty(const char* name, float4 v) noexcept {
+bool DebugRegistry::setProperty(const char* name, float4 const v) noexcept {
     return downcast(this)->setProperty(name, v);
 }
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -108,11 +108,11 @@ Camera* Engine::createCamera(Entity entity) noexcept {
     return downcast(this)->createCamera(entity);
 }
 
-Camera* Engine::getCameraComponent(utils::Entity entity) noexcept {
+Camera* Engine::getCameraComponent(Entity entity) noexcept {
     return downcast(this)->getCameraComponent(entity);
 }
 
-void Engine::destroyCameraComponent(utils::Entity entity) noexcept {
+void Engine::destroyCameraComponent(Entity entity) noexcept {
     downcast(this)->destroyCameraComponent(entity);
 }
 
@@ -342,7 +342,7 @@ void Engine::flush() {
     downcast(this)->flush();
 }
 
-utils::EntityManager& Engine::getEntityManager() noexcept {
+EntityManager& Engine::getEntityManager() noexcept {
     return downcast(this)->getEntityManager();
 }
 
@@ -375,7 +375,7 @@ void Engine::execute() {
     downcast(this)->execute();
 }
 
-utils::JobSystem& Engine::getJobSystem() noexcept {
+JobSystem& Engine::getJobSystem() noexcept {
     return downcast(this)->getJobSystem();
 }
 
@@ -443,7 +443,7 @@ uint64_t Engine::getSteadyClockTimeNano() noexcept {
     return std::chrono::steady_clock::now().time_since_epoch().count();
 }
 
-utils::Slice<const Engine::FeatureFlag> Engine::getFeatureFlags() const noexcept {
+Slice<const Engine::FeatureFlag> Engine::getFeatureFlags() const noexcept {
     return downcast(this)->getFeatureFlags();
 }
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -104,15 +104,15 @@ Scene* Engine::createScene() noexcept {
     return downcast(this)->createScene();
 }
 
-Camera* Engine::createCamera(Entity entity) noexcept {
+Camera* Engine::createCamera(Entity const entity) noexcept {
     return downcast(this)->createCamera(entity);
 }
 
-Camera* Engine::getCameraComponent(Entity entity) noexcept {
+Camera* Engine::getCameraComponent(Entity const entity) noexcept {
     return downcast(this)->getCameraComponent(entity);
 }
 
-void Engine::destroyCameraComponent(Entity entity) noexcept {
+void Engine::destroyCameraComponent(Entity const entity) noexcept {
     downcast(this)->destroyCameraComponent(entity);
 }
 
@@ -120,11 +120,11 @@ Fence* Engine::createFence() noexcept {
     return downcast(this)->createFence();
 }
 
-SwapChain* Engine::createSwapChain(void* nativeWindow, uint64_t flags) noexcept {
+SwapChain* Engine::createSwapChain(void* nativeWindow, uint64_t const flags) noexcept {
     return downcast(this)->createSwapChain(nativeWindow, flags);
 }
 
-SwapChain* Engine::createSwapChain(uint32_t width, uint32_t height, uint64_t flags) noexcept {
+SwapChain* Engine::createSwapChain(uint32_t const width, uint32_t const height, uint64_t const flags) noexcept {
     return downcast(this)->createSwapChain(width, height, flags);
 }
 
@@ -204,7 +204,7 @@ bool Engine::destroy(const InstanceBuffer* p) {
     return downcast(this)->destroy(downcast(p));
 }
 
-void Engine::destroy(Entity e) {
+void Engine::destroy(Entity const e) {
     downcast(this)->destroy(e);
 }
 
@@ -362,7 +362,7 @@ void Engine::enableAccurateTranslations() noexcept  {
     getTransformManager().setAccurateTranslationsEnabled(true);
 }
 
-void* Engine::streamAlloc(size_t size, size_t alignment) noexcept {
+void* Engine::streamAlloc(size_t const size, size_t const alignment) noexcept {
     return downcast(this)->streamAlloc(size, alignment);
 }
 
@@ -385,7 +385,7 @@ bool Engine::isPaused() const noexcept {
     return downcast(this)->isPaused();
 }
 
-void Engine::setPaused(bool paused) {
+void Engine::setPaused(bool const paused) {
     FILAMENT_CHECK_PRECONDITION(UTILS_HAS_THREADING)
             << "Pause is meant for multi-threaded platforms.";
     downcast(this)->setPaused(paused);
@@ -403,7 +403,7 @@ void Engine::unprotected() noexcept {
     downcast(this)->unprotected();
 }
 
-void Engine::setAutomaticInstancingEnabled(bool enable) noexcept {
+void Engine::setAutomaticInstancingEnabled(bool const enable) noexcept {
     downcast(this)->setAutomaticInstancingEnabled(enable);
 }
 
@@ -415,7 +415,7 @@ FeatureLevel Engine::getSupportedFeatureLevel() const noexcept {
     return downcast(this)->getSupportedFeatureLevel();
 }
 
-FeatureLevel Engine::setActiveFeatureLevel(FeatureLevel featureLevel) {
+FeatureLevel Engine::setActiveFeatureLevel(FeatureLevel const featureLevel) {
     return downcast(this)->setActiveFeatureLevel(featureLevel);
 }
 
@@ -447,7 +447,7 @@ Slice<const Engine::FeatureFlag> Engine::getFeatureFlags() const noexcept {
     return downcast(this)->getFeatureFlags();
 }
 
-bool Engine::setFeatureFlag(char const* name, bool value) noexcept {
+bool Engine::setFeatureFlag(char const* name, bool const value) noexcept {
     return downcast(this)->setFeatureFlag(name, value);
 }
 

--- a/filament/src/Exposure.cpp
+++ b/filament/src/Exposure.cpp
@@ -28,7 +28,7 @@ float ev100(const Camera& c) noexcept {
     return ev100(camera.getAperture(), camera.getShutterSpeed(), camera.getSensitivity());
 }
 
-float ev100(float aperture, float shutterSpeed, float sensitivity) noexcept {
+float ev100(float const aperture, float const shutterSpeed, float const sensitivity) noexcept {
     // With N = aperture, t = shutter speed and S = sensitivity,
     // we can compute EV100 knowing that:
     //
@@ -46,7 +46,7 @@ float ev100(float aperture, float shutterSpeed, float sensitivity) noexcept {
     return std::log2((aperture * aperture) / shutterSpeed * 100.0f / sensitivity);
 }
 
-float ev100FromLuminance(float luminance) noexcept {
+float ev100FromLuminance(float const luminance) noexcept {
     // With L the average scene luminance, S the sensitivity and K the
     // reflected-light meter calibration constant:
     //
@@ -61,7 +61,7 @@ float ev100FromLuminance(float luminance) noexcept {
     return std::log2(luminance * (100.0f / 12.5f));
 }
 
-float ev100FromIlluminance(float illuminance) noexcept {
+float ev100FromIlluminance(float const illuminance) noexcept {
     // With E the illuminance, S the sensitivity and C the incident-light meter
     // calibration constant, the exposure value can be computed as such:
     //
@@ -83,14 +83,14 @@ float exposure(const Camera& c) noexcept {
     return exposure(camera.getAperture(), camera.getShutterSpeed(), camera.getSensitivity());
 }
 
-float exposure(float aperture, float shutterSpeed, float sensitivity) noexcept {
+float exposure(float const aperture, float const shutterSpeed, float const sensitivity) noexcept {
     // This is equivalent to calling exposure(ev100(N, t, S))
     // By merging the two calls we can remove extra pow()/log2() calls
     const float e = (aperture * aperture) / shutterSpeed * 100.0f / sensitivity;
     return 1.0f / (1.2f * e);
 }
 
-float exposure(float ev100) noexcept {
+float exposure(float const ev100) noexcept {
     // The photometric exposure H is defined by:
     //
     // H = (q * t / (N^2)) * L
@@ -140,14 +140,14 @@ float luminance(const Camera& c) noexcept {
     return luminance(camera.getAperture(), camera.getShutterSpeed(), camera.getSensitivity());
 }
 
-float luminance(float aperture, float shutterSpeed, float sensitivity) noexcept {
+float luminance(float const aperture, float const shutterSpeed, float const sensitivity) noexcept {
     // This is equivalent to calling luminance(ev100(N, t, S))
     // By merging the two calls we can remove extra pow()/log2() calls
     const float e = (aperture * aperture) / shutterSpeed * 100.0f / sensitivity;
     return e * 0.125f;
 }
 
-float luminance(float ev100) noexcept {
+float luminance(float const ev100) noexcept {
     // With L the average scene luminance, S the sensitivity and K the
     // reflected-light meter calibration constant:
     //
@@ -172,14 +172,14 @@ float illuminance(const Camera& c) noexcept {
     return illuminance(camera.getAperture(), camera.getShutterSpeed(), camera.getSensitivity());
 }
 
-float illuminance(float aperture, float shutterSpeed, float sensitivity) noexcept {
+float illuminance(float const aperture, float const shutterSpeed, float const sensitivity) noexcept {
     // This is equivalent to calling illuminance(ev100(N, t, S))
     // By merging the two calls we can remove extra pow()/log2() calls
     const float e = (aperture * aperture) / shutterSpeed * 100.0f / sensitivity;
     return 2.5f * e;
 }
 
-float illuminance(float ev100) noexcept {
+float illuminance(float const ev100) noexcept {
     // With E the illuminance, S the sensitivity and C the incident-light meter
     // calibration constant, the exposure value can be computed as such:
     //

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -20,11 +20,11 @@ namespace filament {
 
 using namespace backend;
 
-FenceStatus Fence::waitAndDestroy(Fence* fence, Mode mode) {
+FenceStatus Fence::waitAndDestroy(Fence* fence, Mode const mode) {
     return FFence::waitAndDestroy(downcast(fence), mode);
 }
 
-FenceStatus Fence::wait(Mode mode, uint64_t timeout) {
+FenceStatus Fence::wait(Mode const mode, uint64_t const timeout) {
     return downcast(this)->wait(mode, timeout);
 }
 

--- a/filament/src/FilamentBuilder.cpp
+++ b/filament/src/FilamentBuilder.cpp
@@ -20,7 +20,7 @@
 
 namespace filament {
 
-void builderMakeName(utils::CString& outName, const char* name, size_t len) noexcept {
+void builderMakeName(utils::CString& outName, const char* name, size_t const len) noexcept {
     if (!name) {
         return;
     }

--- a/filament/src/FrameInfo.cpp
+++ b/filament/src/FrameInfo.cpp
@@ -172,9 +172,9 @@ void FrameInfoManager::denoiseFrameTime(FrameHistoryQueue& history, Config const
      }
 }
 
-utils::FixedCapacityVector<Renderer::FrameInfo> FrameInfoManager::getFrameInfoHistory(
+FixedCapacityVector<Renderer::FrameInfo> FrameInfoManager::getFrameInfoHistory(
         size_t historySize) const noexcept {
-    auto result = utils::FixedCapacityVector<Renderer::FrameInfo>::with_capacity(MAX_FRAMETIME_HISTORY);
+    auto result = FixedCapacityVector<Renderer::FrameInfo>::with_capacity(MAX_FRAMETIME_HISTORY);
     auto const& history = mFrameTimeHistory;
     size_t i = 0;
     size_t const c = history.size();

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -57,7 +57,7 @@ struct FrameInfoImpl : public details::FrameInfo {
     time_point backendBeginFrame;    // backend thread beginFrame time (makeCurrent time)
     time_point backendEndFrame;      // backend thread endFrame time (present time)
     std::atomic_bool ready{};        // true once backend thread has populated its data
-    explicit FrameInfoImpl(uint32_t frameId) noexcept
+    explicit FrameInfoImpl(uint32_t const frameId) noexcept
         : frameId(frameId) {
     }
 };
@@ -110,7 +110,7 @@ public:
         return front();
     }
 
-    T& operator[](size_t pos) noexcept {
+    T& operator[](size_t const pos) noexcept {
         assert_invariant(pos < size());
         size_t const index = (mFront + CAPACITY - pos) % CAPACITY;
         return *std::launder(reinterpret_cast<T*>(&mStorage[index]));
@@ -135,7 +135,7 @@ private:
     Storage mStorage[CAPACITY];
     uint32_t mFront = 0;    // always index 0
     uint32_t mSize = 0;
-    [[nodiscard]] inline uint32_t advance(uint32_t v) noexcept {
+    [[nodiscard]] inline uint32_t advance(uint32_t const v) noexcept {
         return (v + 1) % CAPACITY;
     }
 };

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -30,7 +30,7 @@ namespace filament {
 using namespace utils;
 using namespace backend;
 
-FrameSkipper::FrameSkipper(size_t latency) noexcept
+FrameSkipper::FrameSkipper(size_t const latency) noexcept
         : mLast(std::clamp(latency, size_t(1), MAX_FRAME_LATENCY) - 1) {
 }
 

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -264,10 +264,10 @@ void Froxelizer::computeFroxelLayout(
 
 UTILS_NOINLINE
 void Froxelizer::updateBoundingSpheres(
-        math::float4* const UTILS_RESTRICT boundingSpheres,
+        float4* const UTILS_RESTRICT boundingSpheres,
         size_t froxelCountX, size_t froxelCountY, size_t froxelCountZ,
-        math::float4 const* UTILS_RESTRICT planesX,
-        math::float4 const* UTILS_RESTRICT planesY,
+        float4 const* UTILS_RESTRICT planesX,
+        float4 const* UTILS_RESTRICT planesY,
         float const* UTILS_RESTRICT planesZ) noexcept {
 
     SYSTRACE_CALL();
@@ -502,7 +502,7 @@ std::pair<size_t, size_t> Froxelizer::clipToIndices(float2 const& clip) const no
 }
 
 
-void Froxelizer::commit(backend::DriverApi& driverApi) {
+void Froxelizer::commit(DriverApi& driverApi) {
     // send data to GPU
     driverApi.updateBufferObject(mFroxelsBuffer,
             { mFroxelBufferUser.data(), getFroxelBufferEntryCount() * 16u }, 0);
@@ -629,7 +629,7 @@ void Froxelizer::froxelizeAssignRecordsCompress() noexcept {
 
     // this gets very well vectorized...
 
-    utils::Slice<LightRecord> records(mLightRecords);
+    Slice<LightRecord> records(mLightRecords);
     for (size_t j = 0, jc = getFroxelBufferEntryCount(); j < jc; j++) {
         for (size_t i = 0; i < LightRecord::bitset::WORLD_COUNT; i++) {
             using container_type = LightRecord::bitset::container_type;
@@ -750,7 +750,7 @@ static inline float2 project(mat4f const& p, float3 const& v) noexcept {
 void Froxelizer::froxelizePointAndSpotLight(
         FroxelThreadData& froxelThread, size_t bit,
         mat4f const& UTILS_RESTRICT p,
-        const Froxelizer::LightParams& UTILS_RESTRICT light) const noexcept {
+        const LightParams& UTILS_RESTRICT light) const noexcept {
 
     if (UTILS_UNLIKELY(light.position.z + light.radius < -mZLightFar)) { // z values are negative
         // This light is fully behind LightFar, it doesn't light anything
@@ -902,7 +902,7 @@ void Froxelizer::froxelizePointAndSpotLight(
  */
 void Froxelizer::computeLightTree(
         LightTreeNode* lightTree,
-        utils::Slice<RecordBufferType> const& lightList,
+        Slice<RecordBufferType> const& lightList,
         const FScene::LightSoa& lightData,
         size_t lightRecordsOffset) noexcept {
 
@@ -910,7 +910,7 @@ void Froxelizer::computeLightTree(
     const size_t count = lightList.size();
 
     // the width of the tree is the next power-of-two (if not already a power of two)
-    const size_t w = 1u << (log2i(count) + (utils::popcount(count) == 1 ? 0 : 1));
+    const size_t w = 1u << (log2i(count) + (popcount(count) == 1 ? 0 : 1));
 
     // height of the tree
     const size_t h = log2i(w) + 1u;

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -143,7 +143,7 @@ void Froxelizer::terminate(DriverApi& driverApi) noexcept {
     }
 }
 
-void Froxelizer::setOptions(float zLightNear, float zLightFar) noexcept {
+void Froxelizer::setOptions(float const zLightNear, float const zLightFar) noexcept {
     if (UTILS_UNLIKELY(mZLightNear != zLightNear || mZLightFar != zLightFar)) {
         mZLightNear = zLightNear;
         mZLightFar = zLightFar;
@@ -160,7 +160,7 @@ void Froxelizer::setViewport(filament::Viewport const& viewport) noexcept {
 }
 
 void Froxelizer::setProjection(const mat4f& projection,
-        float near, UTILS_UNUSED float far) noexcept {
+        float const near, UTILS_UNUSED float far) noexcept {
     if (UTILS_UNLIKELY(!fuzzyEqual(mProjection, projection))) {
         mProjection = projection;
         mNear = near;
@@ -171,7 +171,7 @@ void Froxelizer::setProjection(const mat4f& projection,
 bool Froxelizer::prepare(
         FEngine::DriverApi& driverApi, RootArenaScope& rootArenaScope,
         filament::Viewport const& viewport,
-        const mat4f& projection, float projectionNear, float projectionFar) noexcept {
+        const mat4f& projection, float const projectionNear, float const projectionFar) noexcept {
     setViewport(viewport);
     setProjection(projection, projectionNear, projectionFar);
 
@@ -223,9 +223,9 @@ bool Froxelizer::prepare(
 
 void Froxelizer::computeFroxelLayout(
         uint2* dim, uint16_t* countX, uint16_t* countY, uint16_t* countZ,
-        size_t froxelBufferEntryCount, filament::Viewport const& viewport) noexcept {
+        size_t const froxelBufferEntryCount, filament::Viewport const& viewport) noexcept {
 
-    auto roundTo8 = [](uint32_t v) { return (v + 7u) & ~7u; };
+    auto roundTo8 = [](uint32_t const v) { return (v + 7u) & ~7u; };
 
     const uint32_t width  = std::max(16u, viewport.width);
     const uint32_t height = std::max(16u, viewport.height);
@@ -458,7 +458,7 @@ bool Froxelizer::update() noexcept {
     return uniformsNeedUpdating;
 }
 
-Froxel Froxelizer::getFroxelAt(size_t x, size_t y, size_t z) const noexcept {
+Froxel Froxelizer::getFroxelAt(size_t const x, size_t const y, size_t const z) const noexcept {
     assert_invariant(x < mFroxelCountX);
     assert_invariant(y < mFroxelCountY);
     assert_invariant(z < mFroxelCountZ);
@@ -473,7 +473,7 @@ Froxel Froxelizer::getFroxelAt(size_t x, size_t y, size_t z) const noexcept {
 }
 
 UTILS_NOINLINE
-size_t Froxelizer::findSliceZ(float z) const noexcept {
+size_t Froxelizer::findSliceZ(float const z) const noexcept {
     // The vastly common case is that z<0, so we always do the math for this case
     // and we "undo" it below otherwise. This works because we're using fast::log2 which
     // doesn't care if given a negative number (we'd have to use abs() otherwise).
@@ -563,7 +563,7 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
 
     auto process = [ this, &froxelThreadData,
                      spheres, directions, instances, &viewMatrix, &lcm ]
-            (size_t count, size_t offset, size_t stride) {
+            (size_t const count, size_t const offset, size_t const stride) {
 
         SYSTRACE_NAME("FroxelizeLoop Job");
 
@@ -918,7 +918,7 @@ void Froxelizer::computeLightTree(
     auto const* UTILS_RESTRICT zrange = lightData.data<FScene::SCREEN_SPACE_Z_RANGE>() + 1;
     BinaryTreeArray::traverse(h,
             [lightTree, lightRecordsOffset, zrange, indices = lightList.data(), count]
-            (size_t index, size_t col, size_t next) {
+            (size_t const index, size_t const col, size_t const next) {
                 // indices[] cannot be accessed past 'col'
                 const float min = (col < count) ? zrange[indices[col]].x : 1.0f;
                 const float max = (col < count) ? zrange[indices[col]].y : 0.0f;
@@ -932,7 +932,7 @@ void Froxelizer::computeLightTree(
                         .reserved = 0,
                 };
             },
-            [lightTree](size_t index, size_t l, size_t r, size_t next) {
+            [lightTree](size_t const index, size_t const l, size_t const r, size_t const next) {
                 lightTree[index] = {
                         .min = std::min(lightTree[l].min, lightTree[r].min),
                         .max = std::max(lightTree[l].max, lightTree[r].max),

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -16,27 +16,47 @@
 
 #include "Froxelizer.h"
 
+#include "Allocators.h"
 #include "Intersections.h"
 
 #include "details/Engine.h"
 #include "details/Scene.h"
 
-#include "private/backend/DriverApi.h"
+#include <private/filament/EngineEnums.h>
+#include <private/backend/DriverApi.h>
 
+#include <filament/Box.h>
 #include <filament/Viewport.h>
 
+#include <backend/DriverEnums.h>
+
 #include <utils/BinaryTreeArray.h>
+#include <utils/JobSystem.h>
 #include <utils/Log.h>
+#include <utils/Slice.h>
 #include <utils/Systrace.h>
+#include <utils/compiler.h>
 #include <utils/debug.h>
 
-#include <math/mat4.h>
 #include <math/fast.h>
+#include <math/mat3.h>
+#include <math/mat4.h>
 #include <math/scalar.h>
+#include <math/vec2.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
 
 #include <algorithm>
+#include <utils/architecture.h>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <utility>
 
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 using namespace filament::math;
 using namespace utils;
@@ -603,7 +623,7 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
     JobSystem& js = engine.getJobSystem();
 
     constexpr bool SINGLE_THREADED = false;
-    if (!SINGLE_THREADED) {
+    if constexpr (!SINGLE_THREADED) {
         auto *parent = js.createJob();
         for (size_t i = 0; i < GROUP_COUNT; i++) {
             js.run(jobs::createJob(js, parent, std::cref(process),
@@ -737,7 +757,7 @@ out_of_memory:
     ;
 }
 
-static inline float2 project(mat4f const& p, float3 const& v) noexcept {
+static float2 project(mat4f const& p, float3 const& v) noexcept {
     const float vx = v[0];
     const float vy = v[1];
     const float vz = v[2];

--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -140,7 +140,7 @@ public:
      */
 
     struct FroxelEntry {
-        inline FroxelEntry(uint16_t offset, uint8_t count) noexcept
+        inline FroxelEntry(uint16_t const offset, uint8_t const count) noexcept
             : u32((offset << 16) | count) { }
         inline uint8_t count() const noexcept { return u32 & 0xFFu; }
         inline uint16_t offset() const noexcept { return u32 >> 16u; }
@@ -214,12 +214,12 @@ private:
             math::float4 const* UTILS_RESTRICT planesY,
             float const* UTILS_RESTRICT planesZ) noexcept;
 
-    static size_t getFroxelIndex(size_t ix, size_t iy, size_t iz,
-            size_t froxelCountX, size_t froxelCountY) noexcept {
+    static size_t getFroxelIndex(size_t const ix, size_t const iy, size_t const iz,
+            size_t const froxelCountX, size_t const froxelCountY) noexcept {
         return ix + (iy * froxelCountX) + (iz * froxelCountX * froxelCountY);
     }
 
-    size_t getFroxelIndex(size_t ix, size_t iy, size_t iz) const noexcept {
+    size_t getFroxelIndex(size_t const ix, size_t const iy, size_t const iz) const noexcept {
         return getFroxelIndex(ix, iy, iz, mFroxelCountX, mFroxelCountY);
     }
 

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -26,7 +26,7 @@ using namespace filament::math;
 namespace filament {
 
 Frustum::Frustum(const mat4f& pv) {
-    Frustum::setProjection(pv);
+    setProjection(pv);
 }
 
 // NOTE: if we don't specify noinline here, LLVM inlines this huge function into
@@ -68,7 +68,7 @@ void Frustum::setProjection(const mat4f& pv) {
     mPlanes[5] = n;
 }
 
-float4 Frustum::getNormalizedPlane(Frustum::Plane plane) const noexcept {
+float4 Frustum::getNormalizedPlane(Plane plane) const noexcept {
     return mPlanes[size_t(plane)];
 }
 

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -19,7 +19,13 @@
 #include "Culler.h"
 
 #include <utils/compiler.h>
-#include <utils/Log.h>
+#include <utils/ostream.h>
+
+#include <math/vec3.h>
+#include <math/vec4.h>
+#include <math/mat4.h>
+
+#include <algorithm>
 
 using namespace filament::math;
 

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -89,7 +89,7 @@ bool Frustum::intersects(const float4& sphere) const noexcept {
     return Culler::intersects(*this, sphere);
 }
 
-float Frustum::contains(float3 p) const noexcept {
+float Frustum::contains(float3 const p) const noexcept {
     float const l = dot(mPlanes[0].xyz, p) + mPlanes[0].w;
     float const b = dot(mPlanes[1].xyz, p) + mPlanes[1].w;
     float const r = dot(mPlanes[2].xyz, p) + mPlanes[2].w;

--- a/filament/src/HwDescriptorSetLayoutFactory.cpp
+++ b/filament/src/HwDescriptorSetLayoutFactory.cpp
@@ -39,9 +39,9 @@ using namespace utils;
 using namespace backend;
 
 size_t HwDescriptorSetLayoutFactory::Parameters::hash() const noexcept {
-    return utils::hash::murmurSlow(
+    return hash::murmurSlow(
             reinterpret_cast<uint8_t const *>(dsl.bindings.data()),
-            dsl.bindings.size() * sizeof(backend::DescriptorSetLayoutBinding),
+            dsl.bindings.size() * sizeof(DescriptorSetLayoutBinding),
             42);
 }
 
@@ -68,7 +68,7 @@ void HwDescriptorSetLayoutFactory::terminate(DriverApi&) noexcept {
 }
 
 auto HwDescriptorSetLayoutFactory::create(DriverApi& driver,
-        backend::DescriptorSetLayout dsl) noexcept -> Handle {
+        DescriptorSetLayout dsl) noexcept -> Handle {
 
     std::sort(dsl.bindings.begin(), dsl.bindings.end(),
             [](auto&& lhs, auto&& rhs) {

--- a/filament/src/HwRenderPrimitiveFactory.cpp
+++ b/filament/src/HwRenderPrimitiveFactory.cpp
@@ -34,8 +34,8 @@ using namespace utils;
 using namespace backend;
 
 size_t HwRenderPrimitiveFactory::Parameters::hash() const noexcept {
-    return utils::hash::combine(vbh.getId(),
-            utils::hash::combine(ibh.getId(),
+    return hash::combine(vbh.getId(),
+            hash::combine(ibh.getId(),
                     (size_t)type));
 }
 
@@ -61,9 +61,9 @@ void HwRenderPrimitiveFactory::terminate(DriverApi&) noexcept {
 }
 
 auto HwRenderPrimitiveFactory::create(DriverApi& driver,
-        backend::VertexBufferHandle vbh,
-        backend::IndexBufferHandle ibh,
-        backend::PrimitiveType type) noexcept -> Handle {
+        VertexBufferHandle vbh,
+        IndexBufferHandle ibh,
+        PrimitiveType type) noexcept -> Handle {
 
     // see if we already have seen this RenderPrimitive
     Key const key({ vbh, ibh, type });

--- a/filament/src/HwRenderPrimitiveFactory.cpp
+++ b/filament/src/HwRenderPrimitiveFactory.cpp
@@ -63,7 +63,7 @@ void HwRenderPrimitiveFactory::terminate(DriverApi&) noexcept {
 auto HwRenderPrimitiveFactory::create(DriverApi& driver,
         VertexBufferHandle vbh,
         IndexBufferHandle ibh,
-        PrimitiveType type) noexcept -> Handle {
+        PrimitiveType const type) noexcept -> Handle {
 
     // see if we already have seen this RenderPrimitive
     Key const key({ vbh, ibh, type });

--- a/filament/src/HwVertexBufferInfoFactory.cpp
+++ b/filament/src/HwVertexBufferInfoFactory.cpp
@@ -37,7 +37,7 @@ using namespace backend;
 
 size_t HwVertexBufferInfoFactory::Parameters::hash() const noexcept {
     static_assert((sizeof(*this) % sizeof(uint32_t)) == 0);
-    return utils::hash::murmur3(
+    return hash::murmur3(
             reinterpret_cast<uint32_t const*>(this), sizeof(Parameters) / sizeof(uint32_t), 0);
 }
 
@@ -63,7 +63,7 @@ void HwVertexBufferInfoFactory::terminate(DriverApi&) noexcept {
 auto HwVertexBufferInfoFactory::create(DriverApi& driver,
         uint8_t bufferCount,
         uint8_t attributeCount,
-        backend::AttributeArray attributes) noexcept -> Handle {
+        AttributeArray attributes) noexcept -> Handle {
 
     Key const key({ bufferCount, attributeCount, {}, attributes });
     auto pos = mBimap.find(key);

--- a/filament/src/HwVertexBufferInfoFactory.cpp
+++ b/filament/src/HwVertexBufferInfoFactory.cpp
@@ -61,8 +61,8 @@ void HwVertexBufferInfoFactory::terminate(DriverApi&) noexcept {
 }
 
 auto HwVertexBufferInfoFactory::create(DriverApi& driver,
-        uint8_t bufferCount,
-        uint8_t attributeCount,
+        uint8_t const bufferCount,
+        uint8_t const attributeCount,
         AttributeArray attributes) noexcept -> Handle {
 
     Key const key({ bufferCount, attributeCount, {}, attributes });

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -21,7 +21,7 @@
 namespace filament {
 
 void IndexBuffer::setBuffer(Engine& engine,
-        BufferDescriptor&& buffer, uint32_t byteOffset) {
+        BufferDescriptor&& buffer, uint32_t const byteOffset) {
     downcast(this)->setBuffer(downcast(engine), std::move(buffer), byteOffset);
 }
 

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -21,7 +21,7 @@
 namespace filament {
 
 void IndexBuffer::setBuffer(Engine& engine,
-        IndexBuffer::BufferDescriptor&& buffer, uint32_t byteOffset) {
+        BufferDescriptor&& buffer, uint32_t byteOffset) {
     downcast(this)->setBuffer(downcast(engine), std::move(buffer), byteOffset);
 }
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -22,7 +22,7 @@ namespace filament {
 
 using namespace math;
 
-void IndirectLight::setIntensity(float intensity) noexcept {
+void IndirectLight::setIntensity(float const intensity) noexcept {
     downcast(this)->setIntensity(intensity);
 }
 
@@ -50,7 +50,7 @@ float3 IndirectLight::getDirectionEstimate() const noexcept {
     return downcast(this)->getDirectionEstimate();
 }
 
-float4 IndirectLight::getColorEstimate(float3 direction) const noexcept {
+float4 IndirectLight::getColorEstimate(float3 const direction) const noexcept {
     return downcast(this)->getColorEstimate(direction);
 }
 
@@ -58,7 +58,7 @@ float3 IndirectLight::getDirectionEstimate(const float3* sh) noexcept {
     return FIndirectLight::getDirectionEstimate(sh);
 }
 
-float4 IndirectLight::getColorEstimate(const float3* sh, float3 direction) noexcept {
+float4 IndirectLight::getColorEstimate(const float3* sh, float3 const direction) noexcept {
     return FIndirectLight::getColorEstimate(sh, direction);
 }
 

--- a/filament/src/InstanceBuffer.cpp
+++ b/filament/src/InstanceBuffer.cpp
@@ -23,7 +23,7 @@ size_t InstanceBuffer::getInstanceCount() const noexcept {
 }
 
 void InstanceBuffer::setLocalTransforms(
-        math::mat4f const* localTransforms, size_t count, size_t offset) {
+        math::mat4f const* localTransforms, size_t const count, size_t const offset) {
     downcast(this)->setLocalTransforms(localTransforms, count, offset);
 }
 

--- a/filament/src/Intersections.h
+++ b/filament/src/Intersections.h
@@ -40,7 +40,7 @@ inline constexpr math::float4 spherePlaneIntersection(math::float4 s, math::floa
 // sphere radius must be squared
 // plane equation must be normalized and have the form {0,0,1,w}, sphere radius must be squared
 // return float4.w <= 0 if no intersection
-inline constexpr math::float4 spherePlaneIntersection(math::float4 s, float pw) noexcept {
+inline constexpr math::float4 spherePlaneIntersection(math::float4 const s, float pw) noexcept {
     return spherePlaneIntersection(s, { 0.f, 0.f, 1.f, pw });
 }
 
@@ -65,8 +65,8 @@ inline constexpr bool sphereConeIntersection(
         math::float4 const& sphere,
         math::float3 const& conePosition,
         math::float3 const& coneAxis,
-        float coneSinInverse,
-        float coneCosSquared) noexcept {
+        float const coneSinInverse,
+        float const coneCosSquared) noexcept {
     if (sphereConeIntersectionFast(sphere,
             conePosition, coneAxis, coneSinInverse, coneCosSquared)) {
         math::float3 const d = sphere.xyz - conePosition;

--- a/filament/src/LightManager.cpp
+++ b/filament/src/LightManager.cpp
@@ -22,7 +22,7 @@ namespace filament {
 
 using namespace math;
 
-bool LightManager::hasComponent(Entity e) const noexcept {
+bool LightManager::hasComponent(Entity const e) const noexcept {
     return downcast(this)->hasComponent(e);
 }
 
@@ -34,7 +34,7 @@ bool LightManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-Entity LightManager::getEntity(Instance i) const noexcept {
+Entity LightManager::getEntity(Instance const i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
@@ -42,120 +42,120 @@ Entity const* LightManager::getEntities() const noexcept {
     return downcast(this)->getEntities();
 }
 
-LightManager::Instance LightManager::getInstance(Entity e) const noexcept {
+LightManager::Instance LightManager::getInstance(Entity const e) const noexcept {
     return downcast(this)->getInstance(e);
 }
 
-void LightManager::destroy(Entity e) noexcept {
+void LightManager::destroy(Entity const e) noexcept {
     return downcast(this)->destroy(e);
 }
 
-void LightManager::setLightChannel(Instance i, unsigned int channel, bool enable) noexcept {
+void LightManager::setLightChannel(Instance const i, unsigned int const channel, bool const enable) noexcept {
     downcast(this)->setLightChannel(i, channel, enable);
 }
 
-bool LightManager::getLightChannel(Instance i, unsigned int channel) const noexcept {
+bool LightManager::getLightChannel(Instance const i, unsigned int const channel) const noexcept {
     return downcast(this)->getLightChannel(i, channel);
 }
 
-void LightManager::setPosition(Instance i, const float3& position) noexcept {
+void LightManager::setPosition(Instance const i, const float3& position) noexcept {
     downcast(this)->setLocalPosition(i, position);
 }
 
-const float3& LightManager::getPosition(Instance i) const noexcept {
+const float3& LightManager::getPosition(Instance const i) const noexcept {
     return downcast(this)->getLocalPosition(i);
 }
 
-void LightManager::setDirection(Instance i, const float3& direction) noexcept {
+void LightManager::setDirection(Instance const i, const float3& direction) noexcept {
     downcast(this)->setLocalDirection(i, direction);
 }
 
-const float3& LightManager::getDirection(Instance i) const noexcept {
+const float3& LightManager::getDirection(Instance const i) const noexcept {
     return downcast(this)->getLocalDirection(i);
 }
 
-void LightManager::setColor(Instance i, const LinearColor& color) noexcept {
+void LightManager::setColor(Instance const i, const LinearColor& color) noexcept {
     downcast(this)->setColor(i, color);
 }
 
-const float3& LightManager::getColor(Instance i) const noexcept {
+const float3& LightManager::getColor(Instance const i) const noexcept {
     return downcast(this)->getColor(i);
 }
 
-void LightManager::setIntensity(Instance i, float intensity) noexcept {
+void LightManager::setIntensity(Instance const i, float const intensity) noexcept {
     downcast(this)->setIntensity(i, intensity, FLightManager::IntensityUnit::LUMEN_LUX);
 }
 
-void LightManager::setIntensityCandela(Instance i, float intensity) noexcept {
+void LightManager::setIntensityCandela(Instance const i, float const intensity) noexcept {
     downcast(this)->setIntensity(i, intensity, FLightManager::IntensityUnit::CANDELA);
 }
 
-float LightManager::getIntensity(Instance i) const noexcept {
+float LightManager::getIntensity(Instance const i) const noexcept {
     return downcast(this)->getIntensity(i);
 }
 
-void LightManager::setFalloff(Instance i, float radius) noexcept {
+void LightManager::setFalloff(Instance const i, float const radius) noexcept {
     downcast(this)->setFalloff(i, radius);
 }
 
-float LightManager::getFalloff(Instance i) const noexcept {
+float LightManager::getFalloff(Instance const i) const noexcept {
     return downcast(this)->getFalloff(i);
 }
 
-void LightManager::setSpotLightCone(Instance i, float inner, float outer) noexcept {
+void LightManager::setSpotLightCone(Instance const i, float const inner, float const outer) noexcept {
     downcast(this)->setSpotLightCone(i, inner, outer);
 }
 
-float LightManager::getSpotLightOuterCone(Instance i) const noexcept {
+float LightManager::getSpotLightOuterCone(Instance const i) const noexcept {
     return downcast(this)->getSpotParams(i).outerClamped;
 }
 
-float LightManager::getSpotLightInnerCone(Instance i) const noexcept {
+float LightManager::getSpotLightInnerCone(Instance const i) const noexcept {
     return downcast(this)->getSpotLightInnerCone(i);
 }
 
-void LightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept {
+void LightManager::setSunAngularRadius(Instance const i, float const angularRadius) noexcept {
     downcast(this)->setSunAngularRadius(i, angularRadius);
 }
 
-float LightManager::getSunAngularRadius(Instance i) const noexcept {
+float LightManager::getSunAngularRadius(Instance const i) const noexcept {
     float radius = downcast(this)->getSunAngularRadius(i);
     return radius * f::RAD_TO_DEG;
 }
 
-void LightManager::setSunHaloSize(Instance i, float haloSize) noexcept {
+void LightManager::setSunHaloSize(Instance const i, float const haloSize) noexcept {
     downcast(this)->setSunHaloSize(i, haloSize);
 }
 
-float LightManager::getSunHaloSize(Instance i) const noexcept {
+float LightManager::getSunHaloSize(Instance const i) const noexcept {
     return downcast(this)->getSunHaloSize(i);
 }
 
-void LightManager::setSunHaloFalloff(Instance i, float haloFalloff) noexcept {
+void LightManager::setSunHaloFalloff(Instance const i, float const haloFalloff) noexcept {
     downcast(this)->setSunHaloFalloff(i, haloFalloff);
 }
 
-float LightManager::getSunHaloFalloff(Instance i) const noexcept {
+float LightManager::getSunHaloFalloff(Instance const i) const noexcept {
     return downcast(this)->getSunHaloFalloff(i);
 }
 
-LightManager::Type LightManager::getType(Instance i) const noexcept {
+LightManager::Type LightManager::getType(Instance const i) const noexcept {
     return downcast(this)->getType(i);
 }
 
-const LightManager::ShadowOptions& LightManager::getShadowOptions(Instance i) const noexcept {
+const LightManager::ShadowOptions& LightManager::getShadowOptions(Instance const i) const noexcept {
     return downcast(this)->getShadowOptions(i);
 }
 
-void LightManager::setShadowOptions(Instance i, ShadowOptions const& options) noexcept {
+void LightManager::setShadowOptions(Instance const i, ShadowOptions const& options) noexcept {
     downcast(this)->setShadowOptions(i, options);
 }
 
-bool LightManager::isShadowCaster(Instance i) const noexcept {
+bool LightManager::isShadowCaster(Instance const i) const noexcept {
     return downcast(this)->isShadowCaster(i);
 }
 
-void LightManager::setShadowCaster(Instance i, bool castShadows) noexcept {
+void LightManager::setShadowCaster(Instance const i, bool const castShadows) noexcept {
     downcast(this)->setShadowCaster(i, castShadows);
 }
 

--- a/filament/src/LightManager.cpp
+++ b/filament/src/LightManager.cpp
@@ -34,11 +34,11 @@ bool LightManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-utils::Entity LightManager::getEntity(LightManager::Instance i) const noexcept {
+Entity LightManager::getEntity(Instance i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
-utils::Entity const* LightManager::getEntities() const noexcept {
+Entity const* LightManager::getEntities() const noexcept {
     return downcast(this)->getEntities();
 }
 
@@ -54,7 +54,7 @@ void LightManager::setLightChannel(Instance i, unsigned int channel, bool enable
     downcast(this)->setLightChannel(i, channel, enable);
 }
 
-bool LightManager::getLightChannel(LightManager::Instance i, unsigned int channel) const noexcept {
+bool LightManager::getLightChannel(Instance i, unsigned int channel) const noexcept {
     return downcast(this)->getLightChannel(i, channel);
 }
 
@@ -139,7 +139,7 @@ float LightManager::getSunHaloFalloff(Instance i) const noexcept {
     return downcast(this)->getSunHaloFalloff(i);
 }
 
-LightManager::Type LightManager::getType(LightManager::Instance i) const noexcept {
+LightManager::Type LightManager::getType(Instance i) const noexcept {
     return downcast(this)->getType(i);
 }
 

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -16,7 +16,21 @@
 
 #include "details/Material.h"
 
+#include <filament/Material.h>
+#include <filament/MaterialEnums.h>
+
+#include <backend/CallbackHandler.h>
+#include <backend/DriverEnums.h>
+
+#include <utils/Invocable.h>
+
+#include <utility>
+
+#include <stddef.h>
+
 namespace filament {
+
+class MaterialInstance;
 
 using namespace backend;
 
@@ -140,9 +154,9 @@ MaterialInstance const* Material::getDefaultInstance() const noexcept {
     return downcast(this)->getDefaultInstance();
 }
 
-void Material::compile(CompilerPriorityQueue const priority, UserVariantFilterMask const variantFilter,
+void Material::compile(CompilerPriorityQueue const priority, UserVariantFilterMask const variants,
         CallbackHandler* handler, utils::Invocable<void(Material*)>&& callback) noexcept {
-    downcast(this)->compile(priority, variantFilter, handler, std::move(callback));
+    downcast(this)->compile(priority, variants, handler, std::move(callback));
 }
 
 UserVariantFilterMask Material::getSupportedVariants() const noexcept {

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -100,7 +100,7 @@ size_t Material::getParameterCount() const noexcept {
     return downcast(this)->getParameterCount();
 }
 
-size_t Material::getParameters(ParameterInfo* parameters, size_t count) const noexcept {
+size_t Material::getParameters(ParameterInfo* parameters, size_t const count) const noexcept {
     return downcast(this)->getParameters(parameters, count);
 }
 
@@ -140,7 +140,7 @@ MaterialInstance const* Material::getDefaultInstance() const noexcept {
     return downcast(this)->getDefaultInstance();
 }
 
-void Material::compile(CompilerPriorityQueue priority, UserVariantFilterMask variantFilter,
+void Material::compile(CompilerPriorityQueue const priority, UserVariantFilterMask const variantFilter,
         CallbackHandler* handler, utils::Invocable<void(Material*)>&& callback) noexcept {
     downcast(this)->compile(priority, variantFilter, handler, std::move(callback));
 }

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -141,7 +141,7 @@ MaterialInstance const* Material::getDefaultInstance() const noexcept {
 }
 
 void Material::compile(CompilerPriorityQueue priority, UserVariantFilterMask variantFilter,
-        backend::CallbackHandler* handler, utils::Invocable<void(Material*)>&& callback) noexcept {
+        CallbackHandler* handler, utils::Invocable<void(Material*)>&& callback) noexcept {
     downcast(this)->compile(priority, variantFilter, handler, std::move(callback));
 }
 

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -29,7 +29,7 @@ using namespace backend;
 // vec4<float>. This must not be inlined (this is the whole point).
 template<size_t Size>
 UTILS_NOINLINE
-void FMaterialInstance::setParameterUntypedImpl(std::string_view name, const void* value) {
+void FMaterialInstance::setParameterUntypedImpl(std::string_view const name, const void* value) {
     ssize_t offset = mMaterial->getUniformInterfaceBlock().getFieldOffset(name, 0);
     if (UTILS_LIKELY(offset >= 0)) {
         mUniforms.setUniformUntyped<Size>(size_t(offset), value);  // handles specialization for mat3f
@@ -41,14 +41,14 @@ void FMaterialInstance::setParameterUntypedImpl(std::string_view name, const voi
 // this converts typed calls into the untyped-sized call.
 template<typename T>
 UTILS_ALWAYS_INLINE
-inline void FMaterialInstance::setParameterImpl(std::string_view name, T const& value) {
+inline void FMaterialInstance::setParameterImpl(std::string_view const name, T const& value) {
     static_assert(!std::is_same_v<T, mat3f>);
     setParameterUntypedImpl<sizeof(T)>(name, &value);
 }
 
 // specialization for mat3f
 template<>
-inline void FMaterialInstance::setParameterImpl(std::string_view name, mat3f const& value) {
+inline void FMaterialInstance::setParameterImpl(std::string_view const name, mat3f const& value) {
     ssize_t offset = mMaterial->getUniformInterfaceBlock().getFieldOffset(name, 0);
     if (UTILS_LIKELY(offset >= 0)) {
         mUniforms.setUniform(size_t(offset), value);
@@ -59,8 +59,8 @@ inline void FMaterialInstance::setParameterImpl(std::string_view name, mat3f con
 
 template<size_t Size>
 UTILS_NOINLINE
-void FMaterialInstance::setParameterUntypedImpl(std::string_view name,
-        const void* value, size_t count) {
+void FMaterialInstance::setParameterUntypedImpl(std::string_view const name,
+        const void* value, size_t const count) {
     ssize_t offset = mMaterial->getUniformInterfaceBlock().getFieldOffset(name, 0);
     if (UTILS_LIKELY(offset >= 0)) {
         mUniforms.setUniformArrayUntyped<Size>(size_t(offset), value, count);
@@ -69,8 +69,8 @@ void FMaterialInstance::setParameterUntypedImpl(std::string_view name,
 
 template<typename T>
 UTILS_ALWAYS_INLINE
-inline void FMaterialInstance::setParameterImpl(std::string_view name,
-        const T* value, size_t count) {
+inline void FMaterialInstance::setParameterImpl(std::string_view const name,
+        const T* value, size_t const count) {
     static_assert(!std::is_same_v<T, mat3f>);
     setParameterUntypedImpl<sizeof(T)>(name, value, count);
 }
@@ -83,25 +83,25 @@ void MaterialInstance::setParameter(const char* name, size_t nameLength, T const
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool const& v) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, bool const& v) {
     // this kills tail-call optimization
     setParameter(name, nameLength, (uint32_t)v);
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool2 const& v) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, bool2 const& v) {
     // this kills tail-call optimization
     setParameter(name, nameLength, uint2(v));
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool3 const& v) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, bool3 const& v) {
     // this kills tail-call optimization
     setParameter(name, nameLength, uint3(v));
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool4 const& v) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, bool4 const& v) {
     // this kills tail-call optimization
     setParameter(name, nameLength, uint4(v));
 }
@@ -130,7 +130,7 @@ void MaterialInstance::setParameter(const char* name, size_t nameLength, const T
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool* v, size_t c) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, const bool* v, size_t const c) {
     auto* p = new uint32_t[c];
     std::copy_n(v, c, p);
     setParameter(name, nameLength, p, c);
@@ -138,7 +138,7 @@ UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLe
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool2* v, size_t c) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, const bool2* v, size_t const c) {
     auto* p = new uint2[c];
     std::copy_n(v, c, p);
     setParameter(name, nameLength, p, c);
@@ -146,7 +146,7 @@ UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLe
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool3* v, size_t c) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, const bool3* v, size_t const c) {
     auto* p = new uint3[c];
     std::copy_n(v, c, p);
     setParameter(name, nameLength, p, c);
@@ -154,7 +154,7 @@ UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLe
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool4* v, size_t c) {
+UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t const nameLength, const bool4* v, size_t const c) {
     auto* p = new uint4[c];
     std::copy_n(v, c, p);
     setParameter(name, nameLength, p, c);
@@ -162,7 +162,7 @@ UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLe
 }
 
 template<>
-UTILS_PUBLIC void MaterialInstance::setParameter<mat3f>(const char* name, size_t nameLength, const mat3f* v, size_t c) {
+UTILS_PUBLIC void MaterialInstance::setParameter<mat3f>(const char* name, size_t const nameLength, const mat3f* v, size_t const c) {
     // pretend each mat3 is an array of 3 float3
     setParameter(name, nameLength, reinterpret_cast<float3 const*>(v), c * 3);
 }
@@ -184,7 +184,7 @@ template UTILS_PUBLIC void MaterialInstance::setParameter<mat4f>   (const char* 
 // ------------------------------------------------------------------------------------------------
 
 template<typename T>
-T FMaterialInstance::getParameterImpl(std::string_view name) const {
+T FMaterialInstance::getParameterImpl(std::string_view const name) const {
     ssize_t offset = mMaterial->getUniformInterfaceBlock().getFieldOffset(name, 0);
     assert_invariant(offset>=0);
     return downcast(this)->getUniformBuffer().getUniform<T>(offset);
@@ -226,17 +226,17 @@ void MaterialInstance::setParameter(const char* name, size_t nameLength, Texture
 }
 
 void MaterialInstance::setParameter(
-        const char* name, size_t nameLength, RgbType type, float3 color) {
+        const char* name, size_t nameLength, RgbType const type, float3 const color) {
     downcast(this)->setParameterImpl<float3>({ name, nameLength }, Color::toLinear(type, color));
 }
 
 void MaterialInstance::setParameter(
-        const char* name, size_t nameLength, RgbaType type, float4 color) {
+        const char* name, size_t nameLength, RgbaType const type, float4 const color) {
     downcast(this)->setParameterImpl<float4>({ name, nameLength }, Color::toLinear(type, color));
 }
 
 void MaterialInstance::setScissor(
-        uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) noexcept {
+        uint32_t const left, uint32_t const bottom, uint32_t const width, uint32_t const height) noexcept {
     downcast(this)->setScissor(left, bottom, width, height);
 }
 
@@ -244,47 +244,47 @@ void MaterialInstance::unsetScissor() noexcept {
     downcast(this)->unsetScissor();
 }
 
-void MaterialInstance::setPolygonOffset(float scale, float constant) noexcept {
+void MaterialInstance::setPolygonOffset(float const scale, float const constant) noexcept {
     downcast(this)->setPolygonOffset(scale, constant);
 }
 
-void MaterialInstance::setMaskThreshold(float threshold) noexcept {
+void MaterialInstance::setMaskThreshold(float const threshold) noexcept {
     downcast(this)->setMaskThreshold(threshold);
 }
 
-void MaterialInstance::setSpecularAntiAliasingVariance(float variance) noexcept {
+void MaterialInstance::setSpecularAntiAliasingVariance(float const variance) noexcept {
     downcast(this)->setSpecularAntiAliasingVariance(variance);
 }
 
-void MaterialInstance::setSpecularAntiAliasingThreshold(float threshold) noexcept {
+void MaterialInstance::setSpecularAntiAliasingThreshold(float const threshold) noexcept {
     downcast(this)->setSpecularAntiAliasingThreshold(threshold);
 }
 
-void MaterialInstance::setDoubleSided(bool doubleSided) noexcept {
+void MaterialInstance::setDoubleSided(bool const doubleSided) noexcept {
     downcast(this)->setDoubleSided(doubleSided);
 }
 
-void MaterialInstance::setTransparencyMode(TransparencyMode mode) noexcept {
+void MaterialInstance::setTransparencyMode(TransparencyMode const mode) noexcept {
     downcast(this)->setTransparencyMode(mode);
 }
 
-void MaterialInstance::setCullingMode(CullingMode culling) noexcept {
+void MaterialInstance::setCullingMode(CullingMode const culling) noexcept {
     downcast(this)->setCullingMode(culling);
 }
 
-void MaterialInstance::setColorWrite(bool enable) noexcept {
+void MaterialInstance::setColorWrite(bool const enable) noexcept {
     downcast(this)->setColorWrite(enable);
 }
 
-void MaterialInstance::setDepthWrite(bool enable) noexcept {
+void MaterialInstance::setDepthWrite(bool const enable) noexcept {
     downcast(this)->setDepthWrite(enable);
 }
 
-void MaterialInstance::setDepthCulling(bool enable) noexcept {
+void MaterialInstance::setDepthCulling(bool const enable) noexcept {
     downcast(this)->setDepthCulling(enable);
 }
 
-void MaterialInstance::setDepthFunc(DepthFunc depthFunc) noexcept {
+void MaterialInstance::setDepthFunc(DepthFunc const depthFunc) noexcept {
     downcast(this)->setDepthFunc(depthFunc);
 }
 
@@ -292,35 +292,35 @@ MaterialInstance::DepthFunc MaterialInstance::getDepthFunc() const noexcept {
     return downcast(this)->getDepthFunc();
 }
 
-void MaterialInstance::setStencilWrite(bool enable) noexcept {
+void MaterialInstance::setStencilWrite(bool const enable) noexcept {
     downcast(this)->setStencilWrite(enable);
 }
 
-void MaterialInstance::setStencilCompareFunction(StencilCompareFunc func, StencilFace face) noexcept {
+void MaterialInstance::setStencilCompareFunction(StencilCompareFunc const func, StencilFace const face) noexcept {
     downcast(this)->setStencilCompareFunction(func, face);
 }
 
-void MaterialInstance::setStencilOpStencilFail(StencilOperation op, StencilFace face) noexcept {
+void MaterialInstance::setStencilOpStencilFail(StencilOperation const op, StencilFace const face) noexcept {
     downcast(this)->setStencilOpStencilFail(op, face);
 }
 
-void MaterialInstance::setStencilOpDepthFail(StencilOperation op, StencilFace face) noexcept {
+void MaterialInstance::setStencilOpDepthFail(StencilOperation const op, StencilFace const face) noexcept {
     downcast(this)->setStencilOpDepthFail(op, face);
 }
 
-void MaterialInstance::setStencilOpDepthStencilPass(StencilOperation op, StencilFace face) noexcept {
+void MaterialInstance::setStencilOpDepthStencilPass(StencilOperation const op, StencilFace const face) noexcept {
     downcast(this)->setStencilOpDepthStencilPass(op, face);
 }
 
-void MaterialInstance::setStencilReferenceValue(uint8_t value, StencilFace face) noexcept {
+void MaterialInstance::setStencilReferenceValue(uint8_t const value, StencilFace const face) noexcept {
     downcast(this)->setStencilReferenceValue(value, face);
 }
 
-void MaterialInstance::setStencilReadMask(uint8_t readMask, StencilFace face) noexcept {
+void MaterialInstance::setStencilReadMask(uint8_t const readMask, StencilFace const face) noexcept {
     downcast(this)->setStencilReadMask(readMask, face);
 }
 
-void MaterialInstance::setStencilWriteMask(uint8_t writeMask, StencilFace face) noexcept {
+void MaterialInstance::setStencilWriteMask(uint8_t const writeMask, StencilFace const face) noexcept {
     downcast(this)->setStencilWriteMask(writeMask, face);
 }
 

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -42,7 +42,7 @@ void FMaterialInstance::setParameterUntypedImpl(std::string_view name, const voi
 template<typename T>
 UTILS_ALWAYS_INLINE
 inline void FMaterialInstance::setParameterImpl(std::string_view name, T const& value) {
-    static_assert(!std::is_same_v<T, math::mat3f>);
+    static_assert(!std::is_same_v<T, mat3f>);
     setParameterUntypedImpl<sizeof(T)>(name, &value);
 }
 
@@ -71,7 +71,7 @@ template<typename T>
 UTILS_ALWAYS_INLINE
 inline void FMaterialInstance::setParameterImpl(std::string_view name,
         const T* value, size_t count) {
-    static_assert(!std::is_same_v<T, math::mat3f>);
+    static_assert(!std::is_same_v<T, mat3f>);
     setParameterUntypedImpl<sizeof(T)>(name, value, count);
 }
 
@@ -85,25 +85,25 @@ void MaterialInstance::setParameter(const char* name, size_t nameLength, T const
 template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool const& v) {
     // this kills tail-call optimization
-    MaterialInstance::setParameter(name, nameLength, (uint32_t)v);
+    setParameter(name, nameLength, (uint32_t)v);
 }
 
 template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool2 const& v) {
     // this kills tail-call optimization
-    MaterialInstance::setParameter(name, nameLength, uint2(v));
+    setParameter(name, nameLength, uint2(v));
 }
 
 template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool3 const& v) {
     // this kills tail-call optimization
-    MaterialInstance::setParameter(name, nameLength, uint3(v));
+    setParameter(name, nameLength, uint3(v));
 }
 
 template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, bool4 const& v) {
     // this kills tail-call optimization
-    MaterialInstance::setParameter(name, nameLength, uint4(v));
+    setParameter(name, nameLength, uint4(v));
 }
 
 // explicit template instantiation of our supported types
@@ -133,7 +133,7 @@ template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool* v, size_t c) {
     auto* p = new uint32_t[c];
     std::copy_n(v, c, p);
-    MaterialInstance::setParameter(name, nameLength, p, c);
+    setParameter(name, nameLength, p, c);
     delete [] p;
 }
 
@@ -141,7 +141,7 @@ template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool2* v, size_t c) {
     auto* p = new uint2[c];
     std::copy_n(v, c, p);
-    MaterialInstance::setParameter(name, nameLength, p, c);
+    setParameter(name, nameLength, p, c);
     delete [] p;
 }
 
@@ -149,7 +149,7 @@ template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool3* v, size_t c) {
     auto* p = new uint3[c];
     std::copy_n(v, c, p);
-    MaterialInstance::setParameter(name, nameLength, p, c);
+    setParameter(name, nameLength, p, c);
     delete [] p;
 }
 
@@ -157,14 +157,14 @@ template<>
 UTILS_PUBLIC void MaterialInstance::setParameter(const char* name, size_t nameLength, const bool4* v, size_t c) {
     auto* p = new uint4[c];
     std::copy_n(v, c, p);
-    MaterialInstance::setParameter(name, nameLength, p, c);
+    setParameter(name, nameLength, p, c);
     delete [] p;
 }
 
 template<>
 UTILS_PUBLIC void MaterialInstance::setParameter<mat3f>(const char* name, size_t nameLength, const mat3f* v, size_t c) {
     // pretend each mat3 is an array of 3 float3
-    MaterialInstance::setParameter(name, nameLength, reinterpret_cast<math::float3 const*>(v), c * 3);
+    setParameter(name, nameLength, reinterpret_cast<float3 const*>(v), c * 3);
 }
 
 template UTILS_PUBLIC void MaterialInstance::setParameter<float>   (const char* name, size_t nameLength, const float    *v, size_t c);

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -57,22 +57,22 @@ namespace filament {
 constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage language) {
     switch (language) {
         case ShaderLanguage::ESSL3:
-            return { ChunkType::MaterialGlsl, ChunkType::DictionaryText };
+            return { MaterialGlsl, DictionaryText };
         case ShaderLanguage::ESSL1:
-            return { ChunkType::MaterialEssl1, ChunkType::DictionaryText };
+            return { MaterialEssl1, DictionaryText };
         case ShaderLanguage::MSL:
-            return { ChunkType::MaterialMetal, ChunkType::DictionaryText };
+            return { MaterialMetal, DictionaryText };
         case ShaderLanguage::SPIRV:
-            return { ChunkType::MaterialSpirv, ChunkType::DictionarySpirv };
+            return { MaterialSpirv, DictionarySpirv };
         case ShaderLanguage::METAL_LIBRARY:
-            return { ChunkType::MaterialMetalLibrary, ChunkType::DictionaryMetalLibrary };
+            return { MaterialMetalLibrary, DictionaryMetalLibrary };
     }
 }
 
 // ------------------------------------------------------------------------------------------------
 
 MaterialParser::MaterialParserDetails::MaterialParserDetails(
-        utils::FixedCapacityVector<ShaderLanguage> preferredLanguages, const void* data,
+        FixedCapacityVector<ShaderLanguage> preferredLanguages, const void* data,
         size_t size)
     : mManagedBuffer(data, size),
       mChunkContainer(mManagedBuffer.data(), mManagedBuffer.size()),
@@ -83,7 +83,7 @@ MaterialParser::MaterialParserDetails::MaterialParserDetails(
 template<typename T>
 UTILS_NOINLINE
 bool MaterialParser::MaterialParserDetails::getFromSimpleChunk(
-        filamat::ChunkType type, T* value) const noexcept {
+        ChunkType type, T* value) const noexcept {
     ChunkContainer const& chunkContainer = mChunkContainer;
     ChunkContainer::ChunkDesc chunkDesc;
     if (chunkContainer.hasChunk(type, &chunkDesc)) {
@@ -108,11 +108,11 @@ template<typename T>
 bool MaterialParser::get(typename T::Container* container) const noexcept {
     auto [start, end] = mImpl.mChunkContainer.getChunkRange(T::tag);
     if (start == end) return false;
-    filaflat::Unflattener unflattener{ start, end };
+    Unflattener unflattener{ start, end };
     return T::unflatten(unflattener, container);
 }
 
-MaterialParser::MaterialParser(utils::FixedCapacityVector<ShaderLanguage> preferredLanguages,
+MaterialParser::MaterialParser(FixedCapacityVector<ShaderLanguage> preferredLanguages,
         const void* data, size_t size)
     : mImpl(std::move(preferredLanguages), data, size) {
 }
@@ -160,20 +160,20 @@ MaterialParser::ParseResult MaterialParser::parse() noexcept {
     return ParseResult::SUCCESS;
 }
 
-backend::ShaderLanguage MaterialParser::getShaderLanguage() const noexcept {
+ShaderLanguage MaterialParser::getShaderLanguage() const noexcept {
     return mImpl.mChosenLanguage;
 }
 
 // Accessors
 bool MaterialParser::getMaterialVersion(uint32_t* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialVersion, value);
+    return mImpl.getFromSimpleChunk(MaterialVersion, value);
 }
 
 bool MaterialParser::getFeatureLevel(uint8_t* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialFeatureLevel, value);
+    return mImpl.getFromSimpleChunk(MaterialFeatureLevel, value);
 }
 
-bool MaterialParser::getName(utils::CString* cstring) const noexcept {
+bool MaterialParser::getName(CString* cstring) const noexcept {
    auto [start, end] = mImpl.mChunkContainer.getChunkRange(MaterialName);
     if (start == end) return false;
    Unflattener unflattener(start, end);
@@ -200,11 +200,11 @@ bool MaterialParser::getSubpasses(SubpassInfo* container) const noexcept {
 }
 
 bool MaterialParser::getShaderModels(uint32_t* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialShaderModels, value);
+    return mImpl.getFromSimpleChunk(MaterialShaderModels, value);
 }
 
 bool MaterialParser::getMaterialProperties(uint64_t* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialProperties, value);
+    return mImpl.getFromSimpleChunk(MaterialProperties, value);
 }
 
 bool MaterialParser::getBindingUniformInfo(BindingUniformInfoContainer* container) const noexcept {
@@ -223,75 +223,75 @@ bool MaterialParser::getDescriptorSetLayout(DescriptorSetLayoutContainer* contai
     return get<ChunkDescriptorSetLayoutInfo>(container);
 }
 
-bool MaterialParser::getConstants(utils::FixedCapacityVector<MaterialConstant>* container) const noexcept {
+bool MaterialParser::getConstants(FixedCapacityVector<MaterialConstant>* container) const noexcept {
     return get<ChunkMaterialConstants>(container);
 }
 
-bool MaterialParser::getPushConstants(utils::CString* structVarName,
-        utils::FixedCapacityVector<MaterialPushConstant>* value) const noexcept {
-    auto [start, end] = mImpl.mChunkContainer.getChunkRange(filamat::MaterialPushConstants);
+bool MaterialParser::getPushConstants(CString* structVarName,
+        FixedCapacityVector<MaterialPushConstant>* value) const noexcept {
+    auto [start, end] = mImpl.mChunkContainer.getChunkRange(MaterialPushConstants);
     if (start == end) return false;
     Unflattener unflattener(start, end);
     return ChunkMaterialPushConstants::unflatten(unflattener, structVarName, value);
 }
 
 bool MaterialParser::getDepthWriteSet(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialDepthWriteSet, value);
+    return mImpl.getFromSimpleChunk(MaterialDepthWriteSet, value);
 }
 
 bool MaterialParser::getDepthWrite(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialDepthWrite, value);
+    return mImpl.getFromSimpleChunk(MaterialDepthWrite, value);
 }
 
 bool MaterialParser::getDoubleSidedSet(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialDoubleSidedSet, value);
+    return mImpl.getFromSimpleChunk(MaterialDoubleSidedSet, value);
 }
 
 bool MaterialParser::getDoubleSided(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialDoubleSided, value);
+    return mImpl.getFromSimpleChunk(MaterialDoubleSided, value);
 }
 
 bool MaterialParser::getColorWrite(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialColorWrite, value);
+    return mImpl.getFromSimpleChunk(MaterialColorWrite, value);
 }
 
 bool MaterialParser::getDepthTest(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialDepthTest, value);
+    return mImpl.getFromSimpleChunk(MaterialDepthTest, value);
 }
 
 bool MaterialParser::getInstanced(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialInstanced, value);
+    return mImpl.getFromSimpleChunk(MaterialInstanced, value);
 }
 
 bool MaterialParser::getCullingMode(CullingMode* value) const noexcept {
     static_assert(sizeof(CullingMode) == sizeof(uint8_t),
             "CullingMode expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialCullingMode, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialCullingMode, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getTransparencyMode(TransparencyMode* value) const noexcept {
     static_assert(sizeof(TransparencyMode) == sizeof(uint8_t),
             "TransparencyMode expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialTransparencyMode,
+    return mImpl.getFromSimpleChunk(MaterialTransparencyMode,
             reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getInterpolation(Interpolation* value) const noexcept {
     static_assert(sizeof(Interpolation) == sizeof(uint8_t),
             "Interpolation expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialInterpolation, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialInterpolation, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getVertexDomain(VertexDomain* value) const noexcept {
     static_assert(sizeof(VertexDomain) == sizeof(uint8_t),
             "VertexDomain expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialVertexDomain, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialVertexDomain, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getMaterialVariantFilterMask(UserVariantFilterMask* value) const noexcept {
     static_assert(sizeof(UserVariantFilterMask) == sizeof(uint32_t),
             "UserVariantFilterMask expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialVariantFilterMask,
+    return mImpl.getFromSimpleChunk(MaterialVariantFilterMask,
             reinterpret_cast<UserVariantFilterMask*>(value));
 }
 
@@ -304,12 +304,12 @@ bool MaterialParser::getMaterialDomain(MaterialDomain* value) const noexcept {
 bool MaterialParser::getBlendingMode(BlendingMode* value) const noexcept {
     static_assert(sizeof(BlendingMode) == sizeof(uint8_t),
             "BlendingMode expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialBlendingMode, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialBlendingMode, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getCustomBlendFunction(std::array<BlendFunction, 4>* value) const noexcept {
     uint32_t blendFunctions = 0;
-    bool const result =  mImpl.getFromSimpleChunk(ChunkType::MaterialBlendFunction, &blendFunctions);
+    bool const result =  mImpl.getFromSimpleChunk(MaterialBlendFunction, &blendFunctions);
     (*value)[0] = BlendFunction((blendFunctions >> 24) & 0xFF);
     (*value)[1] = BlendFunction((blendFunctions >> 16) & 0xFF);
     (*value)[2] = BlendFunction((blendFunctions >>  8) & 0xFF);
@@ -318,52 +318,52 @@ bool MaterialParser::getCustomBlendFunction(std::array<BlendFunction, 4>* value)
 }
 
 bool MaterialParser::getMaskThreshold(float* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialMaskThreshold, value);
+    return mImpl.getFromSimpleChunk(MaterialMaskThreshold, value);
 }
 
 bool MaterialParser::getAlphaToCoverageSet(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialAlphaToCoverageSet, value);
+    return mImpl.getFromSimpleChunk(MaterialAlphaToCoverageSet, value);
 }
 
 bool MaterialParser::getAlphaToCoverage(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialAlphaToCoverage, value);
+    return mImpl.getFromSimpleChunk(MaterialAlphaToCoverage, value);
 }
 
 bool MaterialParser::hasShadowMultiplier(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialShadowMultiplier, value);
+    return mImpl.getFromSimpleChunk(MaterialShadowMultiplier, value);
 }
 
 bool MaterialParser::getShading(Shading* value) const noexcept {
     static_assert(sizeof(Shading) == sizeof(uint8_t),
             "Shading expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialShading, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialShading, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::hasCustomDepthShader(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialHasCustomDepthShader, value);
+    return mImpl.getFromSimpleChunk(MaterialHasCustomDepthShader, value);
 }
 
 bool MaterialParser::hasSpecularAntiAliasing(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialSpecularAntiAliasing, value);
+    return mImpl.getFromSimpleChunk(MaterialSpecularAntiAliasing, value);
 }
 
 bool MaterialParser::getSpecularAntiAliasingVariance(float* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialSpecularAntiAliasingVariance, value);
+    return mImpl.getFromSimpleChunk(MaterialSpecularAntiAliasingVariance, value);
 }
 
 bool MaterialParser::getSpecularAntiAliasingThreshold(float* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialSpecularAntiAliasingThreshold, value);
+    return mImpl.getFromSimpleChunk(MaterialSpecularAntiAliasingThreshold, value);
 }
 
-bool MaterialParser::getStereoscopicType(backend::StereoscopicType* value) const noexcept {
+bool MaterialParser::getStereoscopicType(StereoscopicType* value) const noexcept {
     static_assert(sizeof(StereoscopicType) == sizeof(uint8_t),
             "StereoscopicType expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialStereoscopicType, reinterpret_cast<uint8_t*>(value));
+    return mImpl.getFromSimpleChunk(MaterialStereoscopicType, reinterpret_cast<uint8_t*>(value));
 }
 
 bool MaterialParser::getRequiredAttributes(AttributeBitset* value) const noexcept {
     uint32_t rawAttributes = 0;
-    if (!mImpl.getFromSimpleChunk(ChunkType::MaterialRequiredAttributes, &rawAttributes)) {
+    if (!mImpl.getFromSimpleChunk(MaterialRequiredAttributes, &rawAttributes)) {
         return false;
     }
     *value = AttributeBitset();
@@ -374,19 +374,19 @@ bool MaterialParser::getRequiredAttributes(AttributeBitset* value) const noexcep
 bool MaterialParser::getRefractionMode(RefractionMode* value) const noexcept {
     static_assert(sizeof(RefractionMode) == sizeof(uint8_t),
             "Refraction expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialRefraction, (uint8_t*)value);
+    return mImpl.getFromSimpleChunk(MaterialRefraction, (uint8_t*)value);
 }
 
 bool MaterialParser::getRefractionType(RefractionType* value) const noexcept {
     static_assert(sizeof(RefractionType) == sizeof(uint8_t),
             "RefractionType expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialRefractionType, (uint8_t*)value);
+    return mImpl.getFromSimpleChunk(MaterialRefractionType, (uint8_t*)value);
 }
 
 bool MaterialParser::getReflectionMode(ReflectionMode* value) const noexcept {
     static_assert(sizeof(ReflectionMode) == sizeof(uint8_t),
             "ReflectionMode expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialReflectionMode, (uint8_t*)value);
+    return mImpl.getFromSimpleChunk(MaterialReflectionMode, (uint8_t*)value);
 }
 
 bool MaterialParser::getShader(ShaderContent& shader,
@@ -399,7 +399,7 @@ bool MaterialParser::getShader(ShaderContent& shader,
 
 
 bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
-        filament::BufferInterfaceBlock* uib) {
+        BufferInterfaceBlock* uib) {
 
     BufferInterfaceBlock::Builder builder = BufferInterfaceBlock::Builder();
 
@@ -450,7 +450,7 @@ bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
 }
 
 bool ChunkSamplerInterfaceBlock::unflatten(Unflattener& unflattener,
-        filament::SamplerInterfaceBlock* sib) {
+        SamplerInterfaceBlock* sib) {
 
     SamplerInterfaceBlock::Builder builder = SamplerInterfaceBlock::Builder();
 
@@ -467,7 +467,7 @@ bool ChunkSamplerInterfaceBlock::unflatten(Unflattener& unflattener,
     }
 
     for (uint64_t i = 0; i < numFields; i++) {
-        static_assert(sizeof(backend::descriptor_binding_t) == sizeof(uint8_t));
+        static_assert(sizeof(descriptor_binding_t) == sizeof(uint8_t));
         CString fieldName;
         uint8_t fieldBinding = 0;
         uint8_t fieldType = 0;
@@ -512,7 +512,7 @@ bool ChunkSamplerInterfaceBlock::unflatten(Unflattener& unflattener,
 }
 
 bool ChunkSubpassInterfaceBlock::unflatten(Unflattener& unflattener,
-        filament::SubpassInfo* subpass) {
+        SubpassInfo* subpass) {
 
     CString block;
     if (!unflattener.read(&block)) {
@@ -566,7 +566,7 @@ bool ChunkSubpassInterfaceBlock::unflatten(Unflattener& unflattener,
     return true;
 }
 
-bool ChunkBindingUniformInfo::unflatten(filaflat::Unflattener& unflattener,
+bool ChunkBindingUniformInfo::unflatten(Unflattener& unflattener,
         MaterialParser::BindingUniformInfoContainer* bindingUniformInfo) {
     uint8_t bindingPointCount;
     if (!unflattener.read(&bindingPointCount)) {
@@ -578,7 +578,7 @@ bool ChunkBindingUniformInfo::unflatten(filaflat::Unflattener& unflattener,
         if (!unflattener.read(&index)) {
             return false;
         }
-        utils::CString uboName;
+        CString uboName;
         if (!unflattener.read(&uboName)) {
             return false;
         }
@@ -589,7 +589,7 @@ bool ChunkBindingUniformInfo::unflatten(filaflat::Unflattener& unflattener,
 
         Program::UniformInfo uniforms = Program::UniformInfo::with_capacity(uniformCount);
         for (size_t j = 0; j < uniformCount; j++) {
-            utils::CString name;
+            CString name;
             if (!unflattener.read(&name)) {
                 return false;
             }
@@ -612,7 +612,7 @@ bool ChunkBindingUniformInfo::unflatten(filaflat::Unflattener& unflattener,
     return true;
 }
 
-bool ChunkAttributeInfo::unflatten(filaflat::Unflattener& unflattener,
+bool ChunkAttributeInfo::unflatten(Unflattener& unflattener,
         MaterialParser::AttributeInfoContainer* attributeInfoContainer) {
 
     uint8_t attributeCount;
@@ -623,7 +623,7 @@ bool ChunkAttributeInfo::unflatten(filaflat::Unflattener& unflattener,
     attributeInfoContainer->reserve(attributeCount);
 
     for (size_t j = 0; j < attributeCount; j++) {
-        utils::CString name;
+        CString name;
         if (!unflattener.read(&name)) {
             return false;
         }
@@ -637,7 +637,7 @@ bool ChunkAttributeInfo::unflatten(filaflat::Unflattener& unflattener,
     return true;
 }
 
-bool ChunkDescriptorBindingsInfo::unflatten(filaflat::Unflattener& unflattener,
+bool ChunkDescriptorBindingsInfo::unflatten(Unflattener& unflattener,
         MaterialParser::DescriptorBindingsContainer* container) {
 
     uint8_t setCount;
@@ -661,7 +661,7 @@ bool ChunkDescriptorBindingsInfo::unflatten(filaflat::Unflattener& unflattener,
         auto& descriptors = (*container)[+set];
         descriptors.reserve(descriptorCount);
         for (size_t i = 0; i < descriptorCount; i++) {
-            utils::CString name;
+            CString name;
             if (!unflattener.read(&name)) {
                 return false;
             }
@@ -675,15 +675,15 @@ bool ChunkDescriptorBindingsInfo::unflatten(filaflat::Unflattener& unflattener,
             }
             descriptors.push_back({
                     std::move(name),
-                    backend::DescriptorType(type),
-                    backend::descriptor_binding_t(binding)});
+                    DescriptorType(type),
+                    descriptor_binding_t(binding)});
         }
     }
 
     return true;
 }
 
-bool ChunkDescriptorSetLayoutInfo::unflatten(filaflat::Unflattener& unflattener,
+bool ChunkDescriptorSetLayoutInfo::unflatten(Unflattener& unflattener,
         MaterialParser::DescriptorSetLayoutContainer* container) {
     for (size_t j = 0; j < 2; j++) {
         uint8_t descriptorCount;
@@ -714,10 +714,10 @@ bool ChunkDescriptorSetLayoutInfo::unflatten(filaflat::Unflattener& unflattener,
                 return false;
             }
             descriptors.push_back({
-                    backend::DescriptorType(type),
-                    backend::ShaderStageFlags(stageFlags),
-                    backend::descriptor_binding_t(binding),
-                    backend::DescriptorFlags(flags),
+                    DescriptorType(type),
+                    ShaderStageFlags(stageFlags),
+                    descriptor_binding_t(binding),
+                    DescriptorFlags(flags),
                     count,
             });
         }
@@ -725,8 +725,8 @@ bool ChunkDescriptorSetLayoutInfo::unflatten(filaflat::Unflattener& unflattener,
     return true;
 }
 
-bool ChunkMaterialConstants::unflatten(filaflat::Unflattener& unflattener,
-        utils::FixedCapacityVector<MaterialConstant>* materialConstants) {
+bool ChunkMaterialConstants::unflatten(Unflattener& unflattener,
+        FixedCapacityVector<MaterialConstant>* materialConstants) {
     assert_invariant(materialConstants);
 
     // Read number of constants.
@@ -751,15 +751,15 @@ bool ChunkMaterialConstants::unflatten(filaflat::Unflattener& unflattener,
         }
 
         (*materialConstants)[i].name = constantName;
-        (*materialConstants)[i].type = static_cast<backend::ConstantType>(constantType);
+        (*materialConstants)[i].type = static_cast<ConstantType>(constantType);
     }
 
     return true;
 }
 
-bool ChunkMaterialPushConstants::unflatten(filaflat::Unflattener& unflattener,
-        utils::CString* structVarName,
-        utils::FixedCapacityVector<MaterialPushConstant>* materialPushConstants) {
+bool ChunkMaterialPushConstants::unflatten(Unflattener& unflattener,
+        CString* structVarName,
+        FixedCapacityVector<MaterialPushConstant>* materialPushConstants) {
     assert_invariant(materialPushConstants);
 
     if (!unflattener.read(structVarName)) {
@@ -793,8 +793,8 @@ bool ChunkMaterialPushConstants::unflatten(filaflat::Unflattener& unflattener,
         }
 
         (*materialPushConstants)[i].name = constantName;
-        (*materialPushConstants)[i].type = static_cast<backend::ConstantType>(constantType);
-        (*materialPushConstants)[i].stage = static_cast<backend::ShaderStage>(shaderStage);
+        (*materialPushConstants)[i].type = static_cast<ConstantType>(constantType);
+        (*materialPushConstants)[i].stage = static_cast<ShaderStage>(shaderStage);
     }
     return true;
 }

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -54,7 +54,7 @@ using namespace filamat;
 
 namespace filament {
 
-constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage language) {
+constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage const language) {
     switch (language) {
         case ShaderLanguage::ESSL3:
             return { MaterialGlsl, DictionaryText };
@@ -73,7 +73,7 @@ constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage la
 
 MaterialParser::MaterialParserDetails::MaterialParserDetails(
         FixedCapacityVector<ShaderLanguage> preferredLanguages, const void* data,
-        size_t size)
+        size_t const size)
     : mManagedBuffer(data, size),
       mChunkContainer(mManagedBuffer.data(), mManagedBuffer.size()),
       mPreferredLanguages(std::move(preferredLanguages)),
@@ -83,7 +83,7 @@ MaterialParser::MaterialParserDetails::MaterialParserDetails(
 template<typename T>
 UTILS_NOINLINE
 bool MaterialParser::MaterialParserDetails::getFromSimpleChunk(
-        ChunkType type, T* value) const noexcept {
+        ChunkType const type, T* value) const noexcept {
     ChunkContainer const& chunkContainer = mChunkContainer;
     ChunkContainer::ChunkDesc chunkDesc;
     if (chunkContainer.hasChunk(type, &chunkDesc)) {
@@ -93,7 +93,7 @@ bool MaterialParser::MaterialParserDetails::getFromSimpleChunk(
     return false;
 }
 
-MaterialParser::MaterialParserDetails::ManagedBuffer::ManagedBuffer(const void* start, size_t size)
+MaterialParser::MaterialParserDetails::ManagedBuffer::ManagedBuffer(const void* start, size_t const size)
         : mStart(malloc(size)), mSize(size) {
     memcpy(mStart, start, size);
 }
@@ -113,7 +113,7 @@ bool MaterialParser::get(typename T::Container* container) const noexcept {
 }
 
 MaterialParser::MaterialParser(FixedCapacityVector<ShaderLanguage> preferredLanguages,
-        const void* data, size_t size)
+        const void* data, size_t const size)
     : mImpl(std::move(preferredLanguages), data, size) {
 }
 
@@ -390,7 +390,7 @@ bool MaterialParser::getReflectionMode(ReflectionMode* value) const noexcept {
 }
 
 bool MaterialParser::getShader(ShaderContent& shader,
-        ShaderModel shaderModel, Variant variant, ShaderStage stage) noexcept {
+        ShaderModel const shaderModel, Variant const variant, ShaderStage const stage) noexcept {
     return mImpl.mMaterialChunk.getShader(shader,
             mImpl.mBlobDictionary, shaderModel, variant, stage);
 }

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -130,8 +130,8 @@ public:
     bool getShader(filaflat::ShaderContent& shader, backend::ShaderModel shaderModel,
             Variant variant, backend::ShaderStage stage) noexcept;
 
-    bool hasShader(backend::ShaderModel model,
-            Variant variant, backend::ShaderStage stage) const noexcept {
+    bool hasShader(backend::ShaderModel const model,
+            Variant const variant, backend::ShaderStage const stage) const noexcept {
         return getMaterialChunk().hasShader(model, variant, stage);
     }
 

--- a/filament/src/MorphTargetBuffer.cpp
+++ b/filament/src/MorphTargetBuffer.cpp
@@ -20,18 +20,18 @@
 
 namespace filament {
 
-void MorphTargetBuffer::setPositionsAt(Engine& engine, size_t targetIndex,
-        math::float3 const* positions, size_t count, size_t offset) {
+void MorphTargetBuffer::setPositionsAt(Engine& engine, size_t const targetIndex,
+        math::float3 const* positions, size_t const count, size_t const offset) {
     downcast(this)->setPositionsAt(downcast(engine), targetIndex, positions, count, offset);
 }
 
-void MorphTargetBuffer::setPositionsAt(Engine& engine, size_t targetIndex,
-        math::float4 const* positions, size_t count, size_t offset) {
+void MorphTargetBuffer::setPositionsAt(Engine& engine, size_t const targetIndex,
+        math::float4 const* positions, size_t const count, size_t const offset) {
     downcast(this)->setPositionsAt(downcast(engine), targetIndex, positions, count, offset);
 }
 
-void MorphTargetBuffer::setTangentsAt(Engine& engine, size_t targetIndex,
-        math::short4 const* tangents, size_t count, size_t offset) {
+void MorphTargetBuffer::setTangentsAt(Engine& engine, size_t const targetIndex,
+        math::short4 const* tangents, size_t const count, size_t const offset) {
     downcast(this)->setTangentsAt(downcast(engine), targetIndex, tangents, count, offset);
 }
 

--- a/filament/src/PIDController.h
+++ b/filament/src/PIDController.h
@@ -27,43 +27,43 @@ class PIDController {
 public:
     PIDController() noexcept = default;
 
-    void setStandardGains(float Kp, float Ti, float Td) noexcept {
+    void setStandardGains(float const Kp, float const Ti, float const Td) noexcept {
         mKp = Kp;
         mKi = Kp / Ti;
         mKd = Kp * Td;
     }
 
-    void setParallelGains(float Kp, float Ki, float Kd) noexcept {
+    void setParallelGains(float const Kp, float const Ki, float const Kd) noexcept {
         mKp = Kp;
         mKi = Ki;
         mKd = Kd;
     }
 
     // output is kept steady in the dead band
-    void setOutputDeadBand(float low, float high) noexcept {
+    void setOutputDeadBand(float const low, float const high) noexcept {
         mDeadBandLow = low;
         mDeadBandHigh = high;
     }
 
     // integral bounds to prevent windup
-    void setIntegralLimits(float low, float high) noexcept {
+    void setIntegralLimits(float const low, float const high) noexcept {
         mIntegralLimitLow = low;
         mIntegralLimitHigh = high;
     }
 
     // output bounds
-    void setOutputLimits(float low, float high) noexcept {
+    void setOutputLimits(float const low, float const high) noexcept {
         mOutputLimitLow = low;
         mOutputLimitHigh = high;
     }
 
     // disable integral term to prevent windup
-    void setIntegralInhibitionEnabled(bool enabled) noexcept {
+    void setIntegralInhibitionEnabled(bool const enabled) noexcept {
         mIntegralInhibition = enabled ? 0.0f : 1.0f;
     }
 
     // update PID output
-    float update(float measure, float target, float dt) const noexcept {
+    float update(float const measure, float const target, float const dt) const noexcept {
         // compute error
         const float error = target - measure;
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -130,7 +130,7 @@ public:
 
     // SSAO
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOcclusion(FrameGraph& fg,
-            filament::Viewport const& svp, const CameraInfo& cameraInfo,
+            Viewport const& svp, const CameraInfo& cameraInfo,
             FrameGraphId<FrameGraphTexture> structure,
             AmbientOcclusionOptions const& options) noexcept;
 
@@ -201,7 +201,7 @@ public:
 
         // Color grading, tone mapping, dithering and bloom
     FrameGraphId<FrameGraphTexture> colorGrading(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
+            FrameGraphId<FrameGraphTexture> input, Viewport const& vp,
             FrameGraphId<FrameGraphTexture> bloom,
             FrameGraphId<FrameGraphTexture> flare,
             const FColorGrading* colorGrading,
@@ -226,12 +226,12 @@ public:
 
     // Anti-aliasing
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
+            FrameGraphId<FrameGraphTexture> input, Viewport const& vp,
             backend::TextureFormat outFormat, bool translucent) noexcept;
 
     // Temporal Anti-aliasing
     void TaaJitterCamera(
-            filament::Viewport const& svp,
+            Viewport const& svp,
             TemporalAntiAliasingOptions const& taaOptions,
             FrameHistory& frameHistory,
             FrameHistoryEntry::TemporalAA FrameHistoryEntry::*pTaa,
@@ -254,7 +254,7 @@ public:
     //  - doens't handle sub-resouces
     FrameGraphId<FrameGraphTexture> upscale(FrameGraph& fg, bool translucent,
             DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
-            filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+            Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
             backend::SamplerMagFilter filter) noexcept;
 
     FrameGraphId<FrameGraphTexture> rcas(
@@ -267,7 +267,7 @@ public:
     // color blitter using shaders
     FrameGraphId<FrameGraphTexture> blit(FrameGraph& fg, bool translucent,
             FrameGraphId<FrameGraphTexture> input,
-            filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+            Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
             backend::SamplerMagFilter filterMag,
             backend::SamplerMinFilter filterMin) noexcept;
 
@@ -311,7 +311,7 @@ public:
     // is not expected to be used in normal cases.
     FrameGraphId<FrameGraphTexture> debugCombineArrayTexture(FrameGraph& fg, bool translucent,
         FrameGraphId<FrameGraphTexture> input,
-        filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+        Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
         backend::SamplerMagFilter filterMag,
         backend::SamplerMinFilter filterMin) noexcept;
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -131,7 +131,7 @@ public:
     // SSAO
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOcclusion(FrameGraph& fg,
             Viewport const& svp, const CameraInfo& cameraInfo,
-            FrameGraphId<FrameGraphTexture> structure,
+            FrameGraphId<FrameGraphTexture> depth,
             AmbientOcclusionOptions const& options) noexcept;
 
     // Gaussian mipmap

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -428,7 +428,7 @@ private:
 
     template<size_t SIZE>
     struct JitterSequence {
-        math::float2 operator()(size_t i) const noexcept { return positions[i % SIZE] - 0.5f; }
+        math::float2 operator()(size_t const i) const noexcept { return positions[i % SIZE] - 0.5f; }
         const std::array<math::float2, SIZE> positions;
     };
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -222,7 +222,7 @@ void RenderPass::appendCommands(FEngine const& engine,
     auto work = [commandTypeFlags, curr, &soa,
                  variant, renderFlags, visibilityMask,
                  cameraPosition, cameraForwardVector, stereoscopicEyeCount]
-            (uint32_t startIndex, uint32_t indexCount) {
+            (uint32_t const startIndex, uint32_t const indexCount) {
         generateCommands(commandTypeFlags, curr,
                 soa, { startIndex, startIndex + indexCount },
                 variant, renderFlags, visibilityMask,
@@ -253,7 +253,7 @@ void RenderPass::appendCommands(FEngine const& engine,
 }
 
 void RenderPass::appendCustomCommand(Command* commands,
-        uint8_t channel, Pass pass, CustomCommand custom, uint32_t order,
+        uint8_t channel, Pass pass, CustomCommand custom, uint32_t const order,
         Executor::CustomCommandFn command) {
 
     assert_invariant((uint64_t(order) << CUSTOM_ORDER_SHIFT) <=  CUSTOM_ORDER_MASK);
@@ -290,7 +290,7 @@ RenderPass::Command* RenderPass::sortCommands(
 RenderPass::Command* RenderPass::instanceify(DriverApi& driver,
         DescriptorSetLayoutHandle perRenderableDescriptorSetLayoutHandle,
         Command* curr, Command* const last,
-        int32_t eyeCount) const noexcept {
+        int32_t const eyeCount) const noexcept {
     SYSTRACE_NAME("instanceify");
 
     // instanceify works by scanning the **sorted** command stream, looking for repeat draw
@@ -439,7 +439,7 @@ UTILS_ALWAYS_INLINE // This function exists only to make the code more readable.
 inline              // and we don't need it in the compilation unit
 void RenderPass::setupColorCommand(Command& cmdDraw, Variant variant,
         FMaterialInstance const* const UTILS_RESTRICT mi,
-        bool inverseFrontFaces, bool hasDepthClamp) noexcept {
+        bool const inverseFrontFaces, bool const hasDepthClamp) noexcept {
 
     FMaterial const * const UTILS_RESTRICT ma = mi->getMaterial();
     variant = Variant::filterVariant(variant, ma->isVariantLit());

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -426,7 +426,7 @@ private:
             Command* begin, Command* end) noexcept;
 
     // instanceify commands then trims sentinels
-    RenderPass::Command* instanceify(backend::DriverApi& driver,
+    Command* instanceify(backend::DriverApi& driver,
             backend::DescriptorSetLayoutHandle perRenderableDescriptorSetLayoutHandle,
             Command* begin, Command* end,
             int32_t eyeCount) const noexcept;
@@ -446,8 +446,8 @@ private:
             math::float3 cameraPosition, math::float3 cameraForward,
             uint8_t instancedStereoEyeCount) noexcept;
 
-    template<RenderPass::CommandTypeFlags commandTypeFlags>
-    static inline RenderPass::Command* generateCommandsImpl(RenderPass::CommandTypeFlags extraFlags,
+    template<CommandTypeFlags commandTypeFlags>
+    static inline Command* generateCommandsImpl(CommandTypeFlags extraFlags,
             Command* curr, FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
             Variant variant, RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward,

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -273,7 +273,7 @@ public:
         PrimitiveInfo info;    // 56 bytes
         bool operator < (Command const& rhs) const noexcept { return key < rhs.key; }
         // placement new declared as "throw" to avoid the compiler's null-check
-        inline void* operator new (size_t, void* ptr) {
+        void* operator new (size_t, void* ptr) {
             assert_invariant(ptr);
             return ptr;
         }
@@ -412,7 +412,7 @@ private:
             FScene::VisibleMaskType visibilityMask,
             Variant variant,
             math::float3 cameraPosition,
-            math::float3 cameraForwardVector) noexcept;
+            math::float3 cameraForwardVector) const noexcept;
 
     // Appends a custom command.
     void appendCustomCommand(Command* commands,
@@ -447,7 +447,7 @@ private:
             uint8_t instancedStereoEyeCount) noexcept;
 
     template<CommandTypeFlags commandTypeFlags>
-    static inline Command* generateCommandsImpl(CommandTypeFlags extraFlags,
+    static Command* generateCommandsImpl(CommandTypeFlags extraFlags,
             Command* curr, FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
             Variant variant, RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward,

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -219,14 +219,14 @@ public:
      *
      * The variant is inserted while building the commands, because we don't know it before that
      */
-    static CommandKey makeMaterialSortingKey(uint32_t materialId, uint32_t instanceId) noexcept {
+    static CommandKey makeMaterialSortingKey(uint32_t const materialId, uint32_t const instanceId) noexcept {
         CommandKey const key = ((materialId << MATERIAL_ID_SHIFT) & MATERIAL_ID_MASK) |
                          ((instanceId << MATERIAL_INSTANCE_ID_SHIFT) & MATERIAL_INSTANCE_ID_MASK);
         return (key << MATERIAL_SHIFT) & MATERIAL_MASK;
     }
 
     template<typename T>
-    static CommandKey makeField(T value, uint64_t mask, unsigned shift) noexcept {
+    static CommandKey makeField(T value, uint64_t const mask, unsigned const shift) noexcept {
         assert_invariant(!((uint64_t(value) << shift) & ~mask));
         return uint64_t(value) << shift;
     }
@@ -502,21 +502,21 @@ class RenderPassBuilder {
 public:
     explicit RenderPassBuilder(RenderPass::Arena& arena) : mArena(arena) { }
 
-    RenderPassBuilder& commandTypeFlags(RenderPass::CommandTypeFlags commandTypeFlags) noexcept {
+    RenderPassBuilder& commandTypeFlags(RenderPass::CommandTypeFlags const commandTypeFlags) noexcept {
         mCommandTypeFlags = commandTypeFlags;
         return *this;
     }
 
     // Specifies the viewport for the scissor rectangle, that is, the final scissor rect is
     // offset by the viewport's left-top and clipped to the viewport's width/height.
-    RenderPassBuilder& scissorViewport(backend::Viewport viewport) noexcept {
+    RenderPassBuilder& scissorViewport(backend::Viewport const viewport) noexcept {
         mScissorViewport = viewport;
         return *this;
     }
 
     // specifies the geometry to generate commands for
     RenderPassBuilder& geometry(
-            FScene::RenderableSoa const& soa, utils::Range<uint32_t> vr) noexcept {
+            FScene::RenderableSoa const& soa, utils::Range<uint32_t> const vr) noexcept {
         mRenderableSoa = &soa;
         mVisibleRenderables = vr;
         return *this;
@@ -530,14 +530,14 @@ public:
     }
 
     //  flags controlling how commands are generated
-    RenderPassBuilder& renderFlags(RenderPass::RenderFlags flags) noexcept {
+    RenderPassBuilder& renderFlags(RenderPass::RenderFlags const flags) noexcept {
         mFlags = flags;
         return *this;
     }
 
     // like above but allows to set specific flags
     RenderPassBuilder& renderFlags(
-            RenderPass::RenderFlags mask, RenderPass::RenderFlags value) noexcept {
+            RenderPass::RenderFlags const mask, RenderPass::RenderFlags value) noexcept {
         value &= mask;
         mFlags &= ~mask;
         mFlags |= value;
@@ -545,7 +545,7 @@ public:
     }
 
     // variant to use
-    RenderPassBuilder& variant(Variant variant) noexcept {
+    RenderPassBuilder& variant(Variant const variant) noexcept {
         mVariant = variant;
         return *this;
     }
@@ -559,7 +559,7 @@ public:
     // Sets the visibility mask, which is AND-ed against each Renderable's VISIBLE_MASK to
     // determine if the renderable is visible for this pass.
     // Defaults to all 1's, which means all renderables in this render pass will be rendered.
-    RenderPassBuilder& visibilityMask(FScene::VisibleMaskType mask) noexcept {
+    RenderPassBuilder& visibilityMask(FScene::VisibleMaskType const mask) noexcept {
         mVisibilityMask = mask;
         return *this;
     }

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -54,9 +54,9 @@ void FRenderPrimitive::terminate(HwRenderPrimitiveFactory& factory, backend::Dri
 }
 
 void FRenderPrimitive::set(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
-        RenderableManager::PrimitiveType type,
+        RenderableManager::PrimitiveType const type,
         FVertexBuffer* vertexBuffer, FIndexBuffer* indexBuffer,
-        size_t offset, size_t count) noexcept {
+        size_t const offset, size_t const count) noexcept {
     if (mHandle) {
         factory.destroy(driver, mHandle);
     }

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -41,8 +41,8 @@ void FRenderPrimitive::init(HwRenderPrimitiveFactory& factory, backend::DriverAp
     mBlendOrder = entry.blendOrder;
 
     if (entry.indices && entry.vertices) {
-        FVertexBuffer* vertexBuffer = downcast(entry.vertices);
-        FIndexBuffer* indexBuffer = downcast(entry.indices);
+        FVertexBuffer const* vertexBuffer = downcast(entry.vertices);
+        FIndexBuffer const* indexBuffer = downcast(entry.indices);
         set(factory, driver, entry.type, vertexBuffer, indexBuffer, entry.offset, entry.count);
     }
 }
@@ -55,7 +55,7 @@ void FRenderPrimitive::terminate(HwRenderPrimitiveFactory& factory, backend::Dri
 
 void FRenderPrimitive::set(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
         RenderableManager::PrimitiveType const type,
-        FVertexBuffer* vertexBuffer, FIndexBuffer* indexBuffer,
+        FVertexBuffer const* vertexBuffer, FIndexBuffer const* indexBuffer,
         size_t const offset, size_t const count) noexcept {
     if (mHandle) {
         factory.destroy(driver, mHandle);

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -45,7 +45,7 @@ public:
 
     void set(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
             RenderableManager::PrimitiveType type,
-            FVertexBuffer* vertexBuffer, FIndexBuffer* indexBuffer, size_t offset,
+            FVertexBuffer const* vertexBuffer, FIndexBuffer const* indexBuffer, size_t offset,
             size_t count) noexcept;
 
     // frees driver resources, object becomes invalid

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -65,15 +65,15 @@ public:
 
     void setMaterialInstance(FMaterialInstance const* mi) noexcept { mMaterialInstance = mi; }
 
-    void setBlendOrder(uint16_t order) noexcept {
+    void setBlendOrder(uint16_t const order) noexcept {
         mBlendOrder = static_cast<uint16_t>(order & 0x7FFF);
     }
 
-    void setGlobalBlendOrderEnabled(bool enabled) noexcept {
+    void setGlobalBlendOrderEnabled(bool const enabled) noexcept {
         mGlobalBlendOrderEnabled = enabled;
     }
 
-    void setMorphingBufferOffset(uint32_t offset) noexcept {
+    void setMorphingBufferOffset(uint32_t const offset) noexcept {
         mMorphingBufferOffset = offset;
     }
 

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -22,19 +22,19 @@ namespace filament {
 
 using namespace backend;
 
-Texture* RenderTarget::getTexture(AttachmentPoint attachment) const noexcept {
+Texture* RenderTarget::getTexture(AttachmentPoint const attachment) const noexcept {
     return downcast(this)->getAttachment(attachment).texture;
 }
 
-uint8_t RenderTarget::getMipLevel(AttachmentPoint attachment) const noexcept {
+uint8_t RenderTarget::getMipLevel(AttachmentPoint const attachment) const noexcept {
     return downcast(this)->getAttachment(attachment).mipLevel;
 }
 
-RenderTarget::CubemapFace RenderTarget::getFace(AttachmentPoint attachment) const noexcept {
+RenderTarget::CubemapFace RenderTarget::getFace(AttachmentPoint const attachment) const noexcept {
     return downcast(this)->getAttachment(attachment).face;
 }
 
-uint32_t RenderTarget::getLayer(AttachmentPoint attachment) const noexcept {
+uint32_t RenderTarget::getLayer(AttachmentPoint const attachment) const noexcept {
     return downcast(this)->getAttachment(attachment).layer;
 }
 

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -27,7 +27,7 @@ namespace filament {
 using namespace backend;
 using namespace math;
 
-bool RenderableManager::hasComponent(Entity e) const noexcept {
+bool RenderableManager::hasComponent(Entity const e) const noexcept {
     return downcast(this)->hasComponent(e);
 }
 
@@ -39,7 +39,7 @@ bool RenderableManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-Entity RenderableManager::getEntity(Instance i) const noexcept {
+Entity RenderableManager::getEntity(Instance const i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
@@ -48,68 +48,68 @@ Entity const* RenderableManager::getEntities() const noexcept {
 }
 
 RenderableManager::Instance
-RenderableManager::getInstance(Entity e) const noexcept {
+RenderableManager::getInstance(Entity const e) const noexcept {
     return downcast(this)->getInstance(e);
 }
 
-void RenderableManager::destroy(Entity e) noexcept {
+void RenderableManager::destroy(Entity const e) noexcept {
     return downcast(this)->destroy(e);
 }
 
-void RenderableManager::setAxisAlignedBoundingBox(Instance instance, const Box& aabb) {
+void RenderableManager::setAxisAlignedBoundingBox(Instance const instance, const Box& aabb) {
     downcast(this)->setAxisAlignedBoundingBox(instance, aabb);
 }
 
-void RenderableManager::setLayerMask(Instance instance, uint8_t select, uint8_t values) noexcept {
+void RenderableManager::setLayerMask(Instance const instance, uint8_t const select, uint8_t const values) noexcept {
     downcast(this)->setLayerMask(instance, select, values);
 }
 
-void RenderableManager::setPriority(Instance instance, uint8_t priority) noexcept {
+void RenderableManager::setPriority(Instance const instance, uint8_t const priority) noexcept {
     downcast(this)->setPriority(instance, priority);
 }
 
-void RenderableManager::setChannel(Instance instance, uint8_t channel) noexcept{
+void RenderableManager::setChannel(Instance const instance, uint8_t const channel) noexcept{
     downcast(this)->setChannel(instance, channel);
 }
 
-void RenderableManager::setCulling(Instance instance, bool enable) noexcept {
+void RenderableManager::setCulling(Instance const instance, bool const enable) noexcept {
     downcast(this)->setCulling(instance, enable);
 }
 
-void RenderableManager::setCastShadows(Instance instance, bool enable) noexcept {
+void RenderableManager::setCastShadows(Instance const instance, bool const enable) noexcept {
     downcast(this)->setCastShadows(instance, enable);
 }
 
-void RenderableManager::setReceiveShadows(Instance instance, bool enable) noexcept {
+void RenderableManager::setReceiveShadows(Instance const instance, bool const enable) noexcept {
     downcast(this)->setReceiveShadows(instance, enable);
 }
 
-void RenderableManager::setScreenSpaceContactShadows(Instance instance, bool enable) noexcept {
+void RenderableManager::setScreenSpaceContactShadows(Instance const instance, bool const enable) noexcept {
     downcast(this)->setScreenSpaceContactShadows(instance, enable);
 }
 
-bool RenderableManager::isShadowCaster(Instance instance) const noexcept {
+bool RenderableManager::isShadowCaster(Instance const instance) const noexcept {
     return downcast(this)->isShadowCaster(instance);
 }
 
-bool RenderableManager::isShadowReceiver(Instance instance) const noexcept {
+bool RenderableManager::isShadowReceiver(Instance const instance) const noexcept {
     return downcast(this)->isShadowReceiver(instance);
 }
 
-const Box& RenderableManager::getAxisAlignedBoundingBox(Instance instance) const noexcept {
+const Box& RenderableManager::getAxisAlignedBoundingBox(Instance const instance) const noexcept {
     return downcast(this)->getAxisAlignedBoundingBox(instance);
 }
 
-uint8_t RenderableManager::getLayerMask(Instance instance) const noexcept {
+uint8_t RenderableManager::getLayerMask(Instance const instance) const noexcept {
     return downcast(this)->getLayerMask(instance);
 }
 
-size_t RenderableManager::getPrimitiveCount(Instance instance) const noexcept {
+size_t RenderableManager::getPrimitiveCount(Instance const instance) const noexcept {
     return downcast(this)->getPrimitiveCount(instance, 0);
 }
 
-void RenderableManager::setMaterialInstanceAt(Instance instance,
-        size_t primitiveIndex, MaterialInstance const* materialInstance) {
+void RenderableManager::setMaterialInstanceAt(Instance const instance,
+        size_t const primitiveIndex, MaterialInstance const* materialInstance) {
     downcast(this)->setMaterialInstanceAt(instance, 0, primitiveIndex, downcast(materialInstance));
 }
 
@@ -118,77 +118,77 @@ void RenderableManager::clearMaterialInstanceAt(Instance instance, size_t primit
 }
 
 MaterialInstance* RenderableManager::getMaterialInstanceAt(
-        Instance instance, size_t primitiveIndex) const noexcept {
+        Instance const instance, size_t const primitiveIndex) const noexcept {
     return downcast(this)->getMaterialInstanceAt(instance, 0, primitiveIndex);
 }
 
-void RenderableManager::setBlendOrderAt(Instance instance, size_t primitiveIndex, uint16_t order) noexcept {
+void RenderableManager::setBlendOrderAt(Instance const instance, size_t const primitiveIndex, uint16_t const order) noexcept {
     downcast(this)->setBlendOrderAt(instance, 0, primitiveIndex, order);
 }
 
-void RenderableManager::setGlobalBlendOrderEnabledAt(Instance instance,
-        size_t primitiveIndex, bool enabled) noexcept {
+void RenderableManager::setGlobalBlendOrderEnabledAt(Instance const instance,
+        size_t const primitiveIndex, bool const enabled) noexcept {
     downcast(this)->setGlobalBlendOrderEnabledAt(instance, 0, primitiveIndex, enabled);
 }
 
-AttributeBitset RenderableManager::getEnabledAttributesAt(Instance instance, size_t primitiveIndex) const noexcept {
+AttributeBitset RenderableManager::getEnabledAttributesAt(Instance const instance, size_t const primitiveIndex) const noexcept {
     return downcast(this)->getEnabledAttributesAt(instance, 0, primitiveIndex);
 }
 
-void RenderableManager::setGeometryAt(Instance instance, size_t primitiveIndex,
-        PrimitiveType type, VertexBuffer* vertices, IndexBuffer* indices,
-        size_t offset, size_t count) noexcept {
+void RenderableManager::setGeometryAt(Instance const instance, size_t const primitiveIndex,
+        PrimitiveType const type, VertexBuffer* vertices, IndexBuffer* indices,
+        size_t const offset, size_t const count) noexcept {
     downcast(this)->setGeometryAt(instance, 0, primitiveIndex,
             type, downcast(vertices), downcast(indices), offset, count);
 }
 
-void RenderableManager::setBones(Instance instance,
-        Bone const* transforms, size_t boneCount, size_t offset) {
+void RenderableManager::setBones(Instance const instance,
+        Bone const* transforms, size_t const boneCount, size_t const offset) {
     downcast(this)->setBones(instance, transforms, boneCount, offset);
 }
 
-void RenderableManager::setBones(Instance instance,
-        mat4f const* transforms, size_t boneCount, size_t offset) {
+void RenderableManager::setBones(Instance const instance,
+        mat4f const* transforms, size_t const boneCount, size_t const offset) {
     downcast(this)->setBones(instance, transforms, boneCount, offset);
 }
 
-void RenderableManager::setSkinningBuffer(Instance instance,
-        SkinningBuffer* skinningBuffer, size_t count, size_t offset) {
+void RenderableManager::setSkinningBuffer(Instance const instance,
+        SkinningBuffer* skinningBuffer, size_t const count, size_t const offset) {
     downcast(this)->setSkinningBuffer(instance, downcast(skinningBuffer), count, offset);
 }
 
-void RenderableManager::setMorphWeights(Instance instance, float const* weights,
-        size_t count, size_t offset) {
+void RenderableManager::setMorphWeights(Instance const instance, float const* weights,
+        size_t const count, size_t const offset) {
     downcast(this)->setMorphWeights(instance, weights, count, offset);
 }
 
-void RenderableManager::setMorphTargetBufferOffsetAt(Instance instance, uint8_t level,
-        size_t primitiveIndex,
-        size_t offset) {
+void RenderableManager::setMorphTargetBufferOffsetAt(Instance const instance, uint8_t const level,
+        size_t const primitiveIndex,
+        size_t const offset) {
     downcast(this)->setMorphTargetBufferOffsetAt(instance, level, primitiveIndex, offset);
 }
 
-MorphTargetBuffer* RenderableManager::getMorphTargetBuffer(Instance instance) const noexcept {
+MorphTargetBuffer* RenderableManager::getMorphTargetBuffer(Instance const instance) const noexcept {
     return downcast(this)->getMorphTargetBuffer(instance);
 }
 
-size_t RenderableManager::getMorphTargetCount(Instance instance) const noexcept {
+size_t RenderableManager::getMorphTargetCount(Instance const instance) const noexcept {
     return downcast(this)->getMorphTargetCount(instance);
 }
 
-void RenderableManager::setLightChannel(Instance instance, unsigned int channel, bool enable) noexcept {
+void RenderableManager::setLightChannel(Instance const instance, unsigned int const channel, bool const enable) noexcept {
     downcast(this)->setLightChannel(instance, channel, enable);
 }
 
-bool RenderableManager::getLightChannel(Instance instance, unsigned int channel) const noexcept {
+bool RenderableManager::getLightChannel(Instance const instance, unsigned int const channel) const noexcept {
     return downcast(this)->getLightChannel(instance, channel);
 }
 
-void RenderableManager::setFogEnabled(Instance instance, bool enable) noexcept {
+void RenderableManager::setFogEnabled(Instance const instance, bool const enable) noexcept {
     downcast(this)->setFogEnabled(instance, enable);
 }
 
-bool RenderableManager::getFogEnabled(Instance instance) const noexcept {
+bool RenderableManager::getFogEnabled(Instance const instance) const noexcept {
     return downcast(this)->getFogEnabled(instance);
 }
 

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -27,7 +27,7 @@ namespace filament {
 using namespace backend;
 using namespace math;
 
-bool RenderableManager::hasComponent(utils::Entity e) const noexcept {
+bool RenderableManager::hasComponent(Entity e) const noexcept {
     return downcast(this)->hasComponent(e);
 }
 
@@ -39,20 +39,20 @@ bool RenderableManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-utils::Entity RenderableManager::getEntity(RenderableManager::Instance i) const noexcept {
+Entity RenderableManager::getEntity(Instance i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
-utils::Entity const* RenderableManager::getEntities() const noexcept {
+Entity const* RenderableManager::getEntities() const noexcept {
     return downcast(this)->getEntities();
 }
 
 RenderableManager::Instance
-RenderableManager::getInstance(utils::Entity e) const noexcept {
+RenderableManager::getInstance(Entity e) const noexcept {
     return downcast(this)->getInstance(e);
 }
 
-void RenderableManager::destroy(utils::Entity e) noexcept {
+void RenderableManager::destroy(Entity e) noexcept {
     return downcast(this)->destroy(e);
 }
 
@@ -126,7 +126,7 @@ void RenderableManager::setBlendOrderAt(Instance instance, size_t primitiveIndex
     downcast(this)->setBlendOrderAt(instance, 0, primitiveIndex, order);
 }
 
-void RenderableManager::setGlobalBlendOrderEnabledAt(RenderableManager::Instance instance,
+void RenderableManager::setGlobalBlendOrderEnabledAt(Instance instance,
         size_t primitiveIndex, bool enabled) noexcept {
     downcast(this)->setGlobalBlendOrderEnabledAt(instance, 0, primitiveIndex, enabled);
 }
@@ -143,7 +143,7 @@ void RenderableManager::setGeometryAt(Instance instance, size_t primitiveIndex,
 }
 
 void RenderableManager::setBones(Instance instance,
-        RenderableManager::Bone const* transforms, size_t boneCount, size_t offset) {
+        Bone const* transforms, size_t boneCount, size_t offset) {
     downcast(this)->setBones(instance, transforms, boneCount, offset);
 }
 
@@ -184,11 +184,11 @@ bool RenderableManager::getLightChannel(Instance instance, unsigned int channel)
     return downcast(this)->getLightChannel(instance, channel);
 }
 
-void RenderableManager::setFogEnabled(RenderableManager::Instance instance, bool enable) noexcept {
+void RenderableManager::setFogEnabled(Instance instance, bool enable) noexcept {
     downcast(this)->setFogEnabled(instance, enable);
 }
 
-bool RenderableManager::getFogEnabled(RenderableManager::Instance instance) const noexcept {
+bool RenderableManager::getFogEnabled(Instance instance) const noexcept {
     return downcast(this)->getFogEnabled(instance);
 }
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -42,30 +42,30 @@ void Renderer::render(View const* view) {
     downcast(this)->render(downcast(view));
 }
 
-void Renderer::setPresentationTime(int64_t monotonic_clock_ns) {
+void Renderer::setPresentationTime(int64_t const monotonic_clock_ns) {
     downcast(this)->setPresentationTime(monotonic_clock_ns);
 }
 
-void Renderer::skipFrame(uint64_t vsyncSteadyClockTimeNano) {
+void Renderer::skipFrame(uint64_t const vsyncSteadyClockTimeNano) {
     downcast(this)->skipFrame(vsyncSteadyClockTimeNano);
 }
 
-bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano) {
+bool Renderer::beginFrame(SwapChain* swapChain, uint64_t const vsyncSteadyClockTimeNano) {
     return downcast(this)->beginFrame(downcast(swapChain), vsyncSteadyClockTimeNano);
 }
 
 void Renderer::copyFrame(SwapChain* dstSwapChain, filament::Viewport const& dstViewport,
-        filament::Viewport const& srcViewport, CopyFrameFlag flags) {
+        filament::Viewport const& srcViewport, CopyFrameFlag const flags) {
     downcast(this)->copyFrame(downcast(dstSwapChain), dstViewport, srcViewport, flags);
 }
 
-void Renderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
+void Renderer::readPixels(uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
     downcast(this)->readPixels(xoffset, yoffset, width, height, std::move(buffer));
 }
 
 void Renderer::readPixels(RenderTarget* renderTarget,
-        uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
     downcast(this)->readPixels(downcast(renderTarget),
             xoffset, yoffset, width, height, std::move(buffer));
@@ -103,11 +103,11 @@ void Renderer::renderStandaloneView(View const* view) {
     downcast(this)->renderStandaloneView(downcast(view));
 }
 
-void Renderer::setVsyncTime(uint64_t steadyClockTimeNano) noexcept {
+void Renderer::setVsyncTime(uint64_t const steadyClockTimeNano) noexcept {
     downcast(this)->setVsyncTime(steadyClockTimeNano);
 }
 
-utils::FixedCapacityVector<Renderer::FrameInfo> Renderer::getFrameInfoHistory(size_t historySize) const noexcept {
+utils::FixedCapacityVector<Renderer::FrameInfo> Renderer::getFrameInfoHistory(size_t const historySize) const noexcept {
     return downcast(this)->getFrameInfoHistory(historySize);
 }
 

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -55,7 +55,7 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
         FrameGraph& fg, const char* name, FEngine& engine, FView const& view,
         ColorPassInput const& colorPassInput,
         FrameGraphTexture::Descriptor const& colorBufferDesc,
-        ColorPassConfig const& config, PostProcessManager::ColorGradingConfig colorGradingConfig,
+        ColorPassConfig const& config, PostProcessManager::ColorGradingConfig const colorGradingConfig,
         RenderPass::Executor passExecutor) noexcept {
 
     struct ColorPassData {
@@ -273,7 +273,7 @@ std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
         ColorPassInput colorPassInput,
         ColorPassConfig config,
         PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,
-        PostProcessManager::ColorGradingConfig colorGradingConfig,
+        PostProcessManager::ColorGradingConfig const colorGradingConfig,
         RenderPass const& pass) noexcept {
 
     // find the first refractive object in channel 2
@@ -353,7 +353,7 @@ std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
 
 UTILS_NOINLINE
 void RendererUtils::readPixels(DriverApi& driver, Handle<HwRenderTarget> renderTargetHandle,
-        uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
     FILAMENT_CHECK_PRECONDITION(buffer.type != PixelDataType::COMPRESSED)
             << "buffer.format cannot be COMPRESSED";

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -295,7 +295,7 @@ std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
         config.hasScreenSpaceReflectionsOrRefractions = true;
 
         PostProcessManager& ppm = engine.getPostProcessManager();
-        auto const opaquePassOutput = RendererUtils::colorPass(fg,
+        auto const opaquePassOutput = colorPass(fg,
                 "Color Pass (opaque)", engine, view, colorPassInput, {
                         // When rendering the opaques, we need to conserve the sample buffer,
                         // so create a config that specifies the sample count.
@@ -330,7 +330,7 @@ std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
         // and we'd end up clearing the opaque pass. This scenario never happens because it is
         // prevented in Renderer.cpp's final blit.
         config.clearFlags = TargetBufferFlags::NONE;
-        auto transparentPassOutput = RendererUtils::colorPass(fg, "Color Pass (transparent)",
+        auto transparentPassOutput = colorPass(fg, "Color Pass (transparent)",
                 engine, view, colorPassInput, {
                         .width = config.physicalViewport.width,
                         .height = config.physicalViewport.height },
@@ -352,9 +352,9 @@ std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
 }
 
 UTILS_NOINLINE
-void RendererUtils::readPixels(backend::DriverApi& driver, Handle<HwRenderTarget> renderTargetHandle,
+void RendererUtils::readPixels(DriverApi& driver, Handle<HwRenderTarget> renderTargetHandle,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        backend::PixelBufferDescriptor&& buffer) {
+        PixelBufferDescriptor&& buffer) {
     FILAMENT_CHECK_PRECONDITION(buffer.type != PixelDataType::COMPRESSED)
             << "buffer.format cannot be COMPRESSED";
 

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -99,7 +99,7 @@ public:
             PostProcessManager::ColorGradingConfig colorGradingConfig,
             RenderPass::Executor passExecutor) noexcept;
 
-    static std::optional<RendererUtils::ColorPassOutput> refractionPass(
+    static std::optional<ColorPassOutput> refractionPass(
             FrameGraph& fg, FEngine& engine, FView const& view,
             ColorPassInput colorPassInput,
             ColorPassConfig config,

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -144,24 +144,24 @@ void ResourceAllocator::terminate() noexcept {
 }
 
 RenderTargetHandle ResourceAllocator::createRenderTarget(const char* name,
-        TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, uint8_t layerCount, MRT color, TargetBufferInfo depth,
-        TargetBufferInfo stencil) noexcept {
+        TargetBufferFlags const targetBufferFlags, uint32_t const width, uint32_t const height,
+        uint8_t const samples, uint8_t const layerCount, MRT const color, TargetBufferInfo const depth,
+        TargetBufferInfo const stencil) noexcept {
     auto handle = mBackend.createRenderTarget(targetBufferFlags,
             width, height, samples ? samples : 1u, layerCount, color, depth, stencil);
     mBackend.setDebugTag(handle.getId(), CString{ name });
     return handle;
 }
 
-void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {
+void ResourceAllocator::destroyRenderTarget(RenderTargetHandle const h) noexcept {
     mBackend.destroyRenderTarget(h);
 }
 
 TextureHandle ResourceAllocator::createTexture(const char* name,
-        SamplerType target, uint8_t levels, TextureFormat format, uint8_t samples,
-        uint32_t width, uint32_t height, uint32_t depth,
-        std::array<TextureSwizzle, 4> swizzle,
-        TextureUsage usage) noexcept {
+        SamplerType const target, uint8_t const levels, TextureFormat const format, uint8_t samples,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
+        std::array<TextureSwizzle, 4> const swizzle,
+        TextureUsage const usage) noexcept {
     // The frame graph descriptor uses "0" to mean "auto" but the sample count that is passed to the
     // backend should always be 1 or greater.
     samples = samples ? samples : uint8_t(1);
@@ -207,7 +207,7 @@ TextureHandle ResourceAllocator::createTexture(const char* name,
     return handle;
 }
 
-void ResourceAllocator::destroyTexture(TextureHandle h) noexcept {
+void ResourceAllocator::destroyTexture(TextureHandle const h) noexcept {
     auto const key = mDisposer->checkin(h);
     if constexpr (mEnabled) {
         if (UTILS_LIKELY(key.has_value())) {
@@ -225,7 +225,7 @@ ResourceAllocatorDisposerInterface& ResourceAllocator::getDisposer() noexcept {
     return *mDisposer;
 }
 
-void ResourceAllocator::gc(bool skippedFrame) noexcept {
+void ResourceAllocator::gc(bool const skippedFrame) noexcept {
     // this is called regularly -- usually once per frame
 
     // increase our age at each (non-skipped) frame
@@ -289,7 +289,7 @@ void ResourceAllocator::gc(bool skippedFrame) noexcept {
 }
 
 UTILS_NOINLINE
-void ResourceAllocator::dump(bool brief) const noexcept {
+void ResourceAllocator::dump(bool const brief) const noexcept {
     constexpr float MiB = 1.0f / float(1u << 20u);
     slog.d  << "# entries=" << mTextureCache.size()
             << ", sz=" << (float)mCacheSize * MiB << " MiB"
@@ -329,7 +329,7 @@ void ResourceAllocatorDisposer::terminate() noexcept {
     assert_invariant(mInUseTextures.empty());
 }
 
-void ResourceAllocatorDisposer::destroy(TextureHandle handle) noexcept {
+void ResourceAllocatorDisposer::destroy(TextureHandle const handle) noexcept {
     if (handle) {
         auto r = checkin(handle);
         if (r.has_value()) {

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -157,17 +157,17 @@ void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {
     mBackend.destroyRenderTarget(h);
 }
 
-backend::TextureHandle ResourceAllocator::createTexture(const char* name,
-        backend::SamplerType target, uint8_t levels, backend::TextureFormat format, uint8_t samples,
+TextureHandle ResourceAllocator::createTexture(const char* name,
+        SamplerType target, uint8_t levels, TextureFormat format, uint8_t samples,
         uint32_t width, uint32_t height, uint32_t depth,
-        std::array<backend::TextureSwizzle, 4> swizzle,
-        backend::TextureUsage usage) noexcept {
+        std::array<TextureSwizzle, 4> swizzle,
+        TextureUsage usage) noexcept {
     // The frame graph descriptor uses "0" to mean "auto" but the sample count that is passed to the
     // backend should always be 1 or greater.
     samples = samples ? samples : uint8_t(1);
 
-    using TS = backend::TextureSwizzle;
-    constexpr const auto defaultSwizzle = std::array<backend::TextureSwizzle, 4>{
+    using TS = TextureSwizzle;
+    constexpr const auto defaultSwizzle = std::array<TextureSwizzle, 4>{
         TS::CHANNEL_0, TS::CHANNEL_1, TS::CHANNEL_2, TS::CHANNEL_3};
 
     // do we have a suitable texture in the cache?
@@ -253,7 +253,7 @@ void ResourceAllocator::gc(bool skippedFrame) noexcept {
     // maximum number of unique ages in the cache
     constexpr size_t MAX_UNIQUE_AGE_COUNT = 3;
 
-    utils::bitset32 ages;
+    bitset32 ages;
     uint32_t evictedCount = 0;
     for (auto it = textureCache.begin(); it != textureCache.end();) {
         size_t const ageDiff = age - it->second.age;
@@ -274,9 +274,9 @@ void ResourceAllocator::gc(bool skippedFrame) noexcept {
         uint32_t bits = ages.getValue();
         // remove from the set the ages we keep
         for (size_t i = 0; i < MAX_UNIQUE_AGE_COUNT - 1; i++) {
-            bits &= ~(1 << utils::ctz(bits));
+            bits &= ~(1 << ctz(bits));
         }
-        size_t const maxAge = utils::ctz(bits);
+        size_t const maxAge = ctz(bits);
         for (auto it = textureCache.begin(); it != textureCache.end();) {
             const size_t ageDiff = age - it->second.age;
             if (ageDiff >= maxAge) {
@@ -308,7 +308,7 @@ void ResourceAllocator::dump(bool brief) const noexcept {
 
 ResourceAllocator::CacheContainer::iterator
 ResourceAllocator::purge(
-        ResourceAllocator::CacheContainer::iterator const& pos) {
+        CacheContainer::iterator const& pos) {
     //slog.d << "purging " << pos->second.handle.getId() << ", age=" << pos->second.age << io::endl;
     mBackend.destroyTexture(pos->second.handle);
     mCacheSize -= pos->second.size;
@@ -329,7 +329,7 @@ void ResourceAllocatorDisposer::terminate() noexcept {
     assert_invariant(mInUseTextures.empty());
 }
 
-void ResourceAllocatorDisposer::destroy(backend::TextureHandle handle) noexcept {
+void ResourceAllocatorDisposer::destroy(TextureHandle handle) noexcept {
     if (handle) {
         auto r = checkin(handle);
         if (r.has_value()) {
@@ -338,13 +338,13 @@ void ResourceAllocatorDisposer::destroy(backend::TextureHandle handle) noexcept 
     }
 }
 
-void ResourceAllocatorDisposer::checkout(backend::TextureHandle handle,
+void ResourceAllocatorDisposer::checkout(TextureHandle handle,
         ResourceAllocator::TextureKey key) {
     mInUseTextures.emplace(handle, key);
 }
 
 std::optional<ResourceAllocator::TextureKey> ResourceAllocatorDisposer::checkin(
-        backend::TextureHandle handle) {
+        TextureHandle handle) {
     // find the texture in the in-use list (it must be there!)
     auto it = mInUseTextures.find(handle);
     assert_invariant(it != mInUseTextures.end());

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -215,8 +215,8 @@ private:
 
     using CacheContainer = AssociativeContainer<TextureKey, TextureCachePayload>;
 
-    ResourceAllocator::CacheContainer::iterator
-    purge(ResourceAllocator::CacheContainer::iterator const& pos);
+    CacheContainer::iterator
+    purge(CacheContainer::iterator const& pos);
 
     backend::DriverApi& mBackend;
     std::shared_ptr<ResourceAllocatorDisposer> mDisposer;

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -71,7 +71,7 @@ bool Scene::hasEntity(Entity entity) const noexcept {
     return downcast(this)->hasEntity(entity);
 }
 
-void Scene::forEach(Invocable<void(utils::Entity)>&& functor) const noexcept {
+void Scene::forEach(Invocable<void(Entity)>&& functor) const noexcept {
     downcast(this)->forEach(std::move(functor));
 }
 

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -39,19 +39,19 @@ IndirectLight* Scene::getIndirectLight() const noexcept {
     return downcast(this)->getIndirectLight();
 }
 
-void Scene::addEntity(Entity entity) {
+void Scene::addEntity(Entity const entity) {
     downcast(this)->addEntity(entity);
 }
 
-void Scene::addEntities(const Entity* entities, size_t count) {
+void Scene::addEntities(const Entity* entities, size_t const count) {
     downcast(this)->addEntities(entities, count);
 }
 
-void Scene::remove(Entity entity) {
+void Scene::remove(Entity const entity) {
     downcast(this)->remove(entity);
 }
 
-void Scene::removeEntities(const Entity* entities, size_t count) {
+void Scene::removeEntities(const Entity* entities, size_t const count) {
     downcast(this)->removeEntities(entities, count);
 }
 
@@ -67,7 +67,7 @@ size_t Scene::getLightCount() const noexcept {
     return downcast(this)->getLightCount();
 }
 
-bool Scene::hasEntity(Entity entity) const noexcept {
+bool Scene::hasEntity(Entity const entity) const noexcept {
     return downcast(this)->hasEntity(entity);
 }
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -84,8 +84,8 @@ void ShadowMap::terminate(FEngine& engine) {
 
 ShadowMap::~ShadowMap() = default;
 
-void ShadowMap::initialize(size_t lightIndex, ShadowType shadowType,
-        uint16_t shadowIndex, uint8_t face,
+void ShadowMap::initialize(size_t const lightIndex, ShadowType const shadowType,
+        uint16_t const shadowIndex, uint8_t const face,
         LightManager::ShadowOptions const* options) {
     mLightIndex = lightIndex;
     mShadowIndex = shadowIndex;
@@ -266,7 +266,7 @@ ShadowMap::ShaderParameters ShadowMap::updateDirectional(FEngine& engine,
 }
 
 ShadowMap::ShaderParameters ShadowMap::updatePunctual(
-        mat4f const& Mv, float outerConeAngle, float nearPlane, float farPlane,
+        mat4f const& Mv, float const outerConeAngle, float const nearPlane, float const farPlane,
         const ShadowMapInfo& shadowMapInfo, const FLightManager::ShadowParams& params) noexcept {
     const mat4f Mp = mat4f::perspective(
             outerConeAngle * f::RAD_TO_DEG * 2.0f, 1.0f, nearPlane, farPlane);
@@ -363,7 +363,7 @@ ShadowMap::ShaderParameters ShadowMap::updateSpot(FEngine& engine,
 }
 
 ShadowMap::ShaderParameters ShadowMap::updatePoint(FEngine& engine,
-        const FScene::LightSoa& lightData, size_t index, CameraInfo const&,
+        const FScene::LightSoa& lightData, size_t const index, CameraInfo const&,
         const ShadowMapInfo& shadowMapInfo, FScene const& scene, uint8_t face) noexcept {
 
     // check if this shadow map has anything to render
@@ -712,7 +712,7 @@ ShadowMap::TextureCoordsMapping ShadowMap::getTextureCoordsMapping(ShadowMapInfo
 }
 
 mat4f ShadowMap::computeVsmLightSpaceMatrix(const mat4f& lightSpacePcf,
-        const mat4f& Mv, float znear, float zfar) noexcept {
+        const mat4f& Mv, float const znear, float const zfar) noexcept {
     // The lightSpacePcf matrix transforms coordinates from world space into (u, v, z) coordinates,
     // where (u, v) are used to access the shadow map, and z is the (non-linear) PCF comparison
     // value [0, 1].
@@ -732,7 +732,7 @@ mat4f ShadowMap::computeVsmLightSpaceMatrix(const mat4f& lightSpacePcf,
 
 // This construct a frustum (similar to glFrustum or frustum), except
 // it looks towards the +y axis, and assumes -1,1 for the left/right and bottom/top planes.
-mat4f ShadowMap::warpFrustum(float n, float f) noexcept {
+mat4f ShadowMap::warpFrustum(float const n, float const f) noexcept {
     assert_invariant(f > n);
     const float d = 1 / (f - n);
     const float A = (f + n) * d;
@@ -746,7 +746,7 @@ mat4f ShadowMap::warpFrustum(float n, float f) noexcept {
     return Wp;
 }
 
-mat4f ShadowMap::directionalLightFrustum(float near, float far) noexcept {
+mat4f ShadowMap::directionalLightFrustum(float const near, float const far) noexcept {
     const float d = far - near;
     mat4f m;
     m[2][2] = -2 / d;
@@ -755,7 +755,7 @@ mat4f ShadowMap::directionalLightFrustum(float near, float far) noexcept {
 }
 
 float2 ShadowMap::computeNearFar(const mat4f& view,
-        float3 const* wsVertices, size_t count) noexcept {
+        float3 const* wsVertices, size_t const count) noexcept {
     float2 nearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
     for (size_t i = 0; i < count; i++) {
         // we're on the z axis in light space (looking down to -z)
@@ -767,7 +767,7 @@ float2 ShadowMap::computeNearFar(const mat4f& view,
 }
 
 float2 ShadowMap::computeNearFarOfWarpSpace(mat4f const& lightView,
-        float3 const* wsVertices, size_t count) noexcept {
+        float3 const* wsVertices, size_t const count) noexcept {
     float2 nearFar = { std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest() };
     #pragma nounroll
     for (size_t i = 0; i < count; i++) {
@@ -793,7 +793,7 @@ float4 ShadowMap::computeBoundingSphere(float3 const* vertices, size_t count) no
 }
 
 Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
-        float3 const* wsVertices, size_t count) noexcept {
+        float3 const* wsVertices, size_t const count) noexcept {
     Aabb bounds{};
     Slice<float3> const vertices{ wsVertices, count };
     for (auto const& vertice : vertices) {
@@ -849,7 +849,7 @@ ShadowMap::Corners ShadowMap::computeFrustumCorners(
 Aabb ShadowMap::computeLightFrustumBounds(mat4f const& lightView,
         Aabb const& wsShadowReceiversVolume, Aabb const& wsShadowCastersVolume,
         SceneInfo const& sceneInfo,
-        bool stable, bool focusShadowCasters, bool farUsesShadowCasters) noexcept {
+        bool const stable, bool const focusShadowCasters, bool const farUsesShadowCasters) noexcept {
     Aabb lsLightFrustumBounds{};
 
     float const receiversFar = sceneInfo.lsReceiversNearFar[1];
@@ -880,9 +880,9 @@ Aabb ShadowMap::computeLightFrustumBounds(mat4f const& lightView,
 }
 
 void ShadowMap::snapLightFrustum(float2& s, float2& o,
-        double2 lsRef, int2 resolution) noexcept {
+        double2 const lsRef, int2 const resolution) noexcept {
 
-    auto proj2 = [](mat4 m, double2 v) -> double2 {
+    auto proj2 = [](mat4 m, double2 const v) -> double2 {
         double2 p;
         p.x = dot(double2{ m[0].x, m[1].x }, v) + m[3].x;
         p.y = dot(double2{ m[0].y, m[1].y }, v) + m[3].y;
@@ -1198,7 +1198,7 @@ float ShadowMap::texelSizeWorldSpace(const mat4f& Wp, const mat4f& MbMtF,
 }
 
 template<typename Casters, typename Receivers>
-void ShadowMap::visitScene(const FScene& scene, uint32_t visibleLayers,
+void ShadowMap::visitScene(const FScene& scene, uint32_t const visibleLayers,
         Casters casters, Receivers receivers) noexcept {
     SYSTRACE_CALL();
 
@@ -1225,7 +1225,7 @@ void ShadowMap::visitScene(const FScene& scene, uint32_t visibleLayers,
 }
 
 ShadowMap::SceneInfo::SceneInfo(
-        FScene const& scene, uint8_t visibleLayers) noexcept
+        FScene const& scene, uint8_t const visibleLayers) noexcept
         : visibleLayers(visibleLayers) {
 
     // the code below only works with affine transforms
@@ -1263,7 +1263,7 @@ void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene const& scene,
                 sceneInfo.lsCastersNearFar.x = max(sceneInfo.lsCastersNearFar.x, r.max.z);
                 sceneInfo.lsCastersNearFar.y = min(sceneInfo.lsCastersNearFar.y, r.min.z);
             },
-            [&](Aabb receiver, Culler::result_type vis) {
+            [&](Aabb receiver, Culler::result_type const vis) {
                 // account only for objects that are visible by the camera
                 auto mask = 1u << VISIBLE_RENDERABLE_BIT;
                 if ((vis & mask) == mask) {
@@ -1284,7 +1284,7 @@ void ShadowMap::updateSceneInfoSpot(mat4f const& Mv, FScene const& scene,
     sceneInfo.lsCastersNearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
     // account only for objects that are visible by both the camera and the light
     visitScene(scene, sceneInfo.visibleLayers,
-            [&](Aabb caster, Culler::result_type vis) {
+            [&](Aabb caster, Culler::result_type const vis) {
                 auto mask = VISIBLE_DYN_SHADOW_RENDERABLE;
                 if ((vis & mask) == mask) {
                     auto r = Aabb::transform(Mv.upperLeft(), Mv[3].xyz, caster);
@@ -1296,7 +1296,7 @@ void ShadowMap::updateSceneInfoSpot(mat4f const& Mv, FScene const& scene,
             }
     );
 }
-void ShadowMap::setAllocation(uint8_t layer, backend::Viewport viewport) noexcept {
+void ShadowMap::setAllocation(uint8_t const layer, backend::Viewport viewport) noexcept {
     mLayer = layer;
     mOffset = { viewport.left, viewport.bottom };
 }
@@ -1381,7 +1381,7 @@ void ShadowMap::prepareTime(Transaction const& transaction,
 }
 
 void ShadowMap::prepareShadowMapping(Transaction const& transaction,
-        bool highPrecision) noexcept {
+        bool const highPrecision) noexcept {
     ShadowMapDescriptorSet::prepareShadowMapping(transaction, highPrecision);
 }
 

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -145,19 +145,19 @@ public:
     // This computes the light's camera.
     ShaderParameters updateDirectional(FEngine& engine,
             const FScene::LightSoa& lightData, size_t index,
-            filament::CameraInfo const& camera,
+            CameraInfo const& camera,
             ShadowMapInfo const& shadowMapInfo,
             SceneInfo const& sceneInfo,
             bool useDepthClamp) noexcept;
 
     ShaderParameters updateSpot(FEngine& engine,
             const FScene::LightSoa& lightData, size_t index,
-            filament::CameraInfo const& camera,
+            CameraInfo const& camera,
             const ShadowMapInfo& shadowMapInfo, FScene const& scene,
             SceneInfo sceneInfo) noexcept;
 
-    ShadowMap::ShaderParameters updatePoint(FEngine& engine,
-            const FScene::LightSoa& lightData, size_t index, filament::CameraInfo const& camera,
+    ShaderParameters updatePoint(FEngine& engine,
+            const FScene::LightSoa& lightData, size_t index, CameraInfo const& camera,
             const ShadowMapInfo& shadowMapInfo, FScene const& scene, uint8_t face) noexcept;
 
     // Do we have visible shadows. Valid after calling update().
@@ -237,12 +237,12 @@ private:
             FEngine& engine,
             math::float3 direction,
             FLightManager::ShadowParams params,
-            filament::CameraInfo const& camera,
+            CameraInfo const& camera,
             SceneInfo const& sceneInfo,
             bool useDepthClamp) noexcept;
 
     static math::mat4f applyLISPSM(math::mat4f& Wp,
-            filament::CameraInfo const& camera, FLightManager::ShadowParams const& params,
+            CameraInfo const& camera, FLightManager::ShadowParams const& params,
             const math::mat4f& LMp,
             const math::mat4f& Mv,
             const math::mat4f& LMpMv,
@@ -255,7 +255,7 @@ private:
             math::mat4f const& LMpMv,
             math::mat4f const& WLMp,
             FrustumBoxIntersection const& lsShadowVolume, size_t vertexCount,
-            filament::CameraInfo const& camera,
+            CameraInfo const& camera,
             float shadowFar, bool stable) noexcept;
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -175,7 +175,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
     return shadowTechnique;
 }
 
-ShadowMapManager::Builder& ShadowMapManager::Builder::directionalShadowMap(size_t lightIndex,
+ShadowMapManager::Builder& ShadowMapManager::Builder::directionalShadowMap(size_t const lightIndex,
         LightManager::ShadowOptions const* options) noexcept {
     assert_invariant(options->shadowCascades <= CONFIG_MAX_SHADOW_CASCADES);
     // this updates getCascadedShadowMap()
@@ -191,7 +191,7 @@ ShadowMapManager::Builder& ShadowMapManager::Builder::directionalShadowMap(size_
     return *this;
 }
 
-ShadowMapManager::Builder& ShadowMapManager::Builder::shadowMap(size_t lightIndex, bool spotlight,
+ShadowMapManager::Builder& ShadowMapManager::Builder::shadowMap(size_t const lightIndex, bool const spotlight,
         LightManager::ShadowOptions const* options) noexcept {
     if (spotlight) {
         const size_t c = mSpotShadowMapCount++;
@@ -770,7 +770,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
 }
 
 void ShadowMapManager::updateSpotVisibilityMasks(
-        uint8_t visibleLayers,
+        uint8_t const visibleLayers,
         uint8_t const* UTILS_RESTRICT layers,
         FRenderableManager::Visibility const* UTILS_RESTRICT visibility,
         Culler::result_type* UTILS_RESTRICT visibleMask, size_t count) {
@@ -930,7 +930,7 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
 }
 
 void ShadowMapManager::cullPointShadowMap(ShadowMap const& shadowMap, FView const& view,
-        FScene::RenderableSoa& renderableData, utils::Range<uint32_t> range,
+        FScene::RenderableSoa& renderableData, utils::Range<uint32_t> const range,
         FScene::LightSoa const& lightData) noexcept {
 
     uint8_t const face = shadowMap.getFace();

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -858,7 +858,7 @@ void ShadowMapManager::cullSpotShadowMap(ShadowMap const& shadowMap,
     // compute shadow map frustum for culling
     const mat4f Mv = ShadowMap::getDirectionalLightViewMatrix(direction, { 0, 1, 0 }, position);
     const mat4f Mp = mat4f::perspective(outerConeAngle * f::RAD_TO_DEG * 2.0f, 1.0f, 0.01f, radius);
-    const mat4f MpMv = math::highPrecisionMultiply(Mp, Mv);
+    const mat4f MpMv = highPrecisionMultiply(Mp, Mv);
     const Frustum frustum(MpMv);
 
     // Cull shadow casters
@@ -945,7 +945,7 @@ void ShadowMapManager::cullPointShadowMap(ShadowMap const& shadowMap, FView cons
     // compute shadow map frustum for culling
     mat4f const Mv = ShadowMap::getPointLightViewMatrix(TextureCubemapFace(face), position);
     mat4f const Mp = mat4f::perspective(90.0f, 1.0f, 0.01f, radius);
-    Frustum const frustum{ math::highPrecisionMultiply(Mp, Mv) };
+    Frustum const frustum{ highPrecisionMultiply(Mp, Mv) };
 
     // Cull shadow casters
     float3 const* worldAABBCenter = renderableData.data<FScene::WORLD_AABB_CENTER>();

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -795,7 +795,7 @@ void ShadowMapManager::updateSpotVisibilityMasks(
 
 void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap, FEngine& engine, FView& view,
         CameraInfo const& mainCameraInfo,
-        FScene::LightSoa& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept {
+        FScene::LightSoa const& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept {
 
     const size_t lightIndex = shadowMap.getLightIndex();
     FLightManager::ShadowOptions const* const options = shadowMap.getShadowOptions();
@@ -886,7 +886,7 @@ void ShadowMapManager::cullSpotShadowMap(ShadowMap const& shadowMap,
 
 void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
         FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
-        FScene::LightSoa& lightData) noexcept {
+        FScene::LightSoa const& lightData) const noexcept {
 
     const uint8_t face = shadowMap.getFace();
     const size_t lightIndex = shadowMap.getLightIndex();
@@ -971,7 +971,7 @@ void ShadowMapManager::cullPointShadowMap(ShadowMap const& shadowMap, FView cons
 }
 
 ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine& engine,
-        FScene::LightSoa const& lightData) noexcept {
+        FScene::LightSoa const& lightData) const noexcept {
 
     // The const_cast here is a little ugly, but conceptually lightData should be const,
     // it's just that we're using it to store some temporary data. With SoA we can't have
@@ -1088,7 +1088,7 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
     if (useMipmapping) {
         // Limit the lowest mipmap level to 256x256.
         // This avoids artifacts on high derivative tangent surfaces.
-        int const lowMipmapLevel = 7;    // log2(256) - 1
+        constexpr int lowMipmapLevel = 7;    // log2(256) - 1
         mipLevels = std::max(1, FTexture::maxLevelCount(maxDimension) - lowMipmapLevel);
     }
 

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -158,14 +158,14 @@ private:
             FScene::LightSoa const& lightData, ShadowMap::SceneInfo sceneInfo) noexcept;
 
     ShadowTechnique updateSpotShadowMaps(FEngine& engine,
-            FScene::LightSoa const& lightData) noexcept;
+            FScene::LightSoa const& lightData) const noexcept;
 
     void calculateTextureRequirements(FEngine&, FView& view,
             FScene::LightSoa const&) noexcept;
 
     void prepareSpotShadowMap(ShadowMap& shadowMap,
             FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
-            FScene::LightSoa& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept;
+            FScene::LightSoa const& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept;
 
     static void cullSpotShadowMap(ShadowMap const& map,
             FEngine const& engine, FView const& view,
@@ -174,7 +174,7 @@ private:
 
     void preparePointShadowMap(ShadowMap& map,
             FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
-            FScene::LightSoa& lightData) noexcept;
+            FScene::LightSoa const& lightData) const noexcept;
 
     static void cullPointShadowMap(ShadowMap const& shadowMap, FView const& view,
             FScene::RenderableSoa& renderableData, utils::Range<uint32_t> range,

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -77,7 +77,7 @@ struct ShadowMappingUniforms {
 class ShadowMapManager {
 public:
 
-    using ShadowMappingUniforms = filament::ShadowMappingUniforms;
+    using ShadowMappingUniforms = ShadowMappingUniforms;
 
     using ShadowType = ShadowMap::ShadowType;
 
@@ -123,7 +123,7 @@ public:
 
     // Updates all the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
-    ShadowMapManager::ShadowTechnique update(Builder const& builder,
+    ShadowTechnique update(Builder const& builder,
             FEngine& engine, FView& view,
             CameraInfo const& cameraInfo,
             FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept;
@@ -153,11 +153,11 @@ private:
     static void updateNearFarPlanes(math::mat4f* projection,
             float nearDistance, float farDistance) noexcept;
 
-    ShadowMapManager::ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
+    ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
             FView& view, CameraInfo cameraInfo, FScene::RenderableSoa& renderableData,
             FScene::LightSoa const& lightData, ShadowMap::SceneInfo sceneInfo) noexcept;
 
-    ShadowMapManager::ShadowTechnique updateSpotShadowMaps(FEngine& engine,
+    ShadowTechnique updateSpotShadowMaps(FEngine& engine,
             FScene::LightSoa const& lightData) noexcept;
 
     void calculateTextureRequirements(FEngine&, FView& view,

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -239,12 +239,12 @@ private:
     bool mInitialized = false;
     bool mFeatureShadowAllocator = false;
 
-    ShadowMap& getShadowMap(size_t index) noexcept {
+    ShadowMap& getShadowMap(size_t const index) noexcept {
         assert_invariant(index < mShadowMapCache.size());
         return *std::launder(reinterpret_cast<ShadowMap*>(&mShadowMapCache[index]));
     }
 
-    ShadowMap const& getShadowMap(size_t index) const noexcept {
+    ShadowMap const& getShadowMap(size_t const index) const noexcept {
         return const_cast<ShadowMapManager*>(this)->getShadowMap(index);
     }
 

--- a/filament/src/SkinningBuffer.cpp
+++ b/filament/src/SkinningBuffer.cpp
@@ -29,7 +29,7 @@ void SkinningBuffer::setBones(Engine& engine,
 }
 
 void SkinningBuffer::setBones(Engine& engine,
-        math::mat4f const* transforms, size_t count, size_t offset) {
+        mat4f const* transforms, size_t count, size_t offset) {
     downcast(this)->setBones(downcast(engine), transforms, count, offset);
 }
 

--- a/filament/src/SkinningBuffer.cpp
+++ b/filament/src/SkinningBuffer.cpp
@@ -24,12 +24,12 @@ using namespace backend;
 using namespace math;
 
 void SkinningBuffer::setBones(Engine& engine,
-        RenderableManager::Bone const* transforms, size_t count, size_t offset) {
+        RenderableManager::Bone const* transforms, size_t const count, size_t const offset) {
     downcast(this)->setBones(downcast(engine), transforms, count, offset);
 }
 
 void SkinningBuffer::setBones(Engine& engine,
-        mat4f const* transforms, size_t count, size_t offset) {
+        mat4f const* transforms, size_t const count, size_t const offset) {
     downcast(this)->setBones(downcast(engine), transforms, count, offset);
 }
 

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -20,7 +20,7 @@
 
 namespace filament {
 
-void Skybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
+void Skybox::setLayerMask(uint8_t const select, uint8_t const values) noexcept {
     downcast(this)->setLayerMask(select, values);
 }
 
@@ -32,7 +32,7 @@ float Skybox::getIntensity() const noexcept {
     return downcast(this)->getIntensity();
 }
 
-void Skybox::setColor(math::float4 color) noexcept {
+void Skybox::setColor(math::float4 const color) noexcept {
     downcast(this)->setColor(color);
 }
 

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -24,16 +24,16 @@ StreamType Stream::getStreamType() const noexcept {
     return downcast(this)->getStreamType();
 }
 
-void Stream::setAcquiredImage(void* image, Callback callback, void* userdata) noexcept {
+void Stream::setAcquiredImage(void* image, Callback const callback, void* userdata) noexcept {
     downcast(this)->setAcquiredImage(image, callback, userdata);
 }
 
 void Stream::setAcquiredImage(void* image,
-        CallbackHandler* handler, Callback callback, void* userdata) noexcept {
+        CallbackHandler* handler, Callback const callback, void* userdata) noexcept {
     downcast(this)->setAcquiredImage(image, handler, callback, userdata);
 }
 
-void Stream::setDimensions(uint32_t width, uint32_t height) noexcept {
+void Stream::setDimensions(uint32_t const width, uint32_t const height) noexcept {
     downcast(this)->setDimensions(width, height);
 }
 

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -29,7 +29,7 @@ void Stream::setAcquiredImage(void* image, Callback callback, void* userdata) no
 }
 
 void Stream::setAcquiredImage(void* image,
-        backend::CallbackHandler* handler, Callback callback, void* userdata) noexcept {
+        CallbackHandler* handler, Callback callback, void* userdata) noexcept {
     downcast(this)->setAcquiredImage(image, handler, callback, userdata);
 }
 

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -29,7 +29,7 @@ void* SwapChain::getNativeWindow() const noexcept {
 }
 
 void SwapChain::setFrameScheduledCallback(
-        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
+        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t const flags) {
     downcast(this)->setFrameScheduledCallback(handler, std::move(callback), flags);
 }
 

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -21,15 +21,15 @@
 
 namespace filament {
 
-size_t Texture::getWidth(size_t level) const noexcept {
+size_t Texture::getWidth(size_t const level) const noexcept {
     return downcast(this)->getWidth(level);
 }
 
-size_t Texture::getHeight(size_t level) const noexcept {
+size_t Texture::getHeight(size_t const level) const noexcept {
     return downcast(this)->getHeight(level);
 }
 
-size_t Texture::getDepth(size_t level) const noexcept {
+size_t Texture::getDepth(size_t const level) const noexcept {
     return downcast(this)->getDepth(level);
 }
 
@@ -45,15 +45,15 @@ Texture::InternalFormat Texture::getFormat() const noexcept {
     return downcast(this)->getFormat();
 }
 
-void Texture::setImage(Engine& engine, size_t level,
-        uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-        uint32_t width, uint32_t height, uint32_t depth,
+void Texture::setImage(Engine& engine, size_t const level,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& buffer) const {
     downcast(this)->setImage(downcast(engine),
             level, xoffset, yoffset, zoffset, width, height, depth, std::move(buffer));
 }
 
-void Texture::setImage(Engine& engine, size_t level,
+void Texture::setImage(Engine& engine, size_t const level,
         PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
     downcast(this)->setImage(downcast(engine), level, std::move(buffer), faceOffsets);
 }
@@ -62,7 +62,7 @@ void Texture::setExternalImage(Engine& engine, void* image) noexcept {
     downcast(this)->setExternalImage(downcast(engine), image);
 }
 
-void Texture::setExternalImage(Engine& engine, void* image, size_t plane) noexcept {
+void Texture::setExternalImage(Engine& engine, void* image, size_t const plane) noexcept {
     downcast(this)->setExternalImage(downcast(engine), image, plane);
 }
 
@@ -74,7 +74,7 @@ void Texture::generateMipmaps(Engine& engine) const noexcept {
     downcast(this)->generateMipmaps(downcast(engine));
 }
 
-bool Texture::isTextureFormatSupported(Engine& engine, InternalFormat format) noexcept {
+bool Texture::isTextureFormatSupported(Engine& engine, InternalFormat const format) noexcept {
     return FTexture::isTextureFormatSupported(downcast(engine), format);
 }
 
@@ -86,8 +86,8 @@ bool Texture::isTextureSwizzleSupported(Engine& engine) noexcept {
     return FTexture::isTextureSwizzleSupported(downcast(engine));
 }
 
-size_t Texture::computeTextureDataSize(Format format, Type type, size_t stride,
-        size_t height, size_t alignment) noexcept {
+size_t Texture::computeTextureDataSize(Format const format, Type const type, size_t const stride,
+        size_t const height, size_t const alignment) noexcept {
     return FTexture::computeTextureDataSize(format, type, stride, height, alignment);
 }
 

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -54,7 +54,7 @@ void Texture::setImage(Engine& engine, size_t level,
 }
 
 void Texture::setImage(Engine& engine, size_t level,
-        Texture::PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
+        PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
     downcast(this)->setImage(downcast(engine), level, std::move(buffer), faceOffsets);
 }
 
@@ -86,13 +86,13 @@ bool Texture::isTextureSwizzleSupported(Engine& engine) noexcept {
     return FTexture::isTextureSwizzleSupported(downcast(engine));
 }
 
-size_t Texture::computeTextureDataSize(Texture::Format format, Texture::Type type, size_t stride,
+size_t Texture::computeTextureDataSize(Format format, Type type, size_t stride,
         size_t height, size_t alignment) noexcept {
     return FTexture::computeTextureDataSize(format, type, stride, height, alignment);
 }
 
-void Texture::generatePrefilterMipmap(Engine& engine, Texture::PixelBufferDescriptor&& buffer,
-        const Texture::FaceOffsets& faceOffsets, PrefilterOptions const* options) {
+void Texture::generatePrefilterMipmap(Engine& engine, PixelBufferDescriptor&& buffer,
+        const FaceOffsets& faceOffsets, PrefilterOptions const* options) {
     downcast(this)->generatePrefilterMipmap(downcast(engine), std::move(buffer), faceOffsets, options);
 }
 

--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -208,19 +208,19 @@ float3 LinearToneMapper::operator()(float3 v) const noexcept {
 
 DEFAULT_CONSTRUCTORS(ACESToneMapper)
 
-float3 ACESToneMapper::operator()(math::float3 c) const noexcept {
+float3 ACESToneMapper::operator()(float3 c) const noexcept {
     return aces::ACES(c, 1.0f);
 }
 
 DEFAULT_CONSTRUCTORS(ACESLegacyToneMapper)
 
-float3 ACESLegacyToneMapper::operator()(math::float3 c) const noexcept {
+float3 ACESLegacyToneMapper::operator()(float3 c) const noexcept {
     return aces::ACES(c, 1.0f / 0.6f);
 }
 
 DEFAULT_CONSTRUCTORS(FilmicToneMapper)
 
-float3 FilmicToneMapper::operator()(math::float3 x) const noexcept {
+float3 FilmicToneMapper::operator()(float3 x) const noexcept {
     // Narkowicz 2015, "ACES Filmic Tone Mapping Curve"
     constexpr float a = 2.51f;
     constexpr float b = 0.03f;
@@ -236,7 +236,7 @@ float3 FilmicToneMapper::operator()(math::float3 x) const noexcept {
 
 DEFAULT_CONSTRUCTORS(PBRNeutralToneMapper)
 
-float3 PBRNeutralToneMapper::operator()(math::float3 color) const noexcept {
+float3 PBRNeutralToneMapper::operator()(float3 color) const noexcept {
     // PBR Tone Mapping, https://modelviewer.dev/examples/tone-mapping.html
     constexpr float startCompression = 0.8f - 0.04f;
     constexpr float desaturation = 0.15f;
@@ -260,7 +260,7 @@ float3 PBRNeutralToneMapper::operator()(math::float3 color) const noexcept {
 // AgX tone mapper
 //------------------------------------------------------------------------------
 
-AgxToneMapper::AgxToneMapper(AgxToneMapper::AgxLook look) noexcept : look(look) {}
+AgxToneMapper::AgxToneMapper(AgxLook look) noexcept : look(look) {}
 AgxToneMapper::~AgxToneMapper() noexcept = default;
 
 // These matrices taken from Blender's implementation of AgX, which works with Rec.2020 primaries.
@@ -362,7 +362,7 @@ float3 AgxToneMapper::operator()(float3 v) const noexcept {
 
 DEFAULT_CONSTRUCTORS(DisplayRangeToneMapper)
 
-float3 DisplayRangeToneMapper::operator()(math::float3 c) const noexcept {
+float3 DisplayRangeToneMapper::operator()(float3 c) const noexcept {
     // 16 debug colors + 1 duplicated at the end for easy indexing
     constexpr float3 debugColors[17] = {
             {0.0,     0.0,     0.0},         // black
@@ -460,7 +460,7 @@ GenericToneMapper& GenericToneMapper::operator=(GenericToneMapper&& rhs) noexcep
     return *this;
 }
 
-float3 GenericToneMapper::operator()(math::float3 x) const noexcept {
+float3 GenericToneMapper::operator()(float3 x) const noexcept {
     x = pow(x, mOptions->contrast);
     return mOptions->outputScale * x / (x + mOptions->inputScale);
 }

--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -27,7 +27,7 @@ using namespace math;
 
 namespace aces {
 
-inline float rgb_2_saturation(float3 rgb) {
+inline float rgb_2_saturation(float3 const rgb) {
     // Input:  ACES
     // Output: OCES
     constexpr float TINY = 1e-5f;
@@ -36,7 +36,7 @@ inline float rgb_2_saturation(float3 rgb) {
     return (max(ma, TINY) - max(mi, TINY)) / max(ma, 1e-2f);
 }
 
-inline float rgb_2_yc(float3 rgb) {
+inline float rgb_2_yc(float3 const rgb) {
     constexpr float ycRadiusWeight = 1.75f;
 
     // Converts RGB to a luminance proxy, here called YC
@@ -61,14 +61,14 @@ inline float rgb_2_yc(float3 rgb) {
     return (b + g + r + ycRadiusWeight * chroma) / 3.0f;
 }
 
-inline float sigmoid_shaper(float x) {
+inline float sigmoid_shaper(float const x) {
     // Sigmoid function in the range 0 to 1 spanning -2 to +2.
     float t = max(1.0f - std::abs(x / 2.0f), 0.0f);
     float y = 1.0f + sign(x) * (1.0f - t * t);
     return y / 2.0f;
 }
 
-inline float glow_fwd(float ycIn, float glowGainIn, float glowMid) {
+inline float glow_fwd(float const ycIn, float const glowGainIn, float const glowMid) {
     float glowGainOut;
 
     if (ycIn <= 2.0f / 3.0f * glowMid) {
@@ -82,7 +82,7 @@ inline float glow_fwd(float ycIn, float glowGainIn, float glowMid) {
     return glowGainOut;
 }
 
-inline float rgb_2_hue(float3 rgb) {
+inline float rgb_2_hue(float3 const rgb) {
     // Returns a geometric hue angle in degrees (0-360) based on RGB values.
     // For neutral colors, hue is undefined and the function will return a quiet NaN value.
     float hue = 0.0f;
@@ -95,7 +95,7 @@ inline float rgb_2_hue(float3 rgb) {
     return (hue < 0.0f) ? hue + 360.0f : hue;
 }
 
-inline float center_hue(float hue, float centerH) {
+inline float center_hue(float const hue, float const centerH) {
     float hueCentered = hue - centerH;
     if (hueCentered < -180.0f) {
         hueCentered = hueCentered + 360.0f;
@@ -198,7 +198,7 @@ DEFAULT_CONSTRUCTORS(ToneMapper)
 
 DEFAULT_CONSTRUCTORS(LinearToneMapper)
 
-float3 LinearToneMapper::operator()(float3 v) const noexcept {
+float3 LinearToneMapper::operator()(float3 const v) const noexcept {
     return saturate(v);
 }
 
@@ -208,19 +208,19 @@ float3 LinearToneMapper::operator()(float3 v) const noexcept {
 
 DEFAULT_CONSTRUCTORS(ACESToneMapper)
 
-float3 ACESToneMapper::operator()(float3 c) const noexcept {
+float3 ACESToneMapper::operator()(float3 const c) const noexcept {
     return aces::ACES(c, 1.0f);
 }
 
 DEFAULT_CONSTRUCTORS(ACESLegacyToneMapper)
 
-float3 ACESLegacyToneMapper::operator()(float3 c) const noexcept {
+float3 ACESLegacyToneMapper::operator()(float3 const c) const noexcept {
     return aces::ACES(c, 1.0f / 0.6f);
 }
 
 DEFAULT_CONSTRUCTORS(FilmicToneMapper)
 
-float3 FilmicToneMapper::operator()(float3 x) const noexcept {
+float3 FilmicToneMapper::operator()(float3 const x) const noexcept {
     // Narkowicz 2015, "ACES Filmic Tone Mapping Curve"
     constexpr float a = 2.51f;
     constexpr float b = 0.03f;
@@ -260,7 +260,7 @@ float3 PBRNeutralToneMapper::operator()(float3 color) const noexcept {
 // AgX tone mapper
 //------------------------------------------------------------------------------
 
-AgxToneMapper::AgxToneMapper(AgxLook look) noexcept : look(look) {}
+AgxToneMapper::AgxToneMapper(AgxLook const look) noexcept : look(look) {}
 AgxToneMapper::~AgxToneMapper() noexcept = default;
 
 // These matrices taken from Blender's implementation of AgX, which works with Rec.2020 primaries.
@@ -362,7 +362,7 @@ float3 AgxToneMapper::operator()(float3 v) const noexcept {
 
 DEFAULT_CONSTRUCTORS(DisplayRangeToneMapper)
 
-float3 DisplayRangeToneMapper::operator()(float3 c) const noexcept {
+float3 DisplayRangeToneMapper::operator()(float3 const c) const noexcept {
     // 16 debug colors + 1 duplicated at the end for easy indexing
     constexpr float3 debugColors[17] = {
             {0.0,     0.0,     0.0},         // black
@@ -437,10 +437,10 @@ struct GenericToneMapper::Options {
 };
 
 GenericToneMapper::GenericToneMapper(
-        float contrast,
-        float midGrayIn,
-        float midGrayOut,
-        float hdrMax
+        float const contrast,
+        float const midGrayIn,
+        float const midGrayOut,
+        float const hdrMax
 ) noexcept {
     mOptions = new Options();
     mOptions->setParameters(contrast, midGrayIn, midGrayOut, hdrMax);
@@ -470,7 +470,7 @@ float GenericToneMapper::getMidGrayIn() const noexcept { return  mOptions->midGr
 float GenericToneMapper::getMidGrayOut() const noexcept { return  mOptions->midGrayOut; }
 float GenericToneMapper::getHdrMax() const noexcept { return  mOptions->hdrMax; }
 
-void GenericToneMapper::setContrast(float contrast) noexcept {
+void GenericToneMapper::setContrast(float const contrast) noexcept {
     mOptions->setParameters(
             contrast,
             mOptions->midGrayIn,
@@ -478,7 +478,7 @@ void GenericToneMapper::setContrast(float contrast) noexcept {
             mOptions->hdrMax
     );
 }
-void GenericToneMapper::setMidGrayIn(float midGrayIn) noexcept {
+void GenericToneMapper::setMidGrayIn(float const midGrayIn) noexcept {
     mOptions->setParameters(
             mOptions->contrast,
             midGrayIn,
@@ -487,7 +487,7 @@ void GenericToneMapper::setMidGrayIn(float midGrayIn) noexcept {
     );
 }
 
-void GenericToneMapper::setMidGrayOut(float midGrayOut) noexcept {
+void GenericToneMapper::setMidGrayOut(float const midGrayOut) noexcept {
     mOptions->setParameters(
             mOptions->contrast,
             mOptions->midGrayIn,
@@ -496,7 +496,7 @@ void GenericToneMapper::setMidGrayOut(float midGrayOut) noexcept {
     );
 }
 
-void GenericToneMapper::setHdrMax(float hdrMax) noexcept {
+void GenericToneMapper::setHdrMax(float const hdrMax) noexcept {
     mOptions->setParameters(
             mOptions->contrast,
             mOptions->midGrayIn,

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -22,7 +22,7 @@ namespace filament {
 
 using namespace math;
 
-bool TransformManager::hasComponent(Entity e) const noexcept {
+bool TransformManager::hasComponent(Entity const e) const noexcept {
     return downcast(this)->hasComponent(e);
 }
 
@@ -34,7 +34,7 @@ bool TransformManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-Entity TransformManager::getEntity(Instance i) const noexcept {
+Entity TransformManager::getEntity(Instance const i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
@@ -42,64 +42,64 @@ Entity const* TransformManager::getEntities() const noexcept {
     return downcast(this)->getEntities();
 }
 
-TransformManager::Instance TransformManager::getInstance(Entity e) const noexcept {
+TransformManager::Instance TransformManager::getInstance(Entity const e) const noexcept {
     return downcast(this)->getInstance(e);
 }
 
-void TransformManager::create(Entity entity, Instance parent, const mat4f& worldTransform) {
+void TransformManager::create(Entity const entity, Instance const parent, const mat4f& worldTransform) {
     downcast(this)->create(entity, parent, worldTransform);
 }
 
-void TransformManager::create(Entity entity, Instance parent, const mat4& worldTransform) {
+void TransformManager::create(Entity const entity, Instance const parent, const mat4& worldTransform) {
     downcast(this)->create(entity, parent, worldTransform);
 }
 
-void TransformManager::create(Entity entity, Instance parent) {
+void TransformManager::create(Entity const entity, Instance const parent) {
     downcast(this)->create(entity, parent, mat4f{});
 }
 
-void TransformManager::destroy(Entity e) noexcept {
+void TransformManager::destroy(Entity const e) noexcept {
     downcast(this)->destroy(e);
 }
 
-void TransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
+void TransformManager::setTransform(Instance const ci, const mat4f& model) noexcept {
     downcast(this)->setTransform(ci, model);
 }
 
-void TransformManager::setTransform(Instance ci, const mat4& model) noexcept {
+void TransformManager::setTransform(Instance const ci, const mat4& model) noexcept {
     downcast(this)->setTransform(ci, model);
 }
 
-const mat4f& TransformManager::getTransform(Instance ci) const noexcept {
+const mat4f& TransformManager::getTransform(Instance const ci) const noexcept {
     return downcast(this)->getTransform(ci);
 }
 
-mat4 TransformManager::getTransformAccurate(Instance ci) const noexcept {
+mat4 TransformManager::getTransformAccurate(Instance const ci) const noexcept {
     return downcast(this)->getTransformAccurate(ci);
 }
 
-const mat4f& TransformManager::getWorldTransform(Instance ci) const noexcept {
+const mat4f& TransformManager::getWorldTransform(Instance const ci) const noexcept {
     return downcast(this)->getWorldTransform(ci);
 }
 
-mat4 TransformManager::getWorldTransformAccurate(Instance ci) const noexcept {
+mat4 TransformManager::getWorldTransformAccurate(Instance const ci) const noexcept {
     return downcast(this)->getWorldTransformAccurate(ci);
 }
 
-void TransformManager::setParent(Instance i, Instance newParent) noexcept {
+void TransformManager::setParent(Instance const i, Instance const newParent) noexcept {
     downcast(this)->setParent(i, newParent);
 }
 
-Entity TransformManager::getParent(Instance i) const noexcept {
+Entity TransformManager::getParent(Instance const i) const noexcept {
     return downcast(this)->getParent(i);
 }
 
-size_t TransformManager::getChildCount(Instance i) const noexcept {
+size_t TransformManager::getChildCount(Instance const i) const noexcept {
     return downcast(this)->getChildCount(i);
 }
 
-size_t TransformManager::getChildren(Instance i, Entity* children,
-        size_t count) const noexcept {
+size_t TransformManager::getChildren(Instance const i, Entity* children,
+        size_t const count) const noexcept {
     return downcast(this)->getChildren(i, children, count);
 }
 
@@ -112,16 +112,16 @@ void TransformManager::commitLocalTransformTransaction() noexcept {
 }
 
 TransformManager::children_iterator TransformManager::getChildrenBegin(
-        Instance parent) const noexcept {
+        Instance const parent) const noexcept {
     return downcast(this)->getChildrenBegin(parent);
 }
 
 TransformManager::children_iterator TransformManager::getChildrenEnd(
-        Instance parent) const noexcept {
+        Instance const parent) const noexcept {
     return downcast(this)->getChildrenEnd(parent);
 }
 
-void TransformManager::setAccurateTranslationsEnabled(bool enable) noexcept {
+void TransformManager::setAccurateTranslationsEnabled(bool const enable) noexcept {
     downcast(this)->setAccurateTranslationsEnabled(enable);
 }
 

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -34,11 +34,11 @@ bool TransformManager::empty() const noexcept {
     return downcast(this)->empty();
 }
 
-utils::Entity TransformManager::getEntity(TransformManager::Instance i) const noexcept {
+Entity TransformManager::getEntity(Instance i) const noexcept {
     return downcast(this)->getEntity(i);
 }
 
-utils::Entity const* TransformManager::getEntities() const noexcept {
+Entity const* TransformManager::getEntities() const noexcept {
     return downcast(this)->getEntities();
 }
 
@@ -90,7 +90,7 @@ void TransformManager::setParent(Instance i, Instance newParent) noexcept {
     downcast(this)->setParent(i, newParent);
 }
 
-utils::Entity TransformManager::getParent(Instance i) const noexcept {
+Entity TransformManager::getParent(Instance i) const noexcept {
     return downcast(this)->getParent(i);
 }
 
@@ -98,7 +98,7 @@ size_t TransformManager::getChildCount(Instance i) const noexcept {
     return downcast(this)->getChildCount(i);
 }
 
-size_t TransformManager::getChildren(Instance i, utils::Entity* children,
+size_t TransformManager::getChildren(Instance i, Entity* children,
         size_t count) const noexcept {
     return downcast(this)->getChildren(i, children, count);
 }
@@ -112,12 +112,12 @@ void TransformManager::commitLocalTransformTransaction() noexcept {
 }
 
 TransformManager::children_iterator TransformManager::getChildrenBegin(
-        TransformManager::Instance parent) const noexcept {
+        Instance parent) const noexcept {
     return downcast(this)->getChildrenBegin(parent);
 }
 
 TransformManager::children_iterator TransformManager::getChildrenEnd(
-        TransformManager::Instance parent) const noexcept {
+        Instance parent) const noexcept {
     return downcast(this)->getChildrenEnd(parent);
 }
 

--- a/filament/src/UniformBuffer.cpp
+++ b/filament/src/UniformBuffer.cpp
@@ -23,7 +23,7 @@ using namespace filament::math;
 
 namespace filament {
 
-UniformBuffer::UniformBuffer(size_t size) noexcept
+UniformBuffer::UniformBuffer(size_t const size) noexcept
         : mBuffer(mStorage),
           mSize(uint32_t(size)),
           mSomethingDirty(true) {
@@ -81,7 +81,7 @@ UniformBuffer& UniformBuffer::setUniforms(const UniformBuffer& rhs) noexcept {
     return *this;
 }
 
-void* UniformBuffer::alloc(size_t size) noexcept {
+void* UniformBuffer::alloc(size_t const size) noexcept {
     // these allocations have a long life span
     return malloc(size);
 }
@@ -93,7 +93,7 @@ void UniformBuffer::free(void* addr, size_t) noexcept {
 // ------------------------------------------------------------------------------------------------
 
 template<size_t Size>
-void UniformBuffer::setUniformUntyped(size_t offset, void const* UTILS_RESTRICT v) noexcept{
+void UniformBuffer::setUniformUntyped(size_t const offset, void const* UTILS_RESTRICT v) noexcept{
     setUniformUntyped<Size>(invalidateUniforms(offset, Size), 0ul, v);
 }
 
@@ -109,7 +109,7 @@ template
 void UniformBuffer::setUniformUntyped<64ul>(size_t offset, void const* UTILS_RESTRICT v) noexcept;
 
 template<size_t Size>
-void UniformBuffer::setUniformArrayUntyped(size_t offset, void const* UTILS_RESTRICT begin, size_t count) noexcept {
+void UniformBuffer::setUniformArrayUntyped(size_t const offset, void const* UTILS_RESTRICT begin, size_t const count) noexcept {
     constexpr size_t stride = (Size + 0xFu) & ~0xFu;
     size_t arraySize = stride * count - stride + Size;
     void* UTILS_RESTRICT p = invalidateUniforms(offset, arraySize);
@@ -133,7 +133,7 @@ void UniformBuffer::setUniformArrayUntyped<64ul>(size_t offset, void const* UTIL
 // specialization for mat3f (which has a different alignment, see std140 layout rules)
 template<>
 UTILS_NOINLINE
-void UniformBuffer::setUniform(void* addr, size_t offset, const mat3f& v) noexcept {
+void UniformBuffer::setUniform(void* addr, size_t const offset, const mat3f& v) noexcept {
     struct mat43 {
         float v[3][4];
     };
@@ -157,7 +157,7 @@ void UniformBuffer::setUniform(void* addr, size_t offset, const mat3f& v) noexce
 }
 
 template<>
-void UniformBuffer::setUniform(size_t offset, const mat3f& v) noexcept {
+void UniformBuffer::setUniform(size_t const offset, const mat3f& v) noexcept {
     setUniform(invalidateUniforms(offset, sizeof(v)), 0, v);
 }
 

--- a/filament/src/UniformBuffer.cpp
+++ b/filament/src/UniformBuffer.cpp
@@ -28,7 +28,7 @@ UniformBuffer::UniformBuffer(size_t size) noexcept
           mSize(uint32_t(size)),
           mSomethingDirty(true) {
     if (UTILS_LIKELY(size > sizeof(mStorage))) {
-        mBuffer = UniformBuffer::alloc(size);
+        mBuffer = alloc(size);
     }
     memset(mBuffer, 0, size);
 }
@@ -65,13 +65,13 @@ UniformBuffer& UniformBuffer::setUniforms(const UniformBuffer& rhs) noexcept {
         if (UTILS_UNLIKELY(mSize != rhs.mSize)) {
             // first free our storage if any
             if (mBuffer && !isLocalStorage()) {
-                UniformBuffer::free(mBuffer, mSize);
+                free(mBuffer, mSize);
             }
             // and allocate new storage
             mBuffer = mStorage;
             mSize = rhs.mSize;
             if (mSize > sizeof(mStorage)) {
-                mBuffer = UniformBuffer::alloc(mSize);
+                mBuffer = alloc(mSize);
             }
         }
         memcpy(mBuffer, rhs.mBuffer, rhs.mSize);
@@ -83,7 +83,7 @@ UniformBuffer& UniformBuffer::setUniforms(const UniformBuffer& rhs) noexcept {
 
 void* UniformBuffer::alloc(size_t size) noexcept {
     // these allocations have a long life span
-    return ::malloc(size);
+    return malloc(size);
 }
 
 void UniformBuffer::free(void* addr, size_t) noexcept {
@@ -133,7 +133,7 @@ void UniformBuffer::setUniformArrayUntyped<64ul>(size_t offset, void const* UTIL
 // specialization for mat3f (which has a different alignment, see std140 layout rules)
 template<>
 UTILS_NOINLINE
-void UniformBuffer::setUniform(void* addr, size_t offset, const math::mat3f& v) noexcept {
+void UniformBuffer::setUniform(void* addr, size_t offset, const mat3f& v) noexcept {
     struct mat43 {
         float v[3][4];
     };
@@ -157,7 +157,7 @@ void UniformBuffer::setUniform(void* addr, size_t offset, const math::mat3f& v) 
 }
 
 template<>
-void UniformBuffer::setUniform(size_t offset, const math::mat3f& v) noexcept {
+void UniformBuffer::setUniform(size_t offset, const mat3f& v) noexcept {
     setUniform(invalidateUniforms(offset, sizeof(v)), 0, v);
 }
 

--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -67,7 +67,7 @@ public:
     UniformBuffer& setUniforms(const UniformBuffer& rhs) noexcept;
 
     // invalidate a range of uniforms and return a pointer to it. offset and size given in bytes
-    void* invalidateUniforms(size_t offset, size_t size) {
+    void* invalidateUniforms(size_t const offset, size_t const size) {
         assert_invariant(offset + size <= mSize);
         mSomethingDirty = true;
         return static_cast<char*>(mBuffer) + offset;
@@ -133,7 +133,7 @@ public:
     // The "x" symbols represent dummy words.
     template<typename T, typename = typename is_supported_type<T>::type>
     UTILS_ALWAYS_INLINE
-    void setUniformArray(size_t offset, T const* UTILS_RESTRICT begin, size_t count) noexcept {
+    void setUniformArray(size_t const offset, T const* UTILS_RESTRICT begin, size_t const count) noexcept {
         static_assert(!std::is_same_v<T, math::mat3f>);
         setUniformArrayUntyped<sizeof(T)>(offset, begin, count);
     }
@@ -141,21 +141,21 @@ public:
     // (see specialization for mat3f below)
     template<typename T, typename = typename is_supported_type<T>::type>
     UTILS_ALWAYS_INLINE
-    static inline void setUniform(void* addr, size_t offset, const T& v) noexcept {
+    static inline void setUniform(void* addr, size_t const offset, const T& v) noexcept {
         static_assert(!std::is_same_v<T, math::mat3f>);
         setUniformUntyped<sizeof(T)>(addr, offset, &v);
     }
 
     template<typename T, typename = typename is_supported_type<T>::type>
     UTILS_ALWAYS_INLINE
-    inline void setUniform(size_t offset, const T& v) noexcept {
+    inline void setUniform(size_t const offset, const T& v) noexcept {
         static_assert(!std::is_same_v<T, math::mat3f>);
         setUniformUntyped<sizeof(T)>(offset, &v);
     }
 
     // get uniform of known types from the proper offset (e.g.: use offsetof())
     template<typename T, typename = typename is_supported_type<T>::type>
-    T getUniform(size_t offset) const noexcept {
+    T getUniform(size_t const offset) const noexcept {
         static_assert(!std::is_same_v<T, math::mat3f>);
         return *reinterpret_cast<T const*>(static_cast<char const*>(mBuffer) + offset);
     }
@@ -168,7 +168,7 @@ public:
 
     // copy the UBO data and cleans the dirty bits
     backend::BufferDescriptor toBufferDescriptor(
-            backend::DriverApi& driver, size_t offset, size_t size) const noexcept {
+            backend::DriverApi& driver, size_t const offset, size_t const size) const noexcept {
         backend::BufferDescriptor p;
         p.size = size;
         p.buffer = driver.allocate(p.size); // TODO: use out-of-line buffer if too large
@@ -194,7 +194,7 @@ private:
     template<size_t Size, std::enable_if_t<
             Size == 4 || Size == 8 || Size == 12 || Size == 16 || Size == 64, bool> = true>
     UTILS_ALWAYS_INLINE
-    static void setUniformUntyped(void* addr, size_t offset, void const* v) noexcept {
+    static void setUniformUntyped(void* addr, size_t const offset, void const* v) noexcept {
         memcpy(static_cast<char*>(addr) + offset, v, Size); // inlined
     }
 
@@ -215,13 +215,13 @@ void UniformBuffer::setUniform(size_t offset, const math::mat3f& v) noexcept;
 
 template<>
 inline void UniformBuffer::setUniformArray(
-        size_t offset, math::mat3f const* UTILS_RESTRICT begin, size_t count) noexcept {
+        size_t const offset, math::mat3f const* UTILS_RESTRICT begin, size_t const count) noexcept {
     // pretend each mat3 is an array of 3 float3
     setUniformArray(offset, reinterpret_cast<math::float3 const*>(begin), count * 3);
 }
 
 template<>
-inline math::mat3f UniformBuffer::getUniform(size_t offset) const noexcept {
+inline math::mat3f UniformBuffer::getUniform(size_t const offset) const noexcept {
     math::float4 const* p = reinterpret_cast<math::float4 const*>(
             static_cast<char const*>(mBuffer) + offset);
     return { p[0].xyz, p[1].xyz, p[2].xyz };

--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -60,7 +60,7 @@ public:
         // immediately jump into libc's free()
         if (mBuffer && !isLocalStorage()) {
             // test not necessary but avoids a call to libc (and this is a common enough case)
-            UniformBuffer::free(mBuffer, mSize);
+            free(mBuffer, mSize);
         }
     }
 

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -24,12 +24,12 @@ size_t VertexBuffer::getVertexCount() const noexcept {
     return downcast(this)->getVertexCount();
 }
 
-void VertexBuffer::setBufferAt(Engine& engine, uint8_t bufferIndex,
-        backend::BufferDescriptor&& buffer, uint32_t byteOffset) {
+void VertexBuffer::setBufferAt(Engine& engine, uint8_t const bufferIndex,
+        backend::BufferDescriptor&& buffer, uint32_t const byteOffset) {
     downcast(this)->setBufferAt(downcast(engine), bufferIndex, std::move(buffer), byteOffset);
 }
 
-void VertexBuffer::setBufferObjectAt(Engine& engine, uint8_t bufferIndex,
+void VertexBuffer::setBufferObjectAt(Engine& engine, uint8_t const bufferIndex,
         BufferObject const* bufferObject) {
     downcast(this)->setBufferObjectAt(downcast(engine), bufferIndex, downcast(bufferObject));
 }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -49,7 +49,7 @@ Viewport const& View::getViewport() const noexcept {
     return downcast(this)->getViewport();
 }
 
-void View::setFrustumCullingEnabled(bool culling) noexcept {
+void View::setFrustumCullingEnabled(bool const culling) noexcept {
     downcast(this)->setFrustumCullingEnabled(culling);
 }
 
@@ -61,7 +61,7 @@ void View::setDebugCamera(Camera* camera) noexcept {
     downcast(this)->setViewingCamera(downcast(camera));
 }
 
-void View::setVisibleLayers(uint8_t select, uint8_t values) noexcept {
+void View::setVisibleLayers(uint8_t const select, uint8_t const values) noexcept {
     downcast(this)->setVisibleLayers(select, values);
 }
 
@@ -77,7 +77,7 @@ utils::FixedCapacityVector<Camera const*> View::getDirectionalShadowCameras() co
     return downcast(this)->getDirectionalShadowCameras();
 }
 
-void View::setShadowingEnabled(bool enabled) noexcept {
+void View::setShadowingEnabled(bool const enabled) noexcept {
     downcast(this)->setShadowingEnabled(enabled);
 }
 
@@ -89,7 +89,7 @@ RenderTarget* View::getRenderTarget() const noexcept {
     return downcast(this)->getRenderTarget();
 }
 
-void View::setSampleCount(uint8_t count) noexcept {
+void View::setSampleCount(uint8_t const count) noexcept {
     downcast(this)->setSampleCount(count);
 }
 
@@ -97,7 +97,7 @@ uint8_t View::getSampleCount() const noexcept {
     return downcast(this)->getSampleCount();
 }
 
-void View::setAntiAliasing(AntiAliasing type) noexcept {
+void View::setAntiAliasing(AntiAliasing const type) noexcept {
     downcast(this)->setAntiAliasing(type);
 }
 
@@ -113,7 +113,7 @@ const View::TemporalAntiAliasingOptions& View::getTemporalAntiAliasingOptions() 
     return downcast(this)->getTemporalAntiAliasingOptions();
 }
 
-void View::setMultiSampleAntiAliasingOptions(MultiSampleAntiAliasingOptions options) noexcept {
+void View::setMultiSampleAntiAliasingOptions(MultiSampleAntiAliasingOptions const options) noexcept {
     downcast(this)->setMultiSampleAntiAliasingOptions(options);
 }
 
@@ -129,7 +129,7 @@ const View::ScreenSpaceReflectionsOptions& View::getScreenSpaceReflectionsOption
     return downcast(this)->getScreenSpaceReflectionsOptions();
 }
 
-void View::setGuardBandOptions(GuardBandOptions options) noexcept {
+void View::setGuardBandOptions(GuardBandOptions const options) noexcept {
     downcast(this)->setGuardBandOptions(options);
 }
 
@@ -145,7 +145,7 @@ const ColorGrading* View::getColorGrading() const noexcept {
     return downcast(this)->getColorGrading();
 }
 
-void View::setDithering(Dithering dithering) noexcept {
+void View::setDithering(Dithering const dithering) noexcept {
     downcast(this)->setDithering(dithering);
 }
 
@@ -169,7 +169,7 @@ View::RenderQuality View::getRenderQuality() const noexcept {
     return downcast(this)->getRenderQuality();
 }
 
-void View::setPostProcessingEnabled(bool enabled) noexcept {
+void View::setPostProcessingEnabled(bool const enabled) noexcept {
     downcast(this)->setPostProcessingEnabled(enabled);
 }
 
@@ -177,7 +177,7 @@ bool View::isPostProcessingEnabled() const noexcept {
     return downcast(this)->hasPostProcessPass();
 }
 
-void View::setFrontFaceWindingInverted(bool inverted) noexcept {
+void View::setFrontFaceWindingInverted(bool const inverted) noexcept {
     downcast(this)->setFrontFaceWindingInverted(inverted);
 }
 
@@ -185,7 +185,7 @@ bool View::isFrontFaceWindingInverted() const noexcept {
     return downcast(this)->isFrontFaceWindingInverted();
 }
 
-void View::setTransparentPickingEnabled(bool enabled) noexcept {
+void View::setTransparentPickingEnabled(bool const enabled) noexcept {
     downcast(this)->setTransparentPickingEnabled(enabled);
 }
 
@@ -193,11 +193,11 @@ bool View::isTransparentPickingEnabled() const noexcept {
     return downcast(this)->isTransparentPickingEnabled();
 }
 
-void View::setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept {
+void View::setDynamicLightingOptions(float const zLightNear, float const zLightFar) noexcept {
     downcast(this)->setDynamicLightingOptions(zLightNear, zLightFar);
 }
 
-void View::setShadowType(ShadowType shadow) noexcept {
+void View::setShadowType(ShadowType const shadow) noexcept {
     downcast(this)->setShadowType(shadow);
 }
 
@@ -221,7 +221,7 @@ SoftShadowOptions View::getSoftShadowOptions() const noexcept {
     return downcast(this)->getSoftShadowOptions();
 }
 
-void View::setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept {
+void View::setAmbientOcclusion(AmbientOcclusion const ambientOcclusion) noexcept {
     downcast(this)->setAmbientOcclusion(ambientOcclusion);
 }
 
@@ -269,7 +269,7 @@ View::VignetteOptions View::getVignetteOptions() const noexcept {
     return downcast(this)->getVignetteOptions();
 }
 
-void View::setBlendMode(BlendMode blendMode) noexcept {
+void View::setBlendMode(BlendMode const blendMode) noexcept {
     downcast(this)->setBlendMode(blendMode);
 }
 
@@ -285,7 +285,7 @@ bool View::isShadowingEnabled() const noexcept {
     return downcast(this)->isShadowingEnabled();
 }
 
-void View::setScreenSpaceRefractionEnabled(bool enabled) noexcept {
+void View::setScreenSpaceRefractionEnabled(bool const enabled) noexcept {
     downcast(this)->setScreenSpaceRefractionEnabled(enabled);
 }
 
@@ -293,7 +293,7 @@ bool View::isScreenSpaceRefractionEnabled() const noexcept {
     return downcast(this)->isScreenSpaceRefractionEnabled();
 }
 
-void View::setStencilBufferEnabled(bool enabled) noexcept {
+void View::setStencilBufferEnabled(bool const enabled) noexcept {
     downcast(this)->setStencilBufferEnabled(enabled);
 }
 
@@ -309,16 +309,16 @@ const View::StereoscopicOptions& View::getStereoscopicOptions() const noexcept {
     return downcast(this)->getStereoscopicOptions();
 }
 
-View::PickingQuery& View::pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
-        PickingQueryResultCallback callback) noexcept {
+View::PickingQuery& View::pick(uint32_t const x, uint32_t const y, backend::CallbackHandler* handler,
+        PickingQueryResultCallback const callback) noexcept {
     return downcast(this)->pick(x, y, handler, callback);
 }
 
-void View::setMaterialGlobal(uint32_t index, math::float4 const& value) {
+void View::setMaterialGlobal(uint32_t const index, math::float4 const& value) {
     downcast(this)->setMaterialGlobal(index, value);
 }
 
-math::float4 View::getMaterialGlobal(uint32_t index) const {
+math::float4 View::getMaterialGlobal(uint32_t const index) const {
     return downcast(this)->getMaterialGlobal(index);
 }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -41,11 +41,11 @@ Camera& View::getCamera() noexcept {
     return downcast(this)->getCameraUser();
 }
 
-void View::setViewport(filament::Viewport const& viewport) noexcept {
+void View::setViewport(Viewport const& viewport) noexcept {
     downcast(this)->setViewport(viewport);
 }
 
-filament::Viewport const& View::getViewport() const noexcept {
+Viewport const& View::getViewport() const noexcept {
     return downcast(this)->getViewport();
 }
 
@@ -197,7 +197,7 @@ void View::setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept
     downcast(this)->setDynamicLightingOptions(zLightNear, zLightFar);
 }
 
-void View::setShadowType(View::ShadowType shadow) noexcept {
+void View::setShadowType(ShadowType shadow) noexcept {
     downcast(this)->setShadowType(shadow);
 }
 
@@ -221,7 +221,7 @@ SoftShadowOptions View::getSoftShadowOptions() const noexcept {
     return downcast(this)->getSoftShadowOptions();
 }
 
-void View::setAmbientOcclusion(View::AmbientOcclusion ambientOcclusion) noexcept {
+void View::setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept {
     downcast(this)->setAmbientOcclusion(ambientOcclusion);
 }
 
@@ -229,7 +229,7 @@ View::AmbientOcclusion View::getAmbientOcclusion() const noexcept {
     return downcast(this)->getAmbientOcclusion();
 }
 
-void View::setAmbientOcclusionOptions(View::AmbientOcclusionOptions const& options) noexcept {
+void View::setAmbientOcclusionOptions(AmbientOcclusionOptions const& options) noexcept {
     downcast(this)->setAmbientOcclusionOptions(options);
 }
 
@@ -237,7 +237,7 @@ View::AmbientOcclusionOptions const& View::getAmbientOcclusionOptions() const no
     return downcast(this)->getAmbientOcclusionOptions();
 }
 
-void View::setBloomOptions(View::BloomOptions options) noexcept {
+void View::setBloomOptions(BloomOptions options) noexcept {
     downcast(this)->setBloomOptions(options);
 }
 
@@ -245,7 +245,7 @@ View::BloomOptions View::getBloomOptions() const noexcept {
     return downcast(this)->getBloomOptions();
 }
 
-void View::setFogOptions(View::FogOptions options) noexcept {
+void View::setFogOptions(FogOptions options) noexcept {
     downcast(this)->setFogOptions(options);
 }
 
@@ -261,7 +261,7 @@ View::DepthOfFieldOptions View::getDepthOfFieldOptions() const noexcept {
     return downcast(this)->getDepthOfFieldOptions();
 }
 
-void View::setVignetteOptions(View::VignetteOptions options) noexcept {
+void View::setVignetteOptions(VignetteOptions options) noexcept {
     downcast(this)->setVignetteOptions(options);
 }
 
@@ -310,7 +310,7 @@ const View::StereoscopicOptions& View::getStereoscopicOptions() const noexcept {
 }
 
 View::PickingQuery& View::pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
-        View::PickingQueryResultCallback callback) noexcept {
+        PickingQueryResultCallback callback) noexcept {
     return downcast(this)->pick(x, y, handler, callback);
 }
 

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -49,7 +49,7 @@ void FCameraManager::terminate(FEngine& engine) noexcept {
 
 void FCameraManager::gc(FEngine& engine, EntityManager& em) noexcept {
     auto& manager = mManager;
-    manager.gc(em, [this, &engine](Entity e) {
+    manager.gc(em, [this, &engine](Entity const e) {
         destroy(engine, e);
     });
 }
@@ -79,7 +79,7 @@ FCamera* FCameraManager::create(FEngine& engine, Entity entity) {
     return camera;
 }
 
-void FCameraManager::destroy(FEngine& engine, Entity e) noexcept {
+void FCameraManager::destroy(FEngine& engine, Entity const e) noexcept {
     auto& manager = mManager;
     if (Instance const i = manager.getInstance(e) ; i) {
         // destroy the FCamera object

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -40,14 +40,14 @@ void FCameraManager::terminate(FEngine& engine) noexcept {
         slog.d << "cleaning up " << manager.getComponentCount()
                << " leaked Camera components" << io::endl;
 #endif
-        utils::Slice<Entity> const entities{ manager.getEntities(), manager.getComponentCount() };
+        Slice<Entity> const entities{ manager.getEntities(), manager.getComponentCount() };
         for (Entity const e : entities) {
             destroy(engine, e);
         }
     }
 }
 
-void FCameraManager::gc(FEngine& engine, utils::EntityManager& em) noexcept {
+void FCameraManager::gc(FEngine& engine, EntityManager& em) noexcept {
     auto& manager = mManager;
     manager.gc(em, [this, &engine](Entity e) {
         destroy(engine, e);

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -37,7 +37,7 @@ class FCamera;
 
 class UTILS_PRIVATE FCameraManager : public CameraManager {
 public:
-    using Instance = CameraManager::Instance;
+    using Instance = Instance;
 
     explicit FCameraManager(FEngine& engine) noexcept;
 

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -52,11 +52,11 @@ public:
     * Component Manager APIs
     */
 
-    bool hasComponent(utils::Entity e) const noexcept {
+    bool hasComponent(utils::Entity const e) const noexcept {
         return mManager.hasComponent(e);
     }
 
-    Instance getInstance(utils::Entity e) const noexcept {
+    Instance getInstance(utils::Entity const e) const noexcept {
         return { mManager.getInstance(e) };
     }
 
@@ -68,7 +68,7 @@ public:
         return mManager.empty();
     }
 
-    utils::Entity getEntity(Instance i) const noexcept {
+    utils::Entity getEntity(Instance const i) const noexcept {
         return mManager.getEntity(i);
     }
 
@@ -76,7 +76,7 @@ public:
         return mManager.getEntities();
     }
 
-    FCamera* getCamera(Instance i) noexcept {
+    FCamera* getCamera(Instance const i) noexcept {
         return mManager.elementAt<CAMERA>(i);
     }
 

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -64,7 +64,7 @@ struct LightManager::BuilderDetails {
     float mSunHaloFalloff = 80.0f;
     ShadowOptions mShadowOptions;
 
-    explicit BuilderDetails(Type type) noexcept : mType(type) { }
+    explicit BuilderDetails(Type const type) noexcept : mType(type) { }
     // this is only needed for the explicit instantiation below
     BuilderDetails() = default;
 };
@@ -77,7 +77,7 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-LightManager::Builder& LightManager::Builder::castShadows(bool enable) noexcept {
+LightManager::Builder& LightManager::Builder::castShadows(bool const enable) noexcept {
     mImpl->mCastShadows = enable;
     return *this;
 }
@@ -87,7 +87,7 @@ LightManager::Builder& LightManager::Builder::shadowOptions(const ShadowOptions&
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::castLight(bool enable) noexcept {
+LightManager::Builder& LightManager::Builder::castLight(bool const enable) noexcept {
     mImpl->mCastLight = enable;
     return *this;
 }
@@ -107,25 +107,25 @@ LightManager::Builder& LightManager::Builder::color(const LinearColor& color) no
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::intensity(float intensity) noexcept {
+LightManager::Builder& LightManager::Builder::intensity(float const intensity) noexcept {
     mImpl->mIntensity = intensity;
     mImpl->mIntensityUnit = FLightManager::IntensityUnit::LUMEN_LUX;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::intensityCandela(float intensity) noexcept {
+LightManager::Builder& LightManager::Builder::intensityCandela(float const intensity) noexcept {
     mImpl->mIntensity = intensity;
     mImpl->mIntensityUnit = FLightManager::IntensityUnit::CANDELA;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::intensity(float watts, float efficiency) noexcept {
+LightManager::Builder& LightManager::Builder::intensity(float const watts, float const efficiency) noexcept {
     mImpl->mIntensity = efficiency * 683.0f * watts;
     mImpl->mIntensityUnit = FLightManager::IntensityUnit::LUMEN_LUX;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::falloff(float radius) noexcept {
+LightManager::Builder& LightManager::Builder::falloff(float const radius) noexcept {
     mImpl->mFalloff = radius;
     return *this;
 }
@@ -135,22 +135,22 @@ LightManager::Builder& LightManager::Builder::spotLightCone(float inner, float o
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::sunAngularRadius(float sunAngle) noexcept {
+LightManager::Builder& LightManager::Builder::sunAngularRadius(float const sunAngle) noexcept {
     mImpl->mSunAngle = sunAngle;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::sunHaloSize(float haloSize) noexcept {
+LightManager::Builder& LightManager::Builder::sunHaloSize(float const haloSize) noexcept {
     mImpl->mSunHaloSize = haloSize;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::sunHaloFalloff(float haloFalloff) noexcept {
+LightManager::Builder& LightManager::Builder::sunHaloFalloff(float const haloFalloff) noexcept {
     mImpl->mSunHaloFalloff = haloFalloff;
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::lightChannel(unsigned int channel, bool enable) noexcept {
+LightManager::Builder& LightManager::Builder::lightChannel(unsigned int const channel, bool const enable) noexcept {
     if (channel < 8) {
         const uint8_t mask = 1u << channel;
         mImpl->mChannels &= ~mask;
@@ -159,7 +159,7 @@ LightManager::Builder& LightManager::Builder::lightChannel(unsigned int channel,
     return *this;
 }
 
-LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entity entity) {
+LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entity const entity) {
     downcast(engine).createLight(*this, entity);
     return Success;
 }
@@ -179,7 +179,7 @@ FLightManager::~FLightManager() {
 void FLightManager::init(FEngine&) noexcept {
 }
 
-void FLightManager::create(const Builder& builder, Entity entity) {
+void FLightManager::create(const Builder& builder, Entity const entity) {
     auto& manager = mManager;
 
     if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
@@ -218,7 +218,7 @@ void FLightManager::create(const Builder& builder, Entity entity) {
 void FLightManager::prepare(backend::DriverApi&) const noexcept {
 }
 
-void FLightManager::destroy(Entity e) noexcept {
+void FLightManager::destroy(Entity const e) noexcept {
     Instance const i = getInstance(e);
     if (i) {
         auto& manager = mManager;
@@ -240,7 +240,7 @@ void FLightManager::terminate() noexcept {
     }
 }
 void FLightManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity e) {
+    mManager.gc(em, [this](Entity const e) {
         destroy(e);
     });
 }
@@ -258,7 +258,7 @@ void FLightManager::setShadowOptions(Instance const i, ShadowOptions const& opti
     params.options.vsm.blurWidth = std::max(0.0f, options.vsm.blurWidth);
 }
 
-void FLightManager::setLightChannel(Instance i, unsigned int channel, bool enable) noexcept {
+void FLightManager::setLightChannel(Instance const i, unsigned int const channel, bool const enable) noexcept {
     if (i) {
         if (channel < 8) {
             auto& manager = mManager;
@@ -269,7 +269,7 @@ void FLightManager::setLightChannel(Instance i, unsigned int channel, bool enabl
     }
 }
 
-bool FLightManager::getLightChannel(Instance i, unsigned int channel) const noexcept {
+bool FLightManager::getLightChannel(Instance const i, unsigned int const channel) const noexcept {
     if (i) {
         if (channel < 8) {
             auto& manager = mManager;
@@ -280,28 +280,28 @@ bool FLightManager::getLightChannel(Instance i, unsigned int channel) const noex
     return false;
 }
 
-void FLightManager::setLocalPosition(Instance i, const float3& position) noexcept {
+void FLightManager::setLocalPosition(Instance const i, const float3& position) noexcept {
     if (i) {
         auto& manager = mManager;
         manager[i].position = position;
     }
 }
 
-void FLightManager::setLocalDirection(Instance i, float3 direction) noexcept {
+void FLightManager::setLocalDirection(Instance const i, float3 const direction) noexcept {
     if (i) {
         auto& manager = mManager;
         manager[i].direction = direction;
     }
 }
 
-void FLightManager::setColor(Instance i, const LinearColor& color) noexcept {
+void FLightManager::setColor(Instance const i, const LinearColor& color) noexcept {
     if (i) {
         auto& manager = mManager;
         manager[i].color = color;
     }
 }
 
-void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit) noexcept {
+void FLightManager::setIntensity(Instance const i, float const intensity, IntensityUnit const unit) noexcept {
     auto& manager = mManager;
     if (i) {
         Type const type = getLightType(i).type;
@@ -356,7 +356,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
     }
 }
 
-void FLightManager::setFalloff(Instance i, float falloff) noexcept {
+void FLightManager::setFalloff(Instance const i, float const falloff) noexcept {
     auto& manager = mManager;
     if (i && !isDirectionalLight(i)) {
         float const sqFalloff = falloff * falloff;
@@ -366,7 +366,7 @@ void FLightManager::setFalloff(Instance i, float falloff) noexcept {
     }
 }
 
-void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexcept {
+void FLightManager::setSpotLightCone(Instance const i, float const inner, float const outer) noexcept {
     auto& manager = mManager;
     if (i && isSpotLight(i)) {
         // clamp the inner/outer angles to [0.5 degrees, 90 degrees]
@@ -399,33 +399,33 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
     }
 }
 
-void FLightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept {
+void FLightManager::setSunAngularRadius(Instance const i, float angularRadius) noexcept {
     if (i && isSunLight(i)) {
         angularRadius = clamp(angularRadius, 0.25f, 20.0f);
         mManager[i].sunAngularRadius = angularRadius * f::DEG_TO_RAD;
     }
 }
 
-void FLightManager::setSunHaloSize(Instance i, float haloSize) noexcept {
+void FLightManager::setSunHaloSize(Instance const i, float const haloSize) noexcept {
     if (i && isSunLight(i)) {
         mManager[i].sunHaloSize = haloSize;
     }
 }
 
-void FLightManager::setSunHaloFalloff(Instance i, float haloFalloff) noexcept {
+void FLightManager::setSunHaloFalloff(Instance const i, float const haloFalloff) noexcept {
     if (i && isSunLight(i)) {
         mManager[i].sunHaloFalloff = haloFalloff;
     }
 }
 
-void FLightManager::setShadowCaster(Instance i, bool shadowCaster) noexcept {
+void FLightManager::setShadowCaster(Instance const i, bool const shadowCaster) noexcept {
     if (i) {
         LightType& lightType = mManager[i].lightType;
         lightType.shadowCaster = shadowCaster;
     }
 }
 
-float FLightManager::getSpotLightInnerCone(Instance i) const noexcept {
+float FLightManager::getSpotLightInnerCone(Instance const i) const noexcept {
     const auto& spotParams = getSpotParams(i);
     float const cosOuter = std::cos(spotParams.outerClamped);
     float const scale = spotParams.scaleOffset.x;
@@ -446,7 +446,7 @@ void LightManager::ShadowCascades::computeUniformSplits(float splitPositions[3],
 }
 
 void LightManager::ShadowCascades::computeLogSplits(float splitPositions[3], uint8_t cascades,
-        float near, float far) {
+        float const near, float const far) {
     size_t s = 0;
     cascades = min(cascades, (uint8_t) 4u);
     for (size_t c = 1; c < cascades; c++) {
@@ -456,7 +456,7 @@ void LightManager::ShadowCascades::computeLogSplits(float splitPositions[3], uin
 }
 
 void LightManager::ShadowCascades::computePracticalSplits(float splitPositions[3], uint8_t cascades,
-        float near, float far, float lambda) {
+        float const near, float const far, float const lambda) {
     float uniformSplits[3];
     float logSplits[3];
     cascades = min(cascades, (uint8_t) 4u);

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -35,7 +35,7 @@ class FScene;
 
 class FLightManager : public LightManager {
 public:
-    using Instance = LightManager::Instance;
+    using Instance = Instance;
 
     explicit FLightManager(FEngine& engine) noexcept;
     ~FLightManager();
@@ -74,7 +74,7 @@ public:
         return mManager.getEntities();
     }
 
-    void create(const FLightManager::Builder& builder, utils::Entity entity);
+    void create(const Builder& builder, utils::Entity entity);
 
     void destroy(utils::Entity e) noexcept;
 
@@ -101,7 +101,7 @@ public:
     };
 
     struct ShadowParams { // TODO: get rid of this struct
-        LightManager::ShadowOptions options;
+        ShadowOptions options;
     };
 
     UTILS_NOINLINE void setLocalPosition(Instance i, const math::float3& position) noexcept;

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -50,11 +50,11 @@ public:
      * Component Manager APIs
      */
 
-    bool hasComponent(utils::Entity e) const noexcept {
+    bool hasComponent(utils::Entity const e) const noexcept {
         return mManager.hasComponent(e);
     }
 
-    Instance getInstance(utils::Entity e) const noexcept {
+    Instance getInstance(utils::Entity const e) const noexcept {
         return { mManager.getInstance(e) };
     }
 
@@ -66,7 +66,7 @@ public:
         return mManager.empty();
     }
 
-    utils::Entity getEntity(Instance i) const noexcept {
+    utils::Entity getEntity(Instance const i) const noexcept {
         return mManager.getEntity(i);
     }
 
@@ -118,32 +118,32 @@ public:
 
     UTILS_NOINLINE bool getLightChannel(Instance i, unsigned int channel) const noexcept;
 
-    LightType const& getLightType(Instance i) const noexcept {
+    LightType const& getLightType(Instance const i) const noexcept {
         return mManager[i].lightType;
     }
 
-    Type getType(Instance i) const noexcept {
+    Type getType(Instance const i) const noexcept {
         return getLightType(i).type;
     }
 
-    bool isShadowCaster(Instance i) const noexcept {
+    bool isShadowCaster(Instance const i) const noexcept {
         return getLightType(i).shadowCaster;
     }
 
-    bool isLightCaster(Instance i) const noexcept {
+    bool isLightCaster(Instance const i) const noexcept {
         return getLightType(i).lightCaster;
     }
 
-    bool isPointLight(Instance i) const noexcept {
+    bool isPointLight(Instance const i) const noexcept {
         return getType(i) == Type::POINT; 
     }
 
-    bool isSpotLight(Instance i) const noexcept {
+    bool isSpotLight(Instance const i) const noexcept {
         Type const type = getType(i);
         return type == Type::FOCUSED_SPOT || type == Type::SPOT;
     }
 
-    bool isDirectionalLight(Instance i) const noexcept {
+    bool isDirectionalLight(Instance const i) const noexcept {
         Type const type = getType(i);
         return type == Type::DIRECTIONAL || type == Type::SUN;
     }
@@ -152,89 +152,89 @@ public:
         return false;   // TODO: change this when we support IES lights
     }
 
-    bool isSunLight(Instance i) const noexcept {
+    bool isSunLight(Instance const i) const noexcept {
         return getType(i) == Type::SUN; 
     }
 
-    uint32_t getShadowMapSize(Instance i) const noexcept {
+    uint32_t getShadowMapSize(Instance const i) const noexcept {
         return getShadowParams(i).options.mapSize;
     }
 
-    ShadowParams const& getShadowParams(Instance i) const noexcept {
+    ShadowParams const& getShadowParams(Instance const i) const noexcept {
         return mManager[i].shadowParams;
     }
 
-    float getShadowConstantBias(Instance i) const noexcept {
+    float getShadowConstantBias(Instance const i) const noexcept {
         return getShadowParams(i).options.constantBias;
     }
 
-    float getShadowNormalBias(Instance i) const noexcept {
+    float getShadowNormalBias(Instance const i) const noexcept {
         return getShadowParams(i).options.normalBias;
     }
 
-    float getShadowFar(Instance i) const noexcept {
+    float getShadowFar(Instance const i) const noexcept {
         return getShadowParams(i).options.shadowFar;
     }
 
-    const math::float3& getColor(Instance i) const noexcept {
+    const math::float3& getColor(Instance const i) const noexcept {
         return mManager[i].color;
     }
 
-    float getIntensity(Instance i) const noexcept {
+    float getIntensity(Instance const i) const noexcept {
         return mManager[i].intensity;
     }
 
-    float getSunAngularRadius(Instance i) const noexcept {
+    float getSunAngularRadius(Instance const i) const noexcept {
         return mManager[i].sunAngularRadius;
     }
 
-    float getSunHaloSize(Instance i) const noexcept {
+    float getSunHaloSize(Instance const i) const noexcept {
         return mManager[i].sunHaloSize;
     }
 
-    float getSunHaloFalloff(Instance i) const noexcept {
+    float getSunHaloFalloff(Instance const i) const noexcept {
         return mManager[i].sunHaloFalloff;
     }
 
-    float getSquaredFalloffInv(Instance i) const noexcept {
+    float getSquaredFalloffInv(Instance const i) const noexcept {
         return mManager[i].squaredFallOffInv;
     }
 
-    float getFalloff(Instance i) const noexcept {
+    float getFalloff(Instance const i) const noexcept {
         return getRadius(i);
     }
 
-    SpotParams const& getSpotParams(Instance i) const noexcept {
+    SpotParams const& getSpotParams(Instance const i) const noexcept {
         return mManager[i].spotParams;
     }
 
     float getSpotLightInnerCone(Instance i) const noexcept;
 
-    float getCosOuterSquared(Instance i) const noexcept {
+    float getCosOuterSquared(Instance const i) const noexcept {
         return getSpotParams(i).cosOuterSquared;
     }
 
-    float getSinInverse(Instance i) const noexcept {
+    float getSinInverse(Instance const i) const noexcept {
         return getSpotParams(i).sinInverse;
     }
 
-    float getRadius(Instance i) const noexcept {
+    float getRadius(Instance const i) const noexcept {
         return getSpotParams(i).radius;
     }
 
-    uint8_t getLightChannels(Instance i) const noexcept {
+    uint8_t getLightChannels(Instance const i) const noexcept {
         return mManager[i].channels;
     }
 
-    const math::float3& getLocalPosition(Instance i) const noexcept {
+    const math::float3& getLocalPosition(Instance const i) const noexcept {
         return mManager[i].position;
     }
 
-    const math::float3& getLocalDirection(Instance i) const noexcept {
+    const math::float3& getLocalDirection(Instance const i) const noexcept {
         return mManager[i].direction;
     }
 
-    const ShadowOptions& getShadowOptions(Instance i) const noexcept {
+    const ShadowOptions& getShadowOptions(Instance const i) const noexcept {
         return getShadowParams(i).options;
     }
 

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -101,7 +101,7 @@ struct RenderableManager::BuilderDetails {
     std::unordered_map<size_t, FixedCapacityVector<
         FixedCapacityVector<float2>>> mBonePairs;
 
-    explicit BuilderDetails(size_t count)
+    explicit BuilderDetails(size_t const count)
             : mEntries(count), mCulling(true), mCastShadows(false),
               mReceiveShadows(true), mScreenSpaceContactShadows(false),
               mSkinningBufferMode(false), mFogEnabled(true),
@@ -125,22 +125,22 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
-RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
-        PrimitiveType type, VertexBuffer* vertices, IndexBuffer* indices) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::geometry(size_t const index,
+        PrimitiveType const type, VertexBuffer* vertices, IndexBuffer* indices) noexcept {
     return geometry(index, type, vertices, indices,
             0, 0, vertices->getVertexCount() - 1, indices->getIndexCount());
 }
 
-RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
-        PrimitiveType type, VertexBuffer* vertices, IndexBuffer* indices,
-        size_t offset, size_t count) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::geometry(size_t const index,
+        PrimitiveType const type, VertexBuffer* vertices, IndexBuffer* indices,
+        size_t const offset, size_t const count) noexcept {
     return geometry(index, type, vertices, indices, offset,
             0, vertices->getVertexCount() - 1, count);
 }
 
-RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
-        PrimitiveType type, VertexBuffer* vertices, IndexBuffer* indices,
-        size_t offset, UTILS_UNUSED size_t minIndex, UTILS_UNUSED size_t maxIndex, size_t count) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::geometry(size_t const index,
+        PrimitiveType const type, VertexBuffer* vertices, IndexBuffer* indices,
+        size_t const offset, UTILS_UNUSED size_t minIndex, UTILS_UNUSED size_t maxIndex, size_t const count) noexcept {
     std::vector<BuilderDetails::Entry>& entries = mImpl->mEntries;
     if (index < entries.size()) {
         entries[index].vertices = vertices;
@@ -152,12 +152,12 @@ RenderableManager::Builder& RenderableManager::Builder::geometry(size_t index,
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::geometryType(GeometryType type) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::geometryType(GeometryType const type) noexcept {
     mImpl->mGeometryType = type;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::material(size_t index,
+RenderableManager::Builder& RenderableManager::Builder::material(size_t const index,
         MaterialInstance const* materialInstance) noexcept {
     if (index < mImpl->mEntries.size()) {
         mImpl->mEntries[index].materialInstance = materialInstance;
@@ -170,27 +170,27 @@ RenderableManager::Builder& RenderableManager::Builder::boundingBox(const Box& a
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::layerMask(uint8_t select, uint8_t values) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::layerMask(uint8_t const select, uint8_t const values) noexcept {
     mImpl->mLayerMask = (mImpl->mLayerMask & ~select) | (values & select);
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::priority(uint8_t priority) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::priority(uint8_t const priority) noexcept {
     mImpl->mPriority = std::min(priority, uint8_t(0x7));
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::channel(uint8_t channel) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::channel(uint8_t const channel) noexcept {
     mImpl->mCommandChannel = std::min(channel, uint8_t(0x3));
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::culling(bool enable) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::culling(bool const enable) noexcept {
     mImpl->mCulling = enable;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::lightChannel(unsigned int channel, bool enable) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::lightChannel(unsigned int const channel, bool const enable) noexcept {
     if (channel < 8) {
         const uint8_t mask = 1u << channel;
         mImpl->mLightChannels &= ~mask;
@@ -199,55 +199,55 @@ RenderableManager::Builder& RenderableManager::Builder::lightChannel(unsigned in
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::castShadows(bool enable) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::castShadows(bool const enable) noexcept {
     mImpl->mCastShadows = enable;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::receiveShadows(bool enable) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::receiveShadows(bool const enable) noexcept {
     mImpl->mReceiveShadows = enable;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::screenSpaceContactShadows(bool enable) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::screenSpaceContactShadows(bool const enable) noexcept {
     mImpl->mScreenSpaceContactShadows = enable;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::skinning(size_t boneCount) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::skinning(size_t const boneCount) noexcept {
     mImpl->mSkinningBoneCount = boneCount;
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::skinning(
-        size_t boneCount, Bone const* bones) noexcept {
+        size_t const boneCount, Bone const* bones) noexcept {
     mImpl->mSkinningBoneCount = boneCount;
     mImpl->mUserBones = bones;
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::skinning(
-        size_t boneCount, mat4f const* transforms) noexcept {
+        size_t const boneCount, mat4f const* transforms) noexcept {
     mImpl->mSkinningBoneCount = boneCount;
     mImpl->mUserBoneMatrices = transforms;
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::skinning(
-        SkinningBuffer* skinningBuffer, size_t count, size_t offset) noexcept {
+        SkinningBuffer* skinningBuffer, size_t const count, size_t const offset) noexcept {
     mImpl->mSkinningBuffer = downcast(skinningBuffer);
     mImpl->mSkinningBoneCount = count;
     mImpl->mSkinningBufferOffset = offset;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::enableSkinningBuffers(bool enabled) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::enableSkinningBuffers(bool const enabled) noexcept {
     mImpl->mSkinningBufferMode = enabled;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::boneIndicesAndWeights(size_t primitiveIndex,
-               float2 const* indicesAndWeights, size_t count, size_t bonesPerVertex) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::boneIndicesAndWeights(size_t const primitiveIndex,
+               float2 const* indicesAndWeights, size_t const count, size_t const bonesPerVertex) noexcept {
     size_t const vertexCount = count / bonesPerVertex;
     FixedCapacityVector<FixedCapacityVector<float2>> bonePairs(vertexCount);
     for (size_t iVertex = 0; iVertex < vertexCount; iVertex++) {
@@ -259,19 +259,19 @@ RenderableManager::Builder& RenderableManager::Builder::boneIndicesAndWeights(si
     return boneIndicesAndWeights(primitiveIndex, bonePairs);
 }
 
-RenderableManager::Builder& RenderableManager::Builder::boneIndicesAndWeights(size_t primitiveIndex,
+RenderableManager::Builder& RenderableManager::Builder::boneIndicesAndWeights(size_t const primitiveIndex,
         FixedCapacityVector<
             FixedCapacityVector<float2>> indicesAndWeightsVector) noexcept {
     mImpl->mBonePairs[primitiveIndex] = std::move(indicesAndWeightsVector);
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::fog(bool enabled) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::fog(bool const enabled) noexcept {
     mImpl->mFogEnabled = enabled;
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::morphing(size_t targetCount) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::morphing(size_t const targetCount) noexcept {
     mImpl->mMorphTargetCount = targetCount;
     return *this;
 }
@@ -284,7 +284,7 @@ RenderableManager::Builder& RenderableManager::Builder::morphing(
 }
 
 RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level,
-        size_t primitiveIndex, size_t offset) noexcept {
+        size_t const primitiveIndex, size_t const offset) noexcept {
     // the last parameter "count" is unused, because it must be equal to the primitive's vertex count
     std::vector<BuilderDetails::Entry>& entries = mImpl->mEntries;
     if (primitiveIndex < entries.size()) {
@@ -295,7 +295,7 @@ RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level,
 }
 
 RenderableManager::Builder& RenderableManager::Builder::blendOrder(
-        size_t index, uint16_t blendOrder) noexcept {
+        size_t const index, uint16_t const blendOrder) noexcept {
     if (index < mImpl->mEntries.size()) {
         mImpl->mEntries[index].blendOrder = blendOrder;
     }
@@ -303,7 +303,7 @@ RenderableManager::Builder& RenderableManager::Builder::blendOrder(
 }
 
 RenderableManager::Builder& RenderableManager::Builder::globalBlendOrderEnabled(
-        size_t index, bool enabled) noexcept {
+        size_t const index, bool const enabled) noexcept {
     if (index < mImpl->mEntries.size()) {
         mImpl->mEntries[index].globalBlendOrderEnabled = enabled;
     }
@@ -311,7 +311,7 @@ RenderableManager::Builder& RenderableManager::Builder::globalBlendOrderEnabled(
 }
 
 UTILS_NOINLINE
-void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engine, Entity entity) {
+void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engine, Entity const entity) {
     size_t maxPairsCount = 0; //size of texture, number of bone pairs
     size_t maxPairsCountPerVertex = 0; //maximum of number of bone per vertex
 
@@ -432,7 +432,7 @@ void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engi
     mBoneIndicesAndWeightsCount = pairsCount; // only part of mBoneIndicesAndWeights is used for real data
 }
 
-RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity entity) {
+RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity const entity) {
     bool isEmpty = true;
 
     FILAMENT_CHECK_PRECONDITION(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT)
@@ -517,13 +517,13 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
     return Success;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::instances(size_t instanceCount) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::instances(size_t const instanceCount) noexcept {
     mImpl->mInstanceCount = clamp((unsigned int)instanceCount, 1u, 32767u);
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::instances(
-        size_t instanceCount, InstanceBuffer* instanceBuffer) noexcept {
+        size_t const instanceCount, InstanceBuffer* instanceBuffer) noexcept {
     mImpl->mInstanceCount = clamp(instanceCount, (size_t)1, CONFIG_MAX_INSTANCES);
     mImpl->mInstanceBuffer = downcast(instanceBuffer);
     return *this;
@@ -542,7 +542,7 @@ FRenderableManager::~FRenderableManager() {
 }
 
 void FRenderableManager::create(
-        const Builder& UTILS_RESTRICT builder, Entity entity) {
+        const Builder& UTILS_RESTRICT builder, Entity const entity) {
     FEngine& engine = mEngine;
     auto& manager = mManager;
     FEngine::DriverApi& driver = engine.getDriverApi();
@@ -714,7 +714,7 @@ void FRenderableManager::create(
 }
 
 // this destroys a single component from an entity
-void FRenderableManager::destroy(Entity e) noexcept {
+void FRenderableManager::destroy(Entity const e) noexcept {
     Instance const ci = getInstance(e);
     if (ci) {
         destroyComponent(ci);
@@ -740,13 +740,13 @@ void FRenderableManager::terminate() noexcept {
 }
 
 void FRenderableManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity e) {
+    mManager.gc(em, [this](Entity const e) {
         destroy(e);
     });
 }
 
 // This is basically a Renderable's destructor.
-void FRenderableManager::destroyComponent(Instance ci) noexcept {
+void FRenderableManager::destroyComponent(Instance const ci) noexcept {
     auto& manager = mManager;
     FEngine& engine = mEngine;
 
@@ -790,8 +790,8 @@ void FRenderableManager::destroyComponentPrimitives(
     delete[] primitives.data();
 }
 
-void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
-        size_t primitiveIndex, FMaterialInstance const* mi) {
+void FRenderableManager::setMaterialInstanceAt(Instance const instance, uint8_t const level,
+        size_t const primitiveIndex, FMaterialInstance const* mi) {
     assert_invariant(mi);
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
@@ -830,7 +830,7 @@ void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t leve
 }
 
 MaterialInstance* FRenderableManager::getMaterialInstanceAt(
-        Instance instance, uint8_t level, size_t primitiveIndex) const noexcept {
+        Instance const instance, uint8_t const level, size_t const primitiveIndex) const noexcept {
     if (instance) {
         const Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -842,8 +842,8 @@ MaterialInstance* FRenderableManager::getMaterialInstanceAt(
     return nullptr;
 }
 
-void FRenderableManager::setBlendOrderAt(Instance instance, uint8_t level,
-        size_t primitiveIndex, uint16_t order) noexcept {
+void FRenderableManager::setBlendOrderAt(Instance const instance, uint8_t const level,
+        size_t const primitiveIndex, uint16_t const order) noexcept {
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -852,8 +852,8 @@ void FRenderableManager::setBlendOrderAt(Instance instance, uint8_t level,
     }
 }
 
-void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance instance, uint8_t level,
-        size_t primitiveIndex, bool enabled) noexcept {
+void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance const instance, uint8_t const level,
+        size_t const primitiveIndex, bool const enabled) noexcept {
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -863,7 +863,7 @@ void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance instance, uint8_t
 }
 
 AttributeBitset FRenderableManager::getEnabledAttributesAt(
-        Instance instance, uint8_t level, size_t primitiveIndex) const noexcept {
+        Instance const instance, uint8_t const level, size_t const primitiveIndex) const noexcept {
     if (instance) {
         Slice<FRenderPrimitive> const& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -873,9 +873,9 @@ AttributeBitset FRenderableManager::getEnabledAttributesAt(
     return AttributeBitset{};
 }
 
-void FRenderableManager::setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
-        PrimitiveType type, FVertexBuffer* vertices, FIndexBuffer* indices,
-        size_t offset, size_t count) noexcept {
+void FRenderableManager::setGeometryAt(Instance const instance, uint8_t const level, size_t const primitiveIndex,
+        PrimitiveType const type, FVertexBuffer* vertices, FIndexBuffer* indices,
+        size_t const offset, size_t const count) noexcept {
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -885,8 +885,8 @@ void FRenderableManager::setGeometryAt(Instance instance, uint8_t level, size_t 
     }
 }
 
-void FRenderableManager::setBones(Instance ci,
-        Bone const* UTILS_RESTRICT transforms, size_t boneCount, size_t offset) {
+void FRenderableManager::setBones(Instance const ci,
+        Bone const* UTILS_RESTRICT transforms, size_t boneCount, size_t const offset) {
     if (ci) {
         Bones const& bones = mManager[ci].bones;
 
@@ -901,8 +901,8 @@ void FRenderableManager::setBones(Instance ci,
     }
 }
 
-void FRenderableManager::setBones(Instance ci,
-        mat4f const* UTILS_RESTRICT transforms, size_t boneCount, size_t offset) {
+void FRenderableManager::setBones(Instance const ci,
+        mat4f const* UTILS_RESTRICT transforms, size_t boneCount, size_t const offset) {
     if (ci) {
         Bones const& bones = mManager[ci].bones;
 
@@ -917,8 +917,8 @@ void FRenderableManager::setBones(Instance ci,
     }
 }
 
-void FRenderableManager::setSkinningBuffer(Instance ci,
-        FSkinningBuffer* skinningBuffer, size_t count, size_t offset) {
+void FRenderableManager::setSkinningBuffer(Instance const ci,
+        FSkinningBuffer* skinningBuffer, size_t count, size_t const offset) {
 
     Bones& bones = mManager[ci].bones;
 
@@ -948,17 +948,17 @@ void FRenderableManager::setSkinningBuffer(Instance ci,
 }
 
 static void updateMorphWeights(FEngine& engine, Handle<HwBufferObject> handle,
-        float const* weights, size_t count, size_t offset) noexcept {
+        float const* weights, size_t const count, size_t const offset) noexcept {
     auto& driver = engine.getDriverApi();
     auto size = sizeof(float4) * count;
     auto* UTILS_RESTRICT out = (float4*)driver.allocate(size);
     std::transform(weights, weights + count, out,
-            [](float value) { return float4(value, 0, 0, 0); });
+            [](float const value) { return float4(value, 0, 0, 0); });
     driver.updateBufferObject(handle, { out, size }, sizeof(float4) * offset);
 }
 
-void FRenderableManager::setMorphWeights(Instance instance, float const* weights,
-        size_t count, size_t offset) {
+void FRenderableManager::setMorphWeights(Instance const instance, float const* weights,
+        size_t const count, size_t const offset) {
     if (instance) {
         FILAMENT_CHECK_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT)
                 << "Only " << CONFIG_MAX_MORPH_TARGET_COUNT
@@ -971,9 +971,9 @@ void FRenderableManager::setMorphWeights(Instance instance, float const* weights
     }
 }
 
-void FRenderableManager::setMorphTargetBufferOffsetAt(Instance instance, uint8_t level,
-        size_t primitiveIndex,
-        size_t offset) {
+void FRenderableManager::setMorphTargetBufferOffsetAt(Instance const instance, uint8_t level,
+        size_t const primitiveIndex,
+        size_t const offset) {
     if (instance) {
         assert_invariant(mManager[instance].morphTargetBuffer);
         Slice<FRenderPrimitive>& primitives = mManager[instance].primitives;
@@ -983,14 +983,14 @@ void FRenderableManager::setMorphTargetBufferOffsetAt(Instance instance, uint8_t
     }
 }
 
-MorphTargetBuffer* FRenderableManager::getMorphTargetBuffer(Instance instance) const noexcept {
+MorphTargetBuffer* FRenderableManager::getMorphTargetBuffer(Instance const instance) const noexcept {
     if (instance) {
         return mManager[instance].morphTargetBuffer;
     }
     return nullptr;
 }
 
-size_t FRenderableManager::getMorphTargetCount(Instance instance) const noexcept {
+size_t FRenderableManager::getMorphTargetCount(Instance const instance) const noexcept {
     if (instance) {
         const MorphWeights& morphWeights = mManager[instance].morphWeights;
         return morphWeights.count;
@@ -998,7 +998,7 @@ size_t FRenderableManager::getMorphTargetCount(Instance instance) const noexcept
     return 0;
 }
 
-void FRenderableManager::setLightChannel(Instance ci, unsigned int channel, bool enable) noexcept {
+void FRenderableManager::setLightChannel(Instance const ci, unsigned int const channel, bool const enable) noexcept {
     if (ci) {
         if (channel < 8) {
             const uint8_t mask = 1u << channel;
@@ -1008,7 +1008,7 @@ void FRenderableManager::setLightChannel(Instance ci, unsigned int channel, bool
     }
 }
 
-bool FRenderableManager::getLightChannel(Instance ci, unsigned int channel) const noexcept {
+bool FRenderableManager::getLightChannel(Instance const ci, unsigned int const channel) const noexcept {
     if (ci) {
         if (channel < 8) {
             const uint8_t mask = 1u << channel;
@@ -1018,7 +1018,7 @@ bool FRenderableManager::getLightChannel(Instance ci, unsigned int channel) cons
     return false;
 }
 
-size_t FRenderableManager::getPrimitiveCount(Instance instance, uint8_t level) const noexcept {
+size_t FRenderableManager::getPrimitiveCount(Instance const instance, uint8_t const level) const noexcept {
     return getRenderPrimitives(instance, level).size();
 }
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -61,8 +61,8 @@ class MorphTargetBuffer;
 
 class FRenderableManager : public RenderableManager {
 public:
-    using Instance = RenderableManager::Instance;
-    using GeometryType = RenderableManager::Builder::GeometryType;
+    using Instance = Instance;
+    using GeometryType = Builder::GeometryType;
 
     // TODO: consider renaming, this pertains to material variants, not strictly visibility.
     struct Visibility {
@@ -118,7 +118,7 @@ public:
         return mManager.getEntities();
     }
 
-    void create(const RenderableManager::Builder& builder, utils::Entity entity);
+    void create(const Builder& builder, utils::Entity entity);
 
     void destroy(utils::Entity e) noexcept;
 
@@ -273,7 +273,7 @@ private:
             utils::Slice<FRenderPrimitive>,  // PRIMITIVES
             Bones,                           // BONES
             FMorphTargetBuffer*,            // MORPHTARGET_BUFFER
-            filament::DescriptorSet          // DESCRIPTOR_SET
+            DescriptorSet          // DESCRIPTOR_SET
     >;
 
     struct Sim : public Base {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -94,11 +94,11 @@ public:
      * Component Manager APIs
      */
 
-    bool hasComponent(utils::Entity e) const noexcept {
+    bool hasComponent(utils::Entity const e) const noexcept {
         return mManager.hasComponent(e);
     }
 
-    Instance getInstance(utils::Entity e) const noexcept {
+    Instance getInstance(utils::Entity const e) const noexcept {
         return { mManager.getInstance(e) };
     }
 
@@ -110,7 +110,7 @@ public:
         return mManager.empty();
     }
 
-    utils::Entity getEntity(Instance i) const noexcept {
+    utils::Entity getEntity(Instance const i) const noexcept {
         return mManager.getEntity(i);
     }
 
@@ -165,7 +165,7 @@ public:
 
 
     inline Box const& getAABB(Instance instance) const noexcept;
-    inline Box const& getAxisAlignedBoundingBox(Instance instance) const noexcept { return getAABB(instance); }
+    inline Box const& getAxisAlignedBoundingBox(Instance const instance) const noexcept { return getAABB(instance); }
     inline Visibility getVisibility(Instance instance) const noexcept;
     inline uint8_t getLayerMask(Instance instance) const noexcept;
     inline uint8_t getPriority(Instance instance) const noexcept;
@@ -316,7 +316,7 @@ private:
 
 FILAMENT_DOWNCAST(RenderableManager)
 
-void FRenderableManager::setAxisAlignedBoundingBox(Instance instance, const Box& aabb) {
+void FRenderableManager::setAxisAlignedBoundingBox(Instance const instance, const Box& aabb) {
     if (instance) {
         FILAMENT_CHECK_PRECONDITION(
                 static_cast<Visibility const&>(mManager[instance].visibility).geometryType ==
@@ -326,74 +326,74 @@ void FRenderableManager::setAxisAlignedBoundingBox(Instance instance, const Box&
     }
 }
 
-void FRenderableManager::setLayerMask(Instance instance,
-        uint8_t select, uint8_t values) noexcept {
+void FRenderableManager::setLayerMask(Instance const instance,
+        uint8_t const select, uint8_t const values) noexcept {
     if (instance) {
         uint8_t& layers = mManager[instance].layers;
         layers = (layers & ~select) | (values & select);
     }
 }
 
-void FRenderableManager::setLayerMask(Instance instance, uint8_t layerMask) noexcept {
+void FRenderableManager::setLayerMask(Instance const instance, uint8_t const layerMask) noexcept {
     if (instance) {
         mManager[instance].layers = layerMask;
     }
 }
 
-void FRenderableManager::setPriority(Instance instance, uint8_t priority) noexcept {
+void FRenderableManager::setPriority(Instance const instance, uint8_t const priority) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.priority = std::min(priority, uint8_t(0x7));
     }
 }
 
-void FRenderableManager::setChannel(Instance instance, uint8_t channel) noexcept {
+void FRenderableManager::setChannel(Instance const instance, uint8_t const channel) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.channel = std::min(channel, uint8_t(0x3));
     }
 }
 
-void FRenderableManager::setCastShadows(Instance instance, bool enable) noexcept {
+void FRenderableManager::setCastShadows(Instance const instance, bool const enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.castShadows = enable;
     }
 }
 
-void FRenderableManager::setReceiveShadows(Instance instance, bool enable) noexcept {
+void FRenderableManager::setReceiveShadows(Instance const instance, bool const enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.receiveShadows = enable;
     }
 }
 
-void FRenderableManager::setScreenSpaceContactShadows(Instance instance, bool enable) noexcept {
+void FRenderableManager::setScreenSpaceContactShadows(Instance const instance, bool const enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.screenSpaceContactShadows = enable;
     }
 }
 
-void FRenderableManager::setCulling(Instance instance, bool enable) noexcept {
+void FRenderableManager::setCulling(Instance const instance, bool const enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.culling = enable;
     }
 }
 
-void FRenderableManager::setFogEnabled(Instance instance, bool enable) noexcept {
+void FRenderableManager::setFogEnabled(Instance const instance, bool const enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.fog = enable;
     }
 }
 
-bool FRenderableManager::getFogEnabled(RenderableManager::Instance instance) const noexcept {
+bool FRenderableManager::getFogEnabled(RenderableManager::Instance const instance) const noexcept {
     return getVisibility(instance).fog;
 }
 
-void FRenderableManager::setSkinning(Instance instance, bool enable) {
+void FRenderableManager::setSkinning(Instance const instance, bool const enable) {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
 
@@ -404,7 +404,7 @@ void FRenderableManager::setSkinning(Instance instance, bool enable) {
     }
 }
 
-void FRenderableManager::setMorphing(Instance instance, bool enable) {
+void FRenderableManager::setMorphing(Instance const instance, bool const enable) {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
 
@@ -415,7 +415,7 @@ void FRenderableManager::setMorphing(Instance instance, bool enable) {
     }
 }
 
-void FRenderableManager::setPrimitives(Instance instance,
+void FRenderableManager::setPrimitives(Instance const instance,
         utils::Slice<FRenderPrimitive> const& primitives) noexcept {
     if (instance) {
         mManager[instance].primitives = primitives;
@@ -423,72 +423,72 @@ void FRenderableManager::setPrimitives(Instance instance,
 }
 
 FRenderableManager::Visibility
-FRenderableManager::getVisibility(Instance instance) const noexcept {
+FRenderableManager::getVisibility(Instance const instance) const noexcept {
     return mManager[instance].visibility;
 }
 
-bool FRenderableManager::isShadowCaster(Instance instance) const noexcept {
+bool FRenderableManager::isShadowCaster(Instance const instance) const noexcept {
     return getVisibility(instance).castShadows;
 }
 
-bool FRenderableManager::isShadowReceiver(Instance instance) const noexcept {
+bool FRenderableManager::isShadowReceiver(Instance const instance) const noexcept {
     return getVisibility(instance).receiveShadows;
 }
 
-bool FRenderableManager::isCullingEnabled(Instance instance) const noexcept {
+bool FRenderableManager::isCullingEnabled(Instance const instance) const noexcept {
     return getVisibility(instance).culling;
 }
 
-uint8_t FRenderableManager::getLayerMask(Instance instance) const noexcept {
+uint8_t FRenderableManager::getLayerMask(Instance const instance) const noexcept {
     return mManager[instance].layers;
 }
 
-uint8_t FRenderableManager::getPriority(Instance instance) const noexcept {
+uint8_t FRenderableManager::getPriority(Instance const instance) const noexcept {
     return getVisibility(instance).priority;
 }
 
-uint8_t FRenderableManager::getChannels(Instance instance) const noexcept {
+uint8_t FRenderableManager::getChannels(Instance const instance) const noexcept {
     return mManager[instance].channels;
 }
 
-Box const& FRenderableManager::getAABB(Instance instance) const noexcept {
+Box const& FRenderableManager::getAABB(Instance const instance) const noexcept {
     return mManager[instance].aabb;
 }
 
 FRenderableManager::SkinningBindingInfo
-FRenderableManager::getSkinningBufferInfo(Instance instance) const noexcept {
+FRenderableManager::getSkinningBufferInfo(Instance const instance) const noexcept {
     Bones const& bones = mManager[instance].bones;
     return { bones.handle, bones.offset, bones.handleTexture };
 }
 
-inline uint32_t FRenderableManager::getBoneCount(Instance instance) const noexcept {
+inline uint32_t FRenderableManager::getBoneCount(Instance const instance) const noexcept {
     Bones const& bones = mManager[instance].bones;
     return bones.count;
 }
 
 FRenderableManager::MorphingBindingInfo
-FRenderableManager::getMorphingBufferInfo(Instance instance) const noexcept {
+FRenderableManager::getMorphingBufferInfo(Instance const instance) const noexcept {
     MorphWeights const& morphWeights = mManager[instance].morphWeights;
     FMorphTargetBuffer const* const buffer = mManager[instance].morphTargetBuffer;
     return { morphWeights.handle, morphWeights.count, buffer  };
 }
 
 FRenderableManager::InstancesInfo
-FRenderableManager::getInstancesInfo(Instance instance) const noexcept {
+FRenderableManager::getInstancesInfo(Instance const instance) const noexcept {
     return mManager[instance].instances;
 }
 
 utils::Slice<FRenderPrimitive> const& FRenderableManager::getRenderPrimitives(
-        Instance instance, UTILS_UNUSED uint8_t level) const noexcept {
+        Instance const instance, UTILS_UNUSED uint8_t level) const noexcept {
     return mManager[instance].primitives;
 }
 
 utils::Slice<FRenderPrimitive>& FRenderableManager::getRenderPrimitives(
-        Instance instance, UTILS_UNUSED uint8_t level) noexcept {
+        Instance const instance, UTILS_UNUSED uint8_t level) noexcept {
     return mManager[instance].primitives;
 }
 
-DescriptorSet& FRenderableManager::getDescriptorSet(Instance instance) noexcept {
+DescriptorSet& FRenderableManager::getDescriptorSet(Instance const instance) noexcept {
     return mManager[instance].descriptorSet;
 }
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -34,7 +34,7 @@ FTransformManager::~FTransformManager() noexcept = default;
 void FTransformManager::terminate() noexcept {
 }
 
-void FTransformManager::setAccurateTranslationsEnabled(bool enable) noexcept {
+void FTransformManager::setAccurateTranslationsEnabled(bool const enable) noexcept {
     if (enable != mAccurateTranslations) {
         mAccurateTranslations = enable;
         // when enabling accurate translations, we have to recompute all world transforms
@@ -44,11 +44,11 @@ void FTransformManager::setAccurateTranslationsEnabled(bool enable) noexcept {
     }
 }
 
-void FTransformManager::create(Entity entity) {
+void FTransformManager::create(Entity const entity) {
     create(entity, 0, mat4f{});
 }
 
-void FTransformManager::create(Entity entity, Instance parent, const mat4f& localTransform) {
+void FTransformManager::create(Entity const entity, Instance const parent, const mat4f& localTransform) {
     // this always adds at the end, so all existing instances stay valid
     auto& manager = mManager;
 
@@ -70,7 +70,7 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4f& loca
     }
 }
 
-void FTransformManager::create(Entity entity, Instance parent, const mat4& localTransform) {
+void FTransformManager::create(Entity const entity, Instance const parent, const mat4& localTransform) {
     // this always adds at the end, so all existing instances stay valid
     auto& manager = mManager;
 
@@ -92,7 +92,7 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4& local
     }
 }
 
-void FTransformManager::setParent(Instance i, Instance parent) noexcept {
+void FTransformManager::setParent(Instance const i, Instance const parent) noexcept {
     validateNode(i);
     if (i) {
         auto& manager = mManager;
@@ -115,14 +115,14 @@ Entity FTransformManager::getParent(Instance i) const noexcept {
     return i ? mManager.getEntity(i) : Entity();
 }
 
-size_t FTransformManager::getChildCount(Instance i) const noexcept {
+size_t FTransformManager::getChildCount(Instance const i) const noexcept {
     size_t count = 0;
     for (Instance ci = mManager[i].firstChild; ci; ci = mManager[ci].next, ++count);
     return count;
 }
 
-size_t FTransformManager::getChildren(Instance i, Entity* children,
-        size_t count) const noexcept {
+size_t FTransformManager::getChildren(Instance const i, Entity* children,
+        size_t const count) const noexcept {
     Instance ci = mManager[i].firstChild;
     size_t numWritten = 0;
     while (ci && numWritten < count) {
@@ -133,7 +133,7 @@ size_t FTransformManager::getChildren(Instance i, Entity* children,
 }
 
 TransformManager::children_iterator FTransformManager::getChildrenBegin(
-        Instance parent) const noexcept {
+        Instance const parent) const noexcept {
     return { *this, mManager[parent].firstChild };
 }
 
@@ -141,7 +141,7 @@ TransformManager::children_iterator FTransformManager::getChildrenEnd(Instance) 
     return { *this, 0 };
 }
 
-void FTransformManager::destroy(Entity e) noexcept {
+void FTransformManager::destroy(Entity const e) noexcept {
     // update the reference of the element we're removing
     auto& manager = mManager;
     Instance const i = manager.getInstance(e);
@@ -167,7 +167,7 @@ void FTransformManager::destroy(Entity e) noexcept {
     }
 }
 
-void FTransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
+void FTransformManager::setTransform(Instance const ci, const mat4f& model) noexcept {
     validateNode(ci);
     if (ci) {
         auto& manager = mManager;
@@ -178,7 +178,7 @@ void FTransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
     }
 }
 
-void FTransformManager::setTransform(Instance ci, const mat4& model) noexcept {
+void FTransformManager::setTransform(Instance const ci, const mat4& model) noexcept {
     validateNode(ci);
     if (ci) {
         auto& manager = mManager;
@@ -189,7 +189,7 @@ void FTransformManager::setTransform(Instance ci, const mat4& model) noexcept {
     }
 }
 
-void FTransformManager::updateNodeTransform(Instance i) noexcept {
+void FTransformManager::updateNodeTransform(Instance const i) noexcept {
     if (UTILS_UNLIKELY(mLocalTransformTransactionOpen)) {
         return;
     }
@@ -250,7 +250,7 @@ void FTransformManager::computeAllWorldTransforms() noexcept {
 }
 
 // Inserts a parentless node in the hierarchy
-void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
+void FTransformManager::insertNode(Instance const i, Instance const parent) noexcept {
     auto& manager = mManager;
 
     assert_invariant(manager[i].parent == Instance{});
@@ -274,7 +274,7 @@ void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
     validateNode(parent);
 }
 
-void FTransformManager::swapNode(Instance i, Instance j) noexcept {
+void FTransformManager::swapNode(Instance const i, Instance const j) noexcept {
     validateNode(i);
     validateNode(j);
 
@@ -316,7 +316,7 @@ void FTransformManager::swapNode(Instance i, Instance j) noexcept {
 
 // removes a node from the graph, but doesn't remove it or its children from the array
 // (making everybody orphaned).
-void FTransformManager::removeNode(Instance i) noexcept {
+void FTransformManager::removeNode(Instance const i) noexcept {
     auto& manager = mManager;
     Instance const parent = manager[i].parent;
     Instance const prev = manager[i].prev;
@@ -342,7 +342,7 @@ void FTransformManager::removeNode(Instance i) noexcept {
 }
 
 // update references to this node after it has been moved in the array
-void FTransformManager::updateNode(Instance i) noexcept {
+void FTransformManager::updateNode(Instance const i) noexcept {
     auto& manager = mManager;
     // update our preview sibling's next reference (to ourselves)
     Instance const parent = manager[i].parent;
@@ -400,7 +400,7 @@ void FTransformManager::computeWorldTransform(
         mat4f const& UTILS_RESTRICT local,
         float3 const& UTILS_RESTRICT ptTranslationLo,       // reference to avoid unneeded access
         float3 const& UTILS_RESTRICT localTranslationLo,    // reference to avoid unneeded access
-        bool accurate) {
+        bool const accurate) {
 
     outWorld[0] = pt * local[0];
     outWorld[1] = pt * local[1];
@@ -428,7 +428,7 @@ void FTransformManager::computeWorldTransform(
 }
 
 
-void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance i) noexcept {
+void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance const i) noexcept {
 #ifndef NDEBUG
     auto& manager = mManager;
     if (i) {
@@ -471,7 +471,7 @@ void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance i) noexcep
 }
 
 void FTransformManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity e) {
+    mManager.gc(em, [this](Entity const e) {
                 destroy(e);
             });
 }

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -121,7 +121,7 @@ size_t FTransformManager::getChildCount(Instance i) const noexcept {
     return count;
 }
 
-size_t FTransformManager::getChildren(Instance i, utils::Entity* children,
+size_t FTransformManager::getChildren(Instance i, Entity* children,
         size_t count) const noexcept {
     Instance ci = mManager[i].firstChild;
     size_t numWritten = 0;
@@ -201,7 +201,7 @@ void FTransformManager::updateNodeTransform(Instance i) noexcept {
     // find our parent's world transform, if any
     // note: by using the raw_array() we don't need to check that parent is valid.
     Instance const parent = manager[i].parent;
-    FTransformManager::computeWorldTransform(
+    computeWorldTransform(
             manager[i].world, manager[i].worldTranslationLo,
             manager[parent].world, manager[i].local,
             manager[parent].worldTranslationLo, manager[i].localTranslationLo,
@@ -241,7 +241,7 @@ void FTransformManager::computeAllWorldTransforms() noexcept {
         Instance const parent = manager[i].parent;
         assert_invariant(parent < i);
 
-        FTransformManager::computeWorldTransform(
+        computeWorldTransform(
                 manager[i].world, manager[i].worldTranslationLo,
                 manager[parent].world, manager[i].local,
                 manager[parent].worldTranslationLo, manager[i].localTranslationLo,
@@ -376,7 +376,7 @@ void FTransformManager::transformChildren(Sim& manager, Instance i) noexcept {
     while (i) {
         // update child's world transform
         Instance const parent = manager[i].parent;
-        FTransformManager::computeWorldTransform(
+        computeWorldTransform(
                 manager[i].world, manager[i].worldTranslationLo,
                 manager[parent].world, manager[i].local,
                 manager[parent].worldTranslationLo, manager[i].localTranslationLo,
@@ -470,7 +470,7 @@ void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance i) noexcep
 #endif
 }
 
-void FTransformManager::gc(utils::EntityManager& em) noexcept {
+void FTransformManager::gc(EntityManager& em) noexcept {
     mManager.gc(em, [this](Entity e) {
                 destroy(e);
             });

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -32,7 +32,7 @@ namespace filament {
 
 class UTILS_PRIVATE FTransformManager : public TransformManager {
 public:
-    using Instance = TransformManager::Instance;
+    using Instance = Instance;
 
     FTransformManager() noexcept;
     ~FTransformManager() noexcept;
@@ -151,7 +151,7 @@ private:
             math::float3 const& ptTranslationLo, math::float3 const& localTranslationLo,
             bool accurate);
 
-    friend class TransformManager::children_iterator;
+    friend class children_iterator;
 
     enum {
         LOCAL,          // local transform (relative to parent), world if no parent
@@ -179,7 +179,7 @@ private:
         using Base::gc;
         using Base::swap;
 
-        typename Base::SoA& getSoA() { return mData; }
+        SoA& getSoA() { return mData; }
 
         struct Proxy {
             // all of these gets inlined

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -45,11 +45,11 @@ public:
     * Component Manager APIs
     */
 
-    bool hasComponent(utils::Entity e) const noexcept {
+    bool hasComponent(utils::Entity const e) const noexcept {
         return mManager.hasComponent(e);
     }
 
-    Instance getInstance(utils::Entity e) const noexcept {
+    Instance getInstance(utils::Entity const e) const noexcept {
         return { mManager.getInstance(e) };
     }
 
@@ -61,7 +61,7 @@ public:
         return mManager.empty();
     }
 
-    utils::Entity getEntity(Instance i) const noexcept {
+    utils::Entity getEntity(Instance const i) const noexcept {
         return mManager.getEntity(i);
     }
 
@@ -109,15 +109,15 @@ public:
 
     void setTransform(Instance ci, const math::mat4& model) noexcept;
 
-    const math::mat4f& getTransform(Instance ci) const noexcept {
+    const math::mat4f& getTransform(Instance const ci) const noexcept {
         return mManager[ci].local;
     }
 
-    const math::mat4f& getWorldTransform(Instance ci) const noexcept {
+    const math::mat4f& getWorldTransform(Instance const ci) const noexcept {
         return mManager[ci].world;
     }
 
-    math::mat4 getTransformAccurate(Instance ci) const noexcept {
+    math::mat4 getTransformAccurate(Instance const ci) const noexcept {
         math::mat4f const& local = mManager[ci].local;
         math::float3 const localTranslationLo = mManager[ci].localTranslationLo;
         math::mat4 r(local);
@@ -125,7 +125,7 @@ public:
         return r;
     }
 
-    math::mat4 getWorldTransformAccurate(Instance ci) const noexcept {
+    math::mat4 getWorldTransformAccurate(Instance const ci) const noexcept {
         math::mat4f const& world = mManager[ci].world;
         math::float3 const worldTranslationLo = mManager[ci].worldTranslationLo;
         math::mat4 r(world);

--- a/filament/src/details/BufferObject.cpp
+++ b/filament/src/details/BufferObject.cpp
@@ -47,6 +47,10 @@ BufferObject::Builder& BufferObject::Builder::bindingType(BindingType bindingTyp
     return *this;
 }
 
+BufferObject::Builder& BufferObject::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 BufferObject* BufferObject::Builder::build(Engine& engine) {
     return downcast(engine).createBufferObject(*this);
 }

--- a/filament/src/details/BufferObject.cpp
+++ b/filament/src/details/BufferObject.cpp
@@ -32,10 +32,10 @@ struct BufferObject::BuilderDetails {
 using BuilderType = BufferObject;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 BufferObject::Builder& BufferObject::Builder::size(uint32_t byteCount) noexcept {
     mImpl->mByteCount = byteCount;
@@ -57,7 +57,7 @@ BufferObject* BufferObject::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& builder)
+FBufferObject::FBufferObject(FEngine& engine, const Builder& builder)
         : mByteCount(builder->mByteCount), mBindingType(builder->mBindingType) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType,

--- a/filament/src/details/BufferObject.cpp
+++ b/filament/src/details/BufferObject.cpp
@@ -37,17 +37,17 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-BufferObject::Builder& BufferObject::Builder::size(uint32_t byteCount) noexcept {
+BufferObject::Builder& BufferObject::Builder::size(uint32_t const byteCount) noexcept {
     mImpl->mByteCount = byteCount;
     return *this;
 }
 
-BufferObject::Builder& BufferObject::Builder::bindingType(BindingType bindingType) noexcept {
+BufferObject::Builder& BufferObject::Builder::bindingType(BindingType const bindingType) noexcept {
     mImpl->mBindingType = bindingType;
     return *this;
 }
 
-BufferObject::Builder& BufferObject::Builder::name(const char* name, size_t len) noexcept {
+BufferObject::Builder& BufferObject::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -72,7 +72,7 @@ void FBufferObject::terminate(FEngine& engine) {
     driver.destroyBufferObject(mHandle);
 }
 
-void FBufferObject::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
+void FBufferObject::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t const byteOffset) {
     engine.getDriverApi().updateBufferObject(mHandle, std::move(buffer), byteOffset);
 }
 

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -47,11 +47,11 @@ FCamera::FCamera(FEngine& engine, Entity e)
           mEntity(e) {
 }
 
-math::mat4 FCamera::projection(Fov direction, double fovInDegrees,
+mat4 FCamera::projection(Fov direction, double fovInDegrees,
         double aspect, double near, double far) {
     double w;
     double h;
-    double const s = std::tan(fovInDegrees * math::d::DEG_TO_RAD / 2.0) * near;
+    double const s = std::tan(fovInDegrees * d::DEG_TO_RAD / 2.0) * near;
     if (direction == Fov::VERTICAL) {
         w = s * aspect;
         h = s;
@@ -59,7 +59,7 @@ math::mat4 FCamera::projection(Fov direction, double fovInDegrees,
         w = s;
         h = s / aspect;
     }
-    mat4 p = math::mat4::frustum(-w, w, -h, h, near, far);
+    mat4 p = mat4::frustum(-w, w, -h, h, near, far);
     if (far == std::numeric_limits<double>::infinity()) {
         p[2][2] = -1.0f;           // lim(far->inf) = -1
         p[3][2] = -2.0f * near;    // lim(far->inf) = -2*near
@@ -67,12 +67,12 @@ math::mat4 FCamera::projection(Fov direction, double fovInDegrees,
     return p;
 }
 
-math::mat4 FCamera::projection(double focalLengthInMillimeters,
+mat4 FCamera::projection(double focalLengthInMillimeters,
         double aspect, double near, double far) {
     // a 35mm camera has a 36x24mm wide frame size
     double const h = (0.5 * near) * ((SENSOR_SIZE * 1000.0) / focalLengthInMillimeters);
     double const w = h * aspect;
-    mat4 p = math::mat4::frustum(-w, w, -h, h, near, far);
+    mat4 p = mat4::frustum(-w, w, -h, h, near, far);
     if (far == std::numeric_limits<double>::infinity()) {
         p[2][2] = -1.0f;           // lim(far->inf) = -1
         p[3][2] = -2.0f * near;    // lim(far->inf) = -2*near
@@ -94,8 +94,8 @@ void UTILS_NOINLINE FCamera::setCustomProjection(mat4 const& p,
     mFar = far;
 }
 
-void UTILS_NOINLINE FCamera::setCustomEyeProjection(math::mat4 const* projection, size_t count,
-        math::mat4 const& projectionForCulling, double near, double far) {
+void UTILS_NOINLINE FCamera::setCustomEyeProjection(mat4 const* projection, size_t count,
+        mat4 const& projectionForCulling, double near, double far) {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(count >= config.stereoscopicEyeCount)
             << "All eye projections must be supplied together, count must be >= "
@@ -109,7 +109,7 @@ void UTILS_NOINLINE FCamera::setCustomEyeProjection(math::mat4 const* projection
     mFar = far;
 }
 
-void UTILS_NOINLINE FCamera::setProjection(Camera::Projection projection,
+void UTILS_NOINLINE FCamera::setProjection(Projection projection,
         double left, double right,
         double bottom, double top,
         double near, double far) {
@@ -118,7 +118,7 @@ void UTILS_NOINLINE FCamera::setProjection(Camera::Projection projection,
             (projection == Projection::PERSPECTIVE && (near <= 0 || far <= near)) ||
             (projection == Projection::ORTHO && (near == far))))
             << "Camera preconditions not met in setProjection("
-            << (projection == Camera::Projection::PERSPECTIVE ? "PERSPECTIVE" : "ORTHO") << ", "
+            << (projection == Projection::PERSPECTIVE ? "PERSPECTIVE" : "ORTHO") << ", "
             << left << ", " << right << ", " << bottom << ", " << top << ", " << near << ", " << far
             << ")";
 
@@ -161,10 +161,10 @@ void UTILS_NOINLINE FCamera::setProjection(Camera::Projection projection,
             p = c;
             break;
     }
-    FCamera::setCustomProjection(p, c, near, far);
+    setCustomProjection(p, c, near, far);
 }
 
-math::mat4 FCamera::getProjectionMatrix(uint8_t eye) const noexcept {
+mat4 FCamera::getProjectionMatrix(uint8_t eye) const noexcept {
     UTILS_UNUSED_IN_RELEASE const Engine::Config& config = mEngine.getConfig();
     assert_invariant(eye < config.stereoscopicEyeCount);
     // This is where we transform the user clip-space (GL convention) to our virtual clip-space
@@ -180,7 +180,7 @@ math::mat4 FCamera::getProjectionMatrix(uint8_t eye) const noexcept {
     return m * mEyeProjection[eye];
 }
 
-math::mat4 FCamera::getCullingProjectionMatrix() const noexcept {
+mat4 FCamera::getCullingProjectionMatrix() const noexcept {
     // The culling projection matrix stays in the GL convention
     const mat4 m{ mat4::row_major_init{
             mScalingCS.x, 0.0, 0.0, mShiftCS.x,
@@ -191,7 +191,7 @@ math::mat4 FCamera::getCullingProjectionMatrix() const noexcept {
     return m * mProjectionForCulling;
 }
 
-const math::mat4& FCamera::getUserProjectionMatrix(uint8_t eyeId) const {
+const mat4& FCamera::getUserProjectionMatrix(uint8_t eyeId) const {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(eyeId < config.stereoscopicEyeCount)
             << "eyeId must be < config.stereoscopicEyeCount (" << config.stereoscopicEyeCount
@@ -209,7 +209,7 @@ void UTILS_NOINLINE FCamera::setModelMatrix(const mat4& modelMatrix) noexcept {
     transformManager.setTransform(transformManager.getInstance(mEntity), modelMatrix);
 }
 
-void UTILS_NOINLINE FCamera::setEyeModelMatrix(uint8_t eyeId, math::mat4 const& model) {
+void UTILS_NOINLINE FCamera::setEyeModelMatrix(uint8_t eyeId, mat4 const& model) {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(eyeId < config.stereoscopicEyeCount)
             << "eyeId must be < config.stereoscopicEyeCount (" << config.stereoscopicEyeCount
@@ -245,7 +245,7 @@ void FCamera::setExposure(float aperture, float shutterSpeed, float sensitivity)
 
 double FCamera::getFocalLength() const noexcept {
     auto const& monoscopicEyeProjection = mEyeProjection[0];
-    return (FCamera::SENSOR_SIZE * monoscopicEyeProjection[1][1]) * 0.5;
+    return (SENSOR_SIZE * monoscopicEyeProjection[1][1]) * 0.5;
 }
 
 double FCamera::computeEffectiveFocalLength(double focalLength, double focusDistance) noexcept {
@@ -254,10 +254,10 @@ double FCamera::computeEffectiveFocalLength(double focalLength, double focusDist
 }
 
 double FCamera::computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept {
-    double const f = 0.5 * FCamera::SENSOR_SIZE / std::tan(fovInDegrees * math::d::DEG_TO_RAD * 0.5);
+    double const f = 0.5 * SENSOR_SIZE / std::tan(fovInDegrees * d::DEG_TO_RAD * 0.5);
     focusDistance = std::max(f, focusDistance);
-    double const fov = 2.0 * std::atan(FCamera::SENSOR_SIZE * (focusDistance - f) / (2.0 * focusDistance * f));
-    return fov * math::d::RAD_TO_DEG;
+    double const fov = 2.0 * std::atan(SENSOR_SIZE * (focusDistance - f) / (2.0 * focusDistance * f));
+    return fov * d::RAD_TO_DEG;
 }
 
 uint8_t FCamera::getStereoscopicEyeCount() const noexcept {
@@ -271,7 +271,7 @@ CameraInfo::CameraInfo(FCamera const& camera) noexcept
         : CameraInfo(camera, {}, camera.getModelMatrix()) {
 }
 
-CameraInfo::CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept
+CameraInfo::CameraInfo(FCamera const& camera, mat4 const& inWorldTransform) noexcept
         : CameraInfo(camera, inWorldTransform, inWorldTransform * camera.getModelMatrix()) {
 }
 
@@ -280,8 +280,8 @@ CameraInfo::CameraInfo(FCamera const& camera, CameraInfo const& mainCameraInfo) 
 }
 
 CameraInfo::CameraInfo(FCamera const& camera,
-        math::mat4 const& inWorldTransform,
-        math::mat4 const& modelMatrix) noexcept {
+        mat4 const& inWorldTransform,
+        mat4 const& modelMatrix) noexcept {
     for (size_t i = 0; i < camera.getStereoscopicEyeCount(); i++) {
         eyeProjection[i]   = mat4f{ camera.getProjectionMatrix(i) };
         eyeFromView[i]     = mat4f{ camera.getEyeFromViewMatrix(i) };

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -42,13 +42,13 @@ static constexpr const float MAX_SHUTTER_SPEED = 60.0f;
 static constexpr const float MIN_SENSITIVITY = 10.0f;
 static constexpr const float MAX_SENSITIVITY = 204800.0f;
 
-FCamera::FCamera(FEngine& engine, Entity e)
+FCamera::FCamera(FEngine& engine, Entity const e)
         : mEngine(engine),
           mEntity(e) {
 }
 
-mat4 FCamera::projection(Fov direction, double fovInDegrees,
-        double aspect, double near, double far) {
+mat4 FCamera::projection(Fov const direction, double const fovInDegrees,
+        double const aspect, double const near, double const far) {
     double w;
     double h;
     double const s = std::tan(fovInDegrees * d::DEG_TO_RAD / 2.0) * near;
@@ -67,8 +67,8 @@ mat4 FCamera::projection(Fov direction, double fovInDegrees,
     return p;
 }
 
-mat4 FCamera::projection(double focalLengthInMillimeters,
-        double aspect, double near, double far) {
+mat4 FCamera::projection(double const focalLengthInMillimeters,
+        double const aspect, double const near, double const far) {
     // a 35mm camera has a 36x24mm wide frame size
     double const h = (0.5 * near) * ((SENSOR_SIZE * 1000.0) / focalLengthInMillimeters);
     double const w = h * aspect;
@@ -85,7 +85,7 @@ mat4 FCamera::projection(double focalLengthInMillimeters,
  */
 
 void UTILS_NOINLINE FCamera::setCustomProjection(mat4 const& p,
-        mat4 const& c, double near, double far) noexcept {
+        mat4 const& c, double const near, double const far) noexcept {
     for (auto& eyeProjection: mEyeProjection) {
         eyeProjection = p;
     }
@@ -94,8 +94,8 @@ void UTILS_NOINLINE FCamera::setCustomProjection(mat4 const& p,
     mFar = far;
 }
 
-void UTILS_NOINLINE FCamera::setCustomEyeProjection(mat4 const* projection, size_t count,
-        mat4 const& projectionForCulling, double near, double far) {
+void UTILS_NOINLINE FCamera::setCustomEyeProjection(mat4 const* projection, size_t const count,
+        mat4 const& projectionForCulling, double const near, double const far) {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(count >= config.stereoscopicEyeCount)
             << "All eye projections must be supplied together, count must be >= "
@@ -109,10 +109,10 @@ void UTILS_NOINLINE FCamera::setCustomEyeProjection(mat4 const* projection, size
     mFar = far;
 }
 
-void UTILS_NOINLINE FCamera::setProjection(Projection projection,
-        double left, double right,
-        double bottom, double top,
-        double near, double far) {
+void UTILS_NOINLINE FCamera::setProjection(Projection const projection,
+        double const left, double const right,
+        double const bottom, double const top,
+        double const near, double const far) {
 
     FILAMENT_CHECK_PRECONDITION(!(left == right || bottom == top ||
             (projection == Projection::PERSPECTIVE && (near <= 0 || far <= near)) ||
@@ -164,7 +164,7 @@ void UTILS_NOINLINE FCamera::setProjection(Projection projection,
     setCustomProjection(p, c, near, far);
 }
 
-mat4 FCamera::getProjectionMatrix(uint8_t eye) const noexcept {
+mat4 FCamera::getProjectionMatrix(uint8_t const eye) const noexcept {
     UTILS_UNUSED_IN_RELEASE const Engine::Config& config = mEngine.getConfig();
     assert_invariant(eye < config.stereoscopicEyeCount);
     // This is where we transform the user clip-space (GL convention) to our virtual clip-space
@@ -191,7 +191,7 @@ mat4 FCamera::getCullingProjectionMatrix() const noexcept {
     return m * mProjectionForCulling;
 }
 
-const mat4& FCamera::getUserProjectionMatrix(uint8_t eyeId) const {
+const mat4& FCamera::getUserProjectionMatrix(uint8_t const eyeId) const {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(eyeId < config.stereoscopicEyeCount)
             << "eyeId must be < config.stereoscopicEyeCount (" << config.stereoscopicEyeCount
@@ -209,7 +209,7 @@ void UTILS_NOINLINE FCamera::setModelMatrix(const mat4& modelMatrix) noexcept {
     transformManager.setTransform(transformManager.getInstance(mEntity), modelMatrix);
 }
 
-void UTILS_NOINLINE FCamera::setEyeModelMatrix(uint8_t eyeId, mat4 const& model) {
+void UTILS_NOINLINE FCamera::setEyeModelMatrix(uint8_t const eyeId, mat4 const& model) {
     const Engine::Config& config = mEngine.getConfig();
     FILAMENT_CHECK_PRECONDITION(eyeId < config.stereoscopicEyeCount)
             << "eyeId must be < config.stereoscopicEyeCount (" << config.stereoscopicEyeCount
@@ -237,7 +237,7 @@ Frustum FCamera::getCullingFrustum() const noexcept {
     return Frustum(mat4f{ getCullingProjectionMatrix() * getViewMatrix() });
 }
 
-void FCamera::setExposure(float aperture, float shutterSpeed, float sensitivity) noexcept {
+void FCamera::setExposure(float const aperture, float const shutterSpeed, float const sensitivity) noexcept {
     mAperture = clamp(aperture, MIN_APERTURE, MAX_APERTURE);
     mShutterSpeed = clamp(shutterSpeed, MIN_SHUTTER_SPEED, MAX_SHUTTER_SPEED);
     mSensitivity = clamp(sensitivity, MIN_SENSITIVITY, MAX_SENSITIVITY);
@@ -248,12 +248,12 @@ double FCamera::getFocalLength() const noexcept {
     return (SENSOR_SIZE * monoscopicEyeProjection[1][1]) * 0.5;
 }
 
-double FCamera::computeEffectiveFocalLength(double focalLength, double focusDistance) noexcept {
+double FCamera::computeEffectiveFocalLength(double const focalLength, double focusDistance) noexcept {
     focusDistance = std::max(focalLength, focusDistance);
     return (focusDistance * focalLength) / (focusDistance - focalLength);
 }
 
-double FCamera::computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept {
+double FCamera::computeEffectiveFov(double const fovInDegrees, double focusDistance) noexcept {
     double const f = 0.5 * SENSOR_SIZE / std::tan(fovInDegrees * d::DEG_TO_RAD * 0.5);
     focusDistance = std::max(f, focusDistance);
     double const fov = 2.0 * std::atan(SENSOR_SIZE * (focusDistance - f) / (2.0 * focusDistance * f));

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -135,7 +135,7 @@ public:
         return normalize(-getModelMatrix()[2].xyz);
     }
 
-    float getFieldOfView(Camera::Fov direction) const noexcept {
+    float getFieldOfView(Fov direction) const noexcept {
         // note: this is meaningless for an orthographic projection
         auto const& p = getProjectionMatrix();
         switch (direction) {
@@ -146,7 +146,7 @@ public:
         }
     }
 
-    float getFieldOfViewInDegrees(Camera::Fov direction) const noexcept {
+    float getFieldOfViewInDegrees(Fov direction) const noexcept {
         return getFieldOfView(direction) * math::f::RAD_TO_DEG;
     }
 

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -59,7 +59,7 @@ public:
             math::mat4 const& projectionForCulling, double near, double far) noexcept;
 
     inline void setCustomProjection(math::mat4 const& projection,
-            double near, double far) noexcept {
+            double const near, double const far) noexcept {
         setCustomProjection(projection, projection, near, far);
     }
 
@@ -67,11 +67,11 @@ public:
             math::mat4 const& projectionForCulling, double near, double far);
 
 
-    void setScaling(math::double2 scaling) noexcept { mScalingCS = scaling; }
+    void setScaling(math::double2 const scaling) noexcept { mScalingCS = scaling; }
 
     math::double4 getScaling() const noexcept { return math::double4{ mScalingCS, 1.0, 1.0 }; }
 
-    void setShift(math::double2 shift) noexcept { mShiftCS = shift * 2.0; }
+    void setShift(math::double2 const shift) noexcept { mShiftCS = shift * 2.0; }
 
     math::double2 getShift() const noexcept { return mShiftCS * 0.5; }
 
@@ -82,7 +82,7 @@ public:
     // culling the projection matrix to be used for culling, contains scaling/shift
     math::mat4 getCullingProjectionMatrix() const noexcept;
 
-    math::mat4 getEyeFromViewMatrix(uint8_t eye) const noexcept { return mEyeFromView[eye]; }
+    math::mat4 getEyeFromViewMatrix(uint8_t const eye) const noexcept { return mEyeFromView[eye]; }
 
     // viewing projection matrix set by the user
     const math::mat4& getUserProjectionMatrix(uint8_t eyeId) const;
@@ -135,7 +135,7 @@ public:
         return normalize(-getModelMatrix()[2].xyz);
     }
 
-    float getFieldOfView(Fov direction) const noexcept {
+    float getFieldOfView(Fov const direction) const noexcept {
         // note: this is meaningless for an orthographic projection
         auto const& p = getProjectionMatrix();
         switch (direction) {
@@ -146,7 +146,7 @@ public:
         }
     }
 
-    float getFieldOfViewInDegrees(Fov direction) const noexcept {
+    float getFieldOfViewInDegrees(Fov const direction) const noexcept {
         return getFieldOfView(direction) * math::f::RAD_TO_DEG;
     }
 
@@ -171,7 +171,7 @@ public:
         return mSensitivity;
     }
 
-    void setFocusDistance(float distance) noexcept {
+    void setFocusDistance(float const distance) noexcept {
         mFocusDistance = distance;
     }
 

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -133,26 +133,26 @@ struct ColorGrading::BuilderDetails {
 using BuilderType = ColorGrading;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-ColorGrading::Builder& ColorGrading::Builder::quality(ColorGrading::QualityLevel qualityLevel) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::quality(QualityLevel qualityLevel) noexcept {
     switch (qualityLevel) {
-        case ColorGrading::QualityLevel::LOW:
+        case QualityLevel::LOW:
             mImpl->format = LutFormat::INTEGER;
             mImpl->dimension = 16;
             break;
-        case ColorGrading::QualityLevel::MEDIUM:
+        case QualityLevel::MEDIUM:
             mImpl->format = LutFormat::INTEGER;
             mImpl->dimension = 32;
             break;
-        case ColorGrading::QualityLevel::HIGH:
+        case QualityLevel::HIGH:
             mImpl->format = LutFormat::FLOAT;
             mImpl->dimension = 32;
             break;
-        case ColorGrading::QualityLevel::ULTRA:
+        case QualityLevel::ULTRA:
             mImpl->format = LutFormat::FLOAT;
             mImpl->dimension = 64;
             break;
@@ -166,7 +166,7 @@ ColorGrading::Builder& ColorGrading::Builder::format(LutFormat format) noexcept 
 }
 
 ColorGrading::Builder& ColorGrading::Builder::dimensions(uint8_t dim) noexcept {
-    mImpl->dimension = math::clamp(+dim, 16, 64);
+    mImpl->dimension = clamp(+dim, 16, 64);
     return *this;
 }
 
@@ -649,9 +649,9 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     Config c;
     // This lock protects the data inside Config, which is written to by the Filament thread,
     // and read from multiple Job threads.
-    utils::Mutex configLock;
+    Mutex configLock;
     {
-        std::lock_guard<utils::Mutex> const lock(configLock);
+        std::lock_guard<Mutex> const lock(configLock);
         c.lutDimension          = builder->dimension;
         c.adaptationTransform   = adaptationTransform(builder->whiteBalance);
         c.colorGradingIn        = selectColorGradingTransformIn(builder->toneMapping);
@@ -688,7 +688,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
                 [data, converted, b, &c, &configLock, builder](JobSystem&, JobSystem::Job*) {
             Config config;
             {
-                std::lock_guard<utils::Mutex> lock(configLock);
+                std::lock_guard<Mutex> lock(configLock);
                 config = c;
             }
             half4* UTILS_RESTRICT p = (half4*) data + b * config.lutDimension * config.lutDimension;

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -138,7 +138,7 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-ColorGrading::Builder& ColorGrading::Builder::quality(QualityLevel qualityLevel) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::quality(QualityLevel const qualityLevel) noexcept {
     switch (qualityLevel) {
         case QualityLevel::LOW:
             mImpl->format = LutFormat::INTEGER;
@@ -160,12 +160,12 @@ ColorGrading::Builder& ColorGrading::Builder::quality(QualityLevel qualityLevel)
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::format(LutFormat format) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::format(LutFormat const format) noexcept {
     mImpl->format = format;
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::dimensions(uint8_t dim) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::dimensions(uint8_t const dim) noexcept {
     mImpl->dimension = clamp(+dim, 16, 64);
     return *this;
 }
@@ -175,32 +175,32 @@ ColorGrading::Builder& ColorGrading::Builder::toneMapper(const ToneMapper* toneM
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::toneMapping(ToneMapping toneMapping) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::toneMapping(ToneMapping const toneMapping) noexcept {
     mImpl->toneMapping = toneMapping;
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::luminanceScaling(bool luminanceScaling) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::luminanceScaling(bool const luminanceScaling) noexcept {
     mImpl->luminanceScaling = luminanceScaling;
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::gamutMapping(bool gamutMapping) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::gamutMapping(bool const gamutMapping) noexcept {
     mImpl->gamutMapping = gamutMapping;
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::exposure(float exposure) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::exposure(float const exposure) noexcept {
     mImpl->exposure = exposure;
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::nightAdaptation(float adaptation) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::nightAdaptation(float const adaptation) noexcept {
     mImpl->nightAdaptation = saturate(adaptation);
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::whiteBalance(float temperature, float tint) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::whiteBalance(float const temperature, float const tint) noexcept {
     mImpl->whiteBalance = float2{
         clamp(temperature, -1.0f, 1.0f),
         clamp(tint, -1.0f, 1.0f)
@@ -239,17 +239,17 @@ ColorGrading::Builder& ColorGrading::Builder::slopeOffsetPower(
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::contrast(float contrast) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::contrast(float const contrast) noexcept {
     mImpl->contrast = clamp(contrast, 0.0f, 2.0f);
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::vibrance(float vibrance) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::vibrance(float const vibrance) noexcept {
     mImpl->vibrance = clamp(vibrance, 0.0f, 2.0f);
     return *this;
 }
 
-ColorGrading::Builder& ColorGrading::Builder::saturation(float saturation) noexcept {
+ColorGrading::Builder& ColorGrading::Builder::saturation(float const saturation) noexcept {
     mImpl->saturation = clamp(saturation, 0.0f, 2.0f);
     return *this;
 }
@@ -316,7 +316,7 @@ ColorGrading* ColorGrading::Builder::build(Engine& engine) {
 //------------------------------------------------------------------------------
 
 UTILS_ALWAYS_INLINE
-inline float3 adjustExposure(float3 v, float exposure) {
+inline float3 adjustExposure(float3 const v, float const exposure) {
     return v * std::exp2(exposure);
 }
 
@@ -437,7 +437,7 @@ float3 scotopicAdaptation(float3 v, float nightAdaptation) noexcept {
 // the von Kries method, using the CIECAT16 transform.
 // See https://en.wikipedia.org/wiki/Chromatic_adaptation
 // See https://en.wikipedia.org/wiki/CIECAM02#Chromatic_adaptation
-constexpr mat3f adaptationTransform(float2 whiteBalance) noexcept {
+constexpr mat3f adaptationTransform(float2 const whiteBalance) noexcept {
     // See Mathematica notebook in docs/math/White Balance.nb
     float k = whiteBalance.x; // temperature
     float t = whiteBalance.y; // tint
@@ -450,7 +450,7 @@ constexpr mat3f adaptationTransform(float2 whiteBalance) noexcept {
 }
 
 UTILS_ALWAYS_INLINE
-inline float3 chromaticAdaptation(float3 v, mat3f adaptationTransform) {
+inline float3 chromaticAdaptation(float3 const v, mat3f adaptationTransform) {
     return adaptationTransform * v;
 }
 
@@ -499,7 +499,7 @@ inline float3 colorDecisionList(float3 v, float3 slope, float3 offset, float3 po
 }
 
 UTILS_ALWAYS_INLINE
-inline constexpr float3 contrast(float3 v, float contrast) {
+inline constexpr float3 contrast(float3 const v, float const contrast) {
     // Matches contrast as applied in DaVinci Resolve
     return MIDDLE_GRAY_ACEScct + contrast * (v - MIDDLE_GRAY_ACEScct);
 }
@@ -574,7 +574,7 @@ static float3 luminanceScaling(float3 x,
 //------------------------------------------------------------------------------
 
 static std::tuple<TextureFormat, PixelDataFormat, PixelDataType>
-        selectLutTextureParams(ColorGrading::LutFormat lutFormat) noexcept {
+        selectLutTextureParams(ColorGrading::LutFormat const lutFormat) noexcept {
     // We use RGBA16F for high quality modes instead of RGB16F because RGB16F
     // is not supported everywhere
     switch (lutFormat) {
@@ -592,21 +592,21 @@ static std::tuple<TextureFormat, PixelDataFormat, PixelDataType>
 // forces post-processing to be performed in sRGB to guarantee that the inverse tone
 // mapping function in the shaders will match the forward tone mapping step exactly.
 
-static mat3f selectColorGradingTransformIn(ColorGrading::ToneMapping toneMapping) noexcept {
+static mat3f selectColorGradingTransformIn(ColorGrading::ToneMapping const toneMapping) noexcept {
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
         return mat3f{};
     }
     return sRGB_to_Rec2020;
 }
 
-static mat3f selectColorGradingTransformOut(ColorGrading::ToneMapping toneMapping) noexcept {
+static mat3f selectColorGradingTransformOut(ColorGrading::ToneMapping const toneMapping) noexcept {
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
         return mat3f{};
     }
     return Rec2020_to_sRGB;
 }
 
-static float3 selectColorGradingLuminance(ColorGrading::ToneMapping toneMapping) noexcept {
+static float3 selectColorGradingLuminance(ColorGrading::ToneMapping const toneMapping) noexcept {
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
         return LUMINANCE_Rec709;
     }

--- a/filament/src/details/DebugRegistry.cpp
+++ b/filament/src/details/DebugRegistry.cpp
@@ -121,7 +121,7 @@ bool FDebugRegistry::registerDataSource(std::string_view name,
 }
 
 bool FDebugRegistry::registerDataSource(std::string_view name,
-        utils::Invocable<DataSource()>&& creator) noexcept {
+        Invocable<DataSource()>&& creator) noexcept {
     auto& dataSourceCreatorMap = mDataSourceCreatorMap;
     bool const found = dataSourceCreatorMap.find(name) == dataSourceCreatorMap.end();
     if (found) {

--- a/filament/src/details/DebugRegistry.cpp
+++ b/filament/src/details/DebugRegistry.cpp
@@ -59,7 +59,7 @@ void const* FDebugRegistry::getPropertyAddress(const char* name) const noexcept 
     return info.first;
 }
 
-void FDebugRegistry::registerProperty(std::string_view name, void* p, Type,
+void FDebugRegistry::registerProperty(std::string_view const name, void* p, Type,
         std::function<void()> fn) noexcept {
     auto& propertyMap = mPropertyMap;
     if (propertyMap.find(name) == propertyMap.end()) {
@@ -110,8 +110,8 @@ template bool FDebugRegistry::getProperty<float2>(const char* name, float2* v) c
 template bool FDebugRegistry::getProperty<float3>(const char* name, float3* v) const noexcept;
 template bool FDebugRegistry::getProperty<float4>(const char* name, float4* v) const noexcept;
 
-bool FDebugRegistry::registerDataSource(std::string_view name,
-        void const* data, size_t count) noexcept {
+bool FDebugRegistry::registerDataSource(std::string_view const name,
+        void const* data, size_t const count) noexcept {
     auto& dataSourceMap = mDataSourceMap;
     bool const found = dataSourceMap.find(name) == dataSourceMap.end();
     if (found) {
@@ -120,7 +120,7 @@ bool FDebugRegistry::registerDataSource(std::string_view name,
     return found;
 }
 
-bool FDebugRegistry::registerDataSource(std::string_view name,
+bool FDebugRegistry::registerDataSource(std::string_view const name,
         Invocable<DataSource()>&& creator) noexcept {
     auto& dataSourceCreatorMap = mDataSourceCreatorMap;
     bool const found = dataSourceCreatorMap.find(name) == dataSourceCreatorMap.end();
@@ -130,7 +130,7 @@ bool FDebugRegistry::registerDataSource(std::string_view name,
     return found;
 }
 
-void FDebugRegistry::unregisterDataSource(std::string_view name) noexcept {
+void FDebugRegistry::unregisterDataSource(std::string_view const name) noexcept {
     mDataSourceCreatorMap.erase(name);
     mDataSourceMap.erase(name);
 }

--- a/filament/src/details/DebugRegistry.h
+++ b/filament/src/details/DebugRegistry.h
@@ -45,57 +45,57 @@ public:
 
     FDebugRegistry() noexcept;
 
-    void registerProperty(std::string_view name, bool* p) noexcept {
+    void registerProperty(std::string_view const name, bool* p) noexcept {
         registerProperty(name, p, BOOL);
     }
 
-    void registerProperty(std::string_view name, int* p) noexcept {
+    void registerProperty(std::string_view const name, int* p) noexcept {
         registerProperty(name, p, INT);
     }
 
-    void registerProperty(std::string_view name, float* p) noexcept {
+    void registerProperty(std::string_view const name, float* p) noexcept {
         registerProperty(name, p, FLOAT);
     }
 
-    void registerProperty(std::string_view name, math::float2* p) noexcept {
+    void registerProperty(std::string_view const name, math::float2* p) noexcept {
         registerProperty(name, p, FLOAT2);
     }
 
-    void registerProperty(std::string_view name, math::float3* p) noexcept {
+    void registerProperty(std::string_view const name, math::float3* p) noexcept {
         registerProperty(name, p, FLOAT3);
     }
 
-    void registerProperty(std::string_view name, math::float4* p) noexcept {
+    void registerProperty(std::string_view const name, math::float4* p) noexcept {
         registerProperty(name, p, FLOAT4);
     }
 
 
-    void registerProperty(std::string_view name, bool* p,
+    void registerProperty(std::string_view const name, bool* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, BOOL, std::move(fn));
     }
 
-    void registerProperty(std::string_view name, int* p,
+    void registerProperty(std::string_view const name, int* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, INT, std::move(fn));
     }
 
-    void registerProperty(std::string_view name, float* p,
+    void registerProperty(std::string_view const name, float* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, FLOAT, std::move(fn));
     }
 
-    void registerProperty(std::string_view name, math::float2* p,
+    void registerProperty(std::string_view const name, math::float2* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, FLOAT2, std::move(fn));
     }
 
-    void registerProperty(std::string_view name, math::float3* p,
+    void registerProperty(std::string_view const name, math::float3* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, FLOAT3, std::move(fn));
     }
 
-    void registerProperty(std::string_view name, math::float4* p,
+    void registerProperty(std::string_view const name, math::float4* p,
             std::function<void()> fn) noexcept {
         registerProperty(name, p, FLOAT4, std::move(fn));
     }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -81,7 +81,7 @@ using namespace filaflat;
 struct Engine::BuilderDetails {
     Backend mBackend = Backend::DEFAULT;
     Platform* mPlatform = nullptr;
-    Engine::Config mConfig;
+    Config mConfig;
     FeatureLevel mFeatureLevel = FeatureLevel::FEATURE_LEVEL_1;
     void* mSharedContext = nullptr;
     bool mPaused = false;
@@ -90,7 +90,7 @@ struct Engine::BuilderDetails {
     static Config validateConfig(Config config) noexcept;
 };
 
-Engine* FEngine::create(Engine::Builder const& builder) {
+Engine* FEngine::create(Builder const& builder) {
     SYSTRACE_ENABLE();
     SYSTRACE_CALL();
 
@@ -153,7 +153,7 @@ Engine* FEngine::create(Engine::Builder const& builder) {
 
 #if UTILS_HAS_THREADING
 
-void FEngine::create(Engine::Builder const& builder, Invocable<void(void*)>&& callback) {
+void FEngine::create(Builder const& builder, Invocable<void(void*)>&& callback) {
     SYSTRACE_ENABLE();
     SYSTRACE_CALL();
 
@@ -208,7 +208,7 @@ static constexpr float4 sFullScreenTriangleVertices[3] = {
 // these must be static because only a pointer is copied to the render stream
 static const uint16_t sFullScreenTriangleIndices[3] = { 0, 1, 2 };
 
-FEngine::FEngine(Engine::Builder const& builder) :
+FEngine::FEngine(Builder const& builder) :
         mBackend(builder->mBackend),
         mActiveFeatureLevel(builder->mFeatureLevel),
         mPlatform(builder->mPlatform),
@@ -268,7 +268,7 @@ FEngine::FEngine(Engine::Builder const& builder) :
            << "(threading is " << (UTILS_HAS_THREADING ? "enabled)" : "disabled)") << io::endl;
 }
 
-uint32_t FEngine::getJobSystemThreadPoolSize(Engine::Config const& config) noexcept {
+uint32_t FEngine::getJobSystemThreadPoolSize(Config const& config) noexcept {
     if (config.jobSystemThreadCount > 0) {
         return config.jobSystemThreadCount;
     }
@@ -309,7 +309,7 @@ void FEngine::init() {
     mFullScreenTriangleVb = downcast(VertexBuffer::Builder()
             .vertexCount(3)
             .bufferCount(1)
-            .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT4, 0)
+            .attribute(POSITION, 0, VertexBuffer::AttributeType::FLOAT4, 0)
             .build(*this));
 
     mFullScreenTriangleVb->setBufferAt(*this, 0,
@@ -635,7 +635,7 @@ void FEngine::prepare() {
     // prepare() is called once per Renderer frame. Ideally we would upload the content of
     // UBOs that are visible only. It's not such a big issue because the actual upload() is
     // skipped if the UBO hasn't changed. Still we could have a lot of these.
-    FEngine::DriverApi& driver = getDriverApi();
+    DriverApi& driver = getDriverApi();
 
     for (auto& materialInstanceList: mMaterialInstances) {
         materialInstanceList.second.forEach([&driver](FMaterialInstance* item) {
@@ -703,7 +703,7 @@ void FEngine::flushAndWait() {
 
 #else
 
-    FFence::waitAndDestroy(FEngine::createFence(), FFence::Mode::FLUSH);
+    FFence::waitAndDestroy(createFence(), FFence::Mode::FLUSH);
 
 #endif
 
@@ -965,7 +965,7 @@ FCamera* FEngine::getCameraComponent(Entity entity) noexcept {
     return ci ? mCameraManager.getCamera(ci) : nullptr;
 }
 
-void FEngine::destroyCameraComponent(utils::Entity entity) noexcept {
+void FEngine::destroyCameraComponent(Entity entity) noexcept {
     mCameraManager.destroy(*this, entity);
 }
 
@@ -1378,7 +1378,7 @@ void FEngine::setPaused(bool paused) {
 }
 
 Engine::FeatureLevel FEngine::getSupportedFeatureLevel() const noexcept {
-    FEngine::DriverApi& driver = const_cast<FEngine*>(this)->getDriverApi();
+    DriverApi& driver = const_cast<FEngine*>(this)->getDriverApi();
     return driver.getFeatureLevel();
 }
 
@@ -1433,10 +1433,10 @@ bool* FEngine::getFeatureFlagPtr(std::string_view name, bool allowConstant) cons
 
 Engine::Builder::Builder() noexcept = default;
 Engine::Builder::~Builder() noexcept = default;
-Engine::Builder::Builder(Engine::Builder const& rhs) noexcept = default;
-Engine::Builder::Builder(Engine::Builder&& rhs) noexcept = default;
-Engine::Builder& Engine::Builder::operator=(Engine::Builder const& rhs) noexcept = default;
-Engine::Builder& Engine::Builder::operator=(Engine::Builder&& rhs) noexcept = default;
+Engine::Builder::Builder(Builder const& rhs) noexcept = default;
+Engine::Builder::Builder(Builder&& rhs) noexcept = default;
+Engine::Builder& Engine::Builder::operator=(Builder const& rhs) noexcept = default;
+Engine::Builder& Engine::Builder::operator=(Builder&& rhs) noexcept = default;
 
 Engine::Builder& Engine::Builder::backend(Backend backend) noexcept {
     mImpl->mBackend = backend;
@@ -1448,8 +1448,8 @@ Engine::Builder& Engine::Builder::platform(Platform* platform) noexcept {
     return *this;
 }
 
-Engine::Builder& Engine::Builder::config(Engine::Config const* config) noexcept {
-    mImpl->mConfig = config ? *config : Engine::Config{};
+Engine::Builder& Engine::Builder::config(Config const* config) noexcept {
+    mImpl->mConfig = config ? *config : Config{};
     return *this;
 }
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -235,7 +235,7 @@ FEngine::FEngine(Builder const& builder) :
 {
     // update a feature flag from Engine::Config if the flag is not specified in the Builder
     auto const featureFlagsBackwardCompatibility =
-            [this, &builder](std::string_view name, bool value) {
+            [this, &builder](std::string_view const name, bool const value) {
         if (builder->mFeatureFlags.find(name) == builder->mFeatureFlags.end()) {
             auto* const p = getFeatureFlagPtr(name, true);
             if (p) {
@@ -956,21 +956,21 @@ FSwapChain* FEngine::createSwapChain(uint32_t width, uint32_t height, uint64_t f
  */
 
 
-FCamera* FEngine::createCamera(Entity entity) noexcept {
+FCamera* FEngine::createCamera(Entity const entity) noexcept {
     return mCameraManager.create(*this, entity);
 }
 
-FCamera* FEngine::getCameraComponent(Entity entity) noexcept {
+FCamera* FEngine::getCameraComponent(Entity const entity) noexcept {
     auto ci = mCameraManager.getInstance(entity);
     return ci ? mCameraManager.getCamera(ci) : nullptr;
 }
 
-void FEngine::destroyCameraComponent(Entity entity) noexcept {
+void FEngine::destroyCameraComponent(Entity const entity) noexcept {
     mCameraManager.destroy(*this, entity);
 }
 
 
-void FEngine::createRenderable(const RenderableManager::Builder& builder, Entity entity) {
+void FEngine::createRenderable(const RenderableManager::Builder& builder, Entity const entity) {
     mRenderableManager.create(builder, entity);
     auto& tcm = mTransformManager;
     // if this entity doesn't have a transform component, add one.
@@ -979,7 +979,7 @@ void FEngine::createRenderable(const RenderableManager::Builder& builder, Entity
     }
 }
 
-void FEngine::createLight(const LightManager::Builder& builder, Entity entity) {
+void FEngine::createLight(const LightManager::Builder& builder, Entity const entity) {
     mLightManager.create(builder, entity);
 }
 
@@ -1210,7 +1210,7 @@ bool FEngine::destroy(const FMaterialInstance* ptr) {
 }
 
 UTILS_NOINLINE
-void FEngine::destroy(Entity e) {
+void FEngine::destroy(Entity const e) {
     mRenderableManager.destroy(e);
     mLightManager.destroy(e);
     mTransformManager.destroy(e);
@@ -1335,7 +1335,7 @@ size_t FEngine::getMaxShadowMapCount() const noexcept {
         CONFIG_MAX_SHADOWMAPS : CONFIG_MAX_SHADOW_LAYERS;
 }
 
-void* FEngine::streamAlloc(size_t size, size_t alignment) noexcept {
+void* FEngine::streamAlloc(size_t const size, size_t const alignment) noexcept {
     // we allow this only for small allocations
     if (size > 65536) {
         return nullptr;
@@ -1373,7 +1373,7 @@ bool FEngine::isPaused() const noexcept {
     return mCommandBufferQueue.isPaused();
 }
 
-void FEngine::setPaused(bool paused) {
+void FEngine::setPaused(bool const paused) {
     mCommandBufferQueue.setPaused(paused);
 }
 
@@ -1403,7 +1403,7 @@ void FEngine::unprotected() noexcept {
     mUnprotectedDummySwapchain->makeCurrent(getDriverApi());
 }
 
-bool FEngine::setFeatureFlag(char const* name, bool value) noexcept {
+bool FEngine::setFeatureFlag(char const* name, bool const value) noexcept {
     auto* const p = getFeatureFlagPtr(name);
     if (p) {
         *p = value;
@@ -1419,7 +1419,7 @@ std::optional<bool> FEngine::getFeatureFlag(char const* name) const noexcept {
     return std::nullopt;
 }
 
-bool* FEngine::getFeatureFlagPtr(std::string_view name, bool allowConstant) const noexcept {
+bool* FEngine::getFeatureFlagPtr(std::string_view name, bool const allowConstant) const noexcept {
     auto pos = std::find_if(mFeatures.begin(), mFeatures.end(),
             [name](FeatureFlag const& entry) {
                 return name == entry.name;
@@ -1438,7 +1438,7 @@ Engine::Builder::Builder(Builder&& rhs) noexcept = default;
 Engine::Builder& Engine::Builder::operator=(Builder const& rhs) noexcept = default;
 Engine::Builder& Engine::Builder::operator=(Builder&& rhs) noexcept = default;
 
-Engine::Builder& Engine::Builder::backend(Backend backend) noexcept {
+Engine::Builder& Engine::Builder::backend(Backend const backend) noexcept {
     mImpl->mBackend = backend;
     return *this;
 }
@@ -1453,7 +1453,7 @@ Engine::Builder& Engine::Builder::config(Config const* config) noexcept {
     return *this;
 }
 
-Engine::Builder& Engine::Builder::featureLevel(FeatureLevel featureLevel) noexcept {
+Engine::Builder& Engine::Builder::featureLevel(FeatureLevel const featureLevel) noexcept {
     mImpl->mFeatureLevel = featureLevel;
     return *this;
 }
@@ -1463,17 +1463,17 @@ Engine::Builder& Engine::Builder::sharedContext(void* sharedContext) noexcept {
     return *this;
 }
 
-Engine::Builder& Engine::Builder::paused(bool paused) noexcept {
+Engine::Builder& Engine::Builder::paused(bool const paused) noexcept {
     mImpl->mPaused = paused;
     return *this;
 }
 
-Engine::Builder& Engine::Builder::feature(char const* name, bool value) noexcept {
+Engine::Builder& Engine::Builder::feature(char const* name, bool const value) noexcept {
     mImpl->mFeatureFlags[name] = value;
     return *this;
 }
 
-Engine::Builder& Engine::Builder::features(std::initializer_list<char const *> list) noexcept {
+Engine::Builder& Engine::Builder::features(std::initializer_list<char const *> const list) noexcept {
     for (auto name : list) {
         if (name) {
             feature(name, true);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -498,7 +498,7 @@ public:
     Config const& getConfig() const noexcept { return mConfig; }
 
     bool hasFeatureLevel(backend::FeatureLevel neededFeatureLevel) const noexcept {
-        return FEngine::getActiveFeatureLevel() >= neededFeatureLevel;
+        return getActiveFeatureLevel() >= neededFeatureLevel;
     }
 
     auto const& getMaterialInstanceResourceList() const noexcept {
@@ -510,7 +510,7 @@ public:
 #endif
 
 private:
-    explicit FEngine(Engine::Builder const& builder);
+    explicit FEngine(Builder const& builder);
     void init();
     void shutdown();
 
@@ -602,7 +602,7 @@ private:
     HeapAllocatorArena mHeapAllocator;
 
     utils::JobSystem mJobSystem;
-    static uint32_t getJobSystemThreadPoolSize(Engine::Config const& config) noexcept;
+    static uint32_t getJobSystemThreadPoolSize(Config const& config) noexcept;
 
     std::default_random_engine mRandomEngine;
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -115,7 +115,7 @@ class ResourceAllocator;
 class FEngine : public Engine {
 public:
 
-    inline void* operator new(std::size_t size) noexcept {
+    inline void* operator new(std::size_t const size) noexcept {
         return utils::aligned_alloc(size, alignof(FEngine));
     }
 
@@ -453,7 +453,7 @@ public:
 
     void unprotected() noexcept;
 
-    void setAutomaticInstancingEnabled(bool enable) noexcept {
+    void setAutomaticInstancingEnabled(bool const enable) noexcept {
         // instancing is not allowed at feature level 0
         if (hasFeatureLevel(FeatureLevel::FEATURE_LEVEL_1)) {
             mAutomaticInstancingEnabled = enable;
@@ -497,7 +497,7 @@ public:
     size_t getRequestedDriverHandleArenaSize() const noexcept { return mConfig.driverHandleArenaSizeMB * MiB; }
     Config const& getConfig() const noexcept { return mConfig; }
 
-    bool hasFeatureLevel(backend::FeatureLevel neededFeatureLevel) const noexcept {
+    bool hasFeatureLevel(backend::FeatureLevel const neededFeatureLevel) const noexcept {
         return getActiveFeatureLevel() >= neededFeatureLevel;
     }
 

--- a/filament/src/details/Fence.cpp
+++ b/filament/src/details/Fence.cpp
@@ -103,20 +103,20 @@ FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
 
 UTILS_NOINLINE
 void FFence::FenceSignal::signal(State s) noexcept {
-    std::lock_guard<utils::Mutex> const lock(FFence::sLock);
+    std::lock_guard<utils::Mutex> const lock(sLock);
     mState = s;
-    FFence::sCondition.notify_all();
+    sCondition.notify_all();
 }
 
 UTILS_NOINLINE
 Fence::FenceStatus FFence::FenceSignal::wait(uint64_t timeout) noexcept {
-    std::unique_lock<utils::Mutex> lock(FFence::sLock);
+    std::unique_lock<utils::Mutex> lock(sLock);
     while (mState == UNSIGNALED) {
         if (mState == DESTROYED) {
             return FenceStatus::ERROR;
         }
         if (timeout == FENCE_WAIT_FOR_EVER) {
-            FFence::sCondition.wait(lock);
+            sCondition.wait(lock);
         } else {
             if (timeout == 0 ||
                     sCondition.wait_for(lock, ns(timeout)) == std::cv_status::timeout) {

--- a/filament/src/details/Fence.cpp
+++ b/filament/src/details/Fence.cpp
@@ -52,7 +52,7 @@ void FFence::terminate(FEngine&) noexcept {
 }
 
 UTILS_NOINLINE
-FenceStatus FFence::waitAndDestroy(FFence* fence, Mode mode) noexcept {
+FenceStatus FFence::waitAndDestroy(FFence* fence, Mode const mode) noexcept {
     assert_invariant(fence);
     FenceStatus const status = fence->wait(mode, FENCE_WAIT_FOR_EVER);
     fence->mEngine.destroy(fence);
@@ -60,7 +60,7 @@ FenceStatus FFence::waitAndDestroy(FFence* fence, Mode mode) noexcept {
 }
 
 UTILS_NOINLINE
-FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
+FenceStatus FFence::wait(Mode const mode, uint64_t const timeout) noexcept {
     FILAMENT_CHECK_PRECONDITION(UTILS_HAS_THREADING || timeout == 0)
             << "Non-zero timeout requires threads.";
 
@@ -102,14 +102,14 @@ FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
 }
 
 UTILS_NOINLINE
-void FFence::FenceSignal::signal(State s) noexcept {
+void FFence::FenceSignal::signal(State const s) noexcept {
     std::lock_guard<utils::Mutex> const lock(sLock);
     mState = s;
     sCondition.notify_all();
 }
 
 UTILS_NOINLINE
-Fence::FenceStatus FFence::FenceSignal::wait(uint64_t timeout) noexcept {
+Fence::FenceStatus FFence::FenceSignal::wait(uint64_t const timeout) noexcept {
     std::unique_lock<utils::Mutex> lock(sLock);
     while (mState == UNSIGNALED) {
         if (mState == DESTROYED) {

--- a/filament/src/details/IndexBuffer.cpp
+++ b/filament/src/details/IndexBuffer.cpp
@@ -37,17 +37,17 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-IndexBuffer::Builder& IndexBuffer::Builder::indexCount(uint32_t indexCount) noexcept {
+IndexBuffer::Builder& IndexBuffer::Builder::indexCount(uint32_t const indexCount) noexcept {
     mImpl->mIndexCount = indexCount;
     return *this;
 }
 
-IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noexcept {
+IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType const indexType) noexcept {
     mImpl->mIndexType = indexType;
     return *this;
 }
 
-IndexBuffer::Builder& IndexBuffer::Builder::name(const char* name, size_t len) noexcept {
+IndexBuffer::Builder& IndexBuffer::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -79,7 +79,7 @@ void FIndexBuffer::terminate(FEngine& engine) {
     driver.destroyIndexBuffer(mHandle);
 }
 
-void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
+void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t const byteOffset) {
     engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
 }
 

--- a/filament/src/details/IndexBuffer.cpp
+++ b/filament/src/details/IndexBuffer.cpp
@@ -32,10 +32,10 @@ struct IndexBuffer::BuilderDetails {
 using BuilderType = IndexBuffer;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 IndexBuffer::Builder& IndexBuffer::Builder::indexCount(uint32_t indexCount) noexcept {
     mImpl->mIndexCount = indexCount;
@@ -53,7 +53,7 @@ IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
+FIndexBuffer::FIndexBuffer(FEngine& engine, const Builder& builder)
         : mIndexCount(builder->mIndexCount) {
     auto& name = builder.getName();
     const char* const tag = name.empty() ? "(no tag)" : name.c_str_safe();

--- a/filament/src/details/IndexBuffer.cpp
+++ b/filament/src/details/IndexBuffer.cpp
@@ -47,6 +47,10 @@ IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noex
     return *this;
 }
 
+IndexBuffer::Builder& IndexBuffer::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
     return downcast(engine).createIndexBuffer(*this);
 }

--- a/filament/src/details/IndirectLight.cpp
+++ b/filament/src/details/IndirectLight.cpp
@@ -110,7 +110,7 @@ IndirectLight::Builder& IndirectLight::Builder::radiance(uint8_t bands, float3 c
     // this is a way to "document" the actual value of these coefficients and at the same
     // time make sure the expression and values are always in sync.
     struct Debug {
-        static constexpr bool almost(float a, float b) {
+        static constexpr bool almost(float const a, float const b) {
             constexpr float e = 1e-6f;
             return (a > b - e) && (a < b + e);
         }
@@ -138,7 +138,7 @@ IndirectLight::Builder& IndirectLight::Builder::irradiance(Texture const* cubema
     return *this;
 }
 
-IndirectLight::Builder& IndirectLight::Builder::intensity(float envIntensity) noexcept {
+IndirectLight::Builder& IndirectLight::Builder::intensity(float const envIntensity) noexcept {
     mImpl->mIntensity = envIntensity;
     return *this;
 }
@@ -265,7 +265,7 @@ float3 FIndirectLight::getDirectionEstimate() const noexcept {
     return getDirectionEstimate(mIrradianceCoefs.data());
 }
 
-float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
+float4 FIndirectLight::getColorEstimate(float3 const direction) const noexcept {
    return getColorEstimate(mIrradianceCoefs.data(), direction);
 }
 

--- a/filament/src/details/IndirectLight.cpp
+++ b/filament/src/details/IndirectLight.cpp
@@ -52,10 +52,10 @@ struct IndirectLight::BuilderDetails {
 using BuilderType = IndirectLight;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 IndirectLight::Builder& IndirectLight::Builder::reflections(Texture const* cubemap) noexcept {
     mImpl->mReflectionsMap = cubemap;
@@ -209,7 +209,7 @@ backend::Handle<backend::HwTexture> FIndirectLight::getIrradianceHwHandle() cons
                               : backend::Handle<backend::HwTexture>{};
 }
 
-math::float3 FIndirectLight::getDirectionEstimate(math::float3 const* f) noexcept {
+float3 FIndirectLight::getDirectionEstimate(float3 const* f) noexcept {
     // The linear direction is found as normalize(-sh[3], -sh[1], sh[2]), but the coefficients
     // we store are already pre-normalized, so the negative sign disappears.
     // Note: we normalize the directions only after blending, this matches code used elsewhere --
@@ -221,7 +221,7 @@ math::float3 FIndirectLight::getDirectionEstimate(math::float3 const* f) noexcep
     return -normalize(r * 0.2126f + g * 0.7152f + b * 0.0722f);
 }
 
-math::float4 FIndirectLight::getColorEstimate(math::float3 const* Le, math::float3 direction) noexcept {
+float4 FIndirectLight::getColorEstimate(float3 const* Le, float3 direction) noexcept {
     // See: https://www.gamasutra.com/view/news/129689/Indepth_Extracting_dominant_light_from_Spherical_Harmonics.php
 
     // note Le is our pre-convolved, pre-scaled SH coefficients for the environment
@@ -261,7 +261,7 @@ math::float4 FIndirectLight::getColorEstimate(math::float3 const* Le, math::floa
     return { LdDotLe / intensity, intensity };
 }
 
-math::float3 FIndirectLight::getDirectionEstimate() const noexcept {
+float3 FIndirectLight::getDirectionEstimate() const noexcept {
     return getDirectionEstimate(mIrradianceCoefs.data());
 }
 

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -46,7 +46,7 @@ public:
     backend::Handle<backend::HwTexture> getIrradianceHwHandle() const noexcept;
     math::float3 const* getSH() const noexcept{ return mIrradianceCoefs.data(); }
     float getIntensity() const noexcept { return mIntensity; }
-    void setIntensity(float intensity) noexcept { mIntensity = intensity; }
+    void setIntensity(float const intensity) noexcept { mIntensity = intensity; }
     void setRotation(math::mat3f const& rotation) noexcept { mRotation = rotation; }
     const math::mat3f& getRotation() const noexcept { return mRotation; }
     FTexture const* getReflectionsTexture() const noexcept { return mReflectionsTexture; }

--- a/filament/src/details/InstanceBuffer.cpp
+++ b/filament/src/details/InstanceBuffer.cpp
@@ -34,7 +34,7 @@ struct InstanceBuffer::BuilderDetails {
 };
 
 using BuilderType = InstanceBuffer;
-BuilderType::Builder::Builder(size_t instanceCount) noexcept {
+BuilderType::Builder::Builder(size_t const instanceCount) noexcept {
     mImpl->mInstanceCount = instanceCount;
 }
 
@@ -50,7 +50,7 @@ InstanceBuffer::Builder& InstanceBuffer::Builder::localTransforms(
     return *this;
 }
 
-InstanceBuffer::Builder& InstanceBuffer::Builder::name(const char* name, size_t len) noexcept {
+InstanceBuffer::Builder& InstanceBuffer::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -79,7 +79,7 @@ FInstanceBuffer::FInstanceBuffer(FEngine& engine, const Builder& builder)
 }
 
 void FInstanceBuffer::setLocalTransforms(
-        math::mat4f const* localTransforms, size_t count, size_t offset) {
+        math::mat4f const* localTransforms, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mInstanceCount)
             << "setLocalTransforms overflow. InstanceBuffer has only " << mInstanceCount
             << " instances, but trying to set " << count 

--- a/filament/src/details/InstanceBuffer.cpp
+++ b/filament/src/details/InstanceBuffer.cpp
@@ -39,10 +39,10 @@ BuilderType::Builder::Builder(size_t instanceCount) noexcept {
 }
 
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 InstanceBuffer::Builder& InstanceBuffer::Builder::localTransforms(
         math::mat4f const* localTransforms) noexcept {
@@ -89,7 +89,7 @@ void FInstanceBuffer::prepare(FEngine& engine, math::mat4f rootTransform,
 
     // TODO: allocate this staging buffer from a pool.
     uint32_t stagingBufferSize = sizeof(PerRenderableUib);
-    PerRenderableData* stagingBuffer = (PerRenderableData*)::malloc(stagingBufferSize);
+    PerRenderableData* stagingBuffer = (PerRenderableData*)malloc(stagingBufferSize);
     // TODO: consider using JobSystem to parallelize this.
     for (size_t i = 0, c = mInstanceCount; i < c; i++) {
         stagingBuffer[i] = ubo;
@@ -102,7 +102,7 @@ void FInstanceBuffer::prepare(FEngine& engine, math::mat4f rootTransform,
     driver.updateBufferObject(handle, {
             stagingBuffer, stagingBufferSize,
             +[](void* buffer, size_t, void*) {
-                ::free(buffer);
+                free(buffer);
             }
     }, 0);
 }

--- a/filament/src/details/InstanceBuffer.cpp
+++ b/filament/src/details/InstanceBuffer.cpp
@@ -50,6 +50,10 @@ InstanceBuffer::Builder& InstanceBuffer::Builder::localTransforms(
     return *this;
 }
 
+InstanceBuffer::Builder& InstanceBuffer::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 InstanceBuffer* InstanceBuffer::Builder::build(Engine& engine) {
     FILAMENT_CHECK_PRECONDITION(mImpl->mInstanceCount >= 1) << "instanceCount must be >= 1.";
     FILAMENT_CHECK_PRECONDITION(mImpl->mInstanceCount <= engine.getMaxAutomaticInstances())

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -130,7 +130,7 @@ struct Material::BuilderDetails {
         CString::Hasher> mConstantSpecializations;
 };
 
-FMaterial::DefaultMaterialBuilder::DefaultMaterialBuilder() : Builder() {
+FMaterial::DefaultMaterialBuilder::DefaultMaterialBuilder() {
     mImpl->mDefaultMaterial = true;
 }
 
@@ -169,7 +169,7 @@ template Material::Builder& Material::Builder::constant<int32_t>(const char*, si
 template Material::Builder& Material::Builder::constant<float>(const char*, size_t, float);
 template Material::Builder& Material::Builder::constant<bool>(const char*, size_t, bool);
 
-Material* Material::Builder::build(Engine& engine) {
+Material* Material::Builder::build(Engine& engine) const {
     std::unique_ptr<MaterialParser> materialParser = createParser(
         downcast(engine).getBackend(), downcast(engine).getShaderLanguage(),
         mImpl->mPayload, mImpl->mSize);
@@ -345,7 +345,7 @@ FMaterial::FMaterial(FEngine& engine, const Builder& builder,
     // Register the material with matdbg.
     matdbg::DebugServer* server = downcast(engine).debug.server;
     if (UTILS_UNLIKELY(server)) {
-        auto details = builder.mImpl;
+        auto const details = builder.mImpl;
         mDebuggerId = server->addMaterial(mName, details->mPayload, details->mSize, this);
     }
 #endif
@@ -434,7 +434,7 @@ void FMaterial::compile(CompilerPriorityQueue const priority,
             Invocable<void(Material*)> f;
             Material* m;
             static void func(void* user) {
-                auto* const c = reinterpret_cast<Callback*>(user);
+                auto* const c = static_cast<Callback*>(user);
                 c->f(c->m);
                 delete c;
             }
@@ -590,9 +590,9 @@ Program FMaterial::getProgramWithVariants(
                     [this, variant, vertexVariant, fragmentVariant](
                             io::ostream& out) -> io::ostream& {
                         return out << mName.c_str_safe() << ", variant=(" << io::hex
-                                   << (int)variant.key << io::dec << "), vertexVariant=(" << io::hex
-                                   << (int)vertexVariant.key << io::dec << "), fragmentVariant=("
-                                   << io::hex << (int)fragmentVariant.key << io::dec << ")";
+                                   << +variant.key << io::dec << "), vertexVariant=(" << io::hex
+                                   << +vertexVariant.key << io::dec << "), fragmentVariant=("
+                                   << io::hex << +fragmentVariant.key << io::dec << ")";
                     });
 
     if (UTILS_UNLIKELY(mMaterialParser->getShaderLanguage() == ShaderLanguage::ESSL1)) {
@@ -608,8 +608,8 @@ Program FMaterial::getProgramWithVariants(
     program.descriptorBindings(2, mProgramDescriptorBindings[2]);
     program.specializationConstants(mSpecializationConstants);
 
-    program.pushConstants(ShaderStage::VERTEX, mPushConstants[(uint8_t) ShaderStage::VERTEX]);
-    program.pushConstants(ShaderStage::FRAGMENT, mPushConstants[(uint8_t) ShaderStage::FRAGMENT]);
+    program.pushConstants(ShaderStage::VERTEX, mPushConstants[uint8_t(ShaderStage::VERTEX)]);
+    program.pushConstants(ShaderStage::FRAGMENT, mPushConstants[uint8_t(ShaderStage::FRAGMENT)]);
 
     program.cacheId(hash::combine(size_t(mCacheId), variant.key));
 
@@ -626,7 +626,7 @@ void FMaterial::createAndCacheProgram(Program&& p, Variant const variant) const 
     if (isShared) {
         FMaterial const* const pDefaultMaterial = engine.getDefaultMaterial();
         if (pDefaultMaterial) {
-            auto program = pDefaultMaterial->mCachedPrograms[variant.key];
+            auto const program = pDefaultMaterial->mCachedPrograms[variant.key];
             if (program) {
                 mCachedPrograms[variant.key] = program;
                 return;
@@ -634,7 +634,7 @@ void FMaterial::createAndCacheProgram(Program&& p, Variant const variant) const 
         }
     }
 
-    auto program = driverApi.createProgram(std::move(p));
+    auto const program = driverApi.createProgram(std::move(p));
     driverApi.setDebugTag(program.getId(), mName);
     assert_invariant(program);
     mCachedPrograms[variant.key] = program;
@@ -713,14 +713,14 @@ void FMaterial::setPendingEdits(std::unique_ptr<MaterialParser> pendingEdits) no
     std::swap(pendingEdits, mPendingEdits);
 }
 
-bool FMaterial::hasPendingEdits() noexcept {
+bool FMaterial::hasPendingEdits() const noexcept {
     std::lock_guard const lock(mPendingEditsLock);
-    return (bool)mPendingEdits;
+    return bool(mPendingEdits);
 }
 
 void FMaterial::latchPendingEdits() noexcept {
     std::lock_guard const lock(mPendingEditsLock);
-    mMaterialParser.reset(mPendingEdits.release());
+    mMaterialParser = std::move(mPendingEdits);
 }
 
 /**
@@ -732,7 +732,7 @@ void FMaterial::latchPendingEdits() noexcept {
 
 void FMaterial::onEditCallback(void* userdata, const CString&, const void* packageData,
         size_t const packageSize) {
-    FMaterial* material = downcast((Material*) userdata);
+    FMaterial* material = downcast(static_cast<Material*>(userdata));
     FEngine const& engine = material->mEngine;
 
     // This is called on a web server thread, so we defer clearing the program cache
@@ -742,10 +742,10 @@ void FMaterial::onEditCallback(void* userdata, const CString&, const void* packa
     material->setPendingEdits(std::move(pending));
 }
 
-void FMaterial::onQueryCallback(void* userdata, VariantList* pVariants) {
-    FMaterial* material = downcast((Material*) userdata);
-    std::lock_guard<Mutex> const lock(material->mActiveProgramsLock);
-    *pVariants = material->mActivePrograms;
+void FMaterial::onQueryCallback(void* userdata, VariantList* pActiveVariants) {
+    FMaterial const* material = downcast(static_cast<Material*>(userdata));
+    std::lock_guard const lock(material->mActiveProgramsLock);
+    *pActiveVariants = material->mActivePrograms;
     material->mActivePrograms.reset();
 }
 
@@ -763,7 +763,7 @@ void FMaterial::destroyPrograms(FEngine& engine,
     switch (mMaterialDomain) {
         case MaterialDomain::SURFACE: {
             if (mIsDefaultMaterial || mHasCustomDepthShader) {
-                // default material or we have custom depth shaders, we destroy all variants
+                // default material, or we have custom depth shaders, we destroy all variants
                 for (size_t k = 0, n = VARIANT_COUNT; k < n; ++k) {
                     if ((k & variantMask) == variantValue) {
                         // Only destroy if the handle is valid. Not strictly needed, but we have a lot
@@ -780,7 +780,7 @@ void FMaterial::destroyPrograms(FEngine& engine,
                 // During Engine::shutdown(), auto-cleanup destroys the default material first,
                 // so this can be null, but this is only used for debugging.
                 UTILS_UNUSED_IN_RELEASE
-                auto UTILS_NULLABLE pDefaultMaterial = engine.getDefaultMaterial();
+                auto const UTILS_NULLABLE pDefaultMaterial = engine.getDefaultMaterial();
 
                 for (size_t k = 0, n = VARIANT_COUNT; k < n; ++k) {
                     if ((k & variantMask) == variantValue) {
@@ -828,7 +828,7 @@ void FMaterial::destroyPrograms(FEngine& engine,
 }
 
 std::optional<uint32_t> FMaterial::getSpecializationConstantId(std::string_view const name) const noexcept {
-    auto pos = mSpecializationConstantsNameToIndex.find(name);
+    auto const pos = mSpecializationConstantsNameToIndex.find(name);
     if (pos != mSpecializationConstantsNameToIndex.end()) {
         return pos->second + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
     }
@@ -841,7 +841,7 @@ bool FMaterial::setConstant(uint32_t id, T value) noexcept {
     if (UTILS_LIKELY(id < maxId)) {
         if (id >= CONFIG_MAX_RESERVED_SPEC_CONSTANTS) {
             // Constant from the material itself (as opposed to the reserved ones)
-            auto& constant = mMaterialConstants[id - CONFIG_MAX_RESERVED_SPEC_CONSTANTS];
+            auto const& constant = mMaterialConstants[id - CONFIG_MAX_RESERVED_SPEC_CONSTANTS];
             using ConstantType = ConstantType;
             switch (constant.type) {
                 case ConstantType::INT:
@@ -975,9 +975,9 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
     int const maxInstanceCount = (engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)
                                  ? 1 : CONFIG_MAX_INSTANCES;
 
-    int const maxFroxelBufferHeight = (int)std::min(
+    int const maxFroxelBufferHeight = int(std::min(
             FROXEL_BUFFER_MAX_ENTRY_COUNT / 4,
-            engine.getDriverApi().getMaxUniformBufferSize() / 16u);
+            engine.getDriverApi().getMaxUniformBufferSize() / 16u));
 
     bool const staticTextureWorkaround =
             engine.getDriverApi().isWorkaroundNeeded(Workaround::METAL_STATIC_TEXTURE_TARGET_ERROR);
@@ -988,13 +988,13 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
     mSpecializationConstants.reserve(mMaterialConstants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::BACKEND_FEATURE_LEVEL,
-            (int)engine.getSupportedFeatureLevel() });
+            int(engine.getSupportedFeatureLevel()) });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_MAX_INSTANCES,
-            (int)maxInstanceCount });
+            int(maxInstanceCount) });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_FROXEL_BUFFER_HEIGHT,
-            (int)maxFroxelBufferHeight });
+            int(maxFroxelBufferHeight) });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP,
             engine.debug.shadowmap.debug_directional_shadowmap });
@@ -1009,13 +1009,13 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
             powerVrShaderWorkarounds });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_STEREO_EYE_COUNT,
-            (int)engine.getConfig().stereoscopicEyeCount });
+            int(engine.getConfig().stereoscopicEyeCount) });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_SH_BANDS_COUNT,
             builder->mShBandsCount });
     mSpecializationConstants.push_back({
             +ReservedSpecializationConstants::CONFIG_SHADOW_SAMPLING_METHOD,
-            (int32_t)builder->mShadowSamplingQuality });
+            int32_t(builder->mShadowSamplingQuality) });
     if (UTILS_UNLIKELY(parser->getShaderLanguage() == ShaderLanguage::ESSL1)) {
         // The actual value of this spec-constant is set in the OpenGLDriver backend.
         mSpecializationConstants.push_back({
@@ -1029,8 +1029,8 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
         FILAMENT_CHECK_PRECONDITION(pos != mSpecializationConstantsNameToIndex.end())
                 << "The material " << mName.c_str_safe()
                 << " does not have a constant parameter named " << name.c_str() << ".";
-        const char* const types[3] = {"an int", "a float", "a bool"};
-        auto& constant = mMaterialConstants[pos->second];
+        constexpr char const* const types[3] = {"an int", "a float", "a bool"};
+        auto const& constant = mMaterialConstants[pos->second];
         switch (constant.type) {
             case ConstantType::INT:
                 FILAMENT_CHECK_PRECONDITION(std::holds_alternative<int32_t>(value))
@@ -1056,11 +1056,11 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
     }
 }
 
-void FMaterial::processPushConstants(FEngine& engine, MaterialParser const* parser) {
+void FMaterial::processPushConstants(FEngine&, MaterialParser const* parser) {
     FixedCapacityVector<Program::PushConstant>& vertexConstants =
-            mPushConstants[(uint8_t) ShaderStage::VERTEX];
+            mPushConstants[uint8_t(ShaderStage::VERTEX)];
     FixedCapacityVector<Program::PushConstant>& fragmentConstants =
-            mPushConstants[(uint8_t) ShaderStage::FRAGMENT];
+            mPushConstants[uint8_t(ShaderStage::FRAGMENT)];
 
     CString structVarName;
     FixedCapacityVector<MaterialPushConstant> pushConstants;
@@ -1092,7 +1092,7 @@ void FMaterial::processPushConstants(FEngine& engine, MaterialParser const* pars
             });
 }
 
-void FMaterial::precacheDepthVariants(FEngine& engine) {
+void FMaterial::precacheDepthVariants(FEngine const& engine) {
     // pre-cache all depth variants inside the default material. Note that this should be
     // entirely optional; if we remove this pre-caching, these variants will be populated
     // later, when/if needed by createAndCacheProgram(). Doing it now potentially uses more

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -78,7 +78,7 @@ using namespace backend;
 using namespace filaflat;
 using namespace utils;
 
-static std::unique_ptr<MaterialParser> createParser(Backend backend,
+static std::unique_ptr<MaterialParser> createParser(Backend const backend,
         FixedCapacityVector<ShaderLanguage> languages, const void* data, size_t size) {
     // unique_ptr so we don't leak MaterialParser on failures below
     auto materialParser = std::make_unique<MaterialParser>(languages, data, size);
@@ -142,18 +142,18 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-Material::Builder& Material::Builder::package(const void* payload, size_t size) {
+Material::Builder& Material::Builder::package(const void* payload, size_t const size) {
     mImpl->mPayload = payload;
     mImpl->mSize = size;
     return *this;
 }
 
-Material::Builder& Material::Builder::sphericalHarmonicsBandCount(size_t shBandCount) noexcept {
+Material::Builder& Material::Builder::sphericalHarmonicsBandCount(size_t const shBandCount) noexcept {
     mImpl->mShBandsCount = math::clamp(shBandCount, size_t(1), size_t(3));
     return *this;
 }
 
-Material::Builder& Material::Builder::shadowSamplingQuality(ShadowSamplingQuality quality) noexcept {
+Material::Builder& Material::Builder::shadowSamplingQuality(ShadowSamplingQuality const quality) noexcept {
     mImpl->mShadowSamplingQuality = quality;
     return *this;
 }
@@ -404,7 +404,7 @@ void FMaterial::terminate(FEngine& engine) {
     mDescriptorSetLayout.terminate(engine.getDescriptorSetLayoutFactory(), driver);
 }
 
-void FMaterial::compile(CompilerPriorityQueue priority,
+void FMaterial::compile(CompilerPriorityQueue const priority,
         UserVariantFilterMask variantSpec,
         CallbackHandler* handler,
         Invocable<void(Material*)>&& callback) noexcept {
@@ -475,11 +475,11 @@ bool FMaterial::isSampler(const char* name) const noexcept {
 }
 
 BufferInterfaceBlock::FieldInfo const* FMaterial::reflect(
-        std::string_view name) const noexcept {
+        std::string_view const name) const noexcept {
     return mUniformInterfaceBlock.getFieldInfo(name);
 }
 
-bool FMaterial::hasVariant(Variant variant) const noexcept {
+bool FMaterial::hasVariant(Variant const variant) const noexcept {
     Variant vertexVariant, fragmentVariant;
     switch (getMaterialDomain()) {
         case MaterialDomain::SURFACE:
@@ -503,8 +503,8 @@ bool FMaterial::hasVariant(Variant variant) const noexcept {
     return true;
 }
 
-void FMaterial::prepareProgramSlow(Variant variant,
-        backend::CompilerPriorityQueue priorityQueue) const noexcept {
+void FMaterial::prepareProgramSlow(Variant const variant,
+        backend::CompilerPriorityQueue const priorityQueue) const noexcept {
     assert_invariant(mEngine.hasFeatureLevel(mFeatureLevel));
     switch (getMaterialDomain()) {
         case MaterialDomain::SURFACE:
@@ -519,8 +519,8 @@ void FMaterial::prepareProgramSlow(Variant variant,
     }
 }
 
-void FMaterial::getSurfaceProgramSlow(Variant variant,
-        CompilerPriorityQueue priorityQueue) const noexcept {
+void FMaterial::getSurfaceProgramSlow(Variant const variant,
+        CompilerPriorityQueue const priorityQueue) const noexcept {
     // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
     // if we're unlit, we don't have any bits that correspond to lit materials
     assert_invariant(variant == Variant::filterVariant(variant, isVariantLit()) );
@@ -538,8 +538,8 @@ void FMaterial::getSurfaceProgramSlow(Variant variant,
     createAndCacheProgram(std::move(pb), variant);
 }
 
-void FMaterial::getPostProcessProgramSlow(Variant variant,
-        CompilerPriorityQueue priorityQueue) const noexcept {
+void FMaterial::getPostProcessProgramSlow(Variant const variant,
+        CompilerPriorityQueue const priorityQueue) const noexcept {
     Program pb{ getProgramWithVariants(variant, variant, variant) };
     pb.priorityQueue(priorityQueue);
     createAndCacheProgram(std::move(pb), variant);
@@ -616,7 +616,7 @@ Program FMaterial::getProgramWithVariants(
     return program;
 }
 
-void FMaterial::createAndCacheProgram(Program&& p, Variant variant) const noexcept {
+void FMaterial::createAndCacheProgram(Program&& p, Variant const variant) const noexcept {
     FEngine const& engine = mEngine;
     DriverApi& driverApi = mEngine.getDriverApi();
 
@@ -731,7 +731,7 @@ void FMaterial::latchPendingEdits() noexcept {
  */
 
 void FMaterial::onEditCallback(void* userdata, const CString&, const void* packageData,
-        size_t packageSize) {
+        size_t const packageSize) {
     FMaterial* material = downcast((Material*) userdata);
     FEngine const& engine = material->mEngine;
 
@@ -827,7 +827,7 @@ void FMaterial::destroyPrograms(FEngine& engine,
     }
 }
 
-std::optional<uint32_t> FMaterial::getSpecializationConstantId(std::string_view name) const noexcept {
+std::optional<uint32_t> FMaterial::getSpecializationConstantId(std::string_view const name) const noexcept {
     auto pos = mSpecializationConstantsNameToIndex.find(name);
     if (pos != mSpecializationConstantsNameToIndex.end()) {
         return pos->second + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -93,7 +93,7 @@ public:
         return mPerViewDescriptorSetLayout;
     }
 
-    DescriptorSetLayout const& getPerViewDescriptorSetLayout(Variant variant) const noexcept {
+    DescriptorSetLayout const& getPerViewDescriptorSetLayout(Variant const variant) const noexcept {
         if (Variant::isValidDepthVariant(variant)) {
             assert_invariant(mMaterialDomain == MaterialDomain::SURFACE);
             return mEngine.getPerViewDescriptorSetLayoutDepthVariant();
@@ -131,7 +131,7 @@ public:
 
     FEngine& getEngine() const noexcept  { return mEngine; }
 
-    bool isCached(Variant variant) const noexcept {
+    bool isCached(Variant const variant) const noexcept {
         return bool(mCachedPrograms[variant.key]);
     }
 
@@ -140,8 +140,8 @@ public:
     // prepareProgram creates the program for the material's given variant at the backend level.
     // Must be called outside of backend render pass.
     // Must be called before getProgram() below.
-    void prepareProgram(Variant variant,
-            backend::CompilerPriorityQueue priorityQueue = CompilerPriorityQueue::HIGH) const noexcept {
+    void prepareProgram(Variant const variant,
+            backend::CompilerPriorityQueue const priorityQueue = CompilerPriorityQueue::HIGH) const noexcept {
         // prepareProgram() is called for each RenderPrimitive in the scene, so it must be efficient.
         if (UTILS_UNLIKELY(!isCached(variant))) {
             prepareProgramSlow(variant, priorityQueue);
@@ -150,7 +150,7 @@ public:
 
     // getProgram returns the backend program for the material's given variant.
     // Must be called after prepareProgram().
-    [[nodiscard]] backend::Handle<backend::HwProgram> getProgram(Variant variant) const noexcept {
+    [[nodiscard]] backend::Handle<backend::HwProgram> getProgram(Variant const variant) const noexcept {
 #if FILAMENT_ENABLE_MATDBG
         assert_invariant((size_t)variant.key < VARIANT_COUNT);
         std::unique_lock<utils::Mutex> lock(mActiveProgramsLock);
@@ -297,7 +297,7 @@ private:
 
     void createAndCacheProgram(backend::Program&& p, Variant variant) const noexcept;
 
-    inline bool isSharedVariant(Variant variant) const {
+    inline bool isSharedVariant(Variant const variant) const {
         return (mMaterialDomain == MaterialDomain::SURFACE) && !mIsDefaultMaterial &&
                !mHasCustomDepthShader && Variant::isValidDepthVariant(variant);
     }

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -71,11 +71,11 @@ class  FEngine;
 
 class FMaterial : public Material {
 public:
-    FMaterial(FEngine& engine, const Material::Builder& builder,
+    FMaterial(FEngine& engine, const Builder& builder,
             std::unique_ptr<MaterialParser> materialParser);
     ~FMaterial() noexcept;
 
-    class DefaultMaterialBuilder : public Material::Builder {
+    class DefaultMaterialBuilder : public Builder {
     public:
         DefaultMaterialBuilder();
     };
@@ -286,7 +286,7 @@ private:
 
     void processBlendingMode(MaterialParser const* parser);
 
-    void processSpecializationConstants(FEngine& engine, Material::Builder const& builder,
+    void processSpecializationConstants(FEngine& engine, Builder const& builder,
             MaterialParser const* parser);
 
     void processPushConstants(FEngine& engine, MaterialParser const* parser);

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -110,7 +110,7 @@ public:
     }
 
     void compile(CompilerPriorityQueue priority,
-            UserVariantFilterMask variantFilter,
+            UserVariantFilterMask variantSpec,
             backend::CallbackHandler* handler,
             utils::Invocable<void(Material*)>&& callback) noexcept;
 
@@ -291,7 +291,7 @@ private:
 
     void processPushConstants(FEngine& engine, MaterialParser const* parser);
 
-    void precacheDepthVariants(FEngine& engine);
+    void precacheDepthVariants(FEngine const& engine);
 
     void processDescriptorSets(FEngine& engine, MaterialParser const* parser);
 
@@ -374,7 +374,7 @@ private:
     mutable utils::Mutex mPendingEditsLock;
     std::unique_ptr<MaterialParser> mPendingEdits;
     void setPendingEdits(std::unique_ptr<MaterialParser> pendingEdits) noexcept;
-    bool hasPendingEdits() noexcept;
+    bool hasPendingEdits() const noexcept;
     void latchPendingEdits() noexcept;
 #endif
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -75,7 +75,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material,
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms = UniformBuffer(material->getUniformInterfaceBlock().getSize());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::STATIC);
+                BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
         driver.setDebugTag(mUbHandle.getId(), material->getName());
     }
 
@@ -141,7 +141,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms.setUniforms(other->getUniformBuffer());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::DYNAMIC);
+                BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
         driver.setDebugTag(mUbHandle.getId(), material->getName());
     }
 
@@ -215,7 +215,7 @@ void FMaterialInstance::commit(DriverApi& driver) const {
 // ------------------------------------------------------------------------------------------------
 
 void FMaterialInstance::setParameter(std::string_view name,
-        backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) {
+        Handle<HwTexture> texture, SamplerParams params) {
     auto binding = mMaterial->getSamplerBinding(name);
     mDescriptorSet.setSampler(binding, texture, params);
 }
@@ -259,8 +259,8 @@ void FMaterialInstance::setParameterImpl(std::string_view name,
 }
 
 void FMaterialInstance::setMaskThreshold(float threshold) noexcept {
-    setParameter("_maskThreshold", math::saturate(threshold));
-    mMaskThreshold = math::saturate(threshold);
+    setParameter("_maskThreshold", saturate(threshold));
+    mMaskThreshold = saturate(threshold);
 }
 
 float FMaterialInstance::getMaskThreshold() const noexcept {
@@ -268,8 +268,8 @@ float FMaterialInstance::getMaskThreshold() const noexcept {
 }
 
 void FMaterialInstance::setSpecularAntiAliasingVariance(float variance) noexcept {
-    setParameter("_specularAntiAliasingVariance", math::saturate(variance));
-    mSpecularAntiAliasingVariance = math::saturate(variance);
+    setParameter("_specularAntiAliasingVariance", saturate(variance));
+    mSpecularAntiAliasingVariance = saturate(variance);
 }
 
 float FMaterialInstance::getSpecularAntiAliasingVariance() const noexcept {
@@ -277,8 +277,8 @@ float FMaterialInstance::getSpecularAntiAliasingVariance() const noexcept {
 }
 
 void FMaterialInstance::setSpecularAntiAliasingThreshold(float threshold) noexcept {
-    setParameter("_specularAntiAliasingThreshold", math::saturate(threshold * threshold));
-    mSpecularAntiAliasingThreshold = std::sqrt(math::saturate(threshold * threshold));
+    setParameter("_specularAntiAliasingThreshold", saturate(threshold * threshold));
+    mSpecularAntiAliasingThreshold = std::sqrt(saturate(threshold * threshold));
 }
 
 float FMaterialInstance::getSpecularAntiAliasingThreshold() const noexcept {

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -214,13 +214,13 @@ void FMaterialInstance::commit(DriverApi& driver) const {
 
 // ------------------------------------------------------------------------------------------------
 
-void FMaterialInstance::setParameter(std::string_view name,
-        Handle<HwTexture> texture, SamplerParams params) {
+void FMaterialInstance::setParameter(std::string_view const name,
+        Handle<HwTexture> texture, SamplerParams const params) {
     auto binding = mMaterial->getSamplerBinding(name);
     mDescriptorSet.setSampler(binding, texture, params);
 }
 
-void FMaterialInstance::setParameterImpl(std::string_view name,
+void FMaterialInstance::setParameterImpl(std::string_view const name,
         FTexture const* texture, TextureSampler const& sampler) {
 
 #ifndef NDEBUG
@@ -258,7 +258,7 @@ void FMaterialInstance::setParameterImpl(std::string_view name,
     }
 }
 
-void FMaterialInstance::setMaskThreshold(float threshold) noexcept {
+void FMaterialInstance::setMaskThreshold(float const threshold) noexcept {
     setParameter("_maskThreshold", saturate(threshold));
     mMaskThreshold = saturate(threshold);
 }
@@ -267,7 +267,7 @@ float FMaterialInstance::getMaskThreshold() const noexcept {
     return mMaskThreshold;
 }
 
-void FMaterialInstance::setSpecularAntiAliasingVariance(float variance) noexcept {
+void FMaterialInstance::setSpecularAntiAliasingVariance(float const variance) noexcept {
     setParameter("_specularAntiAliasingVariance", saturate(variance));
     mSpecularAntiAliasingVariance = saturate(variance);
 }
@@ -276,7 +276,7 @@ float FMaterialInstance::getSpecularAntiAliasingVariance() const noexcept {
     return mSpecularAntiAliasingVariance;
 }
 
-void FMaterialInstance::setSpecularAntiAliasingThreshold(float threshold) noexcept {
+void FMaterialInstance::setSpecularAntiAliasingThreshold(float const threshold) noexcept {
     setParameter("_specularAntiAliasingThreshold", saturate(threshold * threshold));
     mSpecularAntiAliasingThreshold = std::sqrt(saturate(threshold * threshold));
 }
@@ -285,7 +285,7 @@ float FMaterialInstance::getSpecularAntiAliasingThreshold() const noexcept {
     return mSpecularAntiAliasingThreshold;
 }
 
-void FMaterialInstance::setDoubleSided(bool doubleSided) noexcept {
+void FMaterialInstance::setDoubleSided(bool const doubleSided) noexcept {
     if (UTILS_UNLIKELY(!mMaterial->hasDoubleSidedCapability())) {
         slog.w << "Parent material does not have double-sided capability." << io::endl;
         return;
@@ -301,11 +301,11 @@ bool FMaterialInstance::isDoubleSided() const noexcept {
     return mIsDoubleSided;
 }
 
-void FMaterialInstance::setTransparencyMode(TransparencyMode mode) noexcept {
+void FMaterialInstance::setTransparencyMode(TransparencyMode const mode) noexcept {
     mTransparencyMode = mode;
 }
 
-void FMaterialInstance::setDepthCulling(bool enable) noexcept {
+void FMaterialInstance::setDepthCulling(bool const enable) noexcept {
     mDepthFunc = enable ? RasterState::DepthFunc::GE : RasterState::DepthFunc::A;
 }
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -75,7 +75,7 @@ public:
 
     UniformBuffer const& getUniformBuffer() const noexcept { return mUniforms; }
 
-    void setScissor(uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) noexcept {
+    void setScissor(uint32_t const left, uint32_t const bottom, uint32_t const width, uint32_t const height) noexcept {
         constexpr uint32_t maxvalu = std::numeric_limits<int32_t>::max();
         mScissorRect = { int32_t(left), int32_t(bottom),
                 std::min(width, maxvalu), std::min(height, maxvalu) };
@@ -106,11 +106,11 @@ public:
 
     backend::RasterState::DepthFunc getDepthFunc() const noexcept { return mDepthFunc; }
 
-    void setDepthFunc(backend::RasterState::DepthFunc depthFunc) noexcept {
+    void setDepthFunc(backend::RasterState::DepthFunc const depthFunc) noexcept {
         mDepthFunc = depthFunc;
     }
 
-    void setPolygonOffset(float scale, float constant) noexcept {
+    void setPolygonOffset(float const scale, float const constant) noexcept {
         // handle reversed Z
         mPolygonOffset = { -scale, -constant };
     }
@@ -135,19 +135,19 @@ public:
 
     void setTransparencyMode(TransparencyMode mode) noexcept;
 
-    void setCullingMode(CullingMode culling) noexcept { mCulling = culling; }
+    void setCullingMode(CullingMode const culling) noexcept { mCulling = culling; }
 
-    void setColorWrite(bool enable) noexcept { mColorWrite = enable; }
+    void setColorWrite(bool const enable) noexcept { mColorWrite = enable; }
 
-    void setDepthWrite(bool enable) noexcept { mDepthWrite = enable; }
+    void setDepthWrite(bool const enable) noexcept { mDepthWrite = enable; }
 
-    void setStencilWrite(bool enable) noexcept { mStencilState.stencilWrite = enable; }
+    void setStencilWrite(bool const enable) noexcept { mStencilState.stencilWrite = enable; }
 
     void setDepthCulling(bool enable) noexcept;
 
     bool isDepthCullingEnabled() const noexcept;
 
-    void setStencilCompareFunction(StencilCompareFunc func, StencilFace face) noexcept {
+    void setStencilCompareFunction(StencilCompareFunc const func, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.stencilFunc = func;
         }
@@ -156,7 +156,7 @@ public:
         }
     }
 
-    void setStencilOpStencilFail(StencilOperation op, StencilFace face) noexcept {
+    void setStencilOpStencilFail(StencilOperation const op, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.stencilOpStencilFail = op;
         }
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    void setStencilOpDepthFail(StencilOperation op, StencilFace face) noexcept {
+    void setStencilOpDepthFail(StencilOperation const op, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.stencilOpDepthFail = op;
         }
@@ -174,7 +174,7 @@ public:
         }
     }
 
-    void setStencilOpDepthStencilPass(StencilOperation op, StencilFace face) noexcept {
+    void setStencilOpDepthStencilPass(StencilOperation const op, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.stencilOpDepthStencilPass = op;
         }
@@ -183,7 +183,7 @@ public:
         }
     }
 
-    void setStencilReferenceValue(uint8_t value, StencilFace face) noexcept {
+    void setStencilReferenceValue(uint8_t const value, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.ref = value;
         }
@@ -192,7 +192,7 @@ public:
         }
     }
 
-    void setStencilReadMask(uint8_t readMask, StencilFace face) noexcept {
+    void setStencilReadMask(uint8_t const readMask, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.readMask = readMask;
         }
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    void setStencilWriteMask(uint8_t writeMask, StencilFace face) noexcept {
+    void setStencilWriteMask(uint8_t const writeMask, StencilFace const face) noexcept {
         if (any(face & StencilFace::FRONT)) {
             mStencilState.front.writeMask = writeMask;
         }
@@ -210,7 +210,7 @@ public:
         }
     }
 
-    void setDefaultInstance(bool value) noexcept {
+    void setDefaultInstance(bool const value) noexcept {
         mIsDefaultInstance = value;
     }
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -260,7 +260,7 @@ private:
 
     backend::Handle<backend::HwBufferObject> mUbHandle;
     tsl::robin_map<backend::descriptor_binding_t, TextureParameter> mTextureParameters;
-    mutable filament::DescriptorSet mDescriptorSet;
+    mutable DescriptorSet mDescriptorSet;
     UniformBuffer mUniforms;
 
     backend::PolygonOffset mPolygonOffset{};

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -55,6 +55,10 @@ MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::count(size_t count) noex
     return *this;
 }
 
+MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 MorphTargetBuffer* MorphTargetBuffer::Builder::build(Engine& engine) {
     return downcast(engine).createMorphTargetBuffer(*this);
 }

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -40,10 +40,10 @@ struct MorphTargetBuffer::BuilderDetails {
 using BuilderType = MorphTargetBuffer;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::vertexCount(size_t vertexCount) noexcept {
     mImpl->mVertexCount = vertexCount;
@@ -77,7 +77,7 @@ template<VertexAttribute A>
 inline size_t getSize(size_t vertexCount) noexcept;
 
 template<>
-inline size_t getSize<VertexAttribute::POSITION>(size_t vertexCount) noexcept {
+inline size_t getSize<POSITION>(size_t vertexCount) noexcept {
     const size_t stride = getWidth(vertexCount);
     const size_t height = getHeight(vertexCount);
     return Texture::PixelBufferDescriptor::computeDataSize(
@@ -87,7 +87,7 @@ inline size_t getSize<VertexAttribute::POSITION>(size_t vertexCount) noexcept {
 }
 
 template<>
-inline size_t getSize<VertexAttribute::TANGENTS>(size_t vertexCount) noexcept {
+inline size_t getSize<TANGENTS>(size_t vertexCount) noexcept {
     const size_t stride = getWidth(vertexCount);
     const size_t height = getHeight(vertexCount);
     return Texture::PixelBufferDescriptor::computeDataSize(
@@ -143,12 +143,12 @@ void FMorphTargetBuffer::terminate(FEngine& engine) {
 }
 
 void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
-        math::float3 const* positions, size_t count, size_t offset) {
+        float3 const* positions, size_t count, size_t offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
 
-    auto size = getSize<VertexAttribute::POSITION>(count);
+    auto size = getSize<POSITION>(count);
 
     FILAMENT_CHECK_PRECONDITION(targetIndex < mCount)
             << targetIndex << " target index must be < " << mCount;
@@ -166,19 +166,19 @@ void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
 }
 
 void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
-        math::float4 const* positions, size_t count, size_t offset) {
+        float4 const* positions, size_t count, size_t offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
 
-    auto size = getSize<VertexAttribute::POSITION>(count);
+    auto size = getSize<POSITION>(count);
 
     FILAMENT_CHECK_PRECONDITION(targetIndex < mCount)
             << targetIndex << " target index must be < " << mCount;
 
     // We could use a pool instead of malloc() directly.
     auto* out = (float4*) malloc(size);
-    memcpy(out, positions, sizeof(math::float4) * count);
+    memcpy(out, positions, sizeof(float4) * count);
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     updateDataAt(driver, mPbHandle,
@@ -188,12 +188,12 @@ void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
 }
 
 void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
-        math::short4 const* tangents, size_t count, size_t offset) {
+        short4 const* tangents, size_t count, size_t offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
 
-    const auto size = getSize<VertexAttribute::TANGENTS>(count);
+    const auto size = getSize<TANGENTS>(count);
 
     FILAMENT_CHECK_PRECONDITION(targetIndex < mCount)
             << targetIndex << " target index must be < " << mCount;
@@ -210,7 +210,7 @@ void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
 }
 
 UTILS_NOINLINE
-void FMorphTargetBuffer::updateDataAt(backend::DriverApi& driver,
+void FMorphTargetBuffer::updateDataAt(DriverApi& driver,
         Handle<HwTexture> handle, PixelDataFormat format, PixelDataType type,
         const char* out, size_t elementSize,
         size_t targetIndex, size_t count, size_t offset) {
@@ -225,7 +225,7 @@ void FMorphTargetBuffer::updateDataAt(backend::DriverApi& driver,
     // 'out' buffer is going to be used up to 3 times, so for simplicity we use a shared_buffer
     // to manage its lifetime. One side effect of this is that the callbacks below will allocate
     // a small object on the heap.
-    std::shared_ptr<void> const allocation((void*)out, ::free);
+    std::shared_ptr<void> const allocation((void*)out, free);
 
     // Note: because the texture width is up to 2048, we're expecting that most of the time
     // only a single texture update call will be necessary (i.e. that there are no more

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -45,17 +45,17 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::vertexCount(size_t vertexCount) noexcept {
+MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::vertexCount(size_t const vertexCount) noexcept {
     mImpl->mVertexCount = vertexCount;
     return *this;
 }
 
-MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::count(size_t count) noexcept {
+MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::count(size_t const count) noexcept {
     mImpl->mCount = count;
     return *this;
 }
 
-MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::name(const char* name, size_t len) noexcept {
+MorphTargetBuffer::Builder& MorphTargetBuffer::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -69,11 +69,11 @@ MorphTargetBuffer* MorphTargetBuffer::Builder::build(Engine& engine) {
 // When you change this value, you must change MAX_MORPH_TARGET_BUFFER_WIDTH at getters.vs
 constexpr size_t MAX_MORPH_TARGET_BUFFER_WIDTH = 2048;
 
-static inline size_t getWidth(size_t vertexCount) noexcept {
+static inline size_t getWidth(size_t const vertexCount) noexcept {
     return std::min(vertexCount, MAX_MORPH_TARGET_BUFFER_WIDTH);
 }
 
-static inline size_t getHeight(size_t vertexCount) noexcept {
+static inline size_t getHeight(size_t const vertexCount) noexcept {
     return (vertexCount + MAX_MORPH_TARGET_BUFFER_WIDTH) / MAX_MORPH_TARGET_BUFFER_WIDTH;
 }
 
@@ -81,7 +81,7 @@ template<VertexAttribute A>
 inline size_t getSize(size_t vertexCount) noexcept;
 
 template<>
-inline size_t getSize<POSITION>(size_t vertexCount) noexcept {
+inline size_t getSize<POSITION>(size_t const vertexCount) noexcept {
     const size_t stride = getWidth(vertexCount);
     const size_t height = getHeight(vertexCount);
     return Texture::PixelBufferDescriptor::computeDataSize(
@@ -91,7 +91,7 @@ inline size_t getSize<POSITION>(size_t vertexCount) noexcept {
 }
 
 template<>
-inline size_t getSize<TANGENTS>(size_t vertexCount) noexcept {
+inline size_t getSize<TANGENTS>(size_t const vertexCount) noexcept {
     const size_t stride = getWidth(vertexCount);
     const size_t height = getHeight(vertexCount);
     return Texture::PixelBufferDescriptor::computeDataSize(
@@ -146,8 +146,8 @@ void FMorphTargetBuffer::terminate(FEngine& engine) {
     }
 }
 
-void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
-        float3 const* positions, size_t count, size_t offset) {
+void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t const targetIndex,
+        float3 const* positions, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
@@ -169,8 +169,8 @@ void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
             count, offset);
 }
 
-void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
-        float4 const* positions, size_t count, size_t offset) {
+void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t const targetIndex,
+        float4 const* positions, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
@@ -191,8 +191,8 @@ void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
             count, offset);
 }
 
-void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
-        short4 const* tangents, size_t count, size_t offset) {
+void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t const targetIndex,
+        short4 const* tangents, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION(offset + count <= mVertexCount)
             << "MorphTargetBuffer (size=" << (unsigned)mVertexCount
             << ") overflow (count=" << (unsigned)count << ", offset=" << (unsigned)offset << ")";
@@ -215,9 +215,9 @@ void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
 
 UTILS_NOINLINE
 void FMorphTargetBuffer::updateDataAt(DriverApi& driver,
-        Handle<HwTexture> handle, PixelDataFormat format, PixelDataType type,
-        const char* out, size_t elementSize,
-        size_t targetIndex, size_t count, size_t offset) {
+        Handle<HwTexture> handle, PixelDataFormat const format, PixelDataType const type,
+        const char* out, size_t const elementSize,
+        size_t const targetIndex, size_t const count, size_t const offset) {
 
     size_t yoffset              = offset / MAX_MORPH_TARGET_BUFFER_WIDTH;
     size_t const xoffset        = offset % MAX_MORPH_TARGET_BUFFER_WIDTH;

--- a/filament/src/details/MorphTargetBuffer.h
+++ b/filament/src/details/MorphTargetBuffer.h
@@ -37,7 +37,7 @@ class FEngine;
 
 class FMorphTargetBuffer : public MorphTargetBuffer {
 public:
-    class EmptyMorphTargetBuilder : public MorphTargetBuffer::Builder {
+    class EmptyMorphTargetBuilder : public Builder {
     public:
         EmptyMorphTargetBuilder();
     };

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -63,23 +63,23 @@ RenderTarget::Builder& RenderTarget::Builder::texture(AttachmentPoint pt, Textur
     return *this;
 }
 
-RenderTarget::Builder& RenderTarget::Builder::mipLevel(AttachmentPoint pt, uint8_t level) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::mipLevel(AttachmentPoint pt, uint8_t const level) noexcept {
     mImpl->mAttachments[(size_t)pt].mipLevel = level;
     return *this;
 }
 
-RenderTarget::Builder& RenderTarget::Builder::face(AttachmentPoint pt, CubemapFace face) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::face(AttachmentPoint pt, CubemapFace const face) noexcept {
     mImpl->mAttachments[(size_t)pt].face = face;
     return *this;
 }
 
-RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t layer) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t const layer) noexcept {
     mImpl->mAttachments[(size_t)pt].layer = layer;
     return *this;
 }
 
-RenderTarget::Builder& RenderTarget::Builder::multiview(AttachmentPoint pt, uint8_t layerCount,
-        uint8_t baseLayer/*= 0*/) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::multiview(AttachmentPoint pt, uint8_t const layerCount,
+        uint8_t const baseLayer/*= 0*/) noexcept {
     mImpl->mAttachments[(size_t)pt].layer = baseLayer;
     mImpl->mAttachments[(size_t)pt].layerCount = layerCount;
     return *this;

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -53,10 +53,10 @@ struct RenderTarget::BuilderDetails {
 using BuilderType = RenderTarget;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 RenderTarget::Builder& RenderTarget::Builder::texture(AttachmentPoint pt, Texture* texture) noexcept {
     mImpl->mAttachments[(size_t)pt].texture = downcast(texture);
@@ -155,13 +155,13 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-FRenderTarget::FRenderTarget(FEngine& engine, const RenderTarget::Builder& builder)
+FRenderTarget::FRenderTarget(FEngine& engine, const Builder& builder)
     : mSupportedColorAttachmentsCount(engine.getDriverApi().getMaxDrawBuffers()),
       mSupportsReadPixels(false) {
     std::copy(std::begin(builder.mImpl->mAttachments), std::end(builder.mImpl->mAttachments),
             std::begin(mAttachments));
 
-    backend::MRT mrt{};
+    MRT mrt{};
     TargetBufferInfo dinfo{};
 
     auto setAttachment = [this, &driver = engine.getDriverApi()]

--- a/filament/src/details/RenderTarget.h
+++ b/filament/src/details/RenderTarget.h
@@ -37,7 +37,7 @@ public:
     struct Attachment {
         FTexture* texture = nullptr;
         uint8_t mipLevel = 0;
-        CubemapFace face = RenderTarget::CubemapFace::POSITIVE_X;
+        CubemapFace face = CubemapFace::POSITIVE_X;
         uint32_t layer = 0;
         // Indicates the number of layers used for multiview, starting from the `layer` (baseIndex).
         // This means `layer` + `layerCount` cannot exceed the number of depth for the attachment.

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -188,7 +188,7 @@ void FRenderer::resetUserTime() {
     mUserEpoch = std::chrono::steady_clock::now();
 }
 
-TextureFormat FRenderer::getHdrFormat(const FView& view, bool translucent) const noexcept {
+TextureFormat FRenderer::getHdrFormat(const FView& view, bool const translucent) const noexcept {
     if (translucent) {
         return mHdrTranslucent;
     }
@@ -203,7 +203,7 @@ TextureFormat FRenderer::getHdrFormat(const FView& view, bool translucent) const
     }
 }
 
-TextureFormat FRenderer::getLdrFormat(bool translucent) const noexcept {
+TextureFormat FRenderer::getLdrFormat(bool const translucent) const noexcept {
     return (translucent || !mIsRGB8Supported) ? TextureFormat::RGBA8 : TextureFormat::RGB8;
 }
 
@@ -233,12 +233,12 @@ void FRenderer::initializeClearFlags() noexcept {
     mClearFlags = getClearFlags();
 }
 
-void FRenderer::setPresentationTime(int64_t monotonic_clock_ns) {
+void FRenderer::setPresentationTime(int64_t const monotonic_clock_ns) {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     driver.setPresentationTime(monotonic_clock_ns);
 }
 
-void FRenderer::setVsyncTime(uint64_t steadyClockTimeNano) noexcept {
+void FRenderer::setVsyncTime(uint64_t const steadyClockTimeNano) noexcept {
     mVsyncSteadyClockTimeNano = steadyClockTimeNano;
 }
 
@@ -444,7 +444,7 @@ void FRenderer::endFrame() {
     js.waitAndRelease(job);
 }
 
-void FRenderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
+void FRenderer::readPixels(uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
 #ifndef NDEBUG
     const bool withinFrame = mSwapChain != nullptr;
@@ -456,7 +456,7 @@ void FRenderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, u
 }
 
 void FRenderer::readPixels(FRenderTarget* renderTarget,
-        uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
 
     // TODO: change the following to an assert when client call sites have addressed the issue.
@@ -472,7 +472,7 @@ void FRenderer::readPixels(FRenderTarget* renderTarget,
 }
 
 void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& dstViewport,
-        filament::Viewport const& srcViewport, CopyFrameFlag flags) {
+        filament::Viewport const& srcViewport, CopyFrameFlag const flags) {
     SYSTRACE_CALL();
 
     assert_invariant(mSwapChain);
@@ -748,7 +748,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
         //       Without post-processing, we usually draw directly into
         //       the SwapChain, and we might want to keep it this way.
 
-        auto round = [](uint32_t x) {
+        auto round = [](uint32_t const x) {
             constexpr uint32_t rounding = 16u;
             return (x + (rounding - 1u)) & ~(rounding - 1u);
         };

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -218,7 +218,7 @@ std::pair<Handle<HwRenderTarget>, TargetBufferFlags>
     return { outTarget, outAttachmentMask };
 }
 
-backend::TargetBufferFlags FRenderer::getClearFlags() const noexcept {
+TargetBufferFlags FRenderer::getClearFlags() const noexcept {
     return (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
            | TargetBufferFlags::DEPTH_AND_STENCIL;
 }
@@ -457,14 +457,14 @@ void FRenderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, u
 
 void FRenderer::readPixels(FRenderTarget* renderTarget,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        backend::PixelBufferDescriptor&& buffer) {
+        PixelBufferDescriptor&& buffer) {
 
     // TODO: change the following to an assert when client call sites have addressed the issue.
     if (!renderTarget->supportsReadPixels()) {
-        utils::slog.w << "readPixels() must be called with a renderTarget with COLOR0 created with "
+        slog.w << "readPixels() must be called with a renderTarget with COLOR0 created with "
                          "TextureUsage::BLIT_SRC.  This precondition will be asserted in a later "
                          "release of Filament."
-                      << utils::io::endl;
+                      << io::endl;
     }
 
     RendererUtils::readPixels(mEngine.getDriverApi(), renderTarget->getHwHandle(),
@@ -551,7 +551,7 @@ void FRenderer::renderStandaloneView(FView const* view) {
 
         // This is a workaround for internal bug b/361822355.
         // TODO: properly address the bug and remove this workaround.
-        if (engine.getBackend() == backend::Backend::VULKAN) {
+        if (engine.getBackend() == Backend::VULKAN) {
             engine.flushAndWait();
         }
     }
@@ -632,7 +632,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     auto ssReflectionsOptions = view.getScreenSpaceReflectionsOptions();
     auto guardBandOptions = view.getGuardBandOptions();
     const bool isRenderingMultiview = view.hasStereo() &&
-            engine.getConfig().stereoscopicType == backend::StereoscopicType::MULTIVIEW;
+            engine.getConfig().stereoscopicType == StereoscopicType::MULTIVIEW;
     // FIXME: This is to override some settings that are not supported for multiview at the moment.
     // Remove this when all features are supported.
     if (isRenderingMultiview) {
@@ -1162,7 +1162,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
     // RenderPass::IS_INSTANCED_STEREOSCOPIC only applies to the color pass
     if (view.hasStereo() &&
-        engine.getConfig().stereoscopicType == backend::StereoscopicType::INSTANCED) {
+        engine.getConfig().stereoscopicType == StereoscopicType::INSTANCED) {
         renderFlags |= RenderPass::IS_INSTANCED_STEREOSCOPIC;
         passBuilder.renderFlags(renderFlags);
     }
@@ -1178,7 +1178,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     // Set the depth to the number of layers if we're rendering multiview.
     if (isRenderingMultiview) {
         colorBufferDesc.depth = engine.getConfig().stereoscopicEyeCount;
-        colorBufferDesc.type = backend::SamplerType::SAMPLER_2D_ARRAY;
+        colorBufferDesc.type = SamplerType::SAMPLER_2D_ARRAY;
     }
 
     // a non-drawing pass to prepare everything that need to be before the color passes execute
@@ -1257,7 +1257,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
                     // we can't use colorPassOutput here because it could be tonemapped
                     data.history = builder.sample(colorPassOutput.linearColor); // FIXME: an access must be declared for detach(), why?
                 }, [&view, projection](FrameGraphResources const& resources, auto const& data,
-                        backend::DriverApi&) {
+                        DriverApi&) {
                     auto& history = view.getFrameHistory();
                     auto& current = history.getCurrent();
                     current.ssr.projection = projection;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -147,7 +147,7 @@ public:
         return mClearOptions;
     }
 
-    utils::FixedCapacityVector<Renderer::FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept {
+    utils::FixedCapacityVector<FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept {
         return mFrameInfoManager.getFrameInfoHistory(historySize);
     }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -147,7 +147,7 @@ public:
         return mClearOptions;
     }
 
-    utils::FixedCapacityVector<FrameInfo> getFrameInfoHistory(size_t historySize) const noexcept {
+    utils::FixedCapacityVector<FrameInfo> getFrameInfoHistory(size_t const historySize) const noexcept {
         return mFrameInfoManager.getFrameInfoHistory(historySize);
     }
 
@@ -178,7 +178,7 @@ private:
     std::pair<backend::Handle<backend::HwRenderTarget>, backend::TargetBufferFlags>
             getRenderTarget(FView const& view) const noexcept;
 
-    void recordHighWatermark(size_t watermark) noexcept {
+    void recordHighWatermark(size_t const watermark) noexcept {
         mCommandsHighWatermark = std::max(mCommandsHighWatermark, watermark);
     }
 

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -52,7 +52,7 @@ FScene::FScene(FEngine& engine) :
 FScene::~FScene() noexcept = default;
 
 
-void FScene::prepare(utils::JobSystem& js,
+void FScene::prepare(JobSystem& js,
         RootArenaScope& rootArenaScope,
         mat4 const& worldTransform,
         bool shadowReceiversAreCasters) noexcept {
@@ -78,11 +78,11 @@ void FScene::prepare(utils::JobSystem& js,
 
     using RenderableContainerData = std::pair<RenderableManager::Instance, TransformManager::Instance>;
     using RenderableInstanceContainer = FixedCapacityVector<RenderableContainerData,
-            utils::STLAllocator< RenderableContainerData, LinearAllocatorArena >, false>;
+            STLAllocator< RenderableContainerData, LinearAllocatorArena >, false>;
 
     using LightContainerData = std::pair<LightManager::Instance, TransformManager::Instance>;
     using LightInstanceContainer = FixedCapacityVector<LightContainerData,
-            utils::STLAllocator< LightContainerData, LinearAllocatorArena >, false>;
+            STLAllocator< LightContainerData, LinearAllocatorArena >, false>;
 
     RenderableInstanceContainer renderableInstances{
             RenderableInstanceContainer::with_capacity(entities.size(), localArenaScope.getArena()) };
@@ -246,11 +246,11 @@ void FScene::prepare(utils::JobSystem& js,
 
     JobSystem::Job* rootJob = js.createJob();
 
-    auto* renderableJob = jobs::parallel_for(js, rootJob,
+    auto* renderableJob = parallel_for(js, rootJob,
             renderableInstances.data(), renderableInstances.size(),
             std::cref(renderableWork), jobs::CountSplitter<64>());
 
-    auto* lightJob = jobs::parallel_for(js, rootJob,
+    auto* lightJob = parallel_for(js, rootJob,
             lightInstances.data(), lightInstances.size(),
             std::cref(lightWork), jobs::CountSplitter<32, 5>());
 
@@ -448,7 +448,7 @@ void FScene::prepareDynamicLights(const CameraInfo& camera,
         Handle<HwBufferObject> lightUbh) noexcept {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     FLightManager const& lcm = mEngine.getLightManager();
-    FScene::LightSoa& lightData = getLightData();
+    LightSoa& lightData = getLightData();
 
     /*
      * Here we copy our lights data into the GPU buffer.
@@ -459,17 +459,17 @@ void FScene::prepareDynamicLights(const CameraInfo& camera,
     size_t const positionalLightCount = size - DIRECTIONAL_LIGHTS_COUNT;
     assert_invariant(positionalLightCount);
 
-    float4 const* const UTILS_RESTRICT spheres = lightData.data<FScene::POSITION_RADIUS>();
+    float4 const* const UTILS_RESTRICT spheres = lightData.data<POSITION_RADIUS>();
 
     // compute the light ranges (needed when building light trees)
-    float2* const zrange = lightData.data<FScene::SCREEN_SPACE_Z_RANGE>();
+    float2* const zrange = lightData.data<SCREEN_SPACE_Z_RANGE>();
     computeLightRanges(zrange, camera, spheres + DIRECTIONAL_LIGHTS_COUNT, positionalLightCount);
 
     LightsUib* const lp = driver.allocatePod<LightsUib>(positionalLightCount);
 
-    auto const* UTILS_RESTRICT directions       = lightData.data<FScene::DIRECTION>();
-    auto const* UTILS_RESTRICT instances        = lightData.data<FScene::LIGHT_INSTANCE>();
-    auto const* UTILS_RESTRICT shadowInfo       = lightData.data<FScene::SHADOW_INFO>();
+    auto const* UTILS_RESTRICT directions       = lightData.data<DIRECTION>();
+    auto const* UTILS_RESTRICT instances        = lightData.data<LIGHT_INSTANCE>();
+    auto const* UTILS_RESTRICT shadowInfo       = lightData.data<SHADOW_INFO>();
     for (size_t i = DIRECTIONAL_LIGHTS_COUNT, c = size; i < c; ++i) {
         const size_t gpuIndex = i - DIRECTIONAL_LIGHTS_COUNT;
         auto li = instances[i];

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -428,7 +428,7 @@ void FScene::updateUBOs(
     driver.resetBufferObject(renderableUbh);
     driver.updateBufferObjectUnsynchronized(renderableUbh, {
             buffer, count * sizeof(PerRenderableData),
-            +[](void* p, size_t s, void* user) {
+            +[](void* p, size_t const s, void* user) {
                 std::weak_ptr<SharedState>* const weakShared =
                         static_cast<std::weak_ptr<SharedState>*>(user);
                 if (s >= MAX_STREAM_ALLOCATION_COUNT * sizeof(PerRenderableData)) {
@@ -525,22 +525,22 @@ inline void FScene::computeLightRanges(
 }
 
 UTILS_NOINLINE
-void FScene::addEntity(Entity entity) {
+void FScene::addEntity(Entity const entity) {
     mEntities.insert(entity);
 }
 
 UTILS_NOINLINE
-void FScene::addEntities(const Entity* entities, size_t count) {
+void FScene::addEntities(const Entity* entities, size_t const count) {
     mEntities.insert(entities, entities + count);
 }
 
 UTILS_NOINLINE
-void FScene::remove(Entity entity) {
+void FScene::remove(Entity const entity) {
     mEntities.erase(entity);
 }
 
 UTILS_NOINLINE
-void FScene::removeEntities(const Entity* entities, size_t count) {
+void FScene::removeEntities(const Entity* entities, size_t const count) {
     for (size_t i = 0; i < count; ++i, ++entities) {
         remove(*entities);
     }
@@ -573,7 +573,7 @@ size_t FScene::getLightCount() const noexcept {
 }
 
 UTILS_NOINLINE
-bool FScene::hasEntity(Entity entity) const noexcept {
+bool FScene::hasEntity(Entity const entity) const noexcept {
     return mEntities.find(entity) != mEntities.end();
 }
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -137,13 +137,13 @@ public:
     RenderableSoa& getRenderableData() noexcept { return mRenderableData; }
 
     static inline uint32_t getPrimitiveCount(RenderableSoa const& soa,
-            uint32_t first, uint32_t last) noexcept {
+            uint32_t const first, uint32_t const last) noexcept {
         // the caller must guarantee that last is dereferenceable
         return soa.elementAt<SUMMED_PRIMITIVE_COUNT>(last) -
                 soa.elementAt<SUMMED_PRIMITIVE_COUNT>(first);
     }
 
-    static inline uint32_t getPrimitiveCount(RenderableSoa const& soa, uint32_t last) noexcept {
+    static inline uint32_t getPrimitiveCount(RenderableSoa const& soa, uint32_t const last) noexcept {
         // the caller must guarantee that last is dereferenceable
         return soa.elementAt<SUMMED_PRIMITIVE_COUNT>(last);
     }

--- a/filament/src/details/SkinningBuffer.cpp
+++ b/filament/src/details/SkinningBuffer.cpp
@@ -50,17 +50,17 @@ BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexce
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
-SkinningBuffer::Builder& SkinningBuffer::Builder::boneCount(uint32_t boneCount) noexcept {
+SkinningBuffer::Builder& SkinningBuffer::Builder::boneCount(uint32_t const boneCount) noexcept {
     mImpl->mBoneCount = boneCount;
     return *this;
 }
 
-SkinningBuffer::Builder& SkinningBuffer::Builder::initialize(bool initialize) noexcept {
+SkinningBuffer::Builder& SkinningBuffer::Builder::initialize(bool const initialize) noexcept {
     mImpl->mInitialize = initialize;
     return *this;
 }
 
-SkinningBuffer::Builder& SkinningBuffer::Builder::name(const char* name, size_t len) noexcept {
+SkinningBuffer::Builder& SkinningBuffer::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -106,7 +106,7 @@ void FSkinningBuffer::terminate(FEngine& engine) {
 }
 
 void FSkinningBuffer::setBones(FEngine& engine,
-        RenderableManager::Bone const* transforms, size_t count, size_t offset) {
+        RenderableManager::Bone const* transforms, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION((offset + count) <= mBoneCount)
             << "SkinningBuffer (size=" << (unsigned)mBoneCount
             << ") overflow (boneCount=" << (unsigned)count << ", offset=" << (unsigned)offset
@@ -116,7 +116,7 @@ void FSkinningBuffer::setBones(FEngine& engine,
 }
 
 void FSkinningBuffer::setBones(FEngine& engine,
-        mat4f const* transforms, size_t count, size_t offset) {
+        mat4f const* transforms, size_t const count, size_t const offset) {
     FILAMENT_CHECK_PRECONDITION((offset + count) <= mBoneCount)
             << "SkinningBuffer (size=" << (unsigned)mBoneCount
             << ") overflow (boneCount=" << (unsigned)count << ", offset=" << (unsigned)offset
@@ -133,7 +133,7 @@ static uint32_t packHalf2x16(half2 v) noexcept {
 }
 
 void FSkinningBuffer::setBones(FEngine& engine, Handle<HwBufferObject> handle,
-        RenderableManager::Bone const* transforms, size_t boneCount, size_t offset) noexcept {
+        RenderableManager::Bone const* transforms, size_t const boneCount, size_t const offset) noexcept {
     auto& driverApi = engine.getDriverApi();
     auto* UTILS_RESTRICT out = driverApi.allocatePod<PerRenderableBoneUib::BoneData>(boneCount);
     for (size_t i = 0, c = boneCount; i < c; ++i) {
@@ -162,7 +162,7 @@ PerRenderableBoneUib::BoneData FSkinningBuffer::makeBone(mat4f transform) noexce
 }
 
 void FSkinningBuffer::setBones(FEngine& engine, Handle<HwBufferObject> handle,
-        mat4f const* transforms, size_t boneCount, size_t offset) noexcept {
+        mat4f const* transforms, size_t const boneCount, size_t const offset) noexcept {
     auto& driverApi = engine.getDriverApi();
     auto* UTILS_RESTRICT out = driverApi.allocatePod<PerRenderableBoneUib::BoneData>(boneCount);
     for (size_t i = 0, c = boneCount; i < c; ++i) {
@@ -177,16 +177,16 @@ void FSkinningBuffer::setBones(FEngine& engine, Handle<HwBufferObject> handle,
 // When you change this value, you must change MAX_SKINNING_BUFFER_WIDTH at getters.vs
 constexpr size_t MAX_SKINNING_BUFFER_WIDTH = 2048;
 
-static inline size_t getSkinningBufferWidth(size_t pairCount) noexcept {
+static inline size_t getSkinningBufferWidth(size_t const pairCount) noexcept {
     return std::clamp(pairCount, size_t(1), MAX_SKINNING_BUFFER_WIDTH);
 }
 
-static inline size_t getSkinningBufferHeight(size_t pairCount) noexcept {
+static inline size_t getSkinningBufferHeight(size_t const pairCount) noexcept {
     return std::max(size_t(1),
             (pairCount + MAX_SKINNING_BUFFER_WIDTH - 1) / MAX_SKINNING_BUFFER_WIDTH);
 }
 
-inline size_t getSkinningBufferSize(size_t pairCount) noexcept {
+inline size_t getSkinningBufferSize(size_t const pairCount) noexcept {
     const size_t stride = getSkinningBufferWidth(pairCount);
     const size_t height = getSkinningBufferHeight(pairCount);
     return Texture::PixelBufferDescriptor::computeDataSize(
@@ -197,9 +197,9 @@ inline size_t getSkinningBufferSize(size_t pairCount) noexcept {
 
 UTILS_NOINLINE
 void updateDataAt(DriverApi& driver,
-        Handle<HwTexture> handle, PixelDataFormat format, PixelDataType type,
+        Handle<HwTexture> handle, PixelDataFormat const format, PixelDataType const type,
         const utils::FixedCapacityVector<float2>& pairs,
-        size_t count) {
+        size_t const count) {
 
     size_t const elementSize = sizeof(float2);
     size_t const size = getSkinningBufferSize(count);
@@ -238,7 +238,7 @@ void updateDataAt(DriverApi& driver,
 }
 
 TextureHandle FSkinningBuffer::createIndicesAndWeightsHandle(
-        FEngine& engine, size_t count) {
+        FEngine& engine, size_t const count) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     // create a texture for skinning pairs data (bone index and weight)
     return driver.createTexture(SamplerType::SAMPLER_2D, 1,
@@ -250,7 +250,7 @@ TextureHandle FSkinningBuffer::createIndicesAndWeightsHandle(
 
 void FSkinningBuffer::setIndicesAndWeightsData(FEngine& engine,
         Handle<HwTexture> textureHandle,
-        const utils::FixedCapacityVector<float2>& pairs, size_t count) {
+        const utils::FixedCapacityVector<float2>& pairs, size_t const count) {
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     updateDataAt(driver, textureHandle,

--- a/filament/src/details/SkinningBuffer.cpp
+++ b/filament/src/details/SkinningBuffer.cpp
@@ -60,6 +60,10 @@ SkinningBuffer::Builder& SkinningBuffer::Builder::initialize(bool initialize) no
     return *this;
 }
 
+SkinningBuffer::Builder& SkinningBuffer::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 SkinningBuffer* SkinningBuffer::Builder::build(Engine& engine) {
     return downcast(engine).createSkinningBuffer(*this);
 }

--- a/filament/src/details/SkinningBuffer.h
+++ b/filament/src/details/SkinningBuffer.h
@@ -55,7 +55,7 @@ public:
     size_t getBoneCount() const noexcept { return mBoneCount; }
 
     // round count to the size of the UBO in the shader
-    static size_t getPhysicalBoneCount(size_t count) noexcept {
+    static size_t getPhysicalBoneCount(size_t const count) noexcept {
         static_assert((CONFIG_MAX_BONE_COUNT & (CONFIG_MAX_BONE_COUNT - 1)) == 0);
         return (count + CONFIG_MAX_BONE_COUNT - 1) & ~(CONFIG_MAX_BONE_COUNT - 1);
     }

--- a/filament/src/details/SkinningBuffer.h
+++ b/filament/src/details/SkinningBuffer.h
@@ -61,7 +61,7 @@ public:
     }
 
 private:
-    friend class ::FilamentTest_Bones_Test;
+    friend class FilamentTest_Bones_Test;
     friend class SkinningBuffer;
     friend class FRenderableManager;
 

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -56,10 +56,10 @@ struct Skybox::BuilderDetails {
 using BuilderType = Skybox;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
 Skybox::Builder& Skybox::Builder::environment(Texture* cubemap) noexcept {
@@ -72,7 +72,7 @@ Skybox::Builder& Skybox::Builder::intensity(float envIntensity) noexcept {
     return *this;
 }
 
-Skybox::Builder& Skybox::Builder::color(math::float4 color) noexcept {
+Skybox::Builder& Skybox::Builder::color(float4 color) noexcept {
     mImpl->mColor = color;
     return *this;
 }
@@ -169,7 +169,7 @@ void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
     mLayerMask = (mLayerMask & ~select) | (values & select);
 }
 
-void FSkybox::setColor(math::float4 color) noexcept {
+void FSkybox::setColor(float4 color) noexcept {
     mSkyboxMaterialInstance->setParameter("color", color);
 }
 

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -67,17 +67,17 @@ Skybox::Builder& Skybox::Builder::environment(Texture* cubemap) noexcept {
     return *this;
 }
 
-Skybox::Builder& Skybox::Builder::intensity(float envIntensity) noexcept {
+Skybox::Builder& Skybox::Builder::intensity(float const envIntensity) noexcept {
     mImpl->mIntensity = envIntensity;
     return *this;
 }
 
-Skybox::Builder& Skybox::Builder::color(float4 color) noexcept {
+Skybox::Builder& Skybox::Builder::color(float4 const color) noexcept {
     mImpl->mColor = color;
     return *this;
 }
 
-Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
+Skybox::Builder& Skybox::Builder::showSun(bool const show) noexcept {
     mImpl->mShowSun = show;
     return *this;
 }
@@ -162,14 +162,14 @@ void FSkybox::terminate(FEngine& engine) noexcept {
     mSkyboxMaterialInstance = nullptr;
 }
 
-void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
+void FSkybox::setLayerMask(uint8_t const select, uint8_t const values) noexcept {
     auto& rcm = mRenderableManager;
     rcm.setLayerMask(rcm.getInstance(mSkybox), select, values);
     // we keep a checked version
     mLayerMask = (mLayerMask & ~select) | (values & select);
 }
 
-void FSkybox::setColor(float4 color) noexcept {
+void FSkybox::setColor(float4 const color) noexcept {
     mSkyboxMaterialInstance->setParameter("color", color);
 }
 

--- a/filament/src/details/Stream.cpp
+++ b/filament/src/details/Stream.cpp
@@ -61,6 +61,10 @@ Stream::Builder& Stream::Builder::height(uint32_t height) noexcept {
     return *this;
 }
 
+Stream::Builder& Stream::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 Stream* Stream::Builder::build(Engine& engine) {
     return downcast(engine).createStream(*this);
 }

--- a/filament/src/details/Stream.cpp
+++ b/filament/src/details/Stream.cpp
@@ -51,17 +51,17 @@ Stream::Builder& Stream::Builder::stream(void* stream) noexcept {
     return *this;
 }
 
-Stream::Builder& Stream::Builder::width(uint32_t width) noexcept {
+Stream::Builder& Stream::Builder::width(uint32_t const width) noexcept {
     mImpl->mWidth = width;
     return *this;
 }
 
-Stream::Builder& Stream::Builder::height(uint32_t height) noexcept {
+Stream::Builder& Stream::Builder::height(uint32_t const height) noexcept {
     mImpl->mHeight = height;
     return *this;
 }
 
-Stream::Builder& Stream::Builder::name(const char* name, size_t len) noexcept {
+Stream::Builder& Stream::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -95,16 +95,16 @@ void FStream::terminate(FEngine& engine) noexcept {
 }
 
 void FStream::setAcquiredImage(void* image,
-        Callback callback, void* userdata) noexcept {
+        Callback const callback, void* userdata) noexcept {
     mEngine.getDriverApi().setAcquiredImage(mStreamHandle, image, nullptr, callback, userdata);
 }
 
 void FStream::setAcquiredImage(void* image,
-        CallbackHandler* handler, Callback callback, void* userdata) noexcept {
+        CallbackHandler* handler, Callback const callback, void* userdata) noexcept {
     mEngine.getDriverApi().setAcquiredImage(mStreamHandle, image, handler, callback, userdata);
 }
 
-void FStream::setDimensions(uint32_t width, uint32_t height) noexcept {
+void FStream::setDimensions(uint32_t const width, uint32_t const height) noexcept {
     mWidth = width;
     mHeight = height;
 

--- a/filament/src/details/Stream.cpp
+++ b/filament/src/details/Stream.cpp
@@ -40,10 +40,10 @@ struct Stream::BuilderDetails {
 using BuilderType = Stream;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
 Stream::Builder& Stream::Builder::stream(void* stream) noexcept {

--- a/filament/src/details/SwapChain.cpp
+++ b/filament/src/details/SwapChain.cpp
@@ -31,12 +31,12 @@
 
 namespace filament {
 
-FSwapChain::FSwapChain(FEngine& engine, void* nativeWindow, uint64_t flags)
+FSwapChain::FSwapChain(FEngine& engine, void* nativeWindow, uint64_t const flags)
         : mEngine(engine), mNativeWindow(nativeWindow), mConfigFlags(initFlags(engine, flags)) {
     mHwSwapChain = engine.getDriverApi().createSwapChain(nativeWindow, flags);
 }
 
-FSwapChain::FSwapChain(FEngine& engine, uint32_t width, uint32_t height, uint64_t flags)
+FSwapChain::FSwapChain(FEngine& engine, uint32_t const width, uint32_t const height, uint64_t const flags)
         : mEngine(engine), mWidth(width), mHeight(height), mConfigFlags(initFlags(engine, flags)) {
     mHwSwapChain = engine.getDriverApi().createSwapChainHeadless(width, height, flags);
 }
@@ -70,7 +70,7 @@ void FSwapChain::terminate(FEngine& engine) noexcept {
 }
 
 void FSwapChain::setFrameScheduledCallback(
-        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t flags) {
+        backend::CallbackHandler* handler, FrameScheduledCallback&& callback, uint64_t const flags) {
     mFrameScheduledCallbackIsSet = bool(callback);
     mEngine.getDriverApi().setFrameScheduledCallback(
             mHwSwapChain, handler, std::move(callback), flags);

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -90,10 +90,10 @@ struct Texture::BuilderDetails {
 using BuilderType = Texture;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
 Texture::Builder& Texture::Builder::width(uint32_t width) noexcept {
@@ -116,18 +116,18 @@ Texture::Builder& Texture::Builder::levels(uint8_t levels) noexcept {
     return *this;
 }
 
-Texture::Builder& Texture::Builder::sampler(Texture::Sampler target) noexcept {
+Texture::Builder& Texture::Builder::sampler(Sampler target) noexcept {
     mImpl->mTarget = target;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::format(Texture::InternalFormat format) noexcept {
+Texture::Builder& Texture::Builder::format(InternalFormat format) noexcept {
     mImpl->mFormat = format;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
-    mImpl->mUsage = Texture::Usage(usage);
+Texture::Builder& Texture::Builder::usage(Usage usage) noexcept {
+    mImpl->mUsage = Usage(usage);
     return *this;
 }
 
@@ -308,7 +308,7 @@ size_t FTexture::getDepth(size_t level) const noexcept {
 void FTexture::setImage(FEngine& engine, size_t level,
         uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
         uint32_t width, uint32_t height, uint32_t depth,
-        FTexture::PixelBufferDescriptor&& p) const {
+        PixelBufferDescriptor&& p) const {
 
     if (UTILS_UNLIKELY(!engine.hasFeatureLevel(FeatureLevel::FEATURE_LEVEL_1))) {
         FILAMENT_CHECK_PRECONDITION(p.stride == 0 || p.stride == width)
@@ -398,7 +398,7 @@ void FTexture::setImage(FEngine& engine, size_t level,
 
 // deprecated
 void FTexture::setImage(FEngine& engine, size_t level,
-        Texture::PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
+        PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
 
     auto validateTarget = [](SamplerType sampler) -> bool {
         switch (sampler) {
@@ -527,7 +527,7 @@ void FTexture::setExternalStream(FEngine& engine, FStream* stream) noexcept {
         api.setExternalStream(mHandle, stream->getHandle());
     } else {
         mStream = nullptr;
-        api.setExternalStream(mHandle, backend::Handle<backend::HwStream>());
+        api.setExternalStream(mHandle, backend::Handle<HwStream>());
     }
 }
 
@@ -574,7 +574,7 @@ void FTexture::updateLodRange(uint8_t baseLevel, uint8_t levelCount) noexcept {
     }
 }
 
-void FTexture::setHandles(backend::Handle<backend::HwTexture> handle) noexcept {
+void FTexture::setHandles(Handle<HwTexture> handle) noexcept {
     assert_invariant(!mHandle || mHandleForSampling);
     if (mHandle) {
         mDriver->destroyTexture(mHandle);
@@ -586,8 +586,8 @@ void FTexture::setHandles(backend::Handle<backend::HwTexture> handle) noexcept {
     mHandleForSampling = handle;
 }
 
-backend::Handle<backend::HwTexture> FTexture::setHandleForSampling(
-        backend::Handle<backend::HwTexture> handle) const noexcept {
+Handle<HwTexture> FTexture::setHandleForSampling(
+        Handle<HwTexture> handle) const noexcept {
     assert_invariant(!mHandle || mHandleForSampling);
     if (mHandleForSampling && mHandleForSampling != mHandle) {
         mDriver->destroyTexture(mHandleForSampling);
@@ -595,19 +595,19 @@ backend::Handle<backend::HwTexture> FTexture::setHandleForSampling(
     return mHandleForSampling = handle;
 }
 
-backend::Handle<backend::HwTexture> FTexture::createPlaceholderTexture(
-        backend::DriverApi& driver) noexcept {
+Handle<HwTexture> FTexture::createPlaceholderTexture(
+        DriverApi& driver) noexcept {
     auto handle = driver.createTexture(
             Sampler::SAMPLER_2D, 1, InternalFormat::RGBA8, 1, 1, 1, 1, Usage::DEFAULT);
     static uint8_t pixels[4] = { 0, 0, 0, 0 };
     driver.update3DImage(handle, 0, 0, 0, 0, 1, 1, 1,
             { (char*)&pixels[0], sizeof(pixels),
-                    Texture::PixelBufferDescriptor::PixelDataFormat::RGBA,
-                    Texture::PixelBufferDescriptor::PixelDataType::UBYTE });
+                    PixelBufferDescriptor::PixelDataFormat::RGBA,
+                    PixelBufferDescriptor::PixelDataType::UBYTE });
     return handle;
 }
 
-backend::Handle<backend::HwTexture> FTexture::getHwHandleForSampling() const noexcept {
+Handle<HwTexture> FTexture::getHwHandleForSampling() const noexcept {
     if (UTILS_UNLIKELY(mExternal && !mHandleForSampling)) {
         return setHandleForSampling(createPlaceholderTexture(*mDriver));
     }
@@ -642,7 +642,7 @@ bool FTexture::isTextureSwizzleSupported(FEngine& engine) noexcept {
     return engine.getDriverApi().isTextureSwizzleSupported();
 }
 
-size_t FTexture::computeTextureDataSize(Texture::Format format, Texture::Type type,
+size_t FTexture::computeTextureDataSize(Format format, Type type,
         size_t stride, size_t height, size_t alignment) noexcept {
     return PixelBufferDescriptor::computeDataSize(format, type, stride, height, alignment);
 }
@@ -807,9 +807,9 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
         CubemapIBL::roughnessFilter(js, dst, { levels.begin(), uint32_t(levels.size()) },
                 linearRoughness, numSamples, mirror, true);
 
-        Texture::PixelBufferDescriptor const pbd(image.getData(), image.getSize(),
-                Texture::PixelBufferDescriptor::PixelDataFormat::RGB,
-                Texture::PixelBufferDescriptor::PixelDataType::FLOAT, 1, 0, 0, image.getStride());
+        PixelBufferDescriptor const pbd(image.getData(), image.getSize(),
+                PixelBufferDescriptor::PixelDataFormat::RGB,
+                PixelBufferDescriptor::PixelDataType::FLOAT, 1, 0, 0, image.getStride());
 
         uintptr_t const base = uintptr_t(image.getData());
         for (size_t j = 0; j < 6; j++) {
@@ -817,8 +817,8 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
             auto offset = uintptr_t(faceImage.getData()) - base;
             driver.update3DImage(mHandle, level, 0, 0, j, dim, dim, 1, {
                     (char*)image.getData() + offset, dim * dim * 3 * sizeof(float),
-                    Texture::PixelBufferDescriptor::PixelDataFormat::RGB,
-                    Texture::PixelBufferDescriptor::PixelDataType::FLOAT, 1,
+                    PixelBufferDescriptor::PixelDataFormat::RGB,
+                    PixelBufferDescriptor::PixelDataType::FLOAT, 1,
                     0, 0, uint32_t(image.getStride())
             });
         }

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -96,42 +96,42 @@ BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexce
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 
-Texture::Builder& Texture::Builder::width(uint32_t width) noexcept {
+Texture::Builder& Texture::Builder::width(uint32_t const width) noexcept {
     mImpl->mWidth = width;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::height(uint32_t height) noexcept {
+Texture::Builder& Texture::Builder::height(uint32_t const height) noexcept {
     mImpl->mHeight = height;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::depth(uint32_t depth) noexcept {
+Texture::Builder& Texture::Builder::depth(uint32_t const depth) noexcept {
     mImpl->mDepth = depth;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::levels(uint8_t levels) noexcept {
+Texture::Builder& Texture::Builder::levels(uint8_t const levels) noexcept {
     mImpl->mLevels = std::max(uint8_t(1), levels);
     return *this;
 }
 
-Texture::Builder& Texture::Builder::sampler(Sampler target) noexcept {
+Texture::Builder& Texture::Builder::sampler(Sampler const target) noexcept {
     mImpl->mTarget = target;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::format(InternalFormat format) noexcept {
+Texture::Builder& Texture::Builder::format(InternalFormat const format) noexcept {
     mImpl->mFormat = format;
     return *this;
 }
 
-Texture::Builder& Texture::Builder::usage(Usage usage) noexcept {
+Texture::Builder& Texture::Builder::usage(Usage const usage) noexcept {
     mImpl->mUsage = Usage(usage);
     return *this;
 }
 
-Texture::Builder& Texture::Builder::import(intptr_t id) noexcept {
+Texture::Builder& Texture::Builder::import(intptr_t const id) noexcept {
     assert_invariant(id); // imported id can't be zero
     mImpl->mImportedId = id;
     return *this;
@@ -142,13 +142,13 @@ Texture::Builder& Texture::Builder::external() noexcept {
     return *this;
 }
 
-Texture::Builder& Texture::Builder::swizzle(Swizzle r, Swizzle g, Swizzle b, Swizzle a) noexcept {
+Texture::Builder& Texture::Builder::swizzle(Swizzle const r, Swizzle const g, Swizzle const b, Swizzle const a) noexcept {
     mImpl->mTextureIsSwizzled = true;
     mImpl->mSwizzle = { r, g, b, a };
     return *this;
 }
 
-Texture::Builder& Texture::Builder::name(const char* name, size_t len) noexcept {
+Texture::Builder& Texture::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -216,7 +216,7 @@ Texture* Texture::Builder::build(Engine& engine) {
     FILAMENT_CHECK_PRECONDITION(!swizzled) << "WebGL does not support texture swizzling.";
     #endif
 
-    auto validateSamplerType = [&engine = downcast(engine)](SamplerType sampler) -> bool {
+    auto validateSamplerType = [&engine = downcast(engine)](SamplerType const sampler) -> bool {
         switch (sampler) {
             case SamplerType::SAMPLER_2D:
             case SamplerType::SAMPLER_CUBEMAP:
@@ -297,21 +297,21 @@ void FTexture::terminate(FEngine& engine) {
     setHandles({});
 }
 
-size_t FTexture::getWidth(size_t level) const noexcept {
+size_t FTexture::getWidth(size_t const level) const noexcept {
     return valueForLevel(level, mWidth);
 }
 
-size_t FTexture::getHeight(size_t level) const noexcept {
+size_t FTexture::getHeight(size_t const level) const noexcept {
     return valueForLevel(level, mHeight);
 }
 
-size_t FTexture::getDepth(size_t level) const noexcept {
+size_t FTexture::getDepth(size_t const level) const noexcept {
     return valueForLevel(level, mDepth);
 }
 
-void FTexture::setImage(FEngine& engine, size_t level,
-        uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-        uint32_t width, uint32_t height, uint32_t depth,
+void FTexture::setImage(FEngine& engine, size_t const level,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& p) const {
 
     if (UTILS_UNLIKELY(!engine.hasFeatureLevel(FeatureLevel::FEATURE_LEVEL_1))) {
@@ -401,10 +401,10 @@ void FTexture::setImage(FEngine& engine, size_t level,
 }
 
 // deprecated
-void FTexture::setImage(FEngine& engine, size_t level,
+void FTexture::setImage(FEngine& engine, size_t const level,
         PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const {
 
-    auto validateTarget = [](SamplerType sampler) -> bool {
+    auto validateTarget = [](SamplerType const sampler) -> bool {
         switch (sampler) {
             case SamplerType::SAMPLER_CUBEMAP:
                 return true;
@@ -489,7 +489,7 @@ void FTexture::setExternalImage(FEngine& engine, void* image) noexcept {
     setHandles(texture);
 }
 
-void FTexture::setExternalImage(FEngine& engine, void* image, size_t plane) noexcept {
+void FTexture::setExternalImage(FEngine& engine, void* image, size_t const plane) noexcept {
     FILAMENT_CHECK_PRECONDITION(mExternal) << "The texture must be external.";
 
     // The call to setupExternalImage is synchronous, and allows the driver to take ownership of
@@ -559,7 +559,7 @@ bool FTexture::textureHandleCanMutate() const noexcept {
     return (any(mUsage & Usage::SAMPLEABLE) && mLevelCount > 1) || mExternal;
 }
 
-void FTexture::updateLodRange(uint8_t baseLevel, uint8_t levelCount) noexcept {
+void FTexture::updateLodRange(uint8_t const baseLevel, uint8_t const levelCount) noexcept {
     assert_invariant(!mExternal);
     if (any(mUsage & Usage::SAMPLEABLE) && mLevelCount > 1) {
         auto& range = mLodRange;
@@ -630,11 +630,11 @@ Handle<HwTexture> FTexture::getHwHandleForSampling() const noexcept {
     return mHandleForSampling;
 }
 
-void FTexture::updateLodRange(uint8_t level) noexcept {
+void FTexture::updateLodRange(uint8_t const level) noexcept {
     updateLodRange(level, 1);
 }
 
-bool FTexture::isTextureFormatSupported(FEngine& engine, InternalFormat format) noexcept {
+bool FTexture::isTextureFormatSupported(FEngine& engine, InternalFormat const format) noexcept {
     return engine.getDriverApi().isTextureFormatSupported(format);
 }
 
@@ -646,12 +646,12 @@ bool FTexture::isTextureSwizzleSupported(FEngine& engine) noexcept {
     return engine.getDriverApi().isTextureSwizzleSupported();
 }
 
-size_t FTexture::computeTextureDataSize(Format format, Type type,
-        size_t stride, size_t height, size_t alignment) noexcept {
+size_t FTexture::computeTextureDataSize(Format const format, Type const type,
+        size_t const stride, size_t const height, size_t const alignment) noexcept {
     return PixelBufferDescriptor::computeDataSize(format, type, stride, height, alignment);
 }
 
-size_t FTexture::getFormatSize(InternalFormat format) noexcept {
+size_t FTexture::getFormatSize(InternalFormat const format) noexcept {
     return backend::getFormatSize(format);
 }
 
@@ -835,8 +835,8 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
     // by the caller (without being move()d here).
 }
 
-bool FTexture::validatePixelFormatAndType(TextureFormat internalFormat,
-        PixelDataFormat format, PixelDataType type) noexcept {
+bool FTexture::validatePixelFormatAndType(TextureFormat const internalFormat,
+        PixelDataFormat const format, PixelDataType const type) noexcept {
 
     switch (internalFormat) {
         case TextureFormat::R8:

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -148,6 +148,10 @@ Texture::Builder& Texture::Builder::swizzle(Swizzle r, Swizzle g, Swizzle b, Swi
     return *this;
 }
 
+Texture::Builder& Texture::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 Texture* Texture::Builder::build(Engine& engine) {
     FILAMENT_CHECK_PRECONDITION(Texture::isTextureFormatSupported(engine, mImpl->mFormat))
             << "Texture format " << uint16_t(mImpl->mFormat) << " not supported on this platform";

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -75,7 +75,7 @@ public:
     void setSampleCount(size_t sampleCount) noexcept { mSampleCount = uint8_t(sampleCount); }
     size_t getSampleCount() const noexcept { return mSampleCount; }
     bool isMultisample() const noexcept { return mSampleCount > 1; }
-    bool isCompressed() const noexcept { return backend::isCompressedFormat(mFormat); }
+    bool isCompressed() const noexcept { return isCompressedFormat(mFormat); }
 
     bool isCubemap() const noexcept { return mTarget == Sampler::SAMPLER_CUBEMAP; }
 
@@ -95,7 +95,7 @@ public:
     static bool isTextureSwizzleSupported(FEngine& engine) noexcept;
 
     // storage needed on the CPU side for texture data uploads
-    static size_t computeTextureDataSize(Texture::Format format, Texture::Type type,
+    static size_t computeTextureDataSize(Format format, Type type,
             size_t stride, size_t height, size_t alignment) noexcept;
 
     // Size a of a pixel in bytes for the given format

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -72,7 +72,7 @@ public:
 
     void generateMipmaps(FEngine& engine) const noexcept;
 
-    void setSampleCount(size_t sampleCount) noexcept { mSampleCount = uint8_t(sampleCount); }
+    void setSampleCount(size_t const sampleCount) noexcept { mSampleCount = uint8_t(sampleCount); }
     size_t getSampleCount() const noexcept { return mSampleCount; }
     bool isMultisample() const noexcept { return mSampleCount > 1; }
     bool isCompressed() const noexcept { return isCompressedFormat(mFormat); }
@@ -102,17 +102,17 @@ public:
     static size_t getFormatSize(InternalFormat format) noexcept;
 
     // Returns the with or height for a given mipmap level from the base value.
-    static inline size_t valueForLevel(uint8_t level, size_t baseLevelValue) {
+    static inline size_t valueForLevel(uint8_t const level, size_t const baseLevelValue) {
         return std::max(size_t(1), baseLevelValue >> level);
     }
 
     // Returns the max number of levels for a texture of given max dimensions
-    static inline uint8_t maxLevelCount(uint32_t maxDimension) noexcept {
+    static inline uint8_t maxLevelCount(uint32_t const maxDimension) noexcept {
         return std::max(1, std::ilogbf(float(maxDimension)) + 1);
     }
 
     // Returns the max number of levels for a texture of given dimensions
-    static inline uint8_t maxLevelCount(uint32_t width, uint32_t height) noexcept {
+    static inline uint8_t maxLevelCount(uint32_t const width, uint32_t const height) noexcept {
         uint32_t const maxDimension = std::max(width, height);
         return maxLevelCount(maxDimension);
     }

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -148,6 +148,10 @@ VertexBuffer::Builder& VertexBuffer::Builder::advancedSkinning(bool enabled) noe
     return *this;
 }
 
+VertexBuffer::Builder& VertexBuffer::Builder::name(const char* name, size_t len) noexcept {
+    return BuilderNameMixin::name(name, len);
+}
+
 VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
     FILAMENT_CHECK_PRECONDITION(mImpl->mVertexCount > 0) << "vertexCount cannot be 0";
     FILAMENT_CHECK_PRECONDITION(mImpl->mBufferCount > 0) << "bufferCount cannot be 0";

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -50,8 +50,8 @@ using namespace backend;
 using namespace filament::math;
 
 struct VertexBuffer::BuilderDetails {
-    struct AttributeData : backend::Attribute {
-        AttributeData() : backend::Attribute{ .type = backend::ElementType::FLOAT4 } {
+    struct AttributeData : Attribute {
+        AttributeData() : Attribute{ .type = ElementType::FLOAT4 } {
             static_assert(sizeof(Attribute) == sizeof(AttributeData),
                     "Attribute and Builder::Attribute must match");
         }
@@ -67,10 +67,10 @@ struct VertexBuffer::BuilderDetails {
 using BuilderType = VertexBuffer;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
-BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
 VertexBuffer::Builder& VertexBuffer::Builder::vertexCount(uint32_t vertexCount) noexcept {
     mImpl->mVertexCount = vertexCount;
@@ -117,7 +117,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         entry.offset = byteOffset;
         entry.stride = byteStride;
         entry.type = attributeType;
-        if (attribute == VertexAttribute::BONE_INDICES) {
+        if (attribute == BONE_INDICES) {
             // BONE_INDICES must always be an integer type
             entry.flags |= Attribute::FLAG_INTEGER_TARGET;
         }
@@ -164,7 +164,7 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
         // update set of used buffers
         attributedBuffers.set(attributes[j].buffer);
 
-        if (engine.getActiveFeatureLevel() == backend::FeatureLevel::FEATURE_LEVEL_0) {
+        if (engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0) {
             FILAMENT_CHECK_PRECONDITION(!(attributes[j].flags & Attribute::FLAG_INTEGER_TARGET))
                     << "Attribute::FLAG_INTEGER_TARGET not supported at FEATURE_LEVEL_0";
         }
@@ -205,7 +205,7 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& builder)
+FVertexBuffer::FVertexBuffer(FEngine& engine, const Builder& builder)
         : mVertexCount(builder->mVertexCount), mBufferCount(builder->mBufferCount),
           mBufferObjectsEnabled(builder->mBufferObjectsEnabled),
           mAdvancedSkinningEnabled(builder->mAdvancedSkinningEnabled){
@@ -213,24 +213,24 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
     mDeclaredAttributes = builder->mDeclaredAttributes;
 
     if (mAdvancedSkinningEnabled) {
-        mAttributes[VertexAttribute::BONE_INDICES] = {
+        mAttributes[BONE_INDICES] = {
                 .offset = 0,
                 .stride = 8,
                 .buffer = mBufferCount,
-                .type = VertexBuffer::AttributeType::USHORT4,
+                .type = AttributeType::USHORT4,
                 .flags = Attribute::FLAG_INTEGER_TARGET,
         };
-        mDeclaredAttributes.set(VertexAttribute::BONE_INDICES);
+        mDeclaredAttributes.set(BONE_INDICES);
         mBufferCount++;
 
-        mAttributes[VertexAttribute::BONE_WEIGHTS] = {
+        mAttributes[BONE_WEIGHTS] = {
                 .offset = 0,
                 .stride = 16,
                 .buffer = mBufferCount,
-                .type = VertexBuffer::AttributeType::FLOAT4,
+                .type = AttributeType::FLOAT4,
                 .flags = 0,
         };
-        mDeclaredAttributes.set(VertexAttribute::BONE_WEIGHTS);
+        mDeclaredAttributes.set(BONE_WEIGHTS);
         mBufferCount++;
     } else {
         // Because the Material's SKN variant supports both skinning and morphing, it expects
@@ -289,7 +289,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
                 assert_invariant(bufferSizes[i] > 0);
                 if (!mBufferObjects[i]) {
                     BufferObjectHandle bo = driver.createBufferObject(bufferSizes[i],
-                            backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC);
+                            BufferObjectBinding::VERTEX, BufferUsage::STATIC);
                     if (auto name = builder.getName(); !name.empty()) {
                         driver.setDebugTag(bo.getId(), name);
                     }
@@ -302,13 +302,13 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
         // in advanced skinning mode, we manage the BONE_INDICES and BONE_WEIGHTS arrays ourselves,
         // so we have to set the corresponding buffer objects.
         if (mAdvancedSkinningEnabled) {
-            for (auto index : { VertexAttribute::BONE_INDICES, VertexAttribute::BONE_WEIGHTS }) {
+            for (auto index : { BONE_INDICES, BONE_WEIGHTS }) {
                 size_t const i = mAttributes[index].buffer;
                 assert_invariant(i != Attribute::BUFFER_UNUSED);
                 assert_invariant(bufferSizes[i] > 0);
                 if (!mBufferObjects[i]) {
                     BufferObjectHandle const bo = driver.createBufferObject(bufferSizes[i],
-                            backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC);
+                            BufferObjectBinding::VERTEX, BufferUsage::STATIC);
                     if (auto name = builder.getName(); !name.empty()) {
                         driver.setDebugTag(bo.getId(), name);
                     }
@@ -370,14 +370,14 @@ void FVertexBuffer::updateBoneIndicesAndWeights(FEngine& engine,
         std::unique_ptr<float[]> skinWeights) {
     FILAMENT_CHECK_PRECONDITION(mAdvancedSkinningEnabled) << "No advanced skinning enabled";
     auto jointsData = skinJoints.release();
-    uint8_t const indicesIndex = mAttributes[VertexAttribute::BONE_INDICES].buffer;
+    uint8_t const indicesIndex = mAttributes[BONE_INDICES].buffer;
     engine.getDriverApi().updateBufferObject(mBufferObjects[indicesIndex],
             {jointsData, mVertexCount * 8,
                     [](void* buffer, size_t, void*) { delete[] static_cast<uint16_t*>(buffer); }},
             0);
 
     auto weightsData = skinWeights.release();
-    uint8_t const weightsIndex = mAttributes[VertexAttribute::BONE_WEIGHTS].buffer;
+    uint8_t const weightsIndex = mAttributes[BONE_WEIGHTS].buffer;
     engine.getDriverApi().updateBufferObject(mBufferObjects[weightsIndex],
             {weightsData, mVertexCount * 16,
                     [](void* buffer, size_t, void*) { delete[] static_cast<float*>(buffer); }},

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -72,25 +72,25 @@ BuilderType::Builder::Builder(Builder&& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder const& rhs) noexcept = default;
 BuilderType::Builder& BuilderType::Builder::operator=(Builder&& rhs) noexcept = default;
 
-VertexBuffer::Builder& VertexBuffer::Builder::vertexCount(uint32_t vertexCount) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::vertexCount(uint32_t const vertexCount) noexcept {
     mImpl->mVertexCount = vertexCount;
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::enableBufferObjects(bool enabled) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::enableBufferObjects(bool const enabled) noexcept {
     mImpl->mBufferObjectsEnabled = enabled;
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::bufferCount(uint8_t bufferCount) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::bufferCount(uint8_t const bufferCount) noexcept {
     mImpl->mBufferCount = bufferCount;
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribute,
-        uint8_t bufferIndex,
-        AttributeType attributeType,
-        uint32_t byteOffset,
+VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute const attribute,
+        uint8_t const bufferIndex,
+        AttributeType const attributeType,
+        uint32_t const byteOffset,
         uint8_t byteStride) noexcept {
 
     size_t const attributeSize = Driver::getElementTypeSize(attributeType);
@@ -130,8 +130,8 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribute,
-        bool normalized) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute const attribute,
+        bool const normalized) noexcept {
     if (size_t(attribute) < MAX_VERTEX_ATTRIBUTE_COUNT) {
         auto& entry = mImpl->mAttributes[attribute];
         if (normalized) {
@@ -143,12 +143,12 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::advancedSkinning(bool enabled) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::advancedSkinning(bool const enabled) noexcept {
     mImpl->mAdvancedSkinningEnabled = enabled;
     return *this;
 }
 
-VertexBuffer::Builder& VertexBuffer::Builder::name(const char* name, size_t len) noexcept {
+VertexBuffer::Builder& VertexBuffer::Builder::name(const char* name, size_t const len) noexcept {
     return BuilderNameMixin::name(name, len);
 }
 
@@ -164,7 +164,7 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
     auto const& attributes = mImpl->mAttributes;
     utils::bitset32 attributedBuffers;
 
-    declaredAttributes.forEachSetBit([&](size_t j){
+    declaredAttributes.forEachSetBit([&](size_t const j){
         // update set of used buffers
         attributedBuffers.set(attributes[j].buffer);
 
@@ -339,8 +339,8 @@ size_t FVertexBuffer::getVertexCount() const noexcept {
     return mVertexCount;
 }
 
-void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
-        backend::BufferDescriptor&& buffer, uint32_t byteOffset) {
+void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t const bufferIndex,
+        backend::BufferDescriptor&& buffer, uint32_t const byteOffset) {
     FILAMENT_CHECK_PRECONDITION(!mBufferObjectsEnabled) << "Please use setBufferObjectAt()";
     if (bufferIndex < mBufferCount) {
         assert_invariant(mBufferObjects[bufferIndex]);
@@ -352,7 +352,7 @@ void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
     }
 }
 
-void FVertexBuffer::setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
+void FVertexBuffer::setBufferObjectAt(FEngine& engine, uint8_t const bufferIndex,
         FBufferObject const * bufferObject) {
     FILAMENT_CHECK_PRECONDITION(mBufferObjectsEnabled) << "Please use setBufferAt()";
     FILAMENT_CHECK_PRECONDITION(bufferObject->getBindingType() == BufferObject::BindingType::VERTEX)

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -185,7 +185,7 @@ void FView::setDynamicResolutionOptions(DynamicResolutionOptions const& options)
     }
 }
 
-void FView::setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept {
+void FView::setDynamicLightingOptions(float const zLightNear, float const zLightFar) noexcept {
     mFroxelizer.setOptions(zLightNear, zLightFar);
 }
 
@@ -311,7 +311,7 @@ float2 FView::updateScale(FEngine& engine,
     return mScale;
 }
 
-void FView::setVisibleLayers(uint8_t select, uint8_t values) noexcept {
+void FView::setVisibleLayers(uint8_t const select, uint8_t const values) noexcept {
     mVisibleLayers = (mVisibleLayers & ~select) | (values & select);
 }
 
@@ -481,8 +481,8 @@ CameraInfo FView::computeCameraInfo(FEngine& engine) const noexcept {
 }
 
 void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootArenaScope,
-        filament::Viewport viewport, CameraInfo cameraInfo,
-        float4 const& userTime, bool needsAlphaChannel) noexcept {
+        filament::Viewport const viewport, CameraInfo cameraInfo,
+        float4 const& userTime, bool const needsAlphaChannel) noexcept {
 
         SYSTRACE_CALL();
         SYSTRACE_CONTEXT();
@@ -786,7 +786,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 }
 
 void FView::computeVisibilityMasks(
-        uint8_t visibleLayers,
+        uint8_t const visibleLayers,
         uint8_t const* UTILS_RESTRICT layers,
         FRenderableManager::Visibility const* UTILS_RESTRICT visibility,
         Culler::result_type* UTILS_RESTRICT visibleMask, size_t count) {
@@ -818,8 +818,8 @@ void FView::computeVisibilityMasks(
 
 UTILS_NOINLINE
 /* static */ FScene::RenderableSoa::iterator FView::partition(
-        FScene::RenderableSoa::iterator begin,
-        FScene::RenderableSoa::iterator end,
+        FScene::RenderableSoa::iterator const begin,
+        FScene::RenderableSoa::iterator const end,
         Culler::result_type mask, Culler::result_type value) noexcept {
     return std::partition(begin, end, [mask, value](auto it) {
         // Mask VISIBLE_MASK to ignore higher bits related to spot shadows. We only partition based
@@ -828,7 +828,7 @@ UTILS_NOINLINE
     });
 }
 
-void FView::prepareUpscaler(float2 scale,
+void FView::prepareUpscaler(float2 const scale,
         TemporalAntiAliasingOptions const& taaOptions,
         DynamicResolutionOptions const& dsrOptions) const noexcept {
     SYSTRACE_CALL();
@@ -865,8 +865,8 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
 }
 
 void FView::prepareSSR(Handle<HwTexture> ssr,
-        bool disableSSR,
-        float refractionLodOffset,
+        bool const disableSSR,
+        float const refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
     mColorPassDescriptorSet.prepareSSR(ssr, disableSSR, refractionLodOffset, ssrOptions);
 }
@@ -902,7 +902,7 @@ void FView::prepareShadow(Handle<HwTexture> texture) const noexcept {
     }
 }
 
-void FView::prepareShadowMapping(bool highPrecision) const noexcept {
+void FView::prepareShadowMapping(bool const highPrecision) const noexcept {
     if (mHasShadowing) {
         assert_invariant(mShadowMapManager);
         mColorPassDescriptorSet.prepareShadowMapping(
@@ -946,7 +946,7 @@ void FView::cullRenderables(JobSystem&,
 
     // culling job (this runs on multiple threads)
     auto functor = [&frustum, worldAABBCenter, worldAABBExtent, visibleArray, bit]
-            (uint32_t index, uint32_t c) {
+            (uint32_t const index, uint32_t const c) {
         Culler::intersects(
                 visibleArray + index,
                 frustum,
@@ -1113,7 +1113,7 @@ void FView::clearFrameHistory(FEngine& engine) noexcept {
 }
 
 void FView::executePickingQueries(DriverApi& driver,
-        RenderTargetHandle handle, float2 scale) noexcept {
+        RenderTargetHandle handle, float2 const scale) noexcept {
 
     while (mActivePickingQueriesList) {
         FPickingQuery* const pQuery = mActivePickingQueriesList;
@@ -1182,7 +1182,7 @@ void FView::setScreenSpaceReflectionsOptions(ScreenSpaceReflectionsOptions optio
     mScreenSpaceReflectionsOptions = options;
 }
 
-void FView::setGuardBandOptions(GuardBandOptions options) noexcept {
+void FView::setGuardBandOptions(GuardBandOptions const options) noexcept {
     mGuardBandOptions = options;
 }
 
@@ -1250,8 +1250,8 @@ void FView::setVignetteOptions(VignetteOptions options) noexcept {
     mVignetteOptions = options;
 }
 
-View::PickingQuery& FView::pick(uint32_t x, uint32_t y, CallbackHandler* handler,
-        PickingQueryResultCallback callback) noexcept {
+View::PickingQuery& FView::pick(uint32_t const x, uint32_t const y, CallbackHandler* handler,
+        PickingQueryResultCallback const callback) noexcept {
     FPickingQuery* pQuery = FPickingQuery::get(x, y, handler, callback);
     pQuery->next = mActivePickingQueriesList;
     mActivePickingQueriesList = pQuery;
@@ -1262,13 +1262,13 @@ void FView::setStereoscopicOptions(const StereoscopicOptions& options) noexcept 
     mStereoscopicOptions = options;
 }
 
-void FView::setMaterialGlobal(uint32_t index, float4 const& value) {
+void FView::setMaterialGlobal(uint32_t const index, float4 const& value) {
     FILAMENT_CHECK_PRECONDITION(index < 4)
             << "material global variable index (" << +index << ") out of range";
     mMaterialGlobals[index] = value;
 }
 
-float4 FView::getMaterialGlobal(uint32_t index) const {
+float4 FView::getMaterialGlobal(uint32_t const index) const {
     FILAMENT_CHECK_PRECONDITION(index < 4)
             << "material global variable index (" << +index << ") out of range";
     return mMaterialGlobals[index];

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -127,13 +127,13 @@ public:
     }
     bool isSkyboxVisible() const noexcept;
 
-    void setFrustumCullingEnabled(bool culling) noexcept { mCulling = culling; }
+    void setFrustumCullingEnabled(bool const culling) noexcept { mCulling = culling; }
     bool isFrustumCullingEnabled() const noexcept { return mCulling; }
 
-    void setFrontFaceWindingInverted(bool inverted) noexcept { mFrontFaceWindingInverted = inverted; }
+    void setFrontFaceWindingInverted(bool const inverted) noexcept { mFrontFaceWindingInverted = inverted; }
     bool isFrontFaceWindingInverted() const noexcept { return mFrontFaceWindingInverted; }
 
-    void setTransparentPickingEnabled(bool enabled) noexcept { mIsTransparentPickingEnabled = enabled; }
+    void setTransparentPickingEnabled(bool const enabled) noexcept { mIsTransparentPickingEnabled = enabled; }
     bool isTransparentPickingEnabled() const noexcept { return mIsTransparentPickingEnabled; }
 
 
@@ -208,17 +208,17 @@ public:
             FEngine const& engine, CameraInfo const& camera,
             Range visible) noexcept;
 
-    void setShadowingEnabled(bool enabled) noexcept { mShadowingEnabled = enabled; }
+    void setShadowingEnabled(bool const enabled) noexcept { mShadowingEnabled = enabled; }
 
     bool isShadowingEnabled() const noexcept { return mShadowingEnabled; }
 
-    void setScreenSpaceRefractionEnabled(bool enabled) noexcept { mScreenSpaceRefractionEnabled = enabled; }
+    void setScreenSpaceRefractionEnabled(bool const enabled) noexcept { mScreenSpaceRefractionEnabled = enabled; }
 
     bool isScreenSpaceRefractionEnabled() const noexcept { return mScreenSpaceRefractionEnabled; }
 
     bool isScreenSpaceReflectionEnabled() const noexcept { return mScreenSpaceReflectionsOptions.enabled; }
 
-    void setStencilBufferEnabled(bool enabled) noexcept { mStencilBufferEnabled = enabled; }
+    void setStencilBufferEnabled(bool const enabled) noexcept { mStencilBufferEnabled = enabled; }
 
     bool isStencilBufferEnabled() const noexcept { return mStencilBufferEnabled; }
 
@@ -249,7 +249,7 @@ public:
         return mMultiSampleAntiAliasingOptions.sampleCount;
     }
 
-    void setAntiAliasing(AntiAliasing type) noexcept {
+    void setAntiAliasing(AntiAliasing const type) noexcept {
         mAntiAliasing = type;
     }
 
@@ -289,7 +289,7 @@ public:
         return mColorGrading;
     }
 
-    void setDithering(Dithering dithering) noexcept {
+    void setDithering(Dithering const dithering) noexcept {
         mDithering = dithering;
     }
 
@@ -326,11 +326,11 @@ public:
 
     void setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept;
 
-    void setPostProcessingEnabled(bool enabled) noexcept {
+    void setPostProcessingEnabled(bool const enabled) noexcept {
         mHasPostProcessPass = enabled;
     }
 
-    void setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept {
+    void setAmbientOcclusion(AmbientOcclusion const ambientOcclusion) noexcept {
         mAmbientOcclusionOptions.enabled = ambientOcclusion == AmbientOcclusion::SSAO;
     }
 
@@ -344,7 +344,7 @@ public:
         return mShadowType;
     }
 
-    void setShadowType(ShadowType shadow) noexcept {
+    void setShadowType(ShadowType const shadow) noexcept {
         mShadowType = shadow;
     }
 
@@ -388,7 +388,7 @@ public:
         return mVignetteOptions;
     }
 
-    void setBlendMode(BlendMode blendMode) noexcept {
+    void setBlendMode(BlendMode const blendMode) noexcept {
         mBlendMode = blendMode;
     }
 
@@ -470,15 +470,15 @@ public:
 private:
     struct FPickingQuery : public PickingQuery {
     private:
-        FPickingQuery(uint32_t x, uint32_t y,
+        FPickingQuery(uint32_t const x, uint32_t const y,
                 backend::CallbackHandler* handler,
-                PickingQueryResultCallback callback) noexcept
+                PickingQueryResultCallback const callback) noexcept
                 : PickingQuery{}, x(x), y(y), handler(handler), callback(callback) {}
         ~FPickingQuery() noexcept = default;
     public:
         // TODO: use a small pool
-        static FPickingQuery* get(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
-                PickingQueryResultCallback callback) noexcept {
+        static FPickingQuery* get(uint32_t const x, uint32_t const y, backend::CallbackHandler* handler,
+                PickingQueryResultCallback const callback) noexcept {
             return new(std::nothrow) FPickingQuery(x, y, handler, callback);
         }
         static void put(FPickingQuery* pQuery) noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -106,7 +106,7 @@ public:
     // note: viewport/cameraInfo are passed by value to make it clear that prepare cannot
     // keep references on them that would outlive the scope of prepare() (e.g. with JobSystem).
     void prepare(FEngine& engine, backend::DriverApi& driver, RootArenaScope& rootArenaScope,
-            filament::Viewport viewport, CameraInfo cameraInfo,
+            Viewport viewport, CameraInfo cameraInfo,
             math::float4 const& userTime, bool needsAlphaChannel) noexcept;
 
     void setScene(FScene* scene) { mScene = scene; }
@@ -158,7 +158,7 @@ public:
 
     void prepareViewport(
             const Viewport& physicalViewport,
-            const filament::Viewport& logicalViewport) const noexcept;
+            const Viewport& logicalViewport) const noexcept;
 
     void prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableData,
             FScene::LightSoa const& lightData, CameraInfo const& cameraInfo) noexcept;
@@ -310,7 +310,7 @@ public:
             Renderer::FrameRateOptions const& frameRateOptions,
             Renderer::DisplayInfo const& displayInfo) noexcept;
 
-    void setDynamicResolutionOptions(View::DynamicResolutionOptions const& options) noexcept;
+    void setDynamicResolutionOptions(DynamicResolutionOptions const& options) noexcept;
 
     DynamicResolutionOptions getDynamicResolutionOptions() const noexcept {
         return mDynamicResolution;
@@ -449,8 +449,8 @@ public:
     void clearFrameHistory(FEngine& engine) noexcept;
 
     // create the picking query
-    View::PickingQuery& pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
-            View::PickingQueryResultCallback callback) noexcept;
+    PickingQuery& pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
+            PickingQueryResultCallback callback) noexcept;
 
     void executePickingQueries(backend::DriverApi& driver,
             backend::RenderTargetHandle handle, math::float2 scale) noexcept;
@@ -472,13 +472,13 @@ private:
     private:
         FPickingQuery(uint32_t x, uint32_t y,
                 backend::CallbackHandler* handler,
-                View::PickingQueryResultCallback callback) noexcept
+                PickingQueryResultCallback callback) noexcept
                 : PickingQuery{}, x(x), y(y), handler(handler), callback(callback) {}
         ~FPickingQuery() noexcept = default;
     public:
         // TODO: use a small pool
         static FPickingQuery* get(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
-                View::PickingQueryResultCallback callback) noexcept {
+                PickingQueryResultCallback callback) noexcept {
             return new(std::nothrow) FPickingQuery(x, y, handler, callback);
         }
         static void put(FPickingQuery* pQuery) noexcept {
@@ -489,7 +489,7 @@ private:
         uint32_t const x;
         uint32_t const y;
         backend::CallbackHandler* const handler;
-        View::PickingQueryResultCallback const callback;
+        PickingQueryResultCallback const callback;
         // picking query result
         PickingQueryResult result;
     };
@@ -521,7 +521,7 @@ private:
     // these are accessed in the render loop, keep together
     backend::Handle<backend::HwBufferObject> mLightUbh;
     backend::Handle<backend::HwBufferObject> mRenderableUbh;
-    filament::DescriptorSet mCommonRenderableDescriptorSet;
+    DescriptorSet mCommonRenderableDescriptorSet;
 
     FScene* mScene = nullptr;
     // The camera set by the user, used for culling and viewing

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -65,7 +65,7 @@ using namespace backend;
 using namespace math;
 
 uint8_t ColorPassDescriptorSet::getIndex(
-        bool lit, bool ssr, bool fog) noexcept {
+        bool const lit, bool const ssr, bool const fog) noexcept {
 
     uint8_t index = 0;
 
@@ -183,13 +183,13 @@ void ColorPassDescriptorSet::prepareCamera(FEngine& engine, const CameraInfo& ca
     s.clipControl = engine.getDriverApi().getClipSpaceParams();
 }
 
-void ColorPassDescriptorSet::prepareLodBias(float bias, float2 derivativesScale) noexcept {
+void ColorPassDescriptorSet::prepareLodBias(float const bias, float2 const derivativesScale) noexcept {
     auto& s = mUniforms.edit();
     s.lodBias = bias;
     s.derivativesScale = derivativesScale;
 }
 
-void ColorPassDescriptorSet::prepareExposure(float ev100) noexcept {
+void ColorPassDescriptorSet::prepareExposure(float const ev100) noexcept {
     const float exposure = Exposure::exposure(ev100);
     auto& s = mUniforms.edit();
     s.exposure = exposure;
@@ -322,7 +322,7 @@ void ColorPassDescriptorSet::prepareSSAO(Handle<HwTexture> ssao,
     s.aoBentNormals = options.enabled && options.bentNormals ? 1.0f : 0.0f;
 }
 
-void ColorPassDescriptorSet::prepareBlending(bool needsAlphaChannel) noexcept {
+void ColorPassDescriptorSet::prepareBlending(bool const needsAlphaChannel) noexcept {
     mUniforms.edit().needsAlphaChannel = needsAlphaChannel ? 1.0f : 0.0f;
 }
 
@@ -335,8 +335,8 @@ void ColorPassDescriptorSet::prepareMaterialGlobals(
 }
 
 void ColorPassDescriptorSet::prepareSSR(Handle<HwTexture> ssr,
-        bool disableSSR,
-        float refractionLodOffset,
+        bool const disableSSR,
+        float const refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
     setSampler(+PerViewBindingPoints::SSR, ssr, {
@@ -416,14 +416,14 @@ void ColorPassDescriptorSet::prepareDirectionalLight(FEngine& engine,
 }
 
 void ColorPassDescriptorSet::prepareAmbientLight(FEngine& engine, FIndirectLight const& ibl,
-        float intensity, float exposure) noexcept {
+        float const intensity, float const exposure) noexcept {
     auto& s = mUniforms.edit();
 
     // Set up uniforms and sampler for the IBL, guaranteed to be non-null at this point.
     float const iblRoughnessOneLevel = float(ibl.getLevelCount() - 1);
     s.iblRoughnessOneLevel = iblRoughnessOneLevel;
     s.iblLuminance = intensity * exposure;
-    std::transform(ibl.getSH(), ibl.getSH() + 9, s.iblSH, [](float3 v) {
+    std::transform(ibl.getSH(), ibl.getSH() + 9, s.iblSH, [](float3 const v) {
         return float4(v, 0.0f);
     });
 
@@ -447,7 +447,7 @@ void ColorPassDescriptorSet::prepareDynamicLights(Froxelizer& froxelizer) noexce
     s.lightFarAttenuationParams = 0.5f * float2{ 10.0f, 10.0f / (f * f) };
 }
 
-void ColorPassDescriptorSet::prepareShadowMapping(BufferObjectHandle shadowUniforms, bool highPrecision) noexcept {
+void ColorPassDescriptorSet::prepareShadowMapping(BufferObjectHandle shadowUniforms, bool const highPrecision) noexcept {
     auto& s = mUniforms.edit();
     constexpr float low  = 5.54f; // ~ std::log(std::numeric_limits<math::half>::max()) * 0.5f;
     constexpr float high = 42.0f; // ~ std::log(std::numeric_limits<float>::max()) * 0.5f;
@@ -552,8 +552,8 @@ void ColorPassDescriptorSet::unbindSamplers(DriverApi&) noexcept {
     setSampler(+PerViewBindingPoints::SSR, {}, {});
 }
 
-void ColorPassDescriptorSet::setSampler(descriptor_binding_t binding,
-        TextureHandle th, SamplerParams params) noexcept {
+void ColorPassDescriptorSet::setSampler(descriptor_binding_t const binding,
+        TextureHandle th, SamplerParams const params) noexcept {
     for (size_t i = 0; i < DESCRIPTOR_LAYOUT_COUNT; i++) {
         auto samplers = mDescriptorSetLayout[i].getSamplerDescriptors();
         if (samplers[binding]) {
@@ -562,8 +562,8 @@ void ColorPassDescriptorSet::setSampler(descriptor_binding_t binding,
     }
 }
 
-void ColorPassDescriptorSet::setBuffer(descriptor_binding_t binding,
-        BufferObjectHandle boh, uint32_t offset, uint32_t size) noexcept {
+void ColorPassDescriptorSet::setBuffer(descriptor_binding_t const binding,
+        BufferObjectHandle boh, uint32_t const offset, uint32_t const size) noexcept {
     for (size_t i = 0; i < DESCRIPTOR_LAYOUT_COUNT; i++) {
         auto ubos = mDescriptorSetLayout[i].getUniformBufferDescriptors();
         if (ubos[binding]) {

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -155,7 +155,7 @@ public:
     void unbindSamplers(backend::DriverApi& driver) noexcept;
 
     // bind this UBO
-    void bind(backend::DriverApi& driver, uint8_t index) const noexcept {
+    void bind(backend::DriverApi& driver, uint8_t const index) const noexcept {
         mDescriptorSet[index].bind(driver, DescriptorSetBindingPoints::PER_VIEW);
     }
 

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -96,8 +96,8 @@ public:
      *                  Non-zero when we have guard bands.
      */
     void prepareViewport(
-            const filament::Viewport& physicalViewport,
-            const filament::Viewport& logicalViewport) noexcept;
+            const Viewport& physicalViewport,
+            const Viewport& logicalViewport) noexcept;
 
     void prepareTime(FEngine& engine, math::float4 const& userTime) noexcept;
     void prepareTemporalNoise(FEngine& engine, TemporalAntiAliasingOptions const& options) noexcept;

--- a/filament/src/ds/DescriptorSet.cpp
+++ b/filament/src/ds/DescriptorSet.cpp
@@ -99,11 +99,11 @@ void DescriptorSet::commitSlow(DescriptorSetLayout const& layout,
     });
 }
 
-void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints set) const noexcept {
+void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints const set) const noexcept {
     bind(driver, set, {});
 }
 
-void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints set,
+void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints const set,
         backend::DescriptorSetOffsetArray dynamicOffsets) const noexcept {
     // TODO: on debug check that dynamicOffsets is large enough
 
@@ -114,7 +114,7 @@ void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints 
     // build.
     // assert_invariant(mDirty.none());
     if (mDirty.any() && !mSetAfterCommitWarning) {
-        mDirty.forEachSetBit([&](uint8_t binding) {
+        mDirty.forEachSetBit([&](uint8_t const binding) {
             utils::slog.w << "Descriptor set (handle=" << mDescriptorSetHandle.getId()
                           << ") binding=" << (int) binding
                           << " was set between begin/endRenderPass" << utils::io::endl;
@@ -125,8 +125,8 @@ void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints 
 }
 
 void DescriptorSet::setBuffer(
-        backend::descriptor_binding_t binding,
-        backend::Handle<backend::HwBufferObject> boh, uint32_t offset, uint32_t size) noexcept {
+        backend::descriptor_binding_t const binding,
+        backend::Handle<backend::HwBufferObject> boh, uint32_t const offset, uint32_t const size) noexcept {
     // TODO: validate it's the right kind of descriptor
     if (mDescriptors[binding].buffer.boh != boh || mDescriptors[binding].buffer.size != size) {
         // we don't set the dirty bit if only offset changes
@@ -137,8 +137,8 @@ void DescriptorSet::setBuffer(
 }
 
 void DescriptorSet::setSampler(
-        backend::descriptor_binding_t binding,
-        backend::Handle<backend::HwTexture> th, backend::SamplerParams params) noexcept {
+        backend::descriptor_binding_t const binding,
+        backend::Handle<backend::HwTexture> th, backend::SamplerParams const params) noexcept {
     // TODO: validate it's the right kind of descriptor
     if (mDescriptors[binding].texture.th != th || mDescriptors[binding].texture.params != params) {
         mDirty.set(binding);

--- a/filament/src/ds/DescriptorSetLayout.h
+++ b/filament/src/ds/DescriptorSetLayout.h
@@ -56,7 +56,7 @@ public:
         return mMaxDescriptorBinding;
     }
 
-    bool isSampler(backend::descriptor_binding_t binding) const noexcept {
+    bool isSampler(backend::descriptor_binding_t const binding) const noexcept {
         return mSamplers[binding];
     }
 

--- a/filament/src/ds/PostProcessDescriptorSet.cpp
+++ b/filament/src/ds/PostProcessDescriptorSet.cpp
@@ -59,7 +59,7 @@ void PostProcessDescriptorSet::setFrameUniforms(DriverApi& driver,
     mDescriptorSet.commit(mDescriptorSetLayout, driver);
 }
 
-void PostProcessDescriptorSet::bind(backend::DriverApi& driver) noexcept {
+void PostProcessDescriptorSet::bind(DriverApi& driver) noexcept {
     mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
 }
 

--- a/filament/src/ds/ShadowMapDescriptorSet.cpp
+++ b/filament/src/ds/ShadowMapDescriptorSet.cpp
@@ -88,7 +88,7 @@ void ShadowMapDescriptorSet::prepareCamera(Transaction const& transaction,
     s.clipControl = driver.getClipSpaceParams();
 }
 
-void ShadowMapDescriptorSet::prepareLodBias(Transaction const& transaction, float bias) noexcept {
+void ShadowMapDescriptorSet::prepareLodBias(Transaction const& transaction, float const bias) noexcept {
     auto& s = edit(transaction);
     s.lodBias = bias;
 }
@@ -112,7 +112,7 @@ void ShadowMapDescriptorSet::prepareTime(Transaction const& transaction,
 }
 
 void ShadowMapDescriptorSet::prepareShadowMapping(Transaction const& transaction,
-        bool highPrecision) noexcept {
+        bool const highPrecision) noexcept {
     auto& s = edit(transaction);
     constexpr float low  = 5.54f; // ~ std::log(std::numeric_limits<math::half>::max()) * 0.5f;
     constexpr float high = 42.0f; // ~ std::log(std::numeric_limits<float>::max()) * 0.5f;

--- a/filament/src/ds/ShadowMapDescriptorSet.cpp
+++ b/filament/src/ds/ShadowMapDescriptorSet.cpp
@@ -61,7 +61,7 @@ PerViewUib& ShadowMapDescriptorSet::edit(Transaction const& transaction) noexcep
 }
 
 void ShadowMapDescriptorSet::prepareCamera(Transaction const& transaction,
-        backend::DriverApi& driver, const CameraInfo& camera) noexcept {
+        DriverApi& driver, const CameraInfo& camera) noexcept {
     mat4f const& viewFromWorld = camera.view;
     mat4f const& worldFromView = camera.model;
     mat4f const& clipFromView  = camera.projection;
@@ -103,7 +103,7 @@ void ShadowMapDescriptorSet::prepareViewport(Transaction const& transaction,
 }
 
 void ShadowMapDescriptorSet::prepareTime(Transaction const& transaction,
-        FEngine const& engine, math::float4 const& userTime) noexcept {
+        FEngine const& engine, float4 const& userTime) noexcept {
     auto& s = edit(transaction);
     const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1'000'000'000;
     const float fraction = float(double(oneSecondRemainder) / 1'000'000'000.0);
@@ -119,7 +119,7 @@ void ShadowMapDescriptorSet::prepareShadowMapping(Transaction const& transaction
     s.vsmExponent = highPrecision ? high : low;
 }
 
-ShadowMapDescriptorSet::Transaction ShadowMapDescriptorSet::open(backend::DriverApi& driver) noexcept {
+ShadowMapDescriptorSet::Transaction ShadowMapDescriptorSet::open(DriverApi& driver) noexcept {
     Transaction transaction;
     // TODO: use out-of-line buffer if too large
     transaction.uniforms = (PerViewUib *)driver.allocate(sizeof(PerViewUib), 16);
@@ -128,14 +128,14 @@ ShadowMapDescriptorSet::Transaction ShadowMapDescriptorSet::open(backend::Driver
 }
 
 void ShadowMapDescriptorSet::commit(Transaction& transaction,
-        FEngine& engine, backend::DriverApi& driver) noexcept {
+        FEngine& engine, DriverApi& driver) noexcept {
     driver.updateBufferObject(mUniformBufferHandle, {
             transaction.uniforms, sizeof(PerViewUib) }, 0);
     mDescriptorSet.commit(engine.getPerViewDescriptorSetLayoutDepthVariant(), driver);
     transaction.uniforms = nullptr;
 }
 
-void ShadowMapDescriptorSet::bind(backend::DriverApi& driver) noexcept {
+void ShadowMapDescriptorSet::bind(DriverApi& driver) noexcept {
     mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
 }
 

--- a/filament/src/ds/SsrPassDescriptorSet.cpp
+++ b/filament/src/ds/SsrPassDescriptorSet.cpp
@@ -67,8 +67,8 @@ void SsrPassDescriptorSet::setFrameUniforms(TypedUniformBuffer<PerViewUib>& unif
 }
 
 void SsrPassDescriptorSet::prepareHistorySSR(Handle<HwTexture> ssr,
-        math::mat4f const& historyProjection,
-        math::mat4f const& uvFromViewMatrix,
+        mat4f const& historyProjection,
+        mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
     mDescriptorSet.setSampler(+PerViewBindingPoints::SSR, ssr, {
@@ -101,7 +101,7 @@ void SsrPassDescriptorSet::commit(FEngine& engine) noexcept {
     mDescriptorSet.commit(engine.getPerViewDescriptorSetLayoutSsrVariant(), driver);
 }
 
-void SsrPassDescriptorSet::bind(backend::DriverApi& driver) noexcept {
+void SsrPassDescriptorSet::bind(DriverApi& driver) noexcept {
     mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
 }
 

--- a/filament/src/ds/TypedBuffer.h
+++ b/filament/src/ds/TypedBuffer.h
@@ -56,7 +56,7 @@ public:
 
     // copy the UBO data and cleans the dirty bits
     backend::BufferDescriptor toBufferDescriptor(
-            backend::DriverApi& driver, size_t offset, size_t size) const noexcept {
+            backend::DriverApi& driver, size_t const offset, size_t const size) const noexcept {
         backend::BufferDescriptor p;
         p.size = size;
         p.buffer = driver.allocate(p.size); // TODO: use out-of-line buffer if too large

--- a/filament/src/fg/Blackboard.cpp
+++ b/filament/src/fg/Blackboard.cpp
@@ -24,7 +24,7 @@ Blackboard::Blackboard() noexcept = default;
 
 Blackboard::~Blackboard() noexcept = default;
 
-FrameGraphHandle Blackboard::getHandle(std::string_view name) const noexcept {
+FrameGraphHandle Blackboard::getHandle(std::string_view const name) const noexcept {
     auto it = mMap.find(name);
     if (it != mMap.end()) {
         return it->second;
@@ -32,17 +32,17 @@ FrameGraphHandle Blackboard::getHandle(std::string_view name) const noexcept {
     return {};
 }
 
-FrameGraphHandle& Blackboard::operator [](std::string_view name) noexcept {
+FrameGraphHandle& Blackboard::operator [](std::string_view const name) noexcept {
     auto[pos, _] = mMap.insert_or_assign(name, FrameGraphHandle{});
     return pos->second;
 }
 
-void Blackboard::put(std::string_view name, FrameGraphHandle handle) noexcept {
+void Blackboard::put(std::string_view const name, FrameGraphHandle const handle) noexcept {
     operator[](name) = handle;
 }
 
 
-void Blackboard::remove(std::string_view name) noexcept {
+void Blackboard::remove(std::string_view const name) noexcept {
     mMap.erase(name);
 }
 

--- a/filament/src/fg/DependencyGraph.cpp
+++ b/filament/src/fg/DependencyGraph.cpp
@@ -46,14 +46,14 @@ void DependencyGraph::registerNode(Node* node, NodeID id) noexcept {
     nodes.push_back(node);
 }
 
-bool DependencyGraph::isEdgeValid(DependencyGraph::Edge const* edge) const noexcept {
+bool DependencyGraph::isEdgeValid(Edge const* edge) const noexcept {
     auto& nodes = mNodes;
     Node const* from = nodes[edge->from];
     Node const* to = nodes[edge->to];
     return !from->isCulled() && !to->isCulled();
 }
 
-void DependencyGraph::link(DependencyGraph::Edge* edge) noexcept {
+void DependencyGraph::link(Edge* edge) noexcept {
     // here we manually grow the fixed-size vector
     EdgeContainer& edges = mEdges;
     if (UTILS_UNLIKELY(edges.capacity() == edges.size())) {
@@ -72,7 +72,7 @@ DependencyGraph::NodeContainer const& DependencyGraph::getNodes() const noexcept
 }
 
 DependencyGraph::EdgeContainer DependencyGraph::getIncomingEdges(
-        DependencyGraph::Node const* node) const noexcept {
+        Node const* node) const noexcept {
     // TODO: we might need something more efficient
     auto result = EdgeContainer::with_capacity(mEdges.size());
     NodeID const nodeId = node->getId();
@@ -83,7 +83,7 @@ DependencyGraph::EdgeContainer DependencyGraph::getIncomingEdges(
 }
 
 DependencyGraph::EdgeContainer DependencyGraph::getOutgoingEdges(
-        DependencyGraph::Node const* node) const noexcept {
+        Node const* node) const noexcept {
     // TODO: we might need something more efficient
     auto result = EdgeContainer::with_capacity(mEdges.size());
     NodeID const nodeId = node->getId();
@@ -93,11 +93,11 @@ DependencyGraph::EdgeContainer DependencyGraph::getOutgoingEdges(
     return result;
 }
 
-DependencyGraph::Node const* DependencyGraph::getNode(DependencyGraph::NodeID id) const noexcept {
+DependencyGraph::Node const* DependencyGraph::getNode(NodeID id) const noexcept {
     return mNodes[id];
 }
 
-DependencyGraph::Node* DependencyGraph::getNode(DependencyGraph::NodeID id) noexcept {
+DependencyGraph::Node* DependencyGraph::getNode(NodeID id) noexcept {
     return mNodes[id];
 }
 
@@ -197,7 +197,7 @@ bool DependencyGraph::isAcyclic() const noexcept {
     DependencyGraph graph;
     graph.mEdges = mEdges;
     graph.mNodes = mNodes;
-    return DependencyGraph::isAcyclicInternal(graph);
+    return isAcyclicInternal(graph);
 #else
     return true;
 #endif

--- a/filament/src/fg/DependencyGraph.cpp
+++ b/filament/src/fg/DependencyGraph.cpp
@@ -34,7 +34,7 @@ uint32_t DependencyGraph::generateNodeId() noexcept {
     return mNodes.size();
 }
 
-void DependencyGraph::registerNode(Node* node, NodeID id) noexcept {
+void DependencyGraph::registerNode(Node* node, NodeID const id) noexcept {
     // Node* is not fully constructed here
     assert_invariant(id == mNodes.size());
 
@@ -93,11 +93,11 @@ DependencyGraph::EdgeContainer DependencyGraph::getOutgoingEdges(
     return result;
 }
 
-DependencyGraph::Node const* DependencyGraph::getNode(NodeID id) const noexcept {
+DependencyGraph::Node const* DependencyGraph::getNode(NodeID const id) const noexcept {
     return mNodes[id];
 }
 
-DependencyGraph::Node* DependencyGraph::getNode(NodeID id) noexcept {
+DependencyGraph::Node* DependencyGraph::getNode(NodeID const id) noexcept {
     return mNodes[id];
 }
 

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -52,7 +52,7 @@ void FrameGraph::Builder::sideEffect() noexcept {
     mPassNode->makeTarget();
 }
 
-const char* FrameGraph::Builder::getName(FrameGraphHandle handle) const noexcept {
+const char* FrameGraph::Builder::getName(FrameGraphHandle const handle) const noexcept {
     return mFrameGraph.getResource(handle)->name;
 }
 
@@ -74,7 +74,7 @@ FrameGraphId<FrameGraphTexture> FrameGraph::Builder::declareRenderPass(
 
 // ------------------------------------------------------------------------------------------------
 
-FrameGraph::FrameGraph(ResourceAllocatorInterface& resourceAllocator, Mode mode)
+FrameGraph::FrameGraph(ResourceAllocatorInterface& resourceAllocator, Mode const mode)
         : mResourceAllocator(resourceAllocator),
           mArena("FrameGraph Arena", 262144),
           mMode(mode),
@@ -290,7 +290,7 @@ FrameGraphHandle FrameGraph::addSubResourceInternal(FrameGraphHandle parent,
     return handle;
 }
 
-FrameGraphHandle FrameGraph::readInternal(FrameGraphHandle handle, PassNode* passNode,
+FrameGraphHandle FrameGraph::readInternal(FrameGraphHandle const handle, PassNode* passNode,
         const std::function<bool(ResourceNode*, VirtualResource*)>& connect) {
 
     assertValid(handle);
@@ -397,8 +397,8 @@ FrameGraphHandle FrameGraph::writeInternal(FrameGraphHandle handle, PassNode* pa
     return {};
 }
 
-FrameGraphHandle FrameGraph::forwardResourceInternal(FrameGraphHandle resourceHandle,
-        FrameGraphHandle replaceResourceHandle) {
+FrameGraphHandle FrameGraph::forwardResourceInternal(FrameGraphHandle const resourceHandle,
+        FrameGraphHandle const replaceResourceHandle) {
 
     assertValid(resourceHandle);
 
@@ -449,7 +449,7 @@ FrameGraphId<FrameGraphTexture> FrameGraph::import(char const* name,
     return FrameGraphId<FrameGraphTexture>(addResourceInternal(vresource));
 }
 
-bool FrameGraph::isValid(FrameGraphHandle handle) const {
+bool FrameGraph::isValid(FrameGraphHandle const handle) const {
     // Code below is written this way so that we can set breakpoints easily.
     if (!handle.isInitialized()) {
         return false;
@@ -461,7 +461,7 @@ bool FrameGraph::isValid(FrameGraphHandle handle) const {
     return true;
 }
 
-void FrameGraph::assertValid(FrameGraphHandle handle) const {
+void FrameGraph::assertValid(FrameGraphHandle const handle) const {
     FILAMENT_CHECK_PRECONDITION(isValid(handle))
             << "Resource handle is invalid or uninitialized {id=" << (int)handle.index
             << ", version=" << (int)handle.version << "}";

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -232,7 +232,7 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
     driver.popGroupMarker();
 }
 
-void FrameGraph::addPresentPass(const std::function<void(FrameGraph::Builder&)>& setup) noexcept {
+void FrameGraph::addPresentPass(const std::function<void(Builder&)>& setup) noexcept {
     PresentPassNode* node = mArena.make<PresentPassNode>(*this);
     mPassNodes.push_back(node);
     Builder builder(*this, node);

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -204,7 +204,7 @@ public:
          * @return          A new handle to the FrameGraphTexture.
          *                  The input handle is no-longer valid.
          */
-        FrameGraphId<FrameGraphTexture> sample(FrameGraphId<FrameGraphTexture> input) {
+        FrameGraphId<FrameGraphTexture> sample(FrameGraphId<FrameGraphTexture> const input) {
             return read(input, FrameGraphTexture::Usage::SAMPLEABLE);
         }
 
@@ -484,36 +484,36 @@ private:
     FrameGraphId<RESOURCE> write(PassNode* passNode,
             FrameGraphId<RESOURCE> input, typename RESOURCE::Usage usage);
 
-    ResourceSlot& getResourceSlot(FrameGraphHandle handle) noexcept {
+    ResourceSlot& getResourceSlot(FrameGraphHandle const handle) noexcept {
         assert_invariant((size_t)handle.index < mResourceSlots.size());
         assert_invariant((size_t)mResourceSlots[handle.index].rid < mResources.size());
         assert_invariant((size_t)mResourceSlots[handle.index].nid < mResourceNodes.size());
         return mResourceSlots[handle.index];
     }
 
-    ResourceSlot const& getResourceSlot(FrameGraphHandle handle) const noexcept {
+    ResourceSlot const& getResourceSlot(FrameGraphHandle const handle) const noexcept {
         return const_cast<FrameGraph*>(this)->getResourceSlot(handle);
     }
 
-    VirtualResource* getResource(FrameGraphHandle handle) noexcept {
+    VirtualResource* getResource(FrameGraphHandle const handle) noexcept {
         assert_invariant(handle.isInitialized());
         ResourceSlot const& slot = getResourceSlot(handle);
         assert_invariant((size_t)slot.rid < mResources.size());
         return mResources[slot.rid];
     }
 
-    ResourceNode* getActiveResourceNode(FrameGraphHandle handle) noexcept {
+    ResourceNode* getActiveResourceNode(FrameGraphHandle const handle) noexcept {
         assert_invariant(handle);
         ResourceSlot const& slot = getResourceSlot(handle);
         assert_invariant((size_t)slot.nid < mResourceNodes.size());
         return mResourceNodes[slot.nid];
     }
 
-    VirtualResource const* getResource(FrameGraphHandle handle) const noexcept {
+    VirtualResource const* getResource(FrameGraphHandle const handle) const noexcept {
         return const_cast<FrameGraph*>(this)->getResource(handle);
     }
 
-    ResourceNode const* getResourceNode(FrameGraphHandle handle) const noexcept {
+    ResourceNode const* getResourceNode(FrameGraphHandle const handle) const noexcept {
         return const_cast<FrameGraph*>(this)->getActiveResourceNode(handle);
     }
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -560,7 +560,7 @@ FrameGraphPass<Data>& FrameGraph::addPass(char const* name, Setup setup) {
 
 template<typename Execute>
 void FrameGraph::addTrivialSideEffectPass(char const* name, Execute&& execute) {
-    addPass<Empty>(name, [](FrameGraph::Builder& builder, auto&) { builder.sideEffect(); },
+    addPass<Empty>(name, [](Builder& builder, auto&) { builder.sideEffect(); },
             [execute](FrameGraphResources const&, auto const&, backend::DriverApi& driver) {
                 execute(driver);
             });

--- a/filament/src/fg/FrameGraphId.h
+++ b/filament/src/fg/FrameGraphId.h
@@ -50,7 +50,7 @@ private:
 
     // private ctor -- this cannot be constructed by users
     FrameGraphHandle() noexcept = default;
-    explicit FrameGraphHandle(Index index) noexcept : index(index) {}
+    explicit FrameGraphHandle(Index const index) noexcept : index(index) {}
 
     // index to the resource handle
     static constexpr uint16_t UNINITIALIZED = std::numeric_limits<Index>::max();
@@ -87,7 +87,7 @@ class FrameGraphId : public FrameGraphHandle {
 public:
     using FrameGraphHandle::FrameGraphHandle;
     FrameGraphId() noexcept = default;
-    explicit FrameGraphId(FrameGraphHandle r) : FrameGraphHandle(r) { }
+    explicit FrameGraphId(FrameGraphHandle const r) : FrameGraphHandle(r) { }
 };
 
 } // namespace filament

--- a/filament/src/fg/FrameGraphResources.cpp
+++ b/filament/src/fg/FrameGraphResources.cpp
@@ -33,7 +33,7 @@ const char* FrameGraphResources::getPassName() const noexcept {
 // fails, it has to assert (or throw), it can't return for e.g. a nullptr, because the public
 // API doesn't return pointers.
 // We still use FILAMENT_CHECK_PRECONDITION() because these failures are due to post conditions not met.
-VirtualResource& FrameGraphResources::getResource(FrameGraphHandle handle) const {
+VirtualResource& FrameGraphResources::getResource(FrameGraphHandle const handle) const {
     FILAMENT_CHECK_PRECONDITION(handle) << "Uninitialized handle when using FrameGraphResources.";
 
     VirtualResource* const resource = mFrameGraph.getResource(handle);
@@ -50,7 +50,7 @@ VirtualResource& FrameGraphResources::getResource(FrameGraphHandle handle) const
     return *resource;
 }
 
-FrameGraphResources::RenderPassInfo FrameGraphResources::getRenderPassInfo(uint32_t id) const {
+FrameGraphResources::RenderPassInfo FrameGraphResources::getRenderPassInfo(uint32_t const id) const {
     // this cast is safe because this can only be called from a RenderPassNode
     RenderPassNode const& renderPassNode = static_cast<RenderPassNode const&>(mPassNode);
     RenderPassNode::RenderPassData const* pRenderPassData = renderPassNode.getRenderPassData(id);

--- a/filament/src/fg/FrameGraphResources.h
+++ b/filament/src/fg/FrameGraphResources.h
@@ -115,7 +115,7 @@ public:
      * @param handle to a FrameGraphTexture
      * @return backend concrete Texture handle
      */
-    backend::Handle<backend::HwTexture> getTexture(FrameGraphId<FrameGraphTexture> handle) const {
+    backend::Handle<backend::HwTexture> getTexture(FrameGraphId<FrameGraphTexture> const handle) const {
         return get(handle).handle;
     }
 

--- a/filament/src/fg/FrameGraphTexture.cpp
+++ b/filament/src/fg/FrameGraphTexture.cpp
@@ -24,7 +24,7 @@ namespace filament {
 
 void FrameGraphTexture::create(ResourceAllocatorInterface& resourceAllocator, const char* name,
         Descriptor const& descriptor, Usage usage,
-        bool useProtectedMemory) noexcept {
+        bool const useProtectedMemory) noexcept {
     if (useProtectedMemory) {
         // FIXME: I think we should restrict this to attachments and blit destinations only
         usage |= Usage::PROTECTED;

--- a/filament/src/fg/FrameGraphTexture.cpp
+++ b/filament/src/fg/FrameGraphTexture.cpp
@@ -23,11 +23,11 @@
 namespace filament {
 
 void FrameGraphTexture::create(ResourceAllocatorInterface& resourceAllocator, const char* name,
-        FrameGraphTexture::Descriptor const& descriptor, FrameGraphTexture::Usage usage,
+        Descriptor const& descriptor, Usage usage,
         bool useProtectedMemory) noexcept {
     if (useProtectedMemory) {
         // FIXME: I think we should restrict this to attachments and blit destinations only
-        usage |= FrameGraphTexture::Usage::PROTECTED;
+        usage |= Usage::PROTECTED;
     }
     std::array<backend::TextureSwizzle, 4> swizzle = {
             descriptor.swizzle.r,

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -44,7 +44,7 @@ utils::CString PassNode::graphvizifyEdgeColor() const noexcept {
     return utils::CString{"red"};
 }
 
-void PassNode::registerResource(FrameGraphHandle resourceHandle) noexcept {
+void PassNode::registerResource(FrameGraphHandle const resourceHandle) noexcept {
     VirtualResource* resource = mFrameGraph.getResource(resourceHandle);
     resource->neededByPass(this);
     mDeclaredHandles.insert(resourceHandle.index);
@@ -288,7 +288,7 @@ void RenderPassNode::RenderPassData::destroy(
     }
 }
 
-RenderPassNode::RenderPassData const* RenderPassNode::getRenderPassData(uint32_t id) const noexcept {
+RenderPassNode::RenderPassData const* RenderPassNode::getRenderPassData(uint32_t const id) const noexcept {
     return id < mRenderTargetData.size() ? &mRenderTargetData[id] : nullptr;
 }
 

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -30,7 +30,7 @@ using namespace filament::backend;
 namespace filament {
 
 PassNode::PassNode(FrameGraph& fg) noexcept
-        : DependencyGraph::Node(fg.getGraph()),
+        : Node(fg.getGraph()),
           mFrameGraph(fg),
           devirtualize(fg.getArena()),
           destroy(fg.getArena()) {

--- a/filament/src/fg/Resource.cpp
+++ b/filament/src/fg/Resource.cpp
@@ -95,7 +95,7 @@ ImportedRenderTarget::ImportedRenderTarget(char const* resourceName,
 }
 
 UTILS_NOINLINE
-void ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
+void ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage const u) {
     constexpr auto ANY_ATTACHMENT = FrameGraphTexture::Usage::COLOR_ATTACHMENT |
                                     FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
                                     FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
@@ -106,21 +106,21 @@ void ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
 }
 
 bool ImportedRenderTarget::connect(DependencyGraph& graph, PassNode* passNode,
-        ResourceNode* resourceNode, TextureUsage u) {
+        ResourceNode* resourceNode, TextureUsage const u) {
     // pass Node to resource Node edge (a write to)
     assertConnect(u);
     return Resource::connect(graph, passNode, resourceNode, u);
 }
 
 bool ImportedRenderTarget::connect(DependencyGraph& graph, ResourceNode* resourceNode,
-        PassNode* passNode, TextureUsage u) {
+        PassNode* passNode, TextureUsage const u) {
     // resource Node to pass Node edge (a read from)
     assertConnect(u);
     return Resource::connect(graph, resourceNode, passNode, u);
 }
 
 FrameGraphTexture::Usage ImportedRenderTarget::usageFromAttachmentsFlags(
-        TargetBufferFlags attachments) noexcept {
+        TargetBufferFlags const attachments) noexcept {
 
     if (any(attachments & TargetBufferFlags::COLOR_ALL))
         return FrameGraphTexture::Usage::COLOR_ATTACHMENT;

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -21,7 +21,7 @@
 namespace filament {
 
 ResourceNode::ResourceNode(FrameGraph& fg, FrameGraphHandle h, FrameGraphHandle parent) noexcept
-        : DependencyGraph::Node(fg.getGraph()),
+        : Node(fg.getGraph()),
           resourceHandle(h), mFrameGraph(fg), mReaderPasses(fg.getArena()), mParentHandle(parent) {
 }
 

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -20,7 +20,7 @@
 
 namespace filament {
 
-ResourceNode::ResourceNode(FrameGraph& fg, FrameGraphHandle h, FrameGraphHandle parent) noexcept
+ResourceNode::ResourceNode(FrameGraph& fg, FrameGraphHandle const h, FrameGraphHandle const parent) noexcept
         : Node(fg.getGraph()),
           resourceHandle(h), mFrameGraph(fg), mReaderPasses(fg.getArena()), mParentHandle(parent) {
 }

--- a/filament/src/fg/details/DependencyGraph.h
+++ b/filament/src/fg/details/DependencyGraph.h
@@ -186,7 +186,7 @@ private:
 };
 
 inline DependencyGraph::Edge::Edge(DependencyGraph& graph,
-        DependencyGraph::Node* from, DependencyGraph::Node* to)
+        Node* from, Node* to)
         : from(from->getId()), to(to->getId()) {
     assert_invariant(graph.mNodes[this->from] == from);
     assert_invariant(graph.mNodes[this->to] == to);

--- a/filament/src/fg/details/Resource.h
+++ b/filament/src/fg/details/Resource.h
@@ -199,7 +199,7 @@ protected:
      */
 
     void resolveUsage(DependencyGraph& graph,
-            ResourceEdgeBase const* const* edges, size_t count,
+            ResourceEdgeBase const* const* edges, size_t const count,
             ResourceEdgeBase const* writer) noexcept override {
         for (size_t i = 0; i < count; i++) {
             if (graph.isEdgeValid(edges[i])) {

--- a/filament/src/fg/details/Resource.h
+++ b/filament/src/fg/details/Resource.h
@@ -39,7 +39,7 @@ class ImportedRenderTarget;
  */
 class ResourceEdgeBase : public DependencyGraph::Edge {
 public:
-    using DependencyGraph::Edge::Edge;
+    using Edge::Edge;
 };
 
 /*

--- a/filament/src/fsr.h
+++ b/filament/src/fsr.h
@@ -26,8 +26,8 @@
 namespace filament {
 
 struct FSRScalingConfig {
-    filament::backend::Backend backend;
-    filament::Viewport input;   // region of source to be scaled
+    backend::Backend backend;
+    Viewport input;   // region of source to be scaled
     uint32_t inputWidth;        // width of source
     uint32_t inputHeight;       // height of source
     uint32_t outputWidth;       // width of destination

--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -259,7 +259,7 @@ public:
             return normalize(lerp(d < 0 ? -p : p, q, t));
         }
         const T npq = std::sqrt(dot(p, p) * dot(q, q));  // ||p|| * ||q||
-        const T a = std::acos(filament::math::clamp(absd / npq, T(-1), T(1)));
+        const T a = std::acos(math::clamp(absd / npq, T(-1), T(1)));
         const T a0 = a * (1 - t);
         const T a1 = a * t;
         const T sina = sin(a);

--- a/libs/math/include/math/fast.h
+++ b/libs/math/include/math/fast.h
@@ -50,7 +50,7 @@ constexpr T MATH_PURE cos(T x) noexcept {
 // x between -pi and pi
 template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
 constexpr T MATH_PURE sin(T x) noexcept {
-    return filament::math::fast::cos<T>(x - T(F_PI_2));
+    return fast::cos<T>(x - T(F_PI_2));
 }
 
 constexpr inline float MATH_PURE ilog2(float x) noexcept {

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -164,7 +164,7 @@ inline constexpr half operator""_h(long double v) {
     return half( static_cast<float>(v) );
 }
 
-template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
+template<> struct is_arithmetic<half> : public std::true_type {};
 
 } // namespace math
 } // namespace filament

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -225,7 +225,7 @@ public:
      * Rotate by radians in the 2D plane
      */
     static TMat22<T> rotate(T radian) noexcept {
-        TMat22<T> r(TMat22<T>::NO_INIT);
+        TMat22<T> r(NO_INIT);
         T c = std::cos(radian);
         T s = std::sin(radian);
         r[0][0] = c;

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -256,7 +256,7 @@ public:
      */
     friend inline
     constexpr TMat33 orthogonalize(const TMat33& m) noexcept {
-        TMat33 ret(TMat33::NO_INIT);
+        TMat33 ret(NO_INIT);
         ret[0] = normalize(m[0]);
         ret[2] = normalize(cross(ret[0], m[1]));
         ret[1] = normalize(cross(ret[2], ret[0]));

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -498,10 +498,10 @@ constexpr TMat44<T> TMat44<T>::frustum(T left, T right, T bottom, T top, T near,
 }
 
 template<typename T>
-TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov direction) noexcept {
+TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, Fov direction) noexcept {
     T h, w;
 
-    if (direction == TMat44::Fov::VERTICAL) {
+    if (direction == Fov::VERTICAL) {
         h = std::tan(fov * F_PI / 360.0f) * near;
         w = h * aspect;
     } else {

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -194,7 +194,7 @@ public:
     }
 
     ~LinearAllocatorWithFallback() noexcept {
-        LinearAllocatorWithFallback::reset();
+        reset();
     }
 
     void* alloc(size_t size, size_t alignment = alignof(std::max_align_t));
@@ -204,7 +204,7 @@ public:
     }
 
     void rewind(void* p) noexcept {
-        if (p >= LinearAllocator::base() && p < LinearAllocator::end()) {
+        if (p >= base() && p < end()) {
             LinearAllocator::rewind(p);
         }
     }
@@ -214,7 +214,7 @@ public:
     void free(void*, size_t) noexcept { }
 
     bool isHeapAllocation(void* p) const noexcept {
-        return p < LinearAllocator::base() || p >= LinearAllocator::end();
+        return p < base() || p >= end();
     }
 };
 

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -68,10 +68,10 @@ public:
     intptr_t operator [](size_t index) const;
 
    /** Demangles a C++ type name */
-    static utils::CString demangleTypeName(const char* mangled);
+    static CString demangleTypeName(const char* mangled);
 
     template<typename T>
-    static utils::CString typeName() {
+    static CString typeName() {
 #if UTILS_HAS_RTTI
         return demangleTypeName(typeid(T).name());
 #else
@@ -84,7 +84,7 @@ public:
      * This will print, when possible, the demangled names of functions corresponding to the
      * program-counter recorded.
      */
-    friend utils::io::ostream& operator <<(utils::io::ostream& stream, const CallStack& callstack);
+    friend io::ostream& operator <<(io::ostream& stream, const CallStack& callstack);
 
     bool operator <(const CallStack& rhs) const;
 
@@ -111,7 +111,7 @@ public:
 private:
     void update_gcc(size_t ignore) noexcept;
 
-    static utils::CString demangle(const char* mangled);
+    static CString demangle(const char* mangled);
 
     static constexpr size_t NUM_FRAMES = 20;
 

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -344,7 +344,7 @@ public:
     }
 
     // for debugging
-    friend utils::io::ostream& operator << (utils::io::ostream& out, JobSystem const& js);
+    friend io::ostream& operator << (io::ostream& out, JobSystem const& js);
 
 
     // utility functions...
@@ -419,7 +419,7 @@ private:
     void decRef(Job const* job) noexcept;
 
     Job* allocateJob() noexcept;
-    JobSystem::ThreadState* getStateToStealFrom(JobSystem::ThreadState& state) noexcept;
+    ThreadState* getStateToStealFrom(ThreadState& state) noexcept;
     static bool hasJobCompleted(Job const* job) noexcept;
 
     void requestExit() noexcept;
@@ -427,8 +427,8 @@ private:
     bool hasActiveJobs() const noexcept;
 
     void loop(ThreadState* state) noexcept;
-    bool execute(JobSystem::ThreadState& state) noexcept;
-    Job* steal(JobSystem::ThreadState& state) noexcept;
+    bool execute(ThreadState& state) noexcept;
+    Job* steal(ThreadState& state) noexcept;
     void finish(Job* job) noexcept;
 
     void put(WorkQueue& workQueue, Job* job) noexcept;
@@ -446,10 +446,10 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    utils::Arena<utils::ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
+    Arena<ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
 
     template <typename T>
-    using aligned_vector = std::vector<T, utils::STLAlignedAllocator<T>>;
+    using aligned_vector = std::vector<T, STLAlignedAllocator<T>>;
 
     // These are essentially const, make sure they're on a different cache-lines than the
     // read-write atomics.
@@ -596,7 +596,7 @@ JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
 // parallel jobs on a Slice<>
 template<typename T, typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
-        utils::Slice<T> slice, F functor, const S& splitter) noexcept {
+        Slice<T> slice, F functor, const S& splitter) noexcept {
     return parallel_for(js, parent, slice.data(), slice.size(), functor, splitter);
 }
 

--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -47,7 +47,7 @@ class EntityManager;
  * printf("%s\n", names->getName(names->getInstance(myEntity));
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-class UTILS_PUBLIC NameComponentManager : private SingleInstanceComponentManager<utils::CString> {
+class UTILS_PUBLIC NameComponentManager : private SingleInstanceComponentManager<CString> {
 public:
     using Instance = EntityInstance<NameComponentManager>;
 
@@ -97,7 +97,7 @@ public:
     const char* getName(Instance instance) const noexcept;
 
     void gc(EntityManager& em) noexcept {
-        SingleInstanceComponentManager<utils::CString>::gc(em, [this](Entity e) {
+        SingleInstanceComponentManager<CString>::gc(em, [this](Entity e) {
             removeComponent(e);
         });
     }

--- a/libs/utils/include/utils/Profiler.h
+++ b/libs/utils/include/utils/Profiler.h
@@ -91,7 +91,7 @@ public:
         struct {
             uint64_t value;
             uint64_t id;
-        } counters[Profiler::EVENT_COUNT];
+        } counters[EVENT_COUNT];
 
         friend Counters operator-(Counters lhs, const Counters& rhs) noexcept {
             lhs.nr -= rhs.nr;

--- a/libs/utils/include/utils/QuadTree.h
+++ b/libs/utils/include/utils/QuadTree.h
@@ -50,7 +50,7 @@ static inline constexpr uint16_t morton(uint8_t x, uint8_t y) noexcept {
  * @return the number of elements in the tree
  */
 static inline constexpr size_t size(size_t height) noexcept {
-    return QuadTreeUtils::morton(uint8_t((1u << height) - 1u), 0u);
+    return morton(uint8_t((1u << height) - 1u), 0u);
 }
 
 /**

--- a/libs/utils/include/utils/RangeMap.h
+++ b/libs/utils/include/utils/RangeMap.h
@@ -268,7 +268,7 @@ private:
     Iterator shrink(Iterator iter, KeyType first, KeyType last) {
         assert_invariant(first < last);
         assert_invariant(getRange(iter).first == first || getRange(iter).last == last);
-        std::pair<utils::Range<KeyType>, ValueType> value = {{first, last}, iter->second.second};
+        std::pair<Range<KeyType>, ValueType> value = {{first, last}, iter->second.second};
         mMap.erase(iter);
         return mMap.insert({first, value}).first;
     }

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -108,7 +108,7 @@ public:
         return getComponentCount() == 0;
     }
 
-    utils::Entity const* getEntities() const noexcept {
+    Entity const* getEntities() const noexcept {
         return data<ENTITY_INDEX>() + 1;
     }
 

--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -671,7 +671,7 @@ template<typename Allocator, typename... Elements>
 inline
 typename StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef&
 StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef::operator=(
-        StructureOfArraysBase::IteratorValueRef const& rhs) {
+        IteratorValueRef const& rhs) {
     return operator=(IteratorValue(rhs));
 }
 
@@ -679,7 +679,7 @@ template<typename Allocator, typename... Elements>
 inline
 typename StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef&
 StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef::operator=(
-        StructureOfArraysBase::IteratorValueRef&& rhs) noexcept {
+        IteratorValueRef&& rhs) noexcept {
     return operator=(IteratorValue(rhs));
 }
 
@@ -688,7 +688,7 @@ template<size_t... Is>
 inline
 typename StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef&
 StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef::assign(
-        StructureOfArraysBase::IteratorValue const& rhs, std::index_sequence<Is...>) {
+        IteratorValue const& rhs, std::index_sequence<Is...>) {
     // implements IteratorValueRef& IteratorValueRef::operator=(IteratorValue const& rhs)
     auto UTILS_UNUSED l = { (soa->elementAt<Is>(index) = std::get<Is>(rhs.elements), 0)... };
     return *this;
@@ -699,7 +699,7 @@ template<size_t... Is>
 inline
 typename StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef&
 StructureOfArraysBase<Allocator, Elements...>::IteratorValueRef::assign(
-        StructureOfArraysBase::IteratorValue&& rhs, std::index_sequence<Is...>) noexcept {
+        IteratorValue&& rhs, std::index_sequence<Is...>) noexcept {
     // implements IteratorValueRef& IteratorValueRef::operator=(IteratorValue&& rhs) noexcept
     auto UTILS_UNUSED l = {
             (soa->elementAt<Is>(index) = std::move(std::get<Is>(rhs.elements)), 0)... };

--- a/libs/utils/include/utils/android/PerformanceHintManager.h
+++ b/libs/utils/include/utils/android/PerformanceHintManager.h
@@ -37,7 +37,7 @@ class UTILS_PUBLIC PerformanceHintManager :
 public:
     class UTILS_PUBLIC Session : PrivateImplementation<SessionDetails> {
         friend class PerformanceHintManager;
-        friend struct PerformanceHintManager::SessionDetails;
+        friend struct SessionDetails;
     public:
         Session() noexcept;
         Session(PerformanceHintManager& manager,

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -29,7 +29,7 @@ namespace utils::io {
 
 struct ostream_;
 
-class UTILS_PUBLIC ostream : protected utils::PrivateImplementation<ostream_> {
+class UTILS_PUBLIC ostream : protected PrivateImplementation<ostream_> {
     friend struct ostream_;
 
 public:
@@ -123,7 +123,7 @@ private:
 };
 
 // handles utils::bitset
-inline ostream& operator << (ostream& o, utils::bitset32 const& s) noexcept {
+inline ostream& operator << (ostream& o, bitset32 const& s) noexcept {
     return o << (void*)uintptr_t(s.getValue());
 }
 

--- a/libs/utils/src/CallStack.cpp
+++ b/libs/utils/src/CallStack.cpp
@@ -120,7 +120,7 @@ bool CallStack::operator<(const CallStack& rhs) const {
 
 // ------------------------------------------------------------------------------------------------
 
-utils::CString CallStack::demangle(const char* mangled) {
+CString CallStack::demangle(const char* mangled) {
 #if !defined(NDEBUG) && !defined(WIN32)
     size_t len;
     int status;
@@ -135,7 +135,7 @@ utils::CString CallStack::demangle(const char* mangled) {
 }
 
 
-utils::CString CallStack::demangleTypeName(const char* mangled) {
+CString CallStack::demangleTypeName(const char* mangled) {
     return demangle(mangled);
 }
 

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -49,11 +49,11 @@ void EntityManager::destroy(size_t n, Entity* entities) noexcept {
     static_cast<EntityManagerImpl *>(this)->destroy(n, entities);
 }
 
-void EntityManager::registerListener(EntityManager::Listener* l) noexcept {
+void EntityManager::registerListener(Listener* l) noexcept {
     static_cast<EntityManagerImpl *>(this)->registerListener(l);
 }
 
-void EntityManager::unregisterListener(EntityManager::Listener* l) noexcept {
+void EntityManager::unregisterListener(Listener* l) noexcept {
     static_cast<EntityManagerImpl *>(this)->unregisterListener(l);
 }
 

--- a/libs/utils/src/EntityManagerImpl.h
+++ b/libs/utils/src/EntityManagerImpl.h
@@ -132,12 +132,12 @@ public:
         }
     }
 
-    void registerListener(EntityManager::Listener* l) noexcept {
+    void registerListener(Listener* l) noexcept {
         std::lock_guard<Mutex> const lock(mListenerLock);
         mListeners.insert(l);
     }
 
-    void unregisterListener(EntityManager::Listener* l) noexcept {
+    void unregisterListener(Listener* l) noexcept {
         std::lock_guard<Mutex> const lock(mListenerLock);
         mListeners.erase(l);
     }
@@ -162,10 +162,10 @@ public:
 #endif
 
 private:
-    utils::FixedCapacityVector<EntityManager::Listener*> getListeners() const noexcept {
+    FixedCapacityVector<Listener*> getListeners() const noexcept {
         std::lock_guard<Mutex> const lock(mListenerLock);
         tsl::robin_set<Listener*> const& listeners = mListeners;
-        utils::FixedCapacityVector<EntityManager::Listener*> result(listeners.size());
+        FixedCapacityVector<Listener*> result(listeners.size());
         result.resize(result.capacity()); // unfortunately this memset()
         std::copy(listeners.begin(), listeners.end(), result.begin());
         return result; // the c++ standard guarantees a move

--- a/libs/utils/src/Profiler.cpp
+++ b/libs/utils/src/Profiler.cpp
@@ -59,7 +59,7 @@ Profiler::Profiler() noexcept {
 }
 
 Profiler::Profiler(uint32_t eventMask) noexcept : Profiler() {
-    Profiler::resetEvents(eventMask);
+    resetEvents(eventMask);
 }
 
 Profiler::~Profiler() noexcept {

--- a/libs/utils/src/android/ThermalManager.cpp
+++ b/libs/utils/src/android/ThermalManager.cpp
@@ -46,7 +46,7 @@ ThermalManager& ThermalManager::operator=(ThermalManager&& rhs) noexcept {
 
 ThermalManager::ThermalStatus ThermalManager::getCurrentThermalStatus() const noexcept {
     if (__builtin_available(android 30, *)) {
-        return (ThermalManager::ThermalStatus)AThermal_getCurrentThermalStatus(mThermalManager);
+        return (ThermalStatus)AThermal_getCurrentThermalStatus(mThermalManager);
     } else {
         return ThermalStatus::NONE;
     }

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -75,21 +75,21 @@ ostream::Buffer const& ostream::getBuffer() const noexcept {
     return mImpl->mData;
 }
 
-const char* ostream::getFormat(ostream::type t) const noexcept {
+const char* ostream::getFormat(type t) const noexcept {
     switch (t) {
-        case type::SHORT:       return mImpl->mShowHex ? "0x%hx"  : "%hd";
-        case type::USHORT:      return mImpl->mShowHex ? "0x%hx"  : "%hu";
-        case type::CHAR:        return "%c";
-        case type::UCHAR:       return "%c";
-        case type::INT:         return mImpl->mShowHex ? "0x%x"   : "%d";
-        case type::UINT:        return mImpl->mShowHex ? "0x%x"   : "%u";
-        case type::LONG:        return mImpl->mShowHex ? "0x%lx"  : "%ld";
-        case type::ULONG:       return mImpl->mShowHex ? "0x%lx"  : "%lu";
-        case type::LONG_LONG:   return mImpl->mShowHex ? "0x%llx" : "%lld";
-        case type::ULONG_LONG:  return mImpl->mShowHex ? "0x%llx" : "%llu";
-        case type::FLOAT:       return "%.9g";
-        case type::DOUBLE:      return "%.17g";
-        case type::LONG_DOUBLE: return "%Lf";
+        case SHORT:       return mImpl->mShowHex ? "0x%hx"  : "%hd";
+        case USHORT:      return mImpl->mShowHex ? "0x%hx"  : "%hu";
+        case CHAR:        return "%c";
+        case UCHAR:       return "%c";
+        case INT:         return mImpl->mShowHex ? "0x%x"   : "%d";
+        case UINT:        return mImpl->mShowHex ? "0x%x"   : "%u";
+        case LONG:        return mImpl->mShowHex ? "0x%lx"  : "%ld";
+        case ULONG:       return mImpl->mShowHex ? "0x%lx"  : "%lu";
+        case LONG_LONG:   return mImpl->mShowHex ? "0x%llx" : "%lld";
+        case ULONG_LONG:  return mImpl->mShowHex ? "0x%llx" : "%llu";
+        case FLOAT:       return "%.9g";
+        case DOUBLE:      return "%.17g";
+        case LONG_DOUBLE: return "%Lf";
     }
 }
 
@@ -126,67 +126,67 @@ ostream& ostream::print(const char* format, ...) noexcept {
 }
 
 ostream& ostream::operator<<(short value) noexcept {
-    const char* format = getFormat(type::SHORT);
+    const char* format = getFormat(SHORT);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(unsigned short value) noexcept {
-    const char* format = getFormat(type::USHORT);
+    const char* format = getFormat(USHORT);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(char value) noexcept {
-    const char* format = getFormat(type::CHAR);
+    const char* format = getFormat(CHAR);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(unsigned char value) noexcept {
-    const char* format = getFormat(type::UCHAR);
+    const char* format = getFormat(UCHAR);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(int value) noexcept {
-    const char* format = getFormat(type::INT);
+    const char* format = getFormat(INT);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(unsigned int value) noexcept {
-    const char* format = getFormat(type::UINT);
+    const char* format = getFormat(UINT);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(long value) noexcept {
-    const char* format = getFormat(type::LONG);
+    const char* format = getFormat(LONG);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(unsigned long value) noexcept {
-    const char* format = getFormat(type::ULONG);
+    const char* format = getFormat(ULONG);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(long long value) noexcept {
-    const char* format = getFormat(type::LONG_LONG);
+    const char* format = getFormat(LONG_LONG);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(unsigned long long value) noexcept {
-    const char* format = getFormat(type::ULONG_LONG);
+    const char* format = getFormat(ULONG_LONG);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(float value) noexcept {
-    const char* format = getFormat(type::FLOAT);
+    const char* format = getFormat(FLOAT);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(double value) noexcept {
-    const char* format = getFormat(type::DOUBLE);
+    const char* format = getFormat(DOUBLE);
     return print(format, value);
 }
 
 ostream& ostream::operator<<(long double value) noexcept {
-    const char* format = getFormat(type::LONG_DOUBLE);
+    const char* format = getFormat(LONG_DOUBLE);
     return print(format, value);
 }
 

--- a/libs/utils/src/sstream.cpp
+++ b/libs/utils/src/sstream.cpp
@@ -21,7 +21,7 @@
 
 namespace utils::io {
 
-utils::io::ostream& sstream::flush() noexcept {
+ostream& sstream::flush() noexcept {
     // no-op.
     return *this;
 }


### PR DESCRIPTION
- remove redundant qualifiers
- use is_same_v instead of is_same
- bring back Builder::name() for better documentation
- add missing const parameters in implementation files
- various cleanups
