### PR TITLE
Flips v coordinates for vulkan usage

### DIFF
--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -261,12 +261,20 @@ int main(int argc, char** argv) {
         float3 quadNormal = normalize(float3 {0, 0, 1});
         float3 u = normalize(cross(quadNormal, upVector));
         float3 v = cross(quadNormal, u);
-        static Vertex quadVertices[4] = {
-                {{quadCenter - u - v}, {1, 0}},
-                {{quadCenter + u - v}, {0, 0}},
-                {{quadCenter - u + v}, {1, 1}},
-                {{quadCenter + u + v}, {0, 1}}
-        };
+        static Vertex quadVertices[4];
+        
+        // When using Vulkan, the v coordinates need to be flipped
+        if (engine->getBackend() == filament::Engine::Backend::VULKAN) {
+            quadVertices[0] = {{quadCenter - u - v}, {1, 1}};
+            quadVertices[1] = {{quadCenter + u - v}, {0, 1}};
+            quadVertices[2] = {{quadCenter - u + v}, {1, 0}};
+            quadVertices[3] = {{quadCenter + u + v}, {0, 0}};
+        } else {
+            quadVertices[0] = {{quadCenter - u - v}, {1, 0}};
+            quadVertices[1] = {{quadCenter + u - v}, {0, 0}};
+            quadVertices[2] = {{quadCenter - u + v}, {1, 1}};
+            quadVertices[3] = {{quadCenter + u + v}, {0, 1}};
+        }
 
         static_assert(sizeof(Vertex) == 20, "Strange vertex size.");
         app.quadVb = VertexBuffer::Builder()


### PR DESCRIPTION
Flips the v coordinates for the hellostereo sample when using vulkan. 

Image before flipping coordinates:
<img width="787" alt="Screenshot 2025-01-17 at 10 16 33 AM" src="https://github.com/user-attachments/assets/348c8b26-759e-4a06-88b2-2eaa2bd188c9" />

Image after flipping coordinates:
<img width="758" alt="Screenshot 2025-01-29 at 3 27 27 PM" src="https://github.com/user-attachments/assets/0604e657-d26f-421a-88cd-8c8ad007f85e" />


