### PR TITLE
Add clearEntities API in Scene.

### DIFF
--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -142,9 +142,9 @@ public:
     void removeEntities(const utils::Entity* UTILS_NONNULL entities, size_t count);
 
     /**
-     * Clear all entities to the Scene.
+     * Remove all entities to the Scene.
      */
-    void clearEntities();
+    void removeAllEntities() noexcept;
 
     /**
      * Returns the total number of Entities in the Scene, whether alive or not.

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -142,6 +142,11 @@ public:
     void removeEntities(const utils::Entity* UTILS_NONNULL entities, size_t count);
 
     /**
+     * Clear all entities to the Scene.
+     */
+    void clearEntities();
+
+    /**
      * Returns the total number of Entities in the Scene, whether alive or not.
      * @return Total number of Entities in the Scene.
      */

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -55,8 +55,8 @@ void Scene::removeEntities(const Entity* entities, size_t const count) {
     downcast(this)->removeEntities(entities, count);
 }
 
-void Scene::clearEntities() {
-    downcast(this)->clearEntities();
+void Scene::removeAllEntities() noexcept {
+    downcast(this)->removeAllEntities();
 }
 
 size_t Scene::getEntityCount() const noexcept {

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -55,6 +55,10 @@ void Scene::removeEntities(const Entity* entities, size_t const count) {
     downcast(this)->removeEntities(entities, count);
 }
 
+void Scene::clearEntities() {
+    downcast(this)->clearEntities();
+}
+
 size_t Scene::getEntityCount() const noexcept {
     return downcast(this)->getEntityCount();
 }

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -547,6 +547,11 @@ void FScene::removeEntities(const Entity* entities, size_t const count) {
 }
 
 UTILS_NOINLINE
+void FScene::clearEntities() {
+    mEntities.clear();
+}
+
+UTILS_NOINLINE
 size_t FScene::getRenderableCount() const noexcept {
     FEngine& engine = mEngine;
     EntityManager const& em = engine.getEntityManager();

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -547,7 +547,7 @@ void FScene::removeEntities(const Entity* entities, size_t const count) {
 }
 
 UTILS_NOINLINE
-void FScene::clearEntities() {
+void FScene::removeAllEntities() noexcept {
     mEntities.clear();
 }
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -199,7 +199,7 @@ private:
     void addEntities(const utils::Entity* entities, size_t count);
     void remove(utils::Entity entity);
     void removeEntities(const utils::Entity* entities, size_t count);
-    void clearEntities();
+    void removeAllEntities() noexcept;
     size_t getEntityCount() const noexcept { return mEntities.size(); }
     size_t getRenderableCount() const noexcept;
     size_t getLightCount() const noexcept;

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -199,6 +199,7 @@ private:
     void addEntities(const utils::Entity* entities, size_t count);
     void remove(utils::Entity entity);
     void removeEntities(const utils::Entity* entities, size_t count);
+    void clearEntities();
     size_t getEntityCount() const noexcept { return mEntities.size(); }
     size_t getRenderableCount() const noexcept;
     size_t getLightCount() const noexcept;


### PR DESCRIPTION
The API works for Scene to clear all entities. Sometimes we need clear all entities from Scene.