### PR TITLE
Add a way to query the transform matrix of a surface texture from the driver

### DIFF
--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -323,11 +323,9 @@ public:
     /**
      * Returns the transform matrix of the texture attached to the stream.
      * @param stream Stream to get the transform matrix from
-     * @param uvTransform Output parameter: Transform matrix of the image bound to the texture.
+     * @param uvTransform Output parameter: Transform matrix of the image bound to the texture. Returns identity if not supported.
      */
-    virtual void getTransformMatrix(
-            Stream* UTILS_NONNULL stream,
-            math::mat3f* UTILS_NONNULL uvTransform) noexcept;
+    virtual math::mat3f getTransformMatrix(Stream* UTILS_NONNULL stream) noexcept;
 
 
     // --------------------------------------------------------------------------------------------

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -27,6 +27,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <math/mat3.h>
 
 namespace filament::backend {
 
@@ -318,6 +319,15 @@ public:
      */
     virtual void updateTexImage(Stream* UTILS_NONNULL stream,
             int64_t* UTILS_NONNULL timestamp) noexcept;
+
+    /**
+     * Returns the transform matrix of the texture attached to the stream.
+     * @param stream Stream to get the transform matrix from
+     * @param uvTransform Output parameter: Transform matrix of the image bound to the texture.
+     */
+    virtual void getTransformMatrix(
+            Stream* UTILS_NONNULL stream,
+            math::mat3f* UTILS_NONNULL uvTransform) noexcept;
 
 
     // --------------------------------------------------------------------------------------------

--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -86,7 +86,7 @@ protected:
     void attach(Stream* stream, intptr_t tname) noexcept override;
     void detach(Stream* stream) noexcept override;
     void updateTexImage(Stream* stream, int64_t* timestamp) noexcept override;
-    void getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept override;
+    math::mat3f getTransformMatrix(Stream* stream) noexcept override;
 
     /**
      * Converts a AHardwareBuffer to EGLImage

--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -86,6 +86,7 @@ protected:
     void attach(Stream* stream, intptr_t tname) noexcept override;
     void detach(Stream* stream) noexcept override;
     void updateTexImage(Stream* stream, int64_t* timestamp) noexcept override;
+    void getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept override;
 
     /**
      * Converts a AHardwareBuffer to EGLImage

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2163,6 +2163,16 @@ int64_t OpenGLDriver::getStreamTimestamp(Handle<HwStream> sh) {
     return 0;
 }
 
+math::mat3f OpenGLDriver::getStreamTransformMatrix(Handle<HwStream> sh) {
+    if (sh) {
+        GLStream* s = handle_cast<GLStream*>(sh);
+        math::mat3f out;
+        mPlatform.getTransformMatrix(s->stream, &out);
+        return out;
+    }
+    return math::mat3f();
+}
+
 void OpenGLDriver::destroyFence(Handle<HwFence> fh) {
     if (fh) {
         GLFence* f = handle_cast<GLFence*>(fh);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -58,6 +58,7 @@
 
 #include <math/vec2.h>
 #include <math/vec3.h>
+#include <math/mat3.h>
 
 #include <algorithm>
 #include <chrono>
@@ -2165,10 +2166,8 @@ int64_t OpenGLDriver::getStreamTimestamp(Handle<HwStream> sh) {
 
 math::mat3f OpenGLDriver::getStreamTransformMatrix(Handle<HwStream> sh) {
     if (sh) {
-        GLStream* s = handle_cast<GLStream*>(sh);
-        math::mat3f out;
-        mPlatform.getTransformMatrix(s->stream, &out);
-        return out;
+        GLStream* s = handle_cast<GLStream*>(sh);        
+        return mPlatform.getTransformMatrix(s->stream);
     }
     return math::mat3f();
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -367,6 +367,7 @@ private:
     void attachStream(GLTexture* t, GLStream* stream) noexcept;
     void detachStream(GLTexture* t) noexcept;
     void replaceStream(GLTexture* t, GLStream* stream) noexcept;
+    math::mat3f getStreamTransformMatrix(Handle<HwStream> sh);
 
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     // tasks executed on the main thread after the fence signaled

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -141,9 +141,9 @@ void OpenGLPlatform::updateTexImage(
         UTILS_UNUSED int64_t* timestamp) noexcept {
 }
 
-void OpenGLPlatform::getTransformMatrix(
-    UTILS_UNUSED Stream* stream,
-    UTILS_UNUSED math::mat3f* uvTransform) noexcept {
+math::mat3f OpenGLPlatform::getTransformMatrix(
+    UTILS_UNUSED Stream* stream) noexcept {
+return math::mat3f();
 }
 
 OpenGLPlatform::ExternalTexture* OpenGLPlatform::createExternalImageTexture() noexcept {

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -141,6 +141,10 @@ void OpenGLPlatform::updateTexImage(
         UTILS_UNUSED int64_t* timestamp) noexcept {
 }
 
+void OpenGLPlatform::getTransformMatrix(
+    UTILS_UNUSED Stream* stream,
+    UTILS_UNUSED math::mat3f* uvTransform) noexcept {
+}
 
 OpenGLPlatform::ExternalTexture* OpenGLPlatform::createExternalImageTexture() noexcept {
     return nullptr;

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.cpp
@@ -169,7 +169,7 @@ void ExternalStreamManagerAndroid::updateTexImage(Stream* handle, int64_t* times
     }
 }
 
-void ExternalStreamManagerAndroid::getTransformMatrix(Stream* handle, math::mat3f* uvTransform) noexcept {
+math::mat3f ExternalStreamManagerAndroid::getTransformMatrix(Stream* handle) noexcept {
     EGLStream const* stream = static_cast<EGLStream*>(handle);
     math::mat4f out = math::mat4f();
     if (__builtin_available(android 28, *)) {
@@ -183,7 +183,7 @@ void ExternalStreamManagerAndroid::getTransformMatrix(Stream* handle, math::mat3
         env->DeleteLocalRef(jout);
         VirtualMachineEnv::handleException(env);
     }
-    *uvTransform = math::mat3f {
+    return math::mat3f {
         out[0][0], out[0][1], out[0][3],
         out[1][0], out[1][1], out[1][3],
         out[3][0], out[3][1], out[3][3],

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
@@ -33,6 +33,7 @@ typedef struct ASurfaceTexture ASurfaceTexture;
 #include <jni.h>
 
 #include <stdint.h>
+#include <math/mat3.h>
 
 namespace filament::backend {
 
@@ -63,6 +64,9 @@ public:
     // must be called on GLES context thread, updates the stream content
     void updateTexImage(Stream* stream, int64_t* timestamp) noexcept;
 
+    // must be called on GLES context thread, returns the transform matrix
+    void getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept;
+
 private:
     ExternalStreamManagerAndroid() noexcept;
     ~ExternalStreamManagerAndroid() noexcept;
@@ -88,6 +92,7 @@ private:
 
     jmethodID mSurfaceTextureClass_updateTexImage{};
     jmethodID mSurfaceTextureClass_getTimestamp{};
+    jmethodID mSurfaceTextureClass_getTransformMatrix{};
     jmethodID mSurfaceTextureClass_attachToGLContext{};
     jmethodID mSurfaceTextureClass_detachFromGLContext{};
 };

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
@@ -65,7 +65,7 @@ public:
     void updateTexImage(Stream* stream, int64_t* timestamp) noexcept;
 
     // must be called on GLES context thread, returns the transform matrix
-    void getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept;
+    math::mat3f getTransformMatrix(Stream* stream) noexcept;
 
 private:
     ExternalStreamManagerAndroid() noexcept;

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -283,6 +283,10 @@ void PlatformEGLAndroid::updateTexImage(Stream* stream, int64_t* timestamp) noex
     mExternalStreamManager.updateTexImage(stream, timestamp);
 }
 
+void PlatformEGLAndroid::getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept {
+    mExternalStreamManager.getTransformMatrix(stream, uvTransform);
+}
+
 int PlatformEGLAndroid::getOSVersion() const noexcept {
     return mOSVersion;
 }

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -283,8 +283,8 @@ void PlatformEGLAndroid::updateTexImage(Stream* stream, int64_t* timestamp) noex
     mExternalStreamManager.updateTexImage(stream, timestamp);
 }
 
-void PlatformEGLAndroid::getTransformMatrix(Stream* stream, math::mat3f* uvTransform) noexcept {
-    mExternalStreamManager.getTransformMatrix(stream, uvTransform);
+math::mat3f PlatformEGLAndroid::getTransformMatrix(Stream* stream) noexcept {
+    return mExternalStreamManager.getTransformMatrix(stream);
 }
 
 int PlatformEGLAndroid::getOSVersion() const noexcept {


### PR DESCRIPTION
From: https://developer.android.com/reference/android/graphics/SurfaceTexture

When sampling from the texture one should first transform the texture coordinates using the matrix queried via getTransformMatrix(float[]). The transform matrix may change each time updateTexImage() is called, so it should be re-queried each time the texture image is updated.

Exposing the matrix to the driver is the first step to being able to apply it to the uniform in the shader. 