### PR TITLE
android: prevent leak of cubemap for IndirectLight/Skybox

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- android: breaking changes to API KTX1Loader::createIndirectLight and KTX1Loader::createSkybox

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -98,6 +98,9 @@ class ModelViewer(
     val renderer: Renderer
     @Entity val light: Int
 
+    var indirectLightCubemap: Texture? = null
+    var skyboxCubemap: Texture? = null
+
     private lateinit var displayHelper: DisplayHelper
     private lateinit var cameraManipulator: Manipulator
     private lateinit var gestureDetector: GestureDetector
@@ -331,6 +334,16 @@ class ModelViewer(
                 materialProvider.destroyMaterials()
                 materialProvider.destroy()
                 resourceLoader.destroy()
+
+                if (indirectLightCubemap != null) {
+                    engine.destroyTexture(indirectLightCubemap!!)
+                    indirectLightCubemap = null
+                }
+
+                if (skyboxCubemap != null) {
+                    engine.destroyTexture(skyboxCubemap!!)
+                    skyboxCubemap = null
+                }
 
                 engine.destroyEntity(light)
                 engine.destroyRenderer(renderer)

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -156,12 +156,16 @@ class MainActivity : Activity() {
         val scene = modelViewer.scene
         val ibl = "default_env"
         readCompressedAsset("envs/$ibl/${ibl}_ibl.ktx").let {
-            scene.indirectLight = KTX1Loader.createIndirectLight(engine, it)
+            val bundle = KTX1Loader.createIndirectLight(engine, it)
+            scene.indirectLight = bundle.indirectLight
+            modelViewer.indirectLightCubemap = bundle.cubemap
             scene.indirectLight!!.intensity = 30_000.0f
             viewerContent.indirectLight = modelViewer.scene.indirectLight
         }
         readCompressedAsset("envs/$ibl/${ibl}_skybox.ktx").let {
-            scene.skybox = KTX1Loader.createSkybox(engine, it)
+            val bundle = KTX1Loader.createSkybox(engine, it)
+            scene.skybox = bundle.skybox
+            modelViewer.skyboxCubemap = bundle.cubemap
         }
     }
 


### PR DESCRIPTION
We break existing  API by returning both the IndirectLight and the texture. Same thing with Skybox.

Fix one bug where the float array in getSphericalHarmonics wasn't getting written out.

Fixes #6412