### PR TITLE
Fix material instance check log when destroying material

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -388,11 +388,12 @@ void FMaterial::terminate(FEngine& engine) {
                     << "destroying material \"" << this->getName().c_str_safe() << "\" but "
                     << pos->second.size() << " instances still alive.";
         } else {
-            utils::slog.e << "destroying material \"" << this->getName().c_str_safe() << "\" but "
-                          << pos->second.size() << " instances still alive.";
+            if (UTILS_UNLIKELY(!pos->second.empty())) {
+                slog.e << "destroying material \"" << this->getName().c_str_safe() << "\" but "
+                              << pos->second.size() << " instances still alive." << io::endl;
+            }
         }
     }
-
 
 #if FILAMENT_ENABLE_MATDBG
     // Unregister the material with matdbg.


### PR DESCRIPTION
When the feature flags assert_destroy_material_before_material_instance is disabled, we emit a log instead of an assert. Unfortunately this log would be emitted even when all material instances were destroyed.