### PR TITLE
vk: fix generateMipmaps level

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1262,10 +1262,9 @@ void VulkanDriver::generateMipmaps(Handle<HwTexture> th) {
             mBlitter.blit(VK_FILTER_LINEAR, dst, dstOffsets, src, srcOffsets);
         }
 
-        level++;
         srcw = dstw;
         srch = dsth;
-    } while ((srcw > 1 || srch > 1) && level < t->levels);
+    } while ((srcw > 1 || srch > 1) && ++level < t->levels - 1);
 }
 
 void VulkanDriver::compilePrograms(CompilerPriorityQueue priority,


### PR DESCRIPTION
The level counting was off by one.

FIXES=400710879