### PR TITLE
Add helpers for backend tests (cleanup+render loops).

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -461,6 +461,7 @@ if (APPLE OR LINUX)
         test/ShaderGenerator.cpp
         test/TrianglePrimitive.cpp
         test/Arguments.cpp
+        test/Lifetimes.cpp
         test/test_FeedbackLoops.cpp
         test/test_Blit.cpp
         test/test_MissingRequiredAttributes.cpp

--- a/filament/backend/test/Lifetimes.cpp
+++ b/filament/backend/test/Lifetimes.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Lifetimes.h"
+
+#include "backend/Platform.h"
+#include "private/backend/DriverApi.h"
+
+RenderFrame::RenderFrame(filament::backend::DriverApi& api): mApi(api) {
+    mApi.beginFrame(0, 0, 0);
+}
+
+RenderFrame::~RenderFrame() {
+    mApi.endFrame(0);
+}
+
+Cleanup::Cleanup(filament::backend::DriverApi& driverApi) : mDriverApi(driverApi) {}
+
+Cleanup::~Cleanup() {
+    for (const auto swapChain: mSwapChains) {
+        mDriverApi.destroySwapChain(swapChain);
+    }
+    for (const auto descriptorSet : mDescriptorSets) {
+        mDriverApi.destroyDescriptorSet(descriptorSet);
+    }
+    for (const auto descriptorSetLayout : mDescriptorSetLayouts) {
+        mDriverApi.destroyDescriptorSetLayout(descriptorSetLayout);
+    }
+    for (const auto bufferObject : mBufferObjects) {
+        mDriverApi.destroyBufferObject(bufferObject);
+    }
+    for (const auto program : mPrograms) {
+        mDriverApi.destroyProgram(program);
+    }
+    for (const auto texture : mTextures) {
+        mDriverApi.destroyTexture(texture);
+    }
+    for (const auto renderTarget : mRenderTargets) {
+        mDriverApi.destroyRenderTarget(renderTarget);
+    }
+
+    for (const auto& callback : mCallbacks) {
+        callback();
+    }
+}
+
+template <>
+void Cleanup::addInternal(filament::backend::SwapChainHandle handle) {
+    mSwapChains.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(filament::backend::DescriptorSetHandle handle) {
+    mDescriptorSets.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(
+        filament::backend::DescriptorSetLayoutHandle handle) {
+    mDescriptorSetLayouts.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(filament::backend::BufferObjectHandle handle) {
+    mBufferObjects.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(filament::backend::ProgramHandle handle) {
+    mPrograms.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(filament::backend::TextureHandle handle) {
+    mTextures.push_back(handle);
+}
+template <>
+void Cleanup::addInternal(filament::backend::RenderTargetHandle handle) {
+    mRenderTargets.push_back(handle);
+}
+
+void Cleanup::addPostCall(std::function<void()> callback){
+    mCallbacks.emplace_back(std::move(callback));
+}

--- a/filament/backend/test/Lifetimes.h
+++ b/filament/backend/test/Lifetimes.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_LIFETIMES_H
+#define TNT_LIFETIMES_H
+
+#include <vector>
+#include <functional>
+#include <optional>
+
+#include "backend/Handle.h"
+#include "backend/DriverApiForward.h"
+#include "BackendTest.h"
+
+class RenderFrame {
+public:
+    explicit RenderFrame(filament::backend::DriverApi& api);
+    ~RenderFrame();
+
+    RenderFrame(RenderFrame const& rhs) noexcept = delete;
+    RenderFrame& operator=(RenderFrame const& rhs) noexcept = delete;
+    RenderFrame(RenderFrame const&& rhs) noexcept = delete;
+    RenderFrame& operator=(RenderFrame const&& rhs) noexcept = delete;
+
+private:
+    filament::backend::DriverApi& mApi;
+};
+
+class Cleanup {
+public:
+    /**
+     * @param driverApi Must be valid for the entire lifetime of the Cleanup object.
+     */
+    explicit Cleanup(filament::backend::DriverApi& driverApi);
+    ~Cleanup();
+
+    template <typename HandleType>
+    filament::backend::Handle<HandleType> add(filament::backend::Handle<HandleType> handle);
+
+    void addPostCall(std::function<void()> callback);
+
+private:
+    template <typename HandleType>
+    void addInternal(filament::backend::Handle<HandleType> handle);
+
+    filament::backend::DriverApi & mDriverApi;
+
+    std::vector<filament::backend::SwapChainHandle> mSwapChains;
+    std::vector<filament::backend::DescriptorSetHandle> mDescriptorSets;
+    std::vector<filament::backend::DescriptorSetLayoutHandle> mDescriptorSetLayouts;
+    std::vector<filament::backend::BufferObjectHandle> mBufferObjects;
+    std::vector<filament::backend::ProgramHandle> mPrograms;
+    std::vector<filament::backend::TextureHandle> mTextures;
+    std::vector<filament::backend::RenderTargetHandle> mRenderTargets;
+
+    std::vector<std::function<void()>> mCallbacks;
+};
+
+template <typename HandleType>
+filament::backend::Handle<HandleType> Cleanup::add(filament::backend::Handle<HandleType> handle) {
+    addInternal(handle);
+    return handle;
+}
+
+#endif //TNT_LIFETIMES_H


### PR DESCRIPTION
Both for cleaning up graphics resources at the end of a test and for starting/stopping render loops.