### PR TITLE
validate MaterialInstance references when destroyed

### DIFF
--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -459,6 +459,13 @@ Java_com_google_android_filament_RenderableManager_nSetMaterialInstanceAt(JNIEnv
             materialInstance);
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nClearMaterialInstanceAt(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jint primitiveIndex) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    rm->clearMaterialInstanceAt((RenderableManager::Instance) i, (size_t) primitiveIndex);
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_RenderableManager_nGetMaterialInstanceAt(JNIEnv*, jclass,
         jlong nativeRenderableManager, jint i, jint primitiveIndex) {

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -870,6 +870,13 @@ public class RenderableManager {
     }
 
     /**
+     * Clears the material instance for the given primitive.
+     */
+    public void clearMaterialInstanceAt(@EntityInstance int i, @IntRange(from = 0) int primitiveIndex) {
+        nClearMaterialInstanceAt(mNativeObject, i, primitiveIndex);
+    }
+
+    /**
      * Creates a MaterialInstance Java wrapper object for a particular material instance.
      */
     public @NonNull MaterialInstance getMaterialInstanceAt(@EntityInstance int i,
@@ -1012,6 +1019,7 @@ public class RenderableManager {
     private static native void nGetAxisAlignedBoundingBox(long nativeRenderableManager, int i, float[] center, float[] halfExtent);
     private static native int nGetPrimitiveCount(long nativeRenderableManager, int i);
     private static native void nSetMaterialInstanceAt(long nativeRenderableManager, int i, int primitiveIndex, long nativeMaterialInstance);
+    private static native void nClearMaterialInstanceAt(long nativeRenderableManager, int i, int primitiveIndex);
     private static native long nGetMaterialInstanceAt(long nativeRenderableManager, int i, int primitiveIndex);
     private static native void nSetGeometryAt(long nativeRenderableManager, int i, int primitiveIndex, int primitiveType, long nativeVertexBuffer, long nativeIndexBuffer, int offset, int count);
     private static native void nSetBlendOrderAt(long nativeRenderableManager, int i, int primitiveIndex, int blendOrder);

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -799,6 +799,13 @@ public:
             size_t primitiveIndex, MaterialInstance const* UTILS_NONNULL materialInstance);
 
     /**
+     * Clear the MaterialInstance for the given primitive.
+     * @param instance Renderable's instance
+     * @param primitiveIndex Primitive index
+     */
+    void clearMaterialInstanceAt(Instance instance, size_t primitiveIndex);
+
+    /**
      * Retrieves the material instance that is bound to the given primitive.
      */
     MaterialInstance* UTILS_NULLABLE getMaterialInstanceAt(

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -113,6 +113,10 @@ void RenderableManager::setMaterialInstanceAt(Instance instance,
     downcast(this)->setMaterialInstanceAt(instance, 0, primitiveIndex, downcast(materialInstance));
 }
 
+void RenderableManager::clearMaterialInstanceAt(Instance instance, size_t primitiveIndex) {
+    downcast(this)->clearMaterialInstanceAt(instance, 0, primitiveIndex);
+}
+
 MaterialInstance* RenderableManager::getMaterialInstanceAt(
         Instance instance, size_t primitiveIndex) const noexcept {
     return downcast(this)->getMaterialInstanceAt(instance, 0, primitiveIndex);

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -820,7 +820,7 @@ void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
 }
 
 void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t level,
-    size_t primitiveIndex) {
+        size_t primitiveIndex) {
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -792,10 +792,10 @@ void FRenderableManager::destroyComponentPrimitives(
 
 void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
         size_t primitiveIndex, FMaterialInstance const* mi) {
+    assert_invariant(mi);
     if (instance) {
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
-        if (primitiveIndex < primitives.size()) {
-            assert_invariant(mi);
+        if (primitiveIndex < primitives.size() && mi) {
             FMaterial const* material = mi->getMaterial();
 
             // we want a feature level violation to be a hard error (exception if enabled, or crash)
@@ -815,6 +815,16 @@ void FRenderableManager::setMaterialInstanceAt(Instance instance, uint8_t level,
                        << "] missing required attributes ("
                        << required << "), declared=" << declared << io::endl;
             }
+        }
+    }
+}
+
+void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t level,
+    size_t primitiveIndex) {
+    if (instance) {
+        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        if (primitiveIndex < primitives.size()) {
+            primitives[primitiveIndex].setMaterialInstance(nullptr);
         }
     }
 }

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -204,6 +204,7 @@ public:
     size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;
     void setMaterialInstanceAt(Instance instance, uint8_t level,
             size_t primitiveIndex, FMaterialInstance const* materialInstance);
+    void clearMaterialInstanceAt(Instance instance, uint8_t level, size_t primitiveIndex);
     MaterialInstance* getMaterialInstanceAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
             PrimitiveType type, FVertexBuffer* vertices, FIndexBuffer* indices,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -501,6 +501,10 @@ public:
         return FEngine::getActiveFeatureLevel() >= neededFeatureLevel;
     }
 
+    auto const& getMaterialInstanceResourceList() const noexcept {
+        return mMaterialInstances;
+    }
+
 #if defined(__EMSCRIPTEN__)
     void resetBackendState() noexcept;
 #endif
@@ -683,6 +687,13 @@ public:
             struct {
                 bool use_shadow_atlas = false;
             } shadows;
+            struct {
+#ifndef NDEBUG
+                bool assert_material_instance_in_use = true;
+#else
+                bool assert_material_instance_in_use = false;
+#endif
+            } debug;
         } engine;
         struct {
             struct {
@@ -705,7 +716,10 @@ public:
               &features.backend.opengl.assert_native_window_is_valid, true },
             { "engine.shadows.use_shadow_atlas",
               "Uses an array of atlases to store shadow maps.",
-              &features.engine.shadows.use_shadow_atlas, true }
+              &features.engine.shadows.use_shadow_atlas, true },
+            { "features.engine.debug.assert_material_instance_in_use",
+              "Assert when a MaterialInstance is destroyed while it is in use by RenderableManager.",
+              &features.engine.debug.assert_material_instance_in_use, false }
     }};
 
     utils::Slice<const FeatureFlag> getFeatureFlags() const noexcept {

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -153,13 +153,13 @@ FMaterial const* FSkybox::createMaterial(FEngine& engine) {
 void FSkybox::terminate(FEngine& engine) noexcept {
     // use Engine::destroy because FEngine::destroy is inlined
     Engine& e = engine;
-    e.destroy(mSkyboxMaterialInstance);
     e.destroy(mSkybox);
+    e.destroy(mSkyboxMaterialInstance);
 
     engine.getEntityManager().destroy(mSkybox);
 
-    mSkyboxMaterialInstance = nullptr;
     mSkybox = {};
+    mSkyboxMaterialInstance = nullptr;
 }
 
 void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {

--- a/libs/filamentapp/src/Cube.cpp
+++ b/libs/filamentapp/src/Cube.cpp
@@ -140,11 +140,14 @@ void Cube::mapAabb(filament::Engine& engine, filament::Box const& box) {
 Cube::~Cube() {
     mEngine.destroy(mVertexBuffer);
     mEngine.destroy(mIndexBuffer);
-    mEngine.destroy(mMaterialInstanceSolid);
-    mEngine.destroy(mMaterialInstanceWireFrame);
+
     // We don't own the material, only instances
     mEngine.destroy(mSolidRenderable);
     mEngine.destroy(mWireFrameRenderable);
+
+    // material instances must be destroyed after the renderables
+    mEngine.destroy(mMaterialInstanceSolid);
+    mEngine.destroy(mMaterialInstanceWireFrame);
 
     utils::EntityManager& em = utils::EntityManager::get();
     em.destroy(mSolidRenderable);

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -37,12 +37,8 @@ FFilamentAsset::~FFilamentAsset() {
     // Free transient load-time data if they haven't been freed yet.
     releaseSourceData();
 
-    // Destroy all instance objects. Instance entities / components are
-    // destroyed later in this method because they are owned by the asset
-    // (except for the root of the instance).
     for (FFilamentInstance* instance : mInstances) {
         mEntityManager->destroy(instance->mRoot);
-        delete instance;
     }
 
     delete mWireframe;
@@ -74,6 +70,12 @@ FFilamentAsset::~FFilamentAsset() {
             mEngine->destroy(entity);
             mEntityManager->destroy(entity);
         }
+    }
+
+    // FilamentInstances need to be destroyed after the renderables have been destroyed
+    // so that there are no dangling MaterialInstance around
+    for (FFilamentInstance* instance : mInstances) {
+        delete instance;
     }
 
     for (auto vb : mVertexBuffers) {

--- a/libs/iblprefilter/src/IBLPrefilterContext.cpp
+++ b/libs/iblprefilter/src/IBLPrefilterContext.cpp
@@ -254,8 +254,8 @@ Texture* IBLPrefilterContext::EquirectangularToCubemap::operator()(
     const uint32_t dim = outCube->getWidth();
 
     RenderableManager& rcm = engine.getRenderableManager();
-    rcm.setMaterialInstanceAt(
-            rcm.getInstance(mContext.mFullScreenQuadEntity), 0, mi);
+    auto const ci = rcm.getInstance(mContext.mFullScreenQuadEntity);
+    rcm.setMaterialInstanceAt(ci, 0, mi);
 
     TextureSampler environmentSampler;
     environmentSampler.setMagFilter(SamplerMagFilter::LINEAR);
@@ -289,6 +289,7 @@ Texture* IBLPrefilterContext::EquirectangularToCubemap::operator()(
         engine.destroy(rt);
     }
 
+    rcm.clearMaterialInstanceAt(ci, 0);
     engine.destroy(mi);
 
     return outCube;
@@ -328,8 +329,8 @@ IBLPrefilterContext::IrradianceFilter::IrradianceFilter(IBLPrefilterContext& con
     mi->setParameter("sampleCount", float(mSampleCount));
 
     RenderableManager& rcm = engine.getRenderableManager();
-    rcm.setMaterialInstanceAt(
-            rcm.getInstance(mContext.mFullScreenQuadEntity), 0, mi);
+    auto const ci = rcm.getInstance(mContext.mFullScreenQuadEntity);
+    rcm.setMaterialInstanceAt(ci, 0, mi);
 
     RenderTarget* const rt = RenderTarget::Builder()
             .texture(RenderTarget::AttachmentPoint::COLOR0, mKernelTexture)
@@ -339,6 +340,8 @@ IBLPrefilterContext::IrradianceFilter::IrradianceFilter(IBLPrefilterContext& con
     view->setViewport({ 0, 0, 1, mSampleCount });
 
     renderer->renderStandaloneView(view);
+
+    rcm.clearMaterialInstanceAt(ci, 0);
 
     engine.destroy(rt);
     engine.destroy(mi);
@@ -410,8 +413,8 @@ filament::Texture* IBLPrefilterContext::IrradianceFilter::operator()(
     MaterialInstance* const mi = mContext.mIrradianceIntegrationMaterial->createInstance();
 
     RenderableManager& rcm = engine.getRenderableManager();
-    rcm.setMaterialInstanceAt(
-            rcm.getInstance(mContext.mFullScreenQuadEntity), 0, mi);
+    auto const ci = rcm.getInstance(mContext.mFullScreenQuadEntity);
+    rcm.setMaterialInstanceAt(ci, 0, mi);
 
     const uint32_t sampleCount = mSampleCount;
     const float linear = options.hdrLinear;
@@ -454,6 +457,8 @@ filament::Texture* IBLPrefilterContext::IrradianceFilter::operator()(
         renderer->renderStandaloneView(view);
         engine.destroy(rt);
     }
+
+    rcm.clearMaterialInstanceAt(ci, 0);
 
     engine.destroy(mi);
 
@@ -533,8 +538,8 @@ IBLPrefilterContext::SpecularFilter::SpecularFilter(IBLPrefilterContext& context
     mi->setParameter("roughness", roughnessArray, 16);
 
     RenderableManager& rcm = engine.getRenderableManager();
-    rcm.setMaterialInstanceAt(
-            rcm.getInstance(mContext.mFullScreenQuadEntity), 0, mi);
+    auto const ci = rcm.getInstance(mContext.mFullScreenQuadEntity);
+    rcm.setMaterialInstanceAt(ci, 0, mi);
 
     RenderTarget* const rt = RenderTarget::Builder()
             .texture(RenderTarget::AttachmentPoint::COLOR0, mKernelTexture)
@@ -544,6 +549,8 @@ IBLPrefilterContext::SpecularFilter::SpecularFilter(IBLPrefilterContext& context
     view->setViewport({ 0, 0, mLevelCount, mSampleCount });
 
     renderer->renderStandaloneView(view);
+
+    rcm.clearMaterialInstanceAt(ci, 0);
 
     engine.destroy(rt);
     engine.destroy(mi);
@@ -643,8 +650,8 @@ Texture* IBLPrefilterContext::SpecularFilter::operator()(
     MaterialInstance* const mi = mContext.mIntegrationMaterial->createInstance();
 
     RenderableManager& rcm = engine.getRenderableManager();
-    rcm.setMaterialInstanceAt(
-            rcm.getInstance(mContext.mFullScreenQuadEntity), 0, mi);
+    auto const ci = rcm.getInstance(mContext.mFullScreenQuadEntity);
+    rcm.setMaterialInstanceAt(ci, 0, mi);
 
     const uint32_t sampleCount = mSampleCount;
     const float linear = options.hdrLinear;
@@ -706,6 +713,8 @@ Texture* IBLPrefilterContext::SpecularFilter::operator()(
 
         dim >>= 1;
     }
+
+    rcm.clearMaterialInstanceAt(ci, 0);
 
     engine.destroy(mi);
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1100,6 +1100,7 @@ class_<RenderableManager>("RenderableManager")
     .function("getPrimitiveCount", &RenderableManager::getPrimitiveCount)
     .function("setMaterialInstanceAt", &RenderableManager::setMaterialInstanceAt,
             allow_raw_pointers())
+    .function("clearMaterialInstanceAt", &RenderableManager::clearMaterialInstanceAt)
     .function("getMaterialInstanceAt", &RenderableManager::getMaterialInstanceAt,
             allow_raw_pointers())
 


### PR DESCRIPTION
With this change we now enforce two things:
- All MaterialInstance of a Material must be destroyed when destroying said Material. This has always been a documented  requirement of the public API, but wasn't enforced (only a warning was printed). This new assertion is unconditional.

- A MaterialInstance, when destroyed is no longer in use by any Renderable.

So before destroying a MaterialInstance, the user of API needs to  ensure that either all Renderable using that MaterialInstance in one of their Render Primitives are  destroyed, or, that these Renderable using that MaterialInstance are reset to another one or to null.

There is a new RenderableManager::clearMaterialInstanceAt() that can be used to clear a MaterialInstance on a Render Primitive.
  
Additionally, a Render Primitive with a null MaterialInstance is now silently skipped during rendering, instead of a null-dereference.

Finally, that second assert is protected by a new feature flag:  "features.engine.debug.assert_material_instance_in_use". This flag is enabled on DEBUG builds and disabled on RELEASE builds by default. The flag can be changed at any time using `Engine::setFeatureFlag()`.

BUGS=[333907416]