### PR TITLE
use the more modern syntax for std::enable_if and friends

### DIFF
--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -130,7 +130,7 @@ struct Handle : public HandleBase {
     bool operator>=(const Handle& rhs) const noexcept { return getId() >= rhs.getId(); }
 
     // type-safe Handle cast
-    template<typename B, typename = std::enable_if_t<std::is_base_of<T, B>::value> >
+    template<typename B, typename = std::enable_if_t<std::is_base_of_v<T, B>> >
     Handle(Handle<B> const& base) noexcept : HandleBase(base) { } // NOLINT(hicpp-explicit-conversions,google-explicit-constructor)
 
 private:

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -97,7 +97,7 @@ public:
      *  ConcreteTexture* p = reconstruct(h, w, h);
      */
     template<typename D, typename B, typename ... ARGS>
-    typename std::enable_if_t<std::is_base_of_v<B, D>, D>*
+    std::enable_if_t<std::is_base_of_v<B, D>, D>*
     destroyAndConstruct(Handle<B> const& handle, ARGS&& ... args) {
         assert_invariant(handle);
         D* addr = handle_cast<D*>(const_cast<Handle<B>&>(handle));
@@ -116,7 +116,7 @@ public:
      *  ConcreteTexture* p = construct(h, w, h);
      */
     template<typename D, typename B, typename ... ARGS>
-    typename std::enable_if_t<std::is_base_of_v<B, D>, D>*
+    std::enable_if_t<std::is_base_of_v<B, D>, D>*
     construct(Handle<B> const& handle, ARGS&& ... args) noexcept {
         assert_invariant(handle);
         D* addr = handle_cast<D*>(const_cast<Handle<B>&>(handle));
@@ -133,7 +133,7 @@ public:
      *      deallocate(h, p);
      */
     template <typename B, typename D,
-            typename = typename std::enable_if_t<std::is_base_of_v<B, D>, D>>
+            typename = std::enable_if_t<std::is_base_of_v<B, D>, D>>
     void deallocate(Handle<B>& handle, D const* p) noexcept {
         // allow to destroy the nullptr, similarly to operator delete
         if (p) {
@@ -161,9 +161,9 @@ public:
      *      ConcreteTexture* p = handle_cast<ConcreteTexture*>(h);
      */
     template<typename Dp, typename B>
-    inline typename std::enable_if_t<
+    inline std::enable_if_t<
             std::is_pointer_v<Dp> &&
-            std::is_base_of_v<B, typename std::remove_pointer_t<Dp>>, Dp>
+            std::is_base_of_v<B, std::remove_pointer_t<Dp>>, Dp>
     handle_cast(Handle<B>& handle) {
         assert_invariant(handle);
         auto [p, tag] = handleToPointer(handle.getId());
@@ -217,9 +217,9 @@ public:
     }
 
     template<typename Dp, typename B>
-    inline typename std::enable_if_t<
+    inline std::enable_if_t<
             std::is_pointer_v<Dp> &&
-            std::is_base_of_v<B, typename std::remove_pointer_t<Dp>>, Dp>
+            std::is_base_of_v<B, std::remove_pointer_t<Dp>>, Dp>
     handle_cast(Handle<B> const& handle) {
         return handle_cast<Dp>(const_cast<Handle<B>&>(handle));
     }

--- a/filament/backend/src/vulkan/memory/ResourcePointer.h
+++ b/filament/backend/src/vulkan/memory/ResourcePointer.h
@@ -81,7 +81,7 @@ public:
     inline resource_ptr() = default;
 
     // move constructor operator
-    inline resource_ptr(resource_ptr<D>&& rhs) {
+    inline resource_ptr(resource_ptr<D>&& rhs) noexcept {
         (*this) = std::move(rhs);
     }
 
@@ -98,7 +98,7 @@ public:
     }
 
     // move operator
-    inline resource_ptr<D>& operator=(resource_ptr<D> && rhs) {
+    inline resource_ptr<D>& operator=(resource_ptr<D> && rhs) noexcept {
         std::swap(mRef, rhs.mRef);
         return *this;
     }

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -717,13 +717,13 @@ public:
     // trivially destructible, since free() won't call the destructor and this is allocating
     // an array.
     template <typename T,
-            typename = typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
+            typename = std::enable_if_t<std::is_trivially_destructible_v<T>>>
     T* alloc(size_t count, size_t alignment, size_t extra) noexcept {
         return (T*)alloc(count * sizeof(T), alignment, extra);
     }
 
     template <typename T,
-            typename = typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
+            typename = std::enable_if_t<std::is_trivially_destructible_v<T>>>
     T* alloc(size_t count, size_t alignment = alignof(T)) noexcept {
         return (T*)alloc(count * sizeof(T), alignment);
     }
@@ -879,7 +879,7 @@ public:
     template<typename T, size_t ALIGN = alignof(T), typename... ARGS>
     T* make(ARGS&& ... args) noexcept {
         T* o = nullptr;
-        if (std::is_trivially_destructible<T>::value) {
+        if (std::is_trivially_destructible_v<T>) {
             o = mArena.template make<T, ALIGN>(std::forward<ARGS>(args)...);
         } else {
             void* const p = (Finalizer*)mArena.alloc(sizeof(T), ALIGN, sizeof(Finalizer));

--- a/libs/utils/include/utils/BinaryTreeArray.h
+++ b/libs/utils/include/utils/BinaryTreeArray.h
@@ -31,7 +31,7 @@ class BinaryTreeArray {
 
     // Simple fixed capacity stack
     template<typename TYPE, size_t CAPACITY,
-            typename = typename std::enable_if<std::is_trivial<TYPE>::value>::type>
+            typename = std::enable_if_t<std::is_trivial_v<TYPE>>>
     class stack {
         TYPE mElements[CAPACITY];
         size_t mSize = 0;

--- a/libs/utils/include/utils/BitmaskEnum.h
+++ b/libs/utils/include/utils/BitmaskEnum.h
@@ -41,32 +41,32 @@ size_t count();
 // ------------------------------------------------------------------------------------------------
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableIntegerOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableIntegerOperators<Enum>::value, int> = 0>
 inline constexpr int operator+(Enum value) noexcept {
     return int(value);
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableIntegerOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableIntegerOperators<Enum>::value, int> = 0>
 inline constexpr bool operator==(Enum lhs, size_t rhs) noexcept {
     using underlying_t = std::underlying_type_t<Enum>;
     return underlying_t(lhs) == rhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableIntegerOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableIntegerOperators<Enum>::value, int> = 0>
 inline constexpr bool operator==(size_t lhs, Enum rhs) noexcept {
     return rhs == lhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableIntegerOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableIntegerOperators<Enum>::value, int> = 0>
 inline constexpr bool operator!=(Enum lhs, size_t rhs) noexcept {
     return !(rhs == lhs);
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableIntegerOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableIntegerOperators<Enum>::value, int> = 0>
 inline constexpr bool operator!=(size_t lhs, Enum rhs) noexcept {
     return rhs != lhs;
 }
@@ -74,66 +74,66 @@ inline constexpr bool operator!=(size_t lhs, Enum rhs) noexcept {
 // ------------------------------------------------------------------------------------------------
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr bool operator!(Enum rhs) noexcept {
     using underlying = std::underlying_type_t<Enum>;
     return underlying(rhs) == 0;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator~(Enum rhs) noexcept {
     using underlying = std::underlying_type_t<Enum>;
     return Enum(~underlying(rhs));
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator|(Enum lhs, Enum rhs) noexcept {
     using underlying = std::underlying_type_t<Enum>;
     return Enum(underlying(lhs) | underlying(rhs));
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator&(Enum lhs, Enum rhs) noexcept {
     using underlying = std::underlying_type_t<Enum>;
     return Enum(underlying(lhs) & underlying(rhs));
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator^(Enum lhs, Enum rhs) noexcept {
     using underlying = std::underlying_type_t<Enum>;
     return Enum(underlying(lhs) ^ underlying(rhs));
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator|=(Enum& lhs, Enum rhs) noexcept {
     return lhs = lhs | rhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator&=(Enum& lhs, Enum rhs) noexcept {
     return lhs = lhs & rhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr Enum operator^=(Enum& lhs, Enum rhs) noexcept {
     return lhs = lhs ^ rhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr bool none(Enum lhs) noexcept {
     return !lhs;
 }
 
 template<typename Enum, typename std::enable_if_t<
-        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+        std::is_enum_v<Enum> && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
 inline constexpr bool any(Enum lhs) noexcept {
     return !none(lhs);
 }

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -494,9 +494,9 @@ JobSystem::Job* createJob(JobSystem& js, JobSystem::Job* parent,
 }
 
 template<typename CALLABLE, typename T, typename ... ARGS,
-        typename = typename std::enable_if<
-                std::is_member_function_pointer<typename std::remove_reference<CALLABLE>::type>::value
-        >::type
+        typename = std::enable_if_t<
+                std::is_member_function_pointer_v<std::remove_reference_t<CALLABLE>>
+        >
 >
 JobSystem::Job* createJob(JobSystem& js, JobSystem::Job* parent,
         CALLABLE&& func, T&& o, ARGS&&... args) noexcept {

--- a/libs/utils/include/utils/QuadTree.h
+++ b/libs/utils/include/utils/QuadTree.h
@@ -97,7 +97,7 @@ class QuadTreeArray : public std::array<T, QuadTreeUtils::size(HEIGHT)> {
 
     // Simple fixed capacity stack
     template<typename TYPE, size_t CAPACITY,
-            typename = typename std::enable_if<std::is_trivial<TYPE>::value>::type>
+            typename = std::enable_if_t<std::is_trivial_v<TYPE>>>
     class stack {
         TYPE mElements[CAPACITY];
         size_t mSize = 0;
@@ -147,8 +147,8 @@ public:
      * @param process   closure to process each visited node
      */
     template<typename Process,
-            typename = typename std::enable_if<
-                    std::is_invocable_r_v<TraversalResult, Process, NodeId>>::type>
+            typename = std::enable_if_t<
+                    std::is_invocable_r_v<TraversalResult, Process, NodeId>>>
     static void traverse(int8_t l, code_t code, size_t maxHeight, Process&& process) noexcept {
         assert_invariant(maxHeight < height());
         const int8_t h = int8_t(maxHeight);
@@ -173,8 +173,8 @@ public:
     }
 
     template<typename Node,
-            typename = typename std::enable_if<
-                    std::is_invocable_r_v<TraversalResult, Node, NodeId>>::type>
+            typename = std::enable_if_t<
+                    std::is_invocable_r_v<TraversalResult, Node, NodeId>>>
     static void traverse(int8_t l, code_t code, Node&& process) noexcept {
         traverse(l, code, height() - 1, std::forward<Node>(process));
     }

--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -130,7 +130,7 @@ public:
         friend class IteratorValueRef;
         friend iterator;
         friend const_iterator;
-        using Type = std::tuple<typename std::decay<Elements>::type...>;
+        using Type = std::tuple<std::decay_t<Elements>...>;
         Type elements;
 
         template<size_t ... Is>
@@ -535,22 +535,22 @@ public:
 
 private:
     template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I == sizeof...(Tp), void>::type
+    inline std::enable_if_t<I == sizeof...(Tp), void>
     for_each(std::tuple<Tp...>&, FuncT) {}
 
     template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I < sizeof...(Tp), void>::type
+    inline std::enable_if_t<I < sizeof...(Tp), void>
     for_each(std::tuple<Tp...>& t, FuncT f) {
         f(I, std::get<I>(t));
         for_each<I + 1, FuncT, Tp...>(t, f);
     }
 
     template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I == sizeof...(Tp), void>::type
+    inline std::enable_if_t<I == sizeof...(Tp), void>
     for_each_index(std::tuple<Tp...>&, FuncT) {}
 
     template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I < sizeof...(Tp), void>::type
+    inline std::enable_if_t<I < sizeof...(Tp), void>
     for_each_index(std::tuple<Tp...>& t, FuncT f) {
         f.template operator()<I>(std::get<I>(t));
         for_each_index<I + 1, FuncT, Tp...>(t, f);
@@ -597,7 +597,7 @@ private:
 
     void construct_each(size_t from, size_t to) noexcept {
         forEach([from, to](auto p) {
-            using T = typename std::decay<decltype(*p)>::type;
+            using T = std::decay_t<decltype(*p)>;
             // note: scalar types like int/float get initialized to zero
             if constexpr (!std::is_trivially_default_constructible_v<T>) {
                 for (size_t i = from; i < to; i++) {
@@ -609,7 +609,7 @@ private:
 
     void destroy_each(size_t from, size_t to) noexcept {
         forEach([from, to](auto p) {
-            using T = typename std::decay<decltype(*p)>::type;
+            using T = std::decay_t<decltype(*p)>;
             if constexpr (!std::is_trivially_destructible_v<T>) {
                 for (size_t i = from; i < to; i++) {
                     p[i].~T();
@@ -624,7 +624,7 @@ private:
         if (mSize) {
             auto size = mSize; // placate a compiler warning
             forEach([buffer, &index, &offsets, size](auto p) {
-                using T = typename std::decay<decltype(*p)>::type;
+                using T = std::decay_t<decltype(*p)>;
                 T* UTILS_RESTRICT b = static_cast<T*>(buffer);
 
                 // go through each element and move them from the old array to the new

--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -39,7 +39,7 @@ constexpr inline T popcount(T v) noexcept {
     return (T) (v * (ONES / 255)) >> (sizeof(T) - 1) * CHAR_BIT;
 }
 
-template<typename T, typename = std::enable_if_t<std::is_unsigned<T>::value>>
+template<typename T, typename = std::enable_if_t<std::is_unsigned_v<T>>>
 constexpr inline T clz(T x) noexcept {
     static_assert(sizeof(T) * CHAR_BIT <= 128, "details::clz() only support up to 128 bits");
     x |= (x >> 1u);
@@ -62,7 +62,7 @@ constexpr inline T clz(T x) noexcept {
     return T(sizeof(T) * CHAR_BIT) - details::popcount(x);
 }
 
-template<typename T, typename = std::enable_if_t<std::is_unsigned<T>::value>>
+template<typename T, typename = std::enable_if_t<std::is_unsigned_v<T>>>
 constexpr inline T ctz(T x) noexcept {
     static_assert(sizeof(T) * CHAR_BIT <= 64, "details::ctz() only support up to 64 bits");
     T c = sizeof(T) * CHAR_BIT;
@@ -227,7 +227,7 @@ unsigned long long UTILS_ALWAYS_INLINE popcount(unsigned long long x) noexcept {
 }
 
 template<typename T,
-        typename = std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value>>
+        typename = std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>>>
 constexpr inline UTILS_PUBLIC UTILS_PURE
 T log2i(T x) noexcept {
     return (sizeof(x) * 8 - 1u) - clz(x);

--- a/libs/utils/include/utils/bitset.h
+++ b/libs/utils/include/utils/bitset.h
@@ -45,8 +45,8 @@ namespace utils {
  */
 
 template<typename T, size_t N = 1,
-        typename = typename std::enable_if<std::is_integral<T>::value &&
-                                           std::is_unsigned<T>::value>::type>
+        typename = std::enable_if_t<std::is_integral_v<T> &&
+                                           std::is_unsigned_v<T>>>
 class UTILS_PUBLIC bitset {
     T storage[N];
 


### PR DESCRIPTION
e.g. std::enable_if<cond>::type is replaced by std::enable_if_t<cond>

remove some unneeded typename keywords