### PR TITLE
fix SourceFormatter.h missing header file

### DIFF
--- a/libs/matdbg/src/SourceFormatter.h
+++ b/libs/matdbg/src/SourceFormatter.h
@@ -18,6 +18,7 @@
 #define MATDBG_SOURCE_FORMATTER_H
 
 #include <mutex>
+#include <string>
 
 namespace filament::matdbg {
 


### PR DESCRIPTION
missing <string>, it occurs error in cross-compile