### PR TITLE
Disable picking for multiview rendering

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -638,6 +638,9 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     if (isRenderingMultiview) {
         hasPostProcess = false;
         msaaOptions.enabled = false;
+
+        // Picking is not supported for multiview rendering. Clear any pending picking queries.
+        view.clearPickingQueries();
     }
     const uint8_t msaaSampleCount = msaaOptions.enabled ? msaaOptions.sampleCount : 1u;
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -137,12 +137,7 @@ FView::~FView() noexcept = default;
 void FView::terminate(FEngine& engine) {
     // Here we would cleanly free resources we've allocated, or we own (currently none).
 
-    while (mActivePickingQueriesList) {
-        FPickingQuery* const pQuery = mActivePickingQueriesList;
-        mActivePickingQueriesList = pQuery->next;
-        pQuery->callback(pQuery->result, pQuery);
-        FPickingQuery::put(pQuery);
-    }
+    clearPickingQueries();
 
     DriverApi& driver = engine.getDriverApi();
     driver.destroyBufferObject(mLightUbh);
@@ -1175,6 +1170,15 @@ void FView::executePickingQueries(DriverApi& driver,
                     }, pQuery
             });
         }
+    }
+}
+
+void FView::clearPickingQueries() noexcept {
+    while (mActivePickingQueriesList) {
+        FPickingQuery* const pQuery = mActivePickingQueriesList;
+        mActivePickingQueriesList = pQuery->next;
+        pQuery->callback(pQuery->result, pQuery);
+        FPickingQuery::put(pQuery);
     }
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -463,6 +463,8 @@ public:
     void executePickingQueries(backend::DriverApi& driver,
             backend::RenderTargetHandle handle, math::float2 scale) noexcept;
 
+    void clearPickingQueries() noexcept;
+
     void setMaterialGlobal(uint32_t index, math::float4 const& value);
 
     math::float4 getMaterialGlobal(uint32_t index) const;


### PR DESCRIPTION
Picking is not designed to work with multiview rendering. Disable it when multiview is enabled.