### PR TITLE
Fix cleanup logic in VulkanStagePool::terminate

### DIFF
--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -208,13 +208,13 @@ void VulkanStagePool::terminate() noexcept {
         vmaDestroyImage(mAllocator, image->image, image->memory);
         delete image;
     }
-    mUsedStages.clear();
+    mUsedImages.clear();
 
     for (auto image : mFreeImages) {
         vmaDestroyImage(mAllocator, image->image, image->memory);
         delete image;
     }
-    mFreeStages.clear();
+    mFreeImages.clear();
 }
 
 } // namespace filament::backend


### PR DESCRIPTION
Updated the `terminate` function to correct resource cleanup. Changed `mUsedStages` to `mUsedImages` and `mFreeStages` to `mFreeImages` to ensure proper memory management during termination.