### PR TITLE
Ebridgewater/tint conversion validation

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -104,3 +104,14 @@ jobs:
         with:
           name: presubmit-renderdiff-result
           path: ./out/renderdiff_tests
+
+  validate-wgsl-pipeline:
+    name: validate-wgsl-pipeline
+    runs-on: macos-14-xlarge
+
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - name: Run build script
+        run: ./build.sh -W debug test_filamat
+      - name: Run test
+        run: ./out/cmake-debug/libs/filamat/test_filamat --gtest_filter=MaterialCompiler.Wgsl*

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -182,6 +182,7 @@ enum class ShaderLanguage {
     SPIRV = 2,
     MSL = 3,
     METAL_LIBRARY = 4,
+    WGSL = 5,
 };
 
 static constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguage) {
@@ -196,6 +197,8 @@ static constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguag
             return "MSL";
         case ShaderLanguage::METAL_LIBRARY:
             return "Metal precompiled library";
+        case ShaderLanguage::WGSL:
+            return "WGSL";
     }
 }
 

--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -138,6 +138,7 @@ bool MetalShaderCompiler::isParallelShaderCompileSupported() const noexcept {
             case ShaderLanguage::ESSL1:
             case ShaderLanguage::ESSL3:
             case ShaderLanguage::SPIRV:
+            case ShaderLanguage::WGSL:
                 break;
         }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -45,7 +45,7 @@ ShaderModel WebGPUDriver::getShaderModel() const noexcept {
 }
 
 ShaderLanguage WebGPUDriver::getShaderLanguage() const noexcept {
-    return ShaderLanguage::ESSL3;
+    return ShaderLanguage::WGSL;
 }
 
 // explicit instantiation of the Dispatcher

--- a/filament/backend/test/PlatformRunner.h
+++ b/filament/backend/test/PlatformRunner.h
@@ -30,7 +30,8 @@ enum class Backend : uint8_t {
     OPENGL = 1,
     VULKAN = 2,
     METAL = 3,
-    NOOP = 4,
+    WEBGPU = 4,
+    NOOP = 5,
 };
 
 struct NativeView {

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -90,6 +90,9 @@ ShaderGenerator::ShaderGenerator(std::string vertex, std::string fragment, Backe
         case Backend::METAL:
             mShaderLanguage = filament::backend::ShaderLanguage::MSL;
             break;
+        case Backend::WEBGPU:
+            mShaderLanguage = filament::backend::ShaderLanguage::WGSL;
+            break;
         case Backend::NOOP:
             mShaderLanguage = filament::backend::ShaderLanguage::ESSL3;
             break;
@@ -114,6 +117,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(ShaderStage stage, std::s
     } else if (backend == Backend::METAL) {
         shader.insert(pos, "#define TARGET_METAL_ENVIRONMENT\n");
     } else if (backend == Backend::VULKAN) {
+        shader.insert(pos, "#define TARGET_VULKAN_ENVIRONMENT\n");
+    } else if (backend == Backend::WEBGPU) {
         shader.insert(pos, "#define TARGET_VULKAN_ENVIRONMENT\n");
     }
 
@@ -150,7 +155,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(ShaderStage stage, std::s
 
     assert_invariant(backend == Backend::OPENGL ||
            backend == Backend::METAL  ||
-           backend == Backend::VULKAN);
+           backend == Backend::VULKAN ||
+           backend == Backend::WEBGPU);
 
     if (backend == Backend::OPENGL) {
         if (isMobile) {
@@ -166,6 +172,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(ShaderStage stage, std::s
         return { result.c_str(), result.c_str() + result.length() + 1 };
     } else if (backend == Backend::VULKAN) {
         return { (uint8_t*)spirv.data(), (uint8_t*)(spirv.data() + spirv.size()) };
+    } else if (backend == Backend::WEBGPU){
+        filamat::GLSLPostProcessor::spirvToWgsl(&spirv, &result);
     }
 
     return {};

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -62,6 +62,8 @@ constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage co
             return { MaterialEssl1, DictionaryText };
         case ShaderLanguage::MSL:
             return { MaterialMetal, DictionaryText };
+        case ShaderLanguage::WGSL:
+            return { MaterialWgsl, DictionaryText };
         case ShaderLanguage::SPIRV:
             return { MaterialSpirv, DictionarySpirv };
         case ShaderLanguage::METAL_LIBRARY:

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -45,6 +45,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialEssl1 = charTo64bitNum("MAT_ESS1"),
     MaterialSpirv = charTo64bitNum("MAT_SPIR"),
     MaterialMetal = charTo64bitNum("MAT_METL"),
+    MaterialWgsl = charTo64bitNum("MAT_WGSL"),
     MaterialMetalLibrary = charTo64bitNum("MAT_MLIB"),
     MaterialShaderModels = charTo64bitNum("MAT_SMDL"),
     MaterialBindingUniformInfo = charTo64bitNum("MAT_UFRM"),

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -183,6 +183,7 @@ bool MaterialChunk::getShader(ShaderContent& shaderContent, BlobDictionary const
     switch (mMaterialTag) {
         case filamat::ChunkType::MaterialGlsl:
         case filamat::ChunkType::MaterialEssl1:
+        case filamat::ChunkType::MaterialWgsl:
         case filamat::ChunkType::MaterialMetal:
             return getTextShader(mUnflattener, dictionary, shaderContent, shaderModel, variant, stage);
         case filamat::ChunkType::MaterialSpirv:

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -81,7 +81,11 @@ public:
         VULKAN      = 0x02u,
         METAL       = 0x04u,
         WEBGPU        = 0x08u,
+#ifdef FILAMENT_SUPPORTS_WEBGPU
         ALL         = OPENGL | VULKAN | METAL | WEBGPU
+#else
+        ALL         = OPENGL | VULKAN | METAL
+#endif
     };
 
     /*

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -179,6 +179,14 @@ void MaterialBuilderBase::prepare(bool vulkanSemantics,
                 effectiveFeatureLevel,
             });
         }
+        if (any(mTargetApi & TargetApi::WEBGPU)) {
+            mCodeGenPermutations.push_back({
+                shaderModel,
+                TargetApi::WEBGPU,
+                TargetLanguage::SPIRV,
+                effectiveFeatureLevel,
+            });
+        }
     }
 }
 
@@ -836,6 +844,7 @@ static void showErrorMessage(const char* materialName, filament::Variant variant
             break;
         case TargetApi::WEBGPU:
             targetApiString = "WebGPU.\n";
+            break;
         case TargetApi::ALL:
             assert(0); // Unreachable.
             break;
@@ -879,6 +888,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
     std::vector<TextEntry> essl1Entries;
     std::vector<BinaryEntry> spirvEntries;
     std::vector<TextEntry> metalEntries;
+    std::vector<TextEntry> wgslEntries;
     LineDictionary textDictionary;
     BlobDictionary spirvDictionary;
     // End: must be protected by lock
@@ -907,7 +917,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 
         // Metal Shading Language is cross-compiled from Vulkan.
         const bool targetApiNeedsSpirv =
-                (targetApi == TargetApi::VULKAN || targetApi == TargetApi::METAL);
+                (targetApi == TargetApi::VULKAN || targetApi == TargetApi::METAL || targetApi == TargetApi::WEBGPU);
         const bool targetApiNeedsMsl = targetApi == TargetApi::METAL;
         const bool targetApiNeedsWgsl = targetApi == TargetApi::WEBGPU;
         const bool targetApiNeedsGlsl = targetApi == TargetApi::OPENGL;
@@ -933,14 +943,17 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 TextEntry glslEntry{};
                 BinaryEntry spirvEntry{};
                 TextEntry metalEntry{};
+                TextEntry wgslEntry{};
 
                 glslEntry.shaderModel  = params.shaderModel;
                 spirvEntry.shaderModel = params.shaderModel;
                 metalEntry.shaderModel = params.shaderModel;
+                wgslEntry.shaderModel = params.shaderModel;
 
                 glslEntry.variant  = v.variant;
                 spirvEntry.variant = v.variant;
                 metalEntry.variant = v.variant;
+                wgslEntry.variant = v.variant;
 
                 // Generate raw shader code.
                 // The quotes in Google-style line directives cause problems with certain drivers. These
@@ -1038,6 +1051,12 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 switch (targetApi) {
                     // TODO: Handle webgpu here
                     case TargetApi::WEBGPU:
+                        assert(!spirv.empty());
+                        assert(wgsl.length() > 0);
+                        wgslEntry.stage = v.stage;
+                        wgslEntry.shader = wgsl;
+                        wgslEntries.push_back(wgslEntry);
+                        break;
                     case TargetApi::ALL:
                         // should never happen
                         break;
@@ -1099,6 +1118,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
     std::sort(essl1Entries.begin(), essl1Entries.end(), compare);
     std::sort(spirvEntries.begin(), spirvEntries.end(), compare);
     std::sort(metalEntries.begin(), metalEntries.end(), compare);
+    std::sort(wgslEntries.begin(), wgslEntries.end(), compare);
 
     // Generate the dictionaries.
     for (const auto& s : glslEntries) {
@@ -1112,6 +1132,9 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
         s.dictionaryIndex = spirvDictionary.addBlob(spirv);
     }
     for (const auto& s : metalEntries) {
+        textDictionary.addText(s.shader);
+    }
+    for (const auto& s : wgslEntries) {
         textDictionary.addText(s.shader);
     }
 
@@ -1142,6 +1165,12 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
     if (!metalEntries.empty()) {
         container.push<MaterialTextChunk>(std::move(metalEntries),
                 dictionaryChunk.getDictionary(), ChunkType::MaterialMetal);
+    }
+
+    // Emit WGSL chunk (MaterialTextChunk).
+    if (!wgslEntries.empty()) {
+        container.push<MaterialTextChunk>(std::move(wgslEntries),
+                dictionaryChunk.getDictionary(), ChunkType::MaterialWgsl);
     }
 
     return true;

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -525,6 +525,11 @@ EShMessages GLSLTools::glslangFlagsFromTargetApi(
                 //        choke on gl_VertexIndex.
                 msg |= (Type)EShMessages::EShMsgVulkanRules;
             }
+            if (targetApi == TargetApi::WEBGPU) {
+                // FIXME: We have to use EShMsgVulkanRules for WEBGPU, otherwise compilation will
+                //        choke on gl_VertexIndex.
+                msg |= (Type)EShMessages::EShMsgVulkanRules;
+            }
             return (EShMessages)msg;
     }
 }
@@ -540,13 +545,13 @@ void GLSLTools::prepareShaderParser(MaterialBuilder::TargetApi targetApi,
                 shader.setEnvInput(EShSourceGlsl, stage, EShClientOpenGL, version);
                 shader.setEnvClient(EShClientOpenGL, EShTargetOpenGL_450);
                 break;
+            case MaterialBuilderBase::TargetApi::WEBGPU:
             case MaterialBuilderBase::TargetApi::VULKAN:
             case MaterialBuilderBase::TargetApi::METAL:
                 shader.setEnvInput(EShSourceGlsl, stage, EShClientVulkan, version);
                 shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_1);
                 break;
             // TODO: Handle webgpu here
-            case MaterialBuilderBase::TargetApi::WEBGPU:
             case MaterialBuilderBase::TargetApi::ALL:
                 // can't happen
                 break;

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -175,6 +175,10 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
             break;
         // TODO: Handle webgpu here
         case TargetApi::WEBGPU:
+            //For now, no differences so inherit the same changes.
+            // TODO Define a separte environment, OR relevant checks
+            out << "#define TARGET_VULKAN_ENVIRONMENT\n";
+            break;
         case TargetApi::ALL:
             // invalid should never happen
             break;
@@ -190,6 +194,7 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
     }
 
     if (mTargetApi == TargetApi::VULKAN ||
+        mTargetApi == TargetApi::WEBGPU ||
         mTargetApi == TargetApi::METAL ||
         (mTargetApi == TargetApi::OPENGL && mShaderModel == ShaderModel::DESKTOP) ||
         mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_2) {
@@ -725,6 +730,8 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
                 break;
             // TODO: Handle webgpu here
             case TargetApi::WEBGPU:
+                out << "set = " << +set << ", binding = " << +binding << ", ";
+            break;
             case TargetApi::ALL:
                 // nonsensical, shouldn't happen.
                 break;
@@ -813,6 +820,8 @@ io::sstream& CodeGenerator::generateCommonSamplers(utils::io::sstream& out,
                     break;
                 // TODO: Handle webgpu here
                 case TargetApi::WEBGPU:
+                    out << "layout(binding = " << +info.binding << ", set = " << +set << ") ";
+                break;
                 case TargetApi::ALL:
                     // should not happen
                     break;

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -891,7 +891,7 @@ TEST_F(MaterialCompiler, FeatureLevel0Ess3CallFails) {
   EXPECT_FALSE(result.isValid());
 }
 
-#if TINT_BUILD_SPV_READER
+#if FILAMENT_SUPPORTS_WEBGPU
 TEST_F(MaterialCompiler, WgslConversionBakedColor) {
     std::string bakedColorCodeFrag(R"(
         void material(inout MaterialInputs material) {
@@ -959,5 +959,10 @@ TEST_F(MaterialCompiler, WgslConversionSandboxLitTransparent) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    const int rv = RUN_ALL_TESTS();
+    if (testing::UnitTest::GetInstance()->test_to_run_count() == 0) {
+        //If you run a test filter that contains 0 tests that was likely not intentional. Fail in that scenario.
+        return 1;
+    }
+    return rv;
 }

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -254,6 +254,10 @@ bool JsonWriter::writeActiveInfo(const filaflat::ChunkContainer& package,
             json << "metal";
             chunkType = ChunkType::MaterialMetal;
             break;
+        case ShaderLanguage::WGSL:
+            json << "webgpu";
+            chunkType = ChunkType::MaterialWgsl;
+            break;
         default:
             return false;
     }

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -57,6 +57,10 @@ ShaderExtractor::ShaderExtractor(backend::ShaderLanguage target, const void* dat
             mMaterialTag = ChunkType::MaterialMetalLibrary;
             mDictionaryTag = ChunkType::DictionaryMetalLibrary;
             break;
+        case backend::ShaderLanguage::WGSL:
+            mMaterialTag = ChunkType::MaterialWgsl;
+            mDictionaryTag = ChunkType::DictionaryText;
+            break;
         case backend::ShaderLanguage::SPIRV:
             mMaterialTag = ChunkType::MaterialSpirv;
             mDictionaryTag = ChunkType::DictionarySpirv;

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -135,6 +135,10 @@ ShaderReplacer::ShaderReplacer(Backend backend, ShaderLanguage language,
             mMaterialTag = ChunkType::MaterialMetal;
             mDictionaryTag = ChunkType::DictionaryText;
             break;
+        case backend::ShaderLanguage::WGSL:
+            mMaterialTag = ChunkType::MaterialWgsl;
+            mDictionaryTag = ChunkType::DictionaryText;
+            break;
         case backend::ShaderLanguage::SPIRV:
             mMaterialTag = ChunkType::MaterialSpirv;
             mDictionaryTag = ChunkType::DictionarySpirv;

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -429,7 +429,10 @@ static bool printShaderInfo(ostream& text, const ChunkContainer& container, Chun
             break;
         case ChunkType::MaterialMetalLibrary:
             text << "Metal precompiled shader libraries:" << endl;
-            break;
+        break;
+        case ChunkType::MaterialWgsl:
+            text << "WGSL precompiled shader libraries:" << endl;
+        break;
         default:
             assert(false && "Invalid shader ChunkType");
             break;
@@ -465,6 +468,9 @@ bool TextWriter::writeMaterialInfo(const filaflat::ChunkContainer& container) {
         return false;
     }
     if (!printShaderInfo(text, container, ChunkType::MaterialMetalLibrary)) {
+        return false;
+    }
+    if (!printShaderInfo(text, container, ChunkType::MaterialWgsl)) {
         return false;
     }
 

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -262,6 +262,8 @@ bool CommandlineConfig::parse() {
                     mTargetApi |= TargetApi::VULKAN;
                 } else if (arg == "metal") {
                     mTargetApi |= TargetApi::METAL;
+                } else if (arg == "webgpu") {
+                    mTargetApi |= TargetApi::WEBGPU;
                 } else if (arg == "all") {
                     mTargetApi |= TargetApi::ALL;
                 } else {

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -532,7 +532,7 @@ static bool parseChunks(Config config, void* data, size_t size) {
 
             return true;
         }
-
+        //TODO Include a printWgsl logic here
         if (config.printMetal) {
             const filament::backend::ShaderLanguage language = config.binary
                     ? filament::backend::ShaderLanguage::METAL_LIBRARY


### PR DESCRIPTION
Enable the tint conversion codepath to be run when passed via matc.

Add unit test for tint conversion.

Run this new unit test as part of presubmit.