### PR TITLE
Ensure correct resource cleanup sequence to avoid crashes upon app cl…

### DIFF
--- a/libs/filamentapp/include/filamentapp/MeshAssimp.h
+++ b/libs/filamentapp/include/filamentapp/MeshAssimp.h
@@ -56,6 +56,8 @@ public:
     explicit MeshAssimp(filament::Engine& engine);
     ~MeshAssimp();
 
+    // This function takes over the ownership of `materials` to prevent crashes due to the
+    // incorrect order of resource destruction.
     void addFromFile(const utils::Path& path,
             std::map<std::string, filament::MaterialInstance*>& materials,
             bool overrideMaterial = false);
@@ -127,8 +129,9 @@ private:
 
     filament::Material* mDefaultColorMaterial = nullptr;
     filament::Material* mDefaultTransparentColorMaterial = nullptr;
-
     mutable std::unordered_map<uint64_t, filament::Material*> mGltfMaterialCache;
+    std::map<std::string, filament::MaterialInstance*> mMaterialInstances;
+
     filament::Texture* mDefaultMap = nullptr;
     filament::Texture* mDefaultNormalMap = nullptr;
     float mDefaultMetallic = 0.0f;
@@ -138,8 +141,6 @@ private:
     std::vector<utils::Entity> mRenderables;
 
     std::vector<filament::Texture*> mTextures;
-
-
 };
 
 #endif // TNT_FILAMENT_SAMPLE_MESH_ASSIMP_H

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -146,8 +146,8 @@ int main(int argc, char** argv) {
 
     auto cleanup = [&app](Engine* engine, View*, Scene*) {
         engine->destroy(app.light);
-        engine->destroy(app.materialInstance);
         engine->destroy(app.mesh.renderable);
+        engine->destroy(app.materialInstance);
         engine->destroy(app.material);
     };
 

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -218,7 +218,7 @@ int main(int argc, char** argv) {
                 .depth(eyeCount)
                 .levels(1)
                 .sampler(Texture::Sampler::SAMPLER_2D_ARRAY)
-                .format(Texture::InternalFormat::DEPTH24)
+                .format(Texture::InternalFormat::DEPTH32F)
                 .usage(Texture::Usage::DEPTH_ATTACHMENT)
                 .build(*engine);
         app.stereoRenderTarget = RenderTarget::Builder()
@@ -324,11 +324,11 @@ int main(int argc, char** argv) {
 
         auto& em = utils::EntityManager::get();
 
-        for (MaterialInstance* mi : app.quadMatInstances) {
-            engine->destroy(mi);
-        }
         for (utils::Entity e : app.quadEntities) {
             engine->destroy(e);
+        }
+        for (MaterialInstance* mi : app.quadMatInstances) {
+            engine->destroy(mi);
         }
         engine->destroy(app.quadMaterial);
         engine->destroy(app.quadIb);

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
         app.offscreenDepthTexture = Texture::Builder()
             .width(vp.width).height(vp.height).levels(1)
             .usage(Texture::Usage::DEPTH_ATTACHMENT)
-            .format(Texture::InternalFormat::DEPTH24).build(*engine);
+            .format(Texture::InternalFormat::DEPTH32F).build(*engine);
         app.offscreenRenderTarget = RenderTarget::Builder()
             .texture(RenderTarget::AttachmentPoint::COLOR, app.offscreenColorTexture)
             .texture(RenderTarget::AttachmentPoint::DEPTH, app.offscreenDepthTexture)
@@ -321,11 +321,11 @@ int main(int argc, char** argv) {
         engine->destroy(app.reflectedMonkey);
         engine->destroy(app.lightEntity);
         engine->destroy(app.quadEntity);
-        engine->destroy(app.meshMatInstance);
-        engine->destroy(app.meshMaterial);
         engine->destroy(app.monkeyMesh.renderable);
         engine->destroy(app.monkeyMesh.vertexBuffer);
         engine->destroy(app.monkeyMesh.indexBuffer);
+        engine->destroy(app.meshMatInstance);
+        engine->destroy(app.meshMaterial);
         engine->destroy(app.offscreenColorTexture);
         engine->destroy(app.offscreenDepthTexture);
         engine->destroy(app.offscreenRenderTarget);

--- a/samples/skinningtest.cpp
+++ b/samples/skinningtest.cpp
@@ -639,6 +639,15 @@ int main(int argc, char** argv) {
     };
 
     auto cleanup = [&app](Engine* engine, View*, Scene*) {
+        for (auto i = 0; i < 4; i++) {
+            engine->destroy(app.renderables[i]);
+        }
+        for (auto i = 0; i < app.boCount; i++) {
+            engine->destroy(app.bos[i]);
+        }
+        for (auto i = 0; i < app.vbCount; i++) {
+            engine->destroy(app.vbs[i]);
+        }
         engine->destroy(app.skybox);
         engine->destroy(app.mat);
         engine->destroy(app.ib);
@@ -648,15 +657,6 @@ int main(int argc, char** argv) {
         engine->destroy(app.mt);
         engine->destroyCameraComponent(app.camera);
         EntityManager::get().destroy(app.camera);
-        for (auto i = 0; i < app.vbCount; i++) {
-            engine->destroy(app.vbs[i]);
-        }
-        for ( auto i = 0; i < app.boCount; i++) {
-            engine->destroy(app.bos[i]);
-        }
-        for ( auto i = 0; i < 4; i++) {
-            engine->destroy(app.renderables[i]);
-        }
     };
 
     FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -199,8 +199,8 @@ int main(int argc, char** argv) {
     };
 
     auto cleanup = [&app](Engine* engine, View*, Scene*) {
-        engine->destroy(app.materialInstance);
         engine->destroy(app.mesh.renderable);
+        engine->destroy(app.materialInstance);
         engine->destroy(app.material);
         engine->destroy(app.albedo);
         engine->destroy(app.normal);


### PR DESCRIPTION
…osing

The commit 1747ae8f5ac1fe9f8af9b550a172cd4da432cdec enfoces a correct order for releasing resource. Fix the order to avoid crashes.

Make some samples to use the DEPTH32F format for better compatibility. Some manufacturers don't fully support DEPTH24 on Vulkan. E.g., AMD Radeon PRO W6400