### PR TITLE
build: remove ios build dependency on filamat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,7 +528,7 @@ if (FILAMENT_SUPPORTS_METAL)
 endif()
 
 # Building filamat increases build times and isn't required for web, so turn it off by default.
-if (NOT WEBGL)
+if (NOT WEBGL AND NOT IOS)
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" ON)
 else()
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" OFF)

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -460,7 +460,8 @@ if (APPLE OR LINUX)
         spirv-cross-glsl)
 endif()
 
-if (APPLE)
+# TODO: Disabling IOS test due to breakage wrt glslang update
+if (APPLE AND NOT IOS)
     # TODO: we should expand this test to Linux and other platforms.
     list(APPEND BACKEND_TEST_SRC
          test/test_RenderExternalImage.cpp)

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -144,19 +144,17 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/filamat DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-project(test_filamat)
-set(TARGET test_filamat)
-set(SRCS
-        tests/test_filamat.cpp
-        tests/test_argBufferFixup.cpp
-        tests/test_clipDistanceFixup.cpp
-        tests/test_includes.cpp)
+if (IS_HOST_PLATFORM)
+    project(test_filamat)
+    set(TARGET test_filamat)
+    set(SRCS
+            tests/test_filamat.cpp
+            tests/test_argBufferFixup.cpp
+            tests/test_clipDistanceFixup.cpp
+            tests/test_includes.cpp)
 
-add_executable(${TARGET} ${SRCS})
-
-target_include_directories(${TARGET} PRIVATE src)
-
-target_link_libraries(${TARGET} filamat gtest)
-
-set_target_properties(${TARGET} PROPERTIES FOLDER Tests)
-
+    add_executable(${TARGET} ${SRCS})
+    target_include_directories(${TARGET} PRIVATE src)
+    target_link_libraries(${TARGET} filamat gtest)
+    set_target_properties(${TARGET} PROPERTIES FOLDER Tests)
+endif()


### PR DESCRIPTION
We are in the process of updating glslang, which requires

set(IOS_MIN_TARGET "13.0")

This is a problem since we are targeting iOS 11 in general. glslang is a filamat depedency, and we're building filamat for iOS for the iOS version of the backend test.

So one solution is to set set(IOS_MIN_TARGET "13.0") for the backend test. And we might revisit this solution later.

But for now, we simply disable backend tests (and filamat tests) for iOS.