### PR TITLE
Use CAMetalLayer to create MVK surfaces to avoid potential deadlocks.

### DIFF
--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -704,18 +704,11 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
         ::prepareNativeWindow(mWindow);
 
         void* metalLayer = nullptr;
-        if (config.backend == filament::Engine::Backend::METAL) {
+        if (config.backend == filament::Engine::Backend::METAL || config.backend == filament::Engine::Backend::VULKAN) {
             metalLayer = setUpMetalLayer(nativeWindow);
-            // The swap chain on Metal is a CAMetalLayer.
+            // The swap chain on both native Metal and MoltenVK is a CAMetalLayer.
             nativeSwapChain = metalLayer;
         }
-
-#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
-        if (config.backend == filament::Engine::Backend::VULKAN) {
-            // We request a Metal layer for rendering via MoltenVK.
-            setUpMetalLayer(nativeWindow);
-        }
-#endif
 
 #endif
 

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -205,17 +205,11 @@ void setup_window(Window& w, Engine* engine) {
     void* nativeSwapChain = nativeWindow;
 #if defined(__APPLE__)
     void* metalLayer = nullptr;
-    if (kBackend == filament::Engine::Backend::METAL) {
+    if (kBackend == filament::Engine::Backend::METAL || kBackend == filament::Engine::Backend::VULKAN) {
         metalLayer = setUpMetalLayer(nativeWindow);
-        // The swap chain on Metal is a CAMetalLayer.
+        // The swap chain on both native Metal and MoltenVK is a CAMetalLayer.
         nativeSwapChain = metalLayer;
     }
-#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
-    if (kBackend == filament::Engine::Backend::VULKAN) {
-        // We request a Metal layer for rendering via MoltenVK.
-        setUpMetalLayer(nativeWindow);
-    }
-#endif
 #endif
     w.swapChain = engine->createSwapChain(nativeSwapChain);
 


### PR DESCRIPTION
On macOS using Vulkan backend w/ MoltenVK, filament currently passes down an NSView instance from main thread to create the surface on render thread (by calling the vkCreateMacOSSurfaceMVK). Older versions of MVK simply warn you on this kind of usage:

> [mvk-info] vkCreateMacOSSurfaceMVK(): You are not calling this function from the main thread. NSView should only be accessed from the main thread. When using this function outside the main thread, consider passing the CAMetalLayer itself in VkMacOSSurfaceCreateInfoMVK::pView, instead of the NSView.

Newer versions of MVK will try to post it back to its "main thread" utilizing dispatch_sync (see `MVKOSExtensions.mm`). But if there are any pending waits or fences e.g. `flushAndWait()`, `Fence::waitAndDestroy(mEngine->createFence())`, a deadlock will be introduced, as seen on the screenshots:

![1738936332429](https://github.com/user-attachments/assets/32d04644-a7d0-43cf-91ad-166d6773089f)
![1738936325303](https://github.com/user-attachments/assets/c162ad19-8e87-418c-b5b4-ab4d2ce5f65c)

This can be reproduced by adding `engine->flushAndWait();` at the end of the setup functor on any samples like hellopbr:

![1738936339413](https://github.com/user-attachments/assets/7915af79-d178-4280-864b-f54e3db33597)

So i'm thinking if we can just unify the logic to use the underlying CAMetalLayer on both Metal backend and Vulkan with MVK.