### PR TITLE
Add a way to specify an additional uniform name along with a sampler param for the associated transform matrix

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - android: breaking changes to API KTX1Loader::createIndirectLight and KTX1Loader::createSkybox
+- materials: add an optional `transformName` field to sampler material parameters. [⚠️ **New Material Version**]

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -994,9 +994,10 @@ Value
       name must be a valid GLSL identifier. Entries have an optional `precision`, which can be
       one of `default` (best precision for the platform, typically `high` on desktop, `medium` on
       mobile), `low`, `medium`, `high`. The type must be one of the types described in
-      table [materialParamsTypes]. For external textures, entries also have an option 
-      transformUniformName parameter to specify the name of the shader parameter that will be 
-      used to expose the transform matrix associated with the external sampler.  
+      table [materialParamsTypes]. For Android external textures, entries also have an optional 
+      transformName parameter to specify the name of the material parameter that will be 
+      used to expose the transform matrix associated with the external sampler. In iOS and Vulkan,
+      this will always be identity. 
 
          Type          |            Description
 :----------------------|:---------------------------------

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -991,10 +991,12 @@ Type
 
 Value
 :     Each entry is an object with the properties `name` and `type`, both of `string` type. The
-      name must be a valid GLSL identifier. Entries also have an optional `precision`, which can be
+      name must be a valid GLSL identifier. Entries have an optional `precision`, which can be
       one of `default` (best precision for the platform, typically `high` on desktop, `medium` on
       mobile), `low`, `medium`, `high`. The type must be one of the types described in
-      table [materialParamsTypes].
+      table [materialParamsTypes]. For external textures, entries also have an option 
+      transformUniformName parameter to specify the name of the shader parameter that will be 
+      used to expose the transform matrix associated with the external sampler.  
 
          Type          |            Description
 :----------------------|:---------------------------------

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -421,6 +421,7 @@ bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
         uint64_t fieldSize = 0;
         uint8_t fieldType = 0;
         uint8_t fieldPrecision = 0;
+        uint8_t fieldAssociatedSampler = 0;
 
         if (!unflattener.read(&fieldName)) {
             return false;
@@ -438,11 +439,16 @@ bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
             return false;
         }
 
+        if (!unflattener.read(&fieldAssociatedSampler)) {
+            return false;
+        }
+
         // a size of 1 means not an array
         builder.add({{{ fieldName.data(), fieldName.size() },
                       uint32_t(fieldSize == 1 ? 0 : fieldSize),
                       BufferInterfaceBlock::Type(fieldType),
-                      BufferInterfaceBlock::Precision(fieldPrecision) }});
+                      BufferInterfaceBlock::Precision(fieldPrecision),
+                      fieldAssociatedSampler }});
     }
 
     *uib = builder.build();

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -445,10 +445,10 @@ bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
 
         // a size of 1 means not an array
         builder.add({{{ fieldName.data(), fieldName.size() },
+                      fieldAssociatedSampler,
                       uint32_t(fieldSize == 1 ? 0 : fieldSize),
                       BufferInterfaceBlock::Type(fieldType),
-                      BufferInterfaceBlock::Precision(fieldPrecision),
-                      fieldAssociatedSampler }});
+                      BufferInterfaceBlock::Precision(fieldPrecision) }});
     }
 
     *uib = builder.build();

--- a/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
@@ -41,6 +41,7 @@ public:
         uint32_t size;
         backend::UniformType type;
         backend::Precision precision{};
+        uint8_t associatedSampler;
         backend::FeatureLevel minFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1;
         std::string_view structName{};
         uint32_t stride{};
@@ -68,6 +69,7 @@ public:
         bool isArray;               // true if the field is an array
         uint32_t size;              // size of the array in elements, or 0 if not an array
         Precision precision;        // precision of this field
+        uint8_t associatedSampler;   // sampler associated with this field
         backend::FeatureLevel minFeatureLevel; // below this feature level, this field is not needed
         utils::CString structName;  // name of this field structure if type is STRUCT
         utils::CString sizeName;    // name of the size parameter in the shader
@@ -152,6 +154,10 @@ public:
     // negative value if name doesn't exist or Panic if exceptions are enabled
     ssize_t getFieldOffset(std::string_view name, size_t index) const;
 
+    // returns offset in bytes of the transform matrix for the given external texture binding
+    // returns -1 if the field doesn't exist
+    ssize_t getTransformFieldOffset(uint8_t binding) const;
+
     FieldInfo const* getFieldInfo(std::string_view name) const;
 
     bool hasField(std::string_view name) const noexcept {
@@ -179,6 +185,7 @@ private:
     utils::CString mName;
     utils::FixedCapacityVector<FieldInfo> mFieldInfoList;
     std::unordered_map<std::string_view , uint32_t> mInfoMap;
+    std::unordered_map<uint8_t, uint32_t> mTransformOffsetMap;
     uint32_t mSize = 0; // size in bytes rounded to multiple of 4
     Alignment mAlignment = Alignment::std140;
     Target mTarget = Target::UNIFORM;

--- a/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
@@ -40,12 +40,28 @@ public:
         std::string_view name;
         uint32_t size;
         backend::UniformType type;
-        backend::Precision precision{};
-        uint8_t associatedSampler;
-        backend::FeatureLevel minFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1;
-        std::string_view structName{};
-        uint32_t stride{};
-        std::string_view sizeName{};
+        backend::Precision precision;
+        uint8_t associatedSampler = 0;
+        backend::FeatureLevel minFeatureLevel;
+        std::string_view structName;
+        uint32_t stride;
+        std::string_view sizeName;
+        
+        InterfaceBlockEntry() = default;
+        InterfaceBlockEntry(std::string_view name, uint32_t size, backend::UniformType type,
+                backend::Precision precision = {},
+                backend::FeatureLevel minFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1, std::string_view structName = {},
+                uint32_t stride = {}, std::string_view sizeName = {}) noexcept
+                : name(name), size(size), type(type), precision(precision),
+                associatedSampler(0), minFeatureLevel(minFeatureLevel),
+                structName(structName), stride(stride), sizeName(sizeName) {}
+        InterfaceBlockEntry(std::string_view name, uint8_t associatedSampler, uint32_t size, backend::UniformType type,
+                backend::Precision precision = {},
+                backend::FeatureLevel minFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1, std::string_view structName = {},
+                uint32_t stride = {}, std::string_view sizeName = {}) noexcept
+                : name(name), size(size), type(type), precision(precision),
+                associatedSampler(associatedSampler), minFeatureLevel(minFeatureLevel),
+                structName(structName), stride(stride), sizeName(sizeName) {}
     };
 
     BufferInterfaceBlock();

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -316,7 +316,8 @@ public:
     MaterialBuilder& parameter(const char* name, SamplerType samplerType,
             SamplerFormat format = SamplerFormat::FLOAT,
             ParameterPrecision precision = ParameterPrecision::DEFAULT,
-            bool multisample = false) noexcept;
+            bool multisample = false,
+            const char* transformName = "") noexcept;
 
     MaterialBuilder& buffer(filament::BufferInterfaceBlock bib) noexcept;
 
@@ -648,8 +649,8 @@ public:
         Parameter() noexcept: parameterType(INVALID) {}
 
         // Sampler
-        Parameter(const char* paramName, SamplerType t, SamplerFormat f, ParameterPrecision p, bool ms)
-                : name(paramName), size(1), precision(p), samplerType(t), format(f), parameterType(SAMPLER), multisample(ms) { }
+        Parameter(const char* paramName, SamplerType t, SamplerFormat f, ParameterPrecision p, bool ms, const char* tn)
+                : name(paramName), size(1), precision(p), samplerType(t), format(f), parameterType(SAMPLER), multisample(ms), transformName(tn) { }
 
         // Uniform
         Parameter(const char* paramName, UniformType t, size_t typeSize, ParameterPrecision p)
@@ -667,6 +668,7 @@ public:
         SubpassType subpassType;
         SamplerFormat format;
         bool multisample;
+        utils::CString transformName;
         enum {
             INVALID,
             UNIFORM,

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -279,7 +279,7 @@ MaterialBuilder& MaterialBuilder::parameter(const char* name, UniformType type,
 
 
 MaterialBuilder& MaterialBuilder::parameter(const char* name, SamplerType samplerType,
-        SamplerFormat format, ParameterPrecision precision, bool multisample) noexcept {
+        SamplerFormat format, ParameterPrecision precision, bool multisample, const char* transformName) noexcept {
     FILAMENT_CHECK_PRECONDITION(!multisample ||
             (format != SamplerFormat::SHADOW &&
                     (samplerType == SamplerType::SAMPLER_2D ||
@@ -288,7 +288,7 @@ MaterialBuilder& MaterialBuilder::parameter(const char* name, SamplerType sample
                " as long as type is not SHADOW";
 
     FILAMENT_CHECK_POSTCONDITION(mParameterCount < MAX_PARAMETERS_COUNT) << "Too many parameters";
-    mParameters[mParameterCount++] = { name, samplerType, format, precision, multisample };
+    mParameters[mParameterCount++] = { name, samplerType, format, precision, multisample, transformName };
     return *this;
 }
 
@@ -609,16 +609,22 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     SamplerInterfaceBlock::Builder sbb;
     BufferInterfaceBlock::Builder ibb;
     // sampler bindings start at 1, 0 is the ubo
-    for (size_t i = 0, binding = 1, c = mParameterCount; i < c; i++) {
+    uint16_t binding = 1;
+    for (size_t i = 0, c = mParameterCount; i < c; i++) {
         auto const& param = mParameters[i];
         assert_invariant(!param.isSubpass());
         if (param.isSampler()) {
             sbb.add({ param.name.data(), param.name.size() },
-                    binding++, param.samplerType, param.format, param.precision, param.multisample);
+                    binding, param.samplerType, param.format, param.precision, param.multisample);
+            if (!param.transformName.empty()) {
+                ibb.add({{{ param.transformName.data(), param.transformName.size() },
+                          0, UniformType::MAT3, Precision::DEFAULT, uint8_t(binding), FeatureLevel::FEATURE_LEVEL_0 }});
+            }
+            binding++;
         } else if (param.isUniform()) {
             ibb.add({{{ param.name.data(), param.name.size() },
                       uint32_t(param.size == 1u ? 0u : param.size), param.uniformType,
-                      param.precision, FeatureLevel::FEATURE_LEVEL_0 }});
+                      param.precision, 0, FeatureLevel::FEATURE_LEVEL_0 }});
         }
     }
 
@@ -645,11 +651,11 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     }
 
     if (mBlendingMode == BlendingMode::MASKED) {
-        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
+        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     if (mDoubleSidedCapability) {
-        ibb.add({{ "_doubleSided", 0, UniformType::BOOL, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
+        ibb.add({{ "_doubleSided", 0, UniformType::BOOL, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     mRequiredAttributes.set(VertexAttribute::POSITION);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -617,14 +617,14 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
             sbb.add({ param.name.data(), param.name.size() },
                     binding, param.samplerType, param.format, param.precision, param.multisample);
             if (!param.transformName.empty()) {
-                ibb.add({{{ param.transformName.data(), param.transformName.size() },
-                          0, UniformType::MAT3, Precision::DEFAULT, uint8_t(binding), FeatureLevel::FEATURE_LEVEL_0 }});
+                ibb.add({{{ param.transformName.data(), param.transformName.size() }, uint8_t(binding),
+                          0, UniformType::MAT3, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
             }
             binding++;
         } else if (param.isUniform()) {
             ibb.add({{{ param.name.data(), param.name.size() },
                       uint32_t(param.size == 1u ? 0u : param.size), param.uniformType,
-                      param.precision, 0, FeatureLevel::FEATURE_LEVEL_0 }});
+                      param.precision, FeatureLevel::FEATURE_LEVEL_0 }});
         }
     }
 
@@ -651,11 +651,11 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     }
 
     if (mBlendingMode == BlendingMode::MASKED) {
-        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 }});
+        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     if (mDoubleSidedCapability) {
-        ibb.add({{ "_doubleSided", 0, UniformType::BOOL, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 }});
+        ibb.add({{ "_doubleSided", 0, UniformType::BOOL, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     mRequiredAttributes.set(VertexAttribute::POSITION);

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
@@ -52,6 +52,7 @@ void MaterialUniformInterfaceBlockChunk::flatten(Flattener& f) {
         f.writeUint64(uInfo.size);
         f.writeUint8(static_cast<uint8_t>(uInfo.type));
         f.writeUint8(static_cast<uint8_t>(uInfo.precision));
+        f.writeUint8(static_cast<uint8_t>(uInfo.associatedSampler));
     }
 }
 

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -95,39 +95,39 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerViewUib::_name)
             .add({
-            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "clipFromWorldMatrix",    CONFIG_MAX_STEREOSCOPIC_EYES,
-                                           Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+                                           Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "clipControl",            0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "time",                   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "userTime",               0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipControl",            0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "time",                   0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userTime",               0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // values below should only be accessed in surface materials
             // ------------------------------------------------------------------------------------
 
-            { "resolution",             0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "resolution",             0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "lodBias",                0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "refractionLodOffset",    0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lodBias",                0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "refractionLodOffset",    0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "derivativesScale",       0, Type::FLOAT2                  },
 
-            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "cameraFar",              0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "exposure",               0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 }, // high precision to work around #3602 (qualcom),
-            { "ev100",                  0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "needsAlphaChannel",      0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "cameraFar",              0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "exposure",               0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 }, // high precision to work around #3602 (qualcom),
+            { "ev100",                  0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "needsAlphaChannel",      0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
             // AO
             { "aoSamplingQualityAndEdgeDistance", 0, Type::FLOAT         },
@@ -141,17 +141,17 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "lightChannels",          0, Type::INT                     },
             { "froxelCountXY",          0, Type::FLOAT2                  },
 
-            { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "iblSH",                  9, Type::FLOAT3                  },
 
             // ------------------------------------------------------------------------------------
             // Directional Lighting [variant: DIR]
             // ------------------------------------------------------------------------------------
-            { "lightDirection",         0, Type::FLOAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lightDirection",         0, Type::FLOAT3, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "padding0",               0, Type::FLOAT                   },
-            { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "shadowFarAttenuationParams", 0, Type::FLOAT2, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
@@ -176,19 +176,19 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ------------------------------------------------------------------------------------
             // Fog [variant: FOG]
             // ------------------------------------------------------------------------------------
-            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogStart",                0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogStart",                0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogMinMaxMip",            0, Type::UINT,  Precision::HIGH },
-            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogColorFromIbl",         0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColorFromIbl",         0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogOneOverFarMinusNear",  0, Type::FLOAT, Precision::HIGH },
             { "fogNearOverFarMinusNear", 0, Type::FLOAT, Precision::HIGH },
-            { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]
@@ -203,12 +203,12 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // --------------------------------------------------------------------------------------------
             // user defined global variables
             // --------------------------------------------------------------------------------------------
-            { "custom",                  4, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "custom",                  4, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
 
             // --------------------------------------------------------------------------------------------
             // for feature level 0 / es2 usage
             // --------------------------------------------------------------------------------------------
-            { "rec709",                  0, Type::INT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "rec709",                  0, Type::INT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
             { "es2Reserved0",            0, Type::FLOAT                  },
             { "es2Reserved1",            0, Type::FLOAT                  },
             { "es2Reserved2",            0, Type::FLOAT                  },
@@ -224,7 +224,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 BufferInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
     static BufferInterfaceBlock const uib =  BufferInterfaceBlock::Builder()
             .name(PerRenderableUib::_name)
-            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {}, {},
+            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
                     "PerRenderableData", sizeof(PerRenderableData), "CONFIG_MAX_INSTANCES" }})
             .build();
     return uib;
@@ -243,7 +243,7 @@ BufferInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(ShadowUib::_name)
             .add({{ "shadows", CONFIG_MAX_SHADOWMAPS,
-                    BufferInterfaceBlock::Type::STRUCT, {}, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
                     "ShadowData", sizeof(ShadowUib::ShadowData) }})
             .build();
     return uib;
@@ -253,7 +253,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerRenderableBoneUib::_name)
             .add({{ "bones", CONFIG_MAX_BONE_COUNT,
-                    BufferInterfaceBlock::Type::STRUCT, {}, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
                     "BoneData", sizeof(PerRenderableBoneUib::BoneData) }})
             .build();
     return uib;
@@ -279,7 +279,7 @@ BufferInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
 BufferInterfaceBlock const& UibGenerator::getFroxelsUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(FroxelsUib::_name)
-            .add({{ "records", 1024, BufferInterfaceBlock::Type::UINT4, Precision::HIGH, {},
+            .add({{ "records", 1024, BufferInterfaceBlock::Type::UINT4, Precision::HIGH, 0, {},
                     {}, {}, "CONFIG_FROXEL_BUFFER_HEIGHT"}})
             .build();
     return uib;

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -95,39 +95,39 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerViewUib::_name)
             .add({
-            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "clipFromWorldMatrix",    CONFIG_MAX_STEREOSCOPIC_EYES,
-                                           Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+                                           Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "clipControl",            0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "time",                   0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "userTime",               0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipControl",            0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "time",                   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userTime",               0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // values below should only be accessed in surface materials
             // ------------------------------------------------------------------------------------
 
-            { "resolution",             0, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "resolution",             0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "lodBias",                0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "refractionLodOffset",    0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lodBias",                0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "refractionLodOffset",    0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "derivativesScale",       0, Type::FLOAT2                  },
 
-            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "cameraFar",              0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "exposure",               0, Type::FLOAT,  Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 }, // high precision to work around #3602 (qualcom),
-            { "ev100",                  0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "needsAlphaChannel",      0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "cameraFar",              0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "exposure",               0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 }, // high precision to work around #3602 (qualcom),
+            { "ev100",                  0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "needsAlphaChannel",      0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
 
             // AO
             { "aoSamplingQualityAndEdgeDistance", 0, Type::FLOAT         },
@@ -141,17 +141,17 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "lightChannels",          0, Type::INT                     },
             { "froxelCountXY",          0, Type::FLOAT2                  },
 
-            { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "iblSH",                  9, Type::FLOAT3                  },
 
             // ------------------------------------------------------------------------------------
             // Directional Lighting [variant: DIR]
             // ------------------------------------------------------------------------------------
-            { "lightDirection",         0, Type::FLOAT3, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lightDirection",         0, Type::FLOAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "padding0",               0, Type::FLOAT                   },
-            { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "shadowFarAttenuationParams", 0, Type::FLOAT2, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
@@ -176,19 +176,19 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ------------------------------------------------------------------------------------
             // Fog [variant: FOG]
             // ------------------------------------------------------------------------------------
-            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogStart",                0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogStart",                0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogMinMaxMip",            0, Type::UINT,  Precision::HIGH },
-            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogColorFromIbl",         0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColorFromIbl",         0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogOneOverFarMinusNear",  0, Type::FLOAT, Precision::HIGH },
             { "fogNearOverFarMinusNear", 0, Type::FLOAT, Precision::HIGH },
-            { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]
@@ -203,12 +203,12 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // --------------------------------------------------------------------------------------------
             // user defined global variables
             // --------------------------------------------------------------------------------------------
-            { "custom",                  4, Type::FLOAT4, Precision::HIGH, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "custom",                  4, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // --------------------------------------------------------------------------------------------
             // for feature level 0 / es2 usage
             // --------------------------------------------------------------------------------------------
-            { "rec709",                  0, Type::INT,  Precision::DEFAULT, 0, FeatureLevel::FEATURE_LEVEL_0 },
+            { "rec709",                  0, Type::INT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "es2Reserved0",            0, Type::FLOAT                  },
             { "es2Reserved1",            0, Type::FLOAT                  },
             { "es2Reserved2",            0, Type::FLOAT                  },
@@ -224,7 +224,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 BufferInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
     static BufferInterfaceBlock const uib =  BufferInterfaceBlock::Builder()
             .name(PerRenderableUib::_name)
-            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
+            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "PerRenderableData", sizeof(PerRenderableData), "CONFIG_MAX_INSTANCES" }})
             .build();
     return uib;
@@ -243,7 +243,7 @@ BufferInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(ShadowUib::_name)
             .add({{ "shadows", CONFIG_MAX_SHADOWMAPS,
-                    BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "ShadowData", sizeof(ShadowUib::ShadowData) }})
             .build();
     return uib;
@@ -253,7 +253,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerRenderableBoneUib::_name)
             .add({{ "bones", CONFIG_MAX_BONE_COUNT,
-                    BufferInterfaceBlock::Type::STRUCT, {}, 0, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "BoneData", sizeof(PerRenderableBoneUib::BoneData) }})
             .build();
     return uib;
@@ -279,7 +279,7 @@ BufferInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
 BufferInterfaceBlock const& UibGenerator::getFroxelsUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(FroxelsUib::_name)
-            .add({{ "records", 1024, BufferInterfaceBlock::Type::UINT4, Precision::HIGH, 0, {},
+            .add({{ "records", 1024, BufferInterfaceBlock::Type::UINT4, Precision::HIGH, {},
                     {}, {}, "CONFIG_FROXEL_BUFFER_HEIGHT"}})
             .build();
     return uib;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -153,6 +153,12 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
         std::cerr << "parameters: name value must be STRING." << std::endl;
         return false;
     }
+    
+    const JsonishValue* transformNameValue = jsonObject.getValue("transformName");
+    if (transformNameValue && transformNameValue->getType() != JsonishValue::STRING) {
+        std::cerr << "parameters: transformName value must be STRING." << std::endl;
+        return false;
+    }
 
     const JsonishValue* precisionValue = jsonObject.getValue("precision");
     if (precisionValue) {
@@ -221,7 +227,12 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
 
         auto multisample = multiSampleValue ? multiSampleValue->toJsonBool()->getBool() : false;
 
-        builder.parameter(nameString.c_str(), type, format, precision, multisample);
+        if (transformNameValue) {
+            auto transformName = transformNameValue->toJsonString()->getString();
+            builder.parameter(nameString.c_str(), type, format, precision, multisample, transformName.c_str());
+        } else {
+            builder.parameter(nameString.c_str(), type, format, precision, multisample);
+        }
 
     } else {
         std::cerr << "parameters: the type '" << typeString

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -228,6 +228,13 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
         auto multisample = multiSampleValue ? multiSampleValue->toJsonBool()->getBool() : false;
 
         if (transformNameValue) {
+            if (type != MaterialBuilder::SamplerType::SAMPLER_EXTERNAL) {
+                std::cerr << "parameters: the parameter with name '" << nameString << "'"
+                    << " is a sampler of type " << typeString << " and has a transformName."
+                    << " Transform names are only supported for external samplers."
+                    << std::endl;
+                return false;
+            }
             auto transformName = transformNameValue->toJsonString()->getString();
             builder.parameter(nameString.c_str(), type, format, precision, multisample, transformName.c_str());
         } else {


### PR DESCRIPTION
Followup to https://github.com/google/filament/pull/8489

From: https://developer.android.com/reference/android/graphics/SurfaceTexture

When sampling from the texture one should first transform the texture coordinates using the matrix queried via getTransformMatrix(float[]). The transform matrix may change each time updateTexImage() is called, so it should be re-queried each time the texture image is updated.

Adding a way to specify the transform name in the material is the second step to being able to apply it to the uniform in the shader.