### PR TITLE
attempt to fix crashers when initializing the JVM

### DIFF
--- a/filament/backend/include/private/backend/VirtualMachineEnv.h
+++ b/filament/backend/include/private/backend/VirtualMachineEnv.h
@@ -18,7 +18,7 @@
 #define TNT_FILAMENT_DRIVER_ANDROID_VIRTUAL_MACHINE_ENV_H
 
 #include <utils/compiler.h>
-#include <utils/debug.h>
+#include <utils/Mutex.h>
 
 #include <jni.h>
 
@@ -26,25 +26,17 @@ namespace filament {
 
 class VirtualMachineEnv {
 public:
+    // must be called before VirtualMachineEnv::get() from a thread that is attached to the JavaVM
     static jint JNI_OnLoad(JavaVM* vm) noexcept;
 
-    static VirtualMachineEnv& get() noexcept {
-        // declaring this thread local, will ensure it's destroyed with the calling thread
-        static thread_local VirtualMachineEnv instance;
-        return instance;
-    }
+    // must be called on backend thread
+    static VirtualMachineEnv& get() noexcept;
 
-    static JNIEnv* getThreadEnvironment() noexcept {
-        JNIEnv* env;
-        assert_invariant(sVirtualMachine);
-        if (sVirtualMachine->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
-            return nullptr; // this should not happen
-        }
-        return env;
-    }
+    // can be called from any thread that already has a JniEnv
+    static JNIEnv* getThreadEnvironment() noexcept;
 
-    inline JNIEnv* getEnvironment() noexcept {
-        assert_invariant(mVirtualMachine);
+    // must be called from the backend thread
+    JNIEnv* getEnvironment() noexcept {
         JNIEnv* env = mJniEnv;
         if (UTILS_UNLIKELY(!env)) {
             return getEnvironmentSlow();
@@ -55,20 +47,14 @@ public:
     static void handleException(JNIEnv* env) noexcept;
 
 private:
-    VirtualMachineEnv() noexcept : mVirtualMachine(sVirtualMachine) {
-        // We're not initializing the JVM here -- but we could -- because most of the time
-        // we don't need the jvm. Instead we do the initialization on first use. This means we could get
-        // a nasty slow down the very first time, but we'll live with it for now.
-    }
-
-    ~VirtualMachineEnv() {
-        if (mVirtualMachine) {
-            mVirtualMachine->DetachCurrentThread();
-        }
-    }
-
+    explicit VirtualMachineEnv(JavaVM* vm) noexcept;
+    ~VirtualMachineEnv() noexcept;
     JNIEnv* getEnvironmentSlow() noexcept;
+
+    static utils::Mutex sLock;
     static JavaVM* sVirtualMachine;
+    static JavaVM* getVirtualMachine();
+
     JNIEnv* mJniEnv = nullptr;
     JavaVM* mVirtualMachine = nullptr;
 };

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.cpp
@@ -16,13 +16,28 @@
 
 #include "ExternalStreamManagerAndroid.h"
 
-#include <utils/api_level.h>
+#include <private/backend/VirtualMachineEnv.h>
+
+#include <backend/Platform.h>
+
 #include <utils/compiler.h>
+#include <utils/debug.h>
 #include <utils/Log.h>
+#include <utils/ostream.h>
 
-#include <dlfcn.h>
+#if __has_include(<android/surface_texture.h>)
+#   include <android/surface_texture.h>
+#   include <android/surface_texture_jni.h>
+#else
+struct ASurfaceTexture;
+typedef struct ASurfaceTexture ASurfaceTexture;
+#endif
 
-#include <chrono>
+#include <jni.h>
+
+#include <stdint.h>
+
+#include <new>
 
 using namespace utils;
 
@@ -32,13 +47,8 @@ using namespace backend;
 using Stream = Platform::Stream;
 
 
-template <typename T>
-static void loadSymbol(T*& pfn, const char *symbol) noexcept {
-    pfn = (T*)dlsym(RTLD_DEFAULT, symbol);
-}
-
 ExternalStreamManagerAndroid& ExternalStreamManagerAndroid::create() noexcept {
-    return *(new ExternalStreamManagerAndroid{});
+    return *(new(std::nothrow) ExternalStreamManagerAndroid{});
 }
 
 void ExternalStreamManagerAndroid::destroy(ExternalStreamManagerAndroid* pExternalStreamManagerAndroid) noexcept {
@@ -56,23 +66,13 @@ ExternalStreamManagerAndroid::~ExternalStreamManagerAndroid() noexcept = default
 
 UTILS_NOINLINE
 JNIEnv* ExternalStreamManagerAndroid::getEnvironmentSlow() noexcept {
-    JNIEnv * env = mVm.getEnvironment();
+    JNIEnv* const env = mVm.getEnvironment();
     mJniEnv = env;
-
     jclass SurfaceTextureClass = env->FindClass("android/graphics/SurfaceTexture");
-
-    mSurfaceTextureClass_updateTexImage = env->GetMethodID(
-            SurfaceTextureClass, "updateTexImage", "()V");
-
-    mSurfaceTextureClass_attachToGLContext = env->GetMethodID(
-            SurfaceTextureClass, "attachToGLContext", "(I)V");
-
-    mSurfaceTextureClass_detachFromGLContext = env->GetMethodID(
-            SurfaceTextureClass, "detachFromGLContext", "()V");
-
-    mSurfaceTextureClass_getTimestamp = env->GetMethodID(
-            SurfaceTextureClass, "getTimestamp", "()J");
-
+    mSurfaceTextureClass_updateTexImage = env->GetMethodID(SurfaceTextureClass, "updateTexImage", "()V");
+    mSurfaceTextureClass_attachToGLContext = env->GetMethodID(SurfaceTextureClass, "attachToGLContext", "(I)V");
+    mSurfaceTextureClass_detachFromGLContext = env->GetMethodID(SurfaceTextureClass, "detachFromGLContext", "()V");
+    mSurfaceTextureClass_getTimestamp = env->GetMethodID(SurfaceTextureClass, "getTimestamp", "()J");
     return env;
 }
 
@@ -82,7 +82,7 @@ Stream* ExternalStreamManagerAndroid::acquire(jobject surfaceTexture) noexcept {
     if (!env) {
         return nullptr; // this should not happen
     }
-    EGLStream* stream = new EGLStream();
+    EGLStream* stream = new(std::nothrow) EGLStream();
     stream->jSurfaceTexture = env->NewGlobalRef(surfaceTexture);
     if (__builtin_available(android 28, *)) {
         stream->nSurfaceTexture = ASurfaceTexture_fromSurfaceTexture(env, surfaceTexture);
@@ -91,29 +91,30 @@ Stream* ExternalStreamManagerAndroid::acquire(jobject surfaceTexture) noexcept {
 }
 
 void ExternalStreamManagerAndroid::release(Stream* handle) noexcept {
-    EGLStream* stream = static_cast<EGLStream*>(handle);
+    EGLStream const* stream = static_cast<EGLStream*>(handle);
     if (__builtin_available(android 28, *)) {
         ASurfaceTexture_release(stream->nSurfaceTexture);
     }
-    JNIEnv* const env = getEnvironment();
+    // use VirtualMachineEnv::getEnvironment() directly because we don't need to cache JNI methods here
+    JNIEnv* const env = mVm.getEnvironment();
     assert_invariant(env); // we should have called attach() by now
     env->DeleteGlobalRef(stream->jSurfaceTexture);
     delete stream;
 }
 
 void ExternalStreamManagerAndroid::attach(Stream* handle, intptr_t tname) noexcept {
-    EGLStream* stream = static_cast<EGLStream*>(handle);
+    EGLStream const* stream = static_cast<EGLStream*>(handle);
     if (__builtin_available(android 28, *)) {
         // associate our GL texture to the SurfaceTexture
         ASurfaceTexture* const aSurfaceTexture = stream->nSurfaceTexture;
-        if (UTILS_UNLIKELY(ASurfaceTexture_attachToGLContext(aSurfaceTexture, (uint32_t)tname))) {
+        if (UTILS_UNLIKELY(ASurfaceTexture_attachToGLContext(aSurfaceTexture, uint32_t(tname)))) {
             // Unfortunately, before API 26 SurfaceTexture was always created in attached mode,
             // so attachToGLContext can fail. We consider this the unlikely case, because
             // this is how it should work.
             // So now we have to detach the surfacetexture from its texture
             ASurfaceTexture_detachFromGLContext(aSurfaceTexture);
             // and finally, try attaching again
-            ASurfaceTexture_attachToGLContext(aSurfaceTexture, (uint32_t)tname);
+            ASurfaceTexture_attachToGLContext(aSurfaceTexture, uint32_t(tname));
         }
     } else {
         JNIEnv* const env = getEnvironment();
@@ -121,19 +122,19 @@ void ExternalStreamManagerAndroid::attach(Stream* handle, intptr_t tname) noexce
 
         // associate our GL texture to the SurfaceTexture
         jobject jSurfaceTexture = stream->jSurfaceTexture;
-        env->CallVoidMethod(jSurfaceTexture, mSurfaceTextureClass_attachToGLContext, (jint)tname);
+        env->CallVoidMethod(jSurfaceTexture, mSurfaceTextureClass_attachToGLContext, jint(tname));
         if (UTILS_UNLIKELY(env->ExceptionCheck())) {
             // Unfortunately, before API 26 SurfaceTexture was always created in attached mode,
             // so attachToGLContext can fail. We consider this the unlikely case, because
             // this is how it should work.
             env->ExceptionClear();
 
-            // so now we have to detach the surfacetexture from its texture
+            // so now we have to detach the SurfaceTexture from its texture
             env->CallVoidMethod(jSurfaceTexture, mSurfaceTextureClass_detachFromGLContext);
             VirtualMachineEnv::handleException(env);
 
             // and finally, try attaching again
-            env->CallVoidMethod(jSurfaceTexture, mSurfaceTextureClass_attachToGLContext, (jint)tname);
+            env->CallVoidMethod(jSurfaceTexture, mSurfaceTextureClass_attachToGLContext, jint(tname));
             VirtualMachineEnv::handleException(env);
         }
     }
@@ -144,7 +145,7 @@ void ExternalStreamManagerAndroid::detach(Stream* handle) noexcept {
     if (__builtin_available(android 28, *)) {
         ASurfaceTexture_detachFromGLContext(stream->nSurfaceTexture);
     } else {
-        JNIEnv* const env = mVm.getEnvironment();
+        JNIEnv* const env = getEnvironment();
         assert_invariant(env); // we should have called attach() by now
         env->CallVoidMethod(stream->jSurfaceTexture, mSurfaceTextureClass_detachFromGLContext);
         VirtualMachineEnv::handleException(env);
@@ -152,12 +153,12 @@ void ExternalStreamManagerAndroid::detach(Stream* handle) noexcept {
 }
 
 void ExternalStreamManagerAndroid::updateTexImage(Stream* handle, int64_t* timestamp) noexcept {
-    EGLStream* stream = static_cast<EGLStream*>(handle);
+    EGLStream const* stream = static_cast<EGLStream*>(handle);
     if (__builtin_available(android 28, *)) {
         ASurfaceTexture_updateTexImage(stream->nSurfaceTexture);
         *timestamp = ASurfaceTexture_getTimestamp(stream->nSurfaceTexture);
     } else {
-        JNIEnv* const env = mVm.getEnvironment();
+        JNIEnv* const env = getEnvironment();
         assert_invariant(env); // we should have called attach() by now
         env->CallVoidMethod(stream->jSurfaceTexture, mSurfaceTextureClass_updateTexImage);
         VirtualMachineEnv::handleException(env);

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
@@ -21,13 +21,18 @@
 
 #include <backend/Platform.h>
 
+#include <utils/compiler.h>
+
 #if __has_include(<android/surface_texture.h>)
 #   include <android/surface_texture.h>
-#   include <android/surface_texture_jni.h>
 #else
 struct ASurfaceTexture;
 typedef struct ASurfaceTexture ASurfaceTexture;
 #endif
+
+#include <jni.h>
+
+#include <stdint.h>
 
 namespace filament::backend {
 
@@ -70,7 +75,8 @@ private:
         ASurfaceTexture*    nSurfaceTexture = nullptr;
     };
 
-    inline JNIEnv* getEnvironment() noexcept {
+    // Must only be called from the backend thread
+    JNIEnv* getEnvironment() noexcept {
         JNIEnv* env = mJniEnv;
         if (UTILS_UNLIKELY(!env)) {
             return getEnvironmentSlow();
@@ -85,7 +91,6 @@ private:
     jmethodID mSurfaceTextureClass_attachToGLContext{};
     jmethodID mSurfaceTextureClass_detachFromGLContext{};
 };
-
 } // namespace filament::backend
 
 #endif //TNT_FILAMENT_BACKEND_OPENGL_ANDROID_EXTERNAL_STREAM_MANAGER_ANDROID_H


### PR DESCRIPTION
- clarify precondition for VirtualMachineEnv, in particular,  JNI_OnLoad() must be called from a thread attached to the VM, and should be called once. This is now enforced internally, subsequent calls are ignored.

- sVirtualMachine was written and read from potentially different  threads without synchronization. It is now mutex protected.

- added fatal asserts in all locations that we cannot recover from; previously we would stay in an undefined state.

BUGS=[390724273]