### PR TITLE
Add feature flag for material/instance destroy assert

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -690,11 +690,9 @@ public:
                 bool use_shadow_atlas = false;
             } shadows;
             struct {
-#ifndef NDEBUG
-                bool assert_material_instance_in_use = true;
-#else
+                // TODO: default the following two flags to true.
                 bool assert_material_instance_in_use = false;
-#endif
+                bool assert_destroy_material_before_material_instance = false;
             } debug;
         } engine;
         struct {
@@ -721,7 +719,10 @@ public:
               &features.engine.shadows.use_shadow_atlas, false },
             { "features.engine.debug.assert_material_instance_in_use",
               "Assert when a MaterialInstance is destroyed while it is in use by RenderableManager.",
-              &features.engine.debug.assert_material_instance_in_use, false }
+              &features.engine.debug.assert_material_instance_in_use, false },
+            { "features.engine.debug.assert_destroy_material_before_material_instance",
+              "Assert when a Material is destroyed but its instances are still alive.",
+              &features.engine.debug.assert_destroy_material_before_material_instance, false },
     }};
 
     utils::Slice<const FeatureFlag> getFeatureFlags() const noexcept {

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -383,9 +383,14 @@ void FMaterial::terminate(FEngine& engine) {
     auto const& materialInstanceResourceList = engine.getMaterialInstanceResourceList();
     auto pos = materialInstanceResourceList.find(this);
     if (UTILS_LIKELY(pos != materialInstanceResourceList.cend())) {
-        FILAMENT_CHECK_PRECONDITION(pos->second.empty())
-                << "destroying material \"" << this->getName().c_str_safe() << "\" but "
-                << pos->second.size() << " instances still alive.";
+        if (engine.features.engine.debug.assert_destroy_material_before_material_instance) {
+            FILAMENT_CHECK_PRECONDITION(pos->second.empty())
+                    << "destroying material \"" << this->getName().c_str_safe() << "\" but "
+                    << pos->second.size() << " instances still alive.";
+        } else {
+            utils::slog.e << "destroying material \"" << this->getName().c_str_safe() << "\" but "
+                          << pos->second.size() << " instances still alive.";
+        }
     }
 
 


### PR DESCRIPTION
This will allow a more lenient rollout of the assertion, which otherwise will increase crashes for current clients.

We also disable features.engine.debug.assert_material_instance_in_use by default (it was enabled for debug builds).