### PR TITLE
Fix warnings regarding #pragma clang

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -126,8 +126,10 @@
  * Driver API below...
  */
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
 
 DECL_DRIVER_API_0(tick)
 
@@ -533,7 +535,9 @@ DECL_DRIVER_API_N(scissor,
         Viewport, scissor)
 
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 #undef EXPAND
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -75,9 +75,11 @@
 #include <emscripten.h>
 #endif
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
+#endif
 
 // We can only support this feature on OpenGL ES 3.1+
 // Support is currently disabled as we don't need it
@@ -4094,4 +4096,6 @@ template class ConcreteDispatcher<OpenGLDriver>;
 
 } // namespace filament::backend
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -44,11 +44,13 @@ using namespace bluevk;
 
 using utils::FixedCapacityVector;
 
+#if defined(__clang__)
 // Vulkan functions often immediately dereference pointers, so it's fine to pass in a pointer
 // to a stack-allocated variable.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-stack-address"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
 
 namespace filament::backend {
 
@@ -1882,4 +1884,6 @@ template class ConcreteDispatcher<VulkanDriver>;
 
 } // namespace filament::backend
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif

--- a/filament/backend/src/vulkan/VulkanMemory.cpp
+++ b/filament/backend/src/vulkan/VulkanMemory.cpp
@@ -16,6 +16,7 @@
 
 #include <bluevk/BlueVK.h> // must be included before vk_mem_alloc
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 
 // Needed because not all clang versions have the warning -Wdeprecated-copy.
@@ -32,6 +33,7 @@
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 
 static const PFN_vkGetInstanceProcAddr& vkGetInstanceProcAddr = bluevk::vkGetInstanceProcAddr;
 static const PFN_vkGetDeviceProcAddr& vkGetDeviceProcAddr = bluevk::vkGetDeviceProcAddr;
@@ -39,4 +41,7 @@ static const PFN_vkGetDeviceProcAddr& vkGetDeviceProcAddr = bluevk::vkGetDeviceP
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_IMPLEMENTATION
 #include "vk_mem_alloc.h"
+
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif

--- a/filament/backend/src/vulkan/VulkanMemory.h
+++ b/filament/backend/src/vulkan/VulkanMemory.h
@@ -27,7 +27,9 @@
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 #endif
 
+#if defined(__clang__)
 #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+#endif
 
 #include "vk_mem_alloc.h"
 

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -26,10 +26,12 @@
 #include "VulkanTexture.h"
 #include "VulkanUtility.h"
 
+#if defined(__clang__)
 // Vulkan functions often immediately dereference pointers, so it's fine to pass in a pointer
 // to a stack-allocated variable.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-stack-address"
+#endif
 
 using namespace bluevk;
 
@@ -323,4 +325,6 @@ bool VulkanPipelineCache::PipelineEqual::operator()(const PipelineKey& k1,
 
 } // namespace filament::backend
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -68,8 +68,10 @@ public:
         VkSpecializationInfo* specializationInfos = nullptr;
     };
 
+#if defined(__clang__)
     #pragma clang diagnostic push
     #pragma clang diagnostic warning "-Wpadded"
+#endif
 
     // The RasterState POD contains standard graphics-related state like blending, culling, etc.
     // The following states are omitted because Filament never changes them:
@@ -212,7 +214,9 @@ private:
         bool operator()(const PipelineKey& k1, const PipelineKey& k2) const;
     };
 
+#if defined(__clang__)
     #pragma clang diagnostic pop
+#endif
 
     // CACHE ENTRY STRUCTS
     // -------------------

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -40,12 +40,16 @@ void Culler::intersects(
     float4 const * const UTILS_RESTRICT planes = frustum.mPlanes;
 
     count = round(count);
+#if defined(__clang__)
     #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
+#endif
     for (size_t i = 0; i < count; i++) {
         int visible = ~0;
         float4 const sphere(b[i]);
 
+#if defined(__clang__)
         #pragma clang loop unroll(full)
+#endif
         for (size_t j = 0; j < 6; j++) {
             // clang doesn't seem to generate vector * scalar instructions, which leads
             // to increased register pressure and stack spills
@@ -69,11 +73,15 @@ void Culler::intersects(
     float4 const * UTILS_RESTRICT const planes = frustum.mPlanes;
 
     count = round(count);
+#if defined(__clang__)
     #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
+#endif
     for (size_t i = 0; i < count; i++) {
         int visible = ~0;
 
+#if defined(__clang__)
         #pragma clang loop unroll(full)
+#endif
         for (size_t j = 0; j < 6; j++) {
             // clang doesn't seem to generate vector * scalar instructions, which leads
             // to increased register pressure and stack spills

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -395,7 +395,9 @@ bool Froxelizer::update() noexcept {
         const float linearizer = std::log2(zLightFar / zLightNear) / float(std::max(1u, mFroxelCountZ - 1u));
         // for a strange reason when, vectorizing this loop, clang does some math in double
         // and generates conversions to float. not worth it for so little iterations.
+#if defined(__clang__)
         #pragma clang loop vectorize(disable) unroll(disable)
+#endif
         for (ssize_t i = 1, n = mFroxelCountZ; i <= n; i++) {
             mDistancesZ[i] = zLightFar * std::exp2(float(i - n) * linearizer);
         }

--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -399,8 +399,10 @@ float3 DisplayRangeToneMapper::operator()(float3 const c) const noexcept {
 //------------------------------------------------------------------------------
 
 struct GenericToneMapper::Options {
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
+#endif
     void setParameters(
             float contrast,
             float midGrayIn,
@@ -424,7 +426,9 @@ struct GenericToneMapper::Options {
         inputScale = (a * b * (midGrayOut - 1.0f)) / c;
         outputScale = midGrayOut * (a - b) / c;
     }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
     float contrast;
     float midGrayIn;

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -52,10 +52,14 @@ using namespace backend;
 struct ColorGrading::BuilderDetails {
     const ToneMapper* toneMapper = nullptr;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
     ToneMapping toneMapping = ToneMapping::ACES_LEGACY;
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
     bool hasAdjustments = false;
 
@@ -268,8 +272,10 @@ ColorGrading::Builder& ColorGrading::Builder::outputColorSpace(
     return *this;
 }
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 ColorGrading* ColorGrading::Builder::build(Engine& engine) {
     // We want to see if any of the default adjustment values have been modified
     // We skip the tonemapping operator on purpose since we always want to apply it
@@ -309,7 +315,9 @@ ColorGrading* ColorGrading::Builder::build(Engine& engine) {
     return colorGrading;
 }
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 //------------------------------------------------------------------------------
 // Exposure
@@ -585,8 +593,10 @@ static std::tuple<TextureFormat, PixelDataFormat, PixelDataType>
     }
 }
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 // The following functions exist to preserve backward compatibility with the
 // `FILMIC` set via the deprecated `ToneMapping` API. Selecting `ToneMapping::FILMIC`
 // forces post-processing to be performed in sRGB to guarantee that the inverse tone
@@ -612,7 +622,9 @@ static float3 selectColorGradingLuminance(ColorGrading::ToneMapping const toneMa
     }
     return LUMINANCE_Rec2020;
 }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 using ColorTransform = float3(*)(float3);
 
@@ -792,7 +804,9 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
                 // we use a vectorize width of 8 because, on ARMv8 it allows the compiler to write eight
                 // 32-bits results in one go.
                 const size_t count = (config.lutDimension * config.lutDimension) & ~0x7u; // tell the compiler that we're a multiple of 8
+#if defined(__clang__)
                 #pragma clang loop vectorize_width(8)
+#endif
                 for (size_t i = 0; i < count; ++i) {
                     float4 v{src[i]};
                     uint32_t pr = uint32_t(std::floor(v.x * 1023.0f + 0.5f));

--- a/filament/src/fsr.cpp
+++ b/filament/src/fsr.cpp
@@ -26,9 +26,11 @@ namespace filament {
 
 using namespace math;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #pragma clang diagnostic ignored "-Wignored-qualifiers"
+#endif
 
 #define A_CPU  1
 #include "materials/fsr/ffx_a.h"
@@ -36,7 +38,9 @@ using namespace math;
 #define FSR_RCAS_F 1
 #include "materials/fsr/ffx_fsr1.h"
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 void FSR_ScalingSetup(FSRUniforms* outUniforms, FSRScalingConfig config) noexcept {
     // FsrEasu API claims it needs the left-top offset, however that's not true with OpenGL,


### PR DESCRIPTION
'#pragma clang' is unavailable in MSVC. Wrap them with the proper preprocessor to avoid warnings in MSVC.

BUGS=[390207431]