### PR TITLE
Update multiview shader code generator for Vulkan

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -78,7 +78,11 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
                     out << "#endif\n\n";
                     break;
                 case StereoscopicType::MULTIVIEW:
-                    out << "#extension GL_OVR_multiview2 : require\n";
+                    if (mTargetApi == TargetApi::VULKAN) {
+                        out << "#extension GL_EXT_multiview : enable\n";
+                    } else {
+                        out << "#extension GL_OVR_multiview2 : require\n";
+                    }
                     break;
                 case StereoscopicType::NONE:
                     break;
@@ -101,7 +105,11 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
                     // Nothing to generate
                     break;
                 case StereoscopicType::MULTIVIEW:
-                    out << "#extension GL_OVR_multiview2 : require\n";
+                    if (mTargetApi == TargetApi::VULKAN) {
+                        out << "#extension GL_EXT_multiview : enable\n";
+                    } else {
+                        out << "#extension GL_OVR_multiview2 : require\n";
+                    }
                     break;
                 case StereoscopicType::NONE:
                     break;
@@ -124,7 +132,9 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
             // Nothing to generate
             break;
         case StereoscopicType::MULTIVIEW:
-            out << "layout(num_views = " << material.stereoscopicEyeCount << ") in;\n";
+            if (mTargetApi != TargetApi::VULKAN) {
+                out << "layout(num_views = " << material.stereoscopicEyeCount << ") in;\n";
+            }
             break;
         case StereoscopicType::NONE:
             break;

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -28,7 +28,13 @@ highp mat4 getClipFromWorldMatrix() {
     int eye = instance_index % CONFIG_STEREO_EYE_COUNT;
     return frameUniforms.clipFromWorldMatrix[eye];
 #elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
+
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    return frameUniforms.clipFromWorldMatrix[gl_ViewIndex];
+#else
     return frameUniforms.clipFromWorldMatrix[gl_ViewID_OVR];
+#endif // TARGET_VULKAN_ENVIRONMENT
+
 #else
     return frameUniforms.clipFromWorldMatrix[0];
 #endif

--- a/shaders/src/surface_getters.vs
+++ b/shaders/src/surface_getters.vs
@@ -284,8 +284,14 @@ int getEyeIndex() {
 #if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
     return instance_index % CONFIG_STEREO_EYE_COUNT;
 #elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
+
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    return int(gl_ViewIndex);
+#else
     // gl_ViewID_OVR is of uint type, which needs an explicit conversion.
     return int(gl_ViewID_OVR);
+#endif // TARGET_VULKAN_ENVIRONMENT
+
 #endif
     return 0;
 }


### PR DESCRIPTION
When targeting Vulkan with multiview, the shader
code generator was using the OpenGL extension
and built-in variables, which are not supported on Vulkan.

Changed it to use GL_EXT_multiview instead of
GL_OVR_multiview2 when the target API is Vulkan.