### PR TITLE
Add a way to retrieve the GL_RENDERER and GL_VENDOR strings

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -165,7 +165,7 @@ public:
      *
      * @return nullptr on failure, or a pointer to the newly created driver.
      */
-    virtual backend::Driver* UTILS_NULLABLE createDriver(void* UTILS_NULLABLE sharedContext,
+    virtual Driver* UTILS_NULLABLE createDriver(void* UTILS_NULLABLE sharedContext,
             const DriverConfig& driverConfig) noexcept = 0;
 
     /**

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -23,6 +23,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Invocable.h>
+#include <utils/CString.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -55,6 +56,18 @@ public:
         unsigned int target; // GLenum target
         unsigned int id; // GLuint id
     };
+
+    /**
+     * Return the OpenGL vendor string of the specified Driver instance.
+     * @return The GL_VENDOR string
+     */
+    static utils::CString getVendorString(Driver const* UTILS_NONNULL driver);
+
+    /**
+     * Return the OpenGL vendor string of the specified Driver instance
+     * @return The GL_RENDERER string
+     */
+    static utils::CString getRendererString(Driver const* UTILS_NONNULL driver);
 
     /**
      * Called by the driver to destroy the OpenGL context. This should clean up any windows

--- a/filament/backend/include/backend/platforms/PlatformCocoaGL.h
+++ b/filament/backend/include/backend/platforms/PlatformCocoaGL.h
@@ -17,7 +17,6 @@
 #ifndef TNT_FILAMENT_BACKEND_OPENGL_OPENGL_PLATFORM_COCOA_GL_H
 #define TNT_FILAMENT_BACKEND_OPENGL_OPENGL_PLATFORM_COCOA_GL_H
 
-#include <backend/DriverEnums.h>
 #include <backend/platforms/OpenGLPlatform.h>
 
 #include <stdint.h>

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -80,8 +80,7 @@ protected:
      * Initializes EGL, creates the OpenGL context and returns a concrete Driver implementation
      * that supports OpenGL/OpenGL ES.
      */
-    Driver* createDriver(void* sharedContext,
-            const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, const DriverConfig& driverConfig) noexcept override;
 
     /**
      * This returns zero. This method can be overridden to return something more useful.

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
 #include "noop/NoopDriver.h"
 #include "CommandStreamDispatcher.h"
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -154,7 +154,7 @@ using namespace GLUtils;
 // ------------------------------------------------------------------------------------------------
 
 UTILS_NOINLINE
-Driver* OpenGLDriver::create(OpenGLPlatform* const platform,
+OpenGLDriver* OpenGLDriver::create(OpenGLPlatform* const platform,
         void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     assert_invariant(platform);
     OpenGLPlatform* const ec = platform;

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -18,25 +18,51 @@
 
 #include "OpenGLDriverFactory.h"
 
+#include "platforms/OpenGLDriverBase.h"
+
 #include <backend/AcquiredImage.h>
 #include <backend/DriverEnums.h>
 #include <backend/Platform.h>
 
 #include <utils/compiler.h>
-
+#include <utils/Panic.h>
+#include <utils/CString.h>
 #include <utils/Invocable.h>
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "OpenGLDriver.h"
+
 namespace filament::backend {
 
+OpenGLDriverBase::~OpenGLDriverBase() = default;
+
 Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform,
-        void* sharedContext, const Platform::DriverConfig& driverConfig) {
+        void* sharedContext, const DriverConfig& driverConfig) {
     return OpenGLDriverFactory::create(platform, sharedContext, driverConfig);
 }
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
+
+utils::CString OpenGLPlatform::getVendorString(Driver const* driver) {
+    auto const p = static_cast<OpenGLDriverBase const*>(driver);
+#if UTILS_HAS_RTTI
+    FILAMENT_CHECK_POSTCONDITION(dynamic_cast<OpenGLDriverBase const*>(driver))
+            << "Driver* has not been allocated with OpenGLPlatform";
+#endif
+    return p->getVendorString();
+}
+
+utils::CString OpenGLPlatform::getRendererString(Driver const* driver) {
+    auto const p = static_cast<OpenGLDriverBase const*>(driver);
+#if UTILS_HAS_RTTI
+    FILAMENT_CHECK_POSTCONDITION(dynamic_cast<OpenGLDriverBase const*>(driver))
+            << "Driver* has not been allocated with OpenGLPlatform";
+#endif
+    return p->getRendererString();
+}
 
 void OpenGLPlatform::makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain,
         utils::Invocable<void()>, utils::Invocable<void(size_t)>) noexcept {

--- a/filament/backend/src/opengl/platforms/OpenGLDriverBase.h
+++ b/filament/backend/src/opengl/platforms/OpenGLDriverBase.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_OPENGL_OPENGLDRIVERBASE_H
+#define TNT_FILAMENT_BACKEND_OPENGL_OPENGLDRIVERBASE_H
+
+#include "DriverBase.h"
+
+#include <utils/CString.h>
+
+namespace filament::backend {
+
+class OpenGLDriverBase : public DriverBase {
+protected:
+    ~OpenGLDriverBase() override;
+
+public:
+    virtual utils::CString getVendorString() const noexcept = 0;
+    virtual utils::CString getRendererString() const noexcept = 0;
+};
+
+} // filament::backend
+
+#endif //TNT_FILAMENT_BACKEND_OPENGL_OPENGLDRIVERBASE_H

--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -297,7 +297,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext, const DriverConfig& drive
     clearGlError();
 
     // success!!
-    return OpenGLPlatform::createDefaultDriver(this, sharedContext, driverConfig);
+    return createDefaultDriver(this, sharedContext, driverConfig);
 
 error:
     // if we're here, we've failed
@@ -551,7 +551,7 @@ Platform::SwapChain* PlatformEGL::createSwapChain(
     return sc;
 }
 
-void PlatformEGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
+void PlatformEGL::destroySwapChain(SwapChain* swapChain) noexcept {
     if (swapChain) {
         SwapChainEGL const* const sc = static_cast<SwapChainEGL const*>(swapChain);
         if (sc->sur != EGL_NO_SURFACE) {
@@ -564,7 +564,7 @@ void PlatformEGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
     }
 }
 
-bool PlatformEGL::isSwapChainProtected(Platform::SwapChain* swapChain) noexcept {
+bool PlatformEGL::isSwapChainProtected(SwapChain* swapChain) noexcept {
     if (swapChain) {
         SwapChainEGL const* const sc = static_cast<SwapChainEGL const*>(swapChain);
         return bool(sc->flags & SWAP_CHAIN_CONFIG_PROTECTED_CONTENT);
@@ -585,10 +585,10 @@ bool PlatformEGL::makeCurrent(ContextType type,
     return success == EGL_TRUE ? true : false;
 }
 
-void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
-        Platform::SwapChain* readSwapChain,
-        utils::Invocable<void()> preContextChange,
-        utils::Invocable<void(size_t index)> postContextChange) noexcept {
+void PlatformEGL::makeCurrent(SwapChain* drawSwapChain,
+        SwapChain* readSwapChain,
+        Invocable<void()> preContextChange,
+        Invocable<void(size_t index)> postContextChange) noexcept {
 
     assert_invariant(drawSwapChain);
     assert_invariant(readSwapChain);
@@ -647,7 +647,7 @@ void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     }
 }
 
-void PlatformEGL::commit(Platform::SwapChain* swapChain) noexcept {
+void PlatformEGL::commit(SwapChain* swapChain) noexcept {
     if (swapChain) {
         SwapChainEGL const* const sc = static_cast<SwapChainEGL const*>(swapChain);
         if (sc->sur != EGL_NO_SURFACE) {
@@ -670,7 +670,7 @@ Platform::Fence* PlatformEGL::createFence() noexcept {
     return f;
 }
 
-void PlatformEGL::destroyFence(Platform::Fence* fence) noexcept {
+void PlatformEGL::destroyFence(Fence* fence) noexcept {
 #ifdef EGL_KHR_reusable_sync
     EGLSyncKHR sync = (EGLSyncKHR) fence;
     if (sync != EGL_NO_SYNC_KHR) {
@@ -680,7 +680,7 @@ void PlatformEGL::destroyFence(Platform::Fence* fence) noexcept {
 }
 
 FenceStatus PlatformEGL::waitFence(
-        Platform::Fence* fence, uint64_t timeout) noexcept {
+        Fence* fence, uint64_t timeout) noexcept {
 #ifdef EGL_KHR_reusable_sync
     EGLSyncKHR sync = (EGLSyncKHR) fence;
     if (sync != EGL_NO_SYNC_KHR) {
@@ -746,7 +746,7 @@ void PlatformEGL::initializeGlExtensions() noexcept {
     ext.gl.OES_EGL_image_external_essl3 = glExtensions.has("GL_OES_EGL_image_external_essl3");
 }
 
-EGLContext PlatformEGL::getContextForType(OpenGLPlatform::ContextType type) const noexcept {
+EGLContext PlatformEGL::getContextForType(ContextType type) const noexcept {
     switch (type) {
         case ContextType::NONE:
             return EGL_NO_CONTEXT;

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -17,6 +17,7 @@
 #ifndef TNT_FILAMENT_ENGINE_H
 #define TNT_FILAMENT_ENGINE_H
 
+
 #include <filament/FilamentAPI.h>
 
 #include <backend/DriverEnums.h>
@@ -32,6 +33,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
+
 namespace utils {
 class Entity;
 class EntityManager;
@@ -39,6 +41,10 @@ class JobSystem;
 } // namespace utils
 
 namespace filament {
+
+namespace backend {
+class Driver;
+} // backend
 
 class BufferObject;
 class Camera;
@@ -183,6 +189,7 @@ public:
     using DriverConfig = backend::Platform::DriverConfig;
     using FeatureLevel = backend::FeatureLevel;
     using StereoscopicType = backend::StereoscopicType;
+    using Driver = backend::Driver;
 
     /**
      * Config is used to define the memory footprint used by the engine, such as the
@@ -582,6 +589,11 @@ public:
     static Engine* UTILS_NULLABLE getEngine(void* UTILS_NONNULL token);
 #endif
 
+    /**
+     * @return the Driver instance used by this Engine.
+     * @see OpenGLPlatform
+     */
+    backend::Driver const* UTILS_NONNULL getDriver() const noexcept;
 
     /**
      * Destroy the Engine instance and all associated resources.

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -68,6 +68,10 @@ Engine* Engine::getEngine(void* token) {
 }
 #endif
 
+Driver const* Engine::getDriver() const noexcept {
+    return std::addressof(downcast(this)->getDriver());
+}
+
 void Engine::destroy(Engine** pEngine) {
     if (pEngine) {
         Engine* engine = *pEngine;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -61,6 +61,8 @@
 #include <filament/Texture.h>
 #include <filament/VertexBuffer.h>
 
+#include <backend/DriverEnums.h>
+
 #include <utils/Allocator.h>
 #include <utils/compiler.h>
 #include <utils/CountDownLatch.h>
@@ -122,12 +124,11 @@ class ResourceAllocator;
  */
 class FEngine : public Engine {
 public:
-
-    inline void* operator new(std::size_t const size) noexcept {
+    void* operator new(std::size_t const size) noexcept {
         return utils::aligned_alloc(size, alignof(FEngine));
     }
 
-    inline void operator delete(void* p) noexcept {
+    void operator delete(void* p) noexcept {
         utils::aligned_free(p);
     }
 
@@ -490,7 +491,7 @@ public:
     backend::Handle<backend::HwTexture> getOneTextureArray() const { return mDummyOneTextureArray; }
     backend::Handle<backend::HwTexture> getZeroTextureArray() const { return mDummyZeroTextureArray; }
 
-    static constexpr const size_t MiB = 1024u * 1024u;
+    static constexpr size_t MiB = 1024u * 1024u;
     size_t getMinCommandBufferSize() const noexcept { return mConfig.minCommandBufferSizeMB * MiB; }
     size_t getCommandBufferSize() const noexcept { return mConfig.commandBufferSizeMB * MiB; }
     size_t getPerFrameCommandsSize() const noexcept { return mConfig.perFrameCommandsSizeMB * MiB; }
@@ -510,6 +511,8 @@ public:
     void resetBackendState() noexcept;
 #endif
 
+    backend::Driver& getDriver() const noexcept { return *mDriver; }
+
 private:
     explicit FEngine(Builder const& builder);
     void init();
@@ -517,8 +520,6 @@ private:
 
     int loop();
     void flushCommandBuffer(backend::CommandBufferQueue& commandBufferQueue);
-
-    backend::Driver& getDriver() const noexcept { return *mDriver; }
 
     template<typename T>
     bool isValid(const T* ptr, ResourceList<T> const& list) const;


### PR DESCRIPTION
Add a way to retrieve the GL_RENDERER and GL_VENDOR strings

The API works this way:

```
auto vendor = OpenGLPlatform::getVendorString(engine->getDriver());
```

Obviously the Backend must be `Backend::OPENGL` and the `Driver` must 
have been created with an `OpenGLPlatform` subclass.


FIXES=[385367277]