### PR TITLE
Remove noexcept from UserPanicHandler::call() so that panic handlers can throw as documented

### DIFF
--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -43,7 +43,7 @@ class UserPanicHandler {
     struct CallBack {
         Panic::PanicHandlerCallback handler = nullptr;
         void* user = nullptr;
-        void call(Panic const& panic) const noexcept {
+        void call(Panic const& panic) const {
             if (UTILS_UNLIKELY(handler)) {
                 handler(user, panic);
             }
@@ -64,7 +64,7 @@ public:
         return data;
     }
 
-    void call(Panic const& panic) const noexcept {
+    void call(Panic const& panic) const {
         getCallback().call(panic);
     }
 


### PR DESCRIPTION
Without this change, throwing inside the user panic handler calls terminate(). Note that the docs for setPanicHandler() explicitly say that it's okay for the handler to throw, which is not true prior to this change:

```
     * Sets a user-defined handler for the Panic. If exceptions are enabled, the concrete Panic
     * object will be thrown upon return; moreover it is acceptable to throw from the provided
     * callback, but it is unsafe to throw the Panic object itself, since it's just an interface.
     * It is also acceptable to abort from the callback. If exceptions are not enabled, std::abort()
     * will be automatically called upon return.
```