### PR TITLE
Promote getEyeIndex() as a common helper

### DIFF
--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -1,4 +1,28 @@
 //------------------------------------------------------------------------------
+// Common Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Index of the eye being rendered, starting at 0.
+ * @public-api
+ */
+int getEyeIndex() {
+#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
+    return instance_index % CONFIG_STEREO_EYE_COUNT;
+#elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
+
+#   if defined(TARGET_VULKAN_ENVIRONMENT)
+    return int(gl_ViewIndex);
+#   else
+    // gl_ViewID_OVR is of uint type, which needs an explicit conversion.
+    return int(gl_ViewID_OVR);
+#   endif // TARGET_VULKAN_ENVIRONMENT
+
+#endif
+    return 0;
+}
+
+//------------------------------------------------------------------------------
 // Uniforms access
 //------------------------------------------------------------------------------
 
@@ -24,20 +48,7 @@ highp mat4 getViewFromClipMatrix() {
 
 /** @public-api */
 highp mat4 getClipFromWorldMatrix() {
-#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
-    int eye = instance_index % CONFIG_STEREO_EYE_COUNT;
-    return frameUniforms.clipFromWorldMatrix[eye];
-#elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
-
-#if defined(TARGET_VULKAN_ENVIRONMENT)
-    return frameUniforms.clipFromWorldMatrix[gl_ViewIndex];
-#else
-    return frameUniforms.clipFromWorldMatrix[gl_ViewID_OVR];
-#endif // TARGET_VULKAN_ENVIRONMENT
-
-#else
-    return frameUniforms.clipFromWorldMatrix[0];
-#endif
+    return frameUniforms.clipFromWorldMatrix[getEyeIndex()];
 }
 
 /** @public-api */

--- a/shaders/src/surface_getters.vs
+++ b/shaders/src/surface_getters.vs
@@ -235,7 +235,7 @@ vec4 getCustom7() { return mesh_custom7; }
 #endif
 
 //------------------------------------------------------------------------------
-// Helpers
+// Surface Helpers
 //------------------------------------------------------------------------------
 
 /**
@@ -274,24 +274,4 @@ vec4 computeWorldPosition() {
 #else
 #error Unknown Vertex Domain
 #endif
-}
-
-/**
- * Index of the eye being rendered, starting at 0.
- * @public-api
- */
-int getEyeIndex() {
-#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
-    return instance_index % CONFIG_STEREO_EYE_COUNT;
-#elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
-
-#if defined(TARGET_VULKAN_ENVIRONMENT)
-    return int(gl_ViewIndex);
-#else
-    // gl_ViewID_OVR is of uint type, which needs an explicit conversion.
-    return int(gl_ViewID_OVR);
-#endif // TARGET_VULKAN_ENVIRONMENT
-
-#endif
-    return 0;
 }


### PR DESCRIPTION
Now the helper function `getEyeIndex` becomes available for all shader stages including post-processing. It used to be only accessible from surface vertex shaders.