### PR TITLE
Generate 1D LUTs for color grading when possible

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- engine: Generate 1D instead of 3D LUTs for color grading whenever possible.

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -46,9 +46,8 @@ import static com.google.android.filament.Asserts.assertFloat4In;
  *
  * <h1>Performance</h1>
  *
- * Creating a new ColorGrading object may be more expensive than other Filament objects as a
- * 3D LUT may need to be generated. The generation of a 3D LUT, if necessary, may happen on
- * the CPU.
+ * Creating a new ColorGrading object may be more expensive than other Filament objects as a LUT may
+ * need to be generated. The generation of this LUT, if necessary, may happen on the CPU.
  *
  * <h1>Ordering</h1>
  *
@@ -160,6 +159,11 @@ public class ColorGrading {
          * quality level will use a 32x32x32 10 bit LUT, a high quality will use a 32x32x32 16 bit
          * LUT, and a ultra quality will use a 64x64x64 16 bit LUT.
          *
+         * When color grading can be implemented using a 1D LUT, this setting only affects the
+         * resolution of the LUT, using the same values as in 3D (i.e. 16, 32, 64).
+         *
+         * This overrides the values set by format() and dimensions().
+         *
          * The default quality is {@link QualityLevel#MEDIUM}.
          *
          * @param qualityLevel The desired quality of the color grading process
@@ -175,6 +179,8 @@ public class ColorGrading {
          * When color grading is implemented using a 3D LUT, this sets the texture format of
          * of the LUT. This overrides the value set by quality().
          *
+         * This setting has no effect if generating a 1D LUT.
+         *
          * The default is INTEGER
          *
          * @param format The desired format of the 3D LUT.
@@ -187,8 +193,8 @@ public class ColorGrading {
         }
 
         /**
-         * When color grading is implemented using a 3D LUT, this sets the dimension of the LUT.
-         * This overrides the value set by quality().
+         * When color grading is implemented using a LUT, this sets the dimension of the LUT. This
+         * overrides the value set by quality().
          *
          * The default is 32
          *
@@ -616,4 +622,3 @@ public class ColorGrading {
 
     private static native long nBuilderBuild(long nativeBuilder, long nativeEngine);
 }
-

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -159,8 +159,7 @@ public class ColorGrading {
          * quality level will use a 32x32x32 10 bit LUT, a high quality will use a 32x32x32 16 bit
          * LUT, and a ultra quality will use a 64x64x64 16 bit LUT.
          *
-         * When color grading can be implemented using a 1D LUT, this setting only affects the
-         * resolution of the LUT, using the same values as in 3D (i.e. 16, 32, 64).
+         * This setting has no effect if generating a 1D LUT.
          *
          * This overrides the values set by format() and dimensions().
          *
@@ -193,8 +192,10 @@ public class ColorGrading {
         }
 
         /**
-         * When color grading is implemented using a LUT, this sets the dimension of the LUT. This
-         * overrides the value set by quality().
+         * When color grading is implemented using a 3D LUT, this sets the dimension of the LUT.
+         * This overrides the value set by quality().
+         *
+         * This setting has no effect if generating a 1D LUT.
          *
          * The default is 32
          *

--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -31,8 +31,6 @@ package com.google.android.filament;
  *   <li>DisplayRangeToneMapper</li>
  * </ul>
  * </ul>
- *
- * You can create custom tone mapping operators by subclassing ToneMapper.
  */
 public class ToneMapper {
     private final long mNativeObject;

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -155,8 +155,7 @@ public:
          * quality level will use a 32x32x32 10 bit LUT, a high quality will use a 32x32x32 16 bit
          * LUT, and a ultra quality will use a 64x64x64 16 bit LUT.
          *
-         * When color grading can be implemented using a 1D LUT, this setting only affects the
-         * resolution of the LUT, using the same values as in 3D (i.e. 16, 32, 64).
+         * This setting has no effect if generating a 1D LUT.
          *
          * This overrides the values set by format() and dimensions().
          *
@@ -183,8 +182,10 @@ public:
         Builder& format(LutFormat format) noexcept;
 
         /**
-         * When color grading is implemented using a LUT, this sets the dimension of the LUT. This
-         * overrides the value set by quality().
+         * When color grading is implemented using a 3D LUT, this sets the dimension of the LUT.
+         * This overrides the value set by quality().
+         *
+         * This setting has no effect if generating a 1D LUT.
          *
          * The default is 32
          *

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -64,9 +64,8 @@ class ColorSpace;
  * Performance
  * ===========
  *
- * Creating a new ColorGrading object may be more expensive than other Filament objects as a
- * 3D LUT may need to be generated. The generation of a 3D LUT, if necessary, may happen on
- * the CPU.
+ * Creating a new ColorGrading object may be more expensive than other Filament objects as a LUT may
+ * need to be generated. The generation of this LUT, if necessary, may happen on the CPU.
  *
  * Ordering
  * ========
@@ -155,6 +154,10 @@ public:
          * 3D texture. For instance, a low quality level will use a 16x16x16 10 bit LUT, a medium
          * quality level will use a 32x32x32 10 bit LUT, a high quality will use a 32x32x32 16 bit
          * LUT, and a ultra quality will use a 64x64x64 16 bit LUT.
+         *
+         * When color grading can be implemented using a 1D LUT, this setting only affects the
+         * resolution of the LUT, using the same values as in 3D (i.e. 16, 32, 64).
+         *
          * This overrides the values set by format() and dimensions().
          *
          * The default quality is medium.
@@ -169,6 +172,8 @@ public:
          * When color grading is implemented using a 3D LUT, this sets the texture format of
          * of the LUT. This overrides the value set by quality().
          *
+         * This setting has no effect if generating a 1D LUT.
+         *
          * The default is INTEGER
          *
          * @param format The desired format of the 3D LUT.
@@ -178,8 +183,8 @@ public:
         Builder& format(LutFormat format) noexcept;
 
         /**
-         * When color grading is implemented using a 3D LUT, this sets the dimension of the LUT.
-         * This overrides the value set by quality().
+         * When color grading is implemented using a LUT, this sets the dimension of the LUT. This
+         * overrides the value set by quality().
          *
          * The default is 32
          *

--- a/filament/include/filament/ToneMapper.h
+++ b/filament/include/filament/ToneMapper.h
@@ -68,6 +68,21 @@ struct UTILS_PUBLIC ToneMapper {
      *         function applied ("linear")
      */
     virtual math::float3 operator()(math::float3 c) const noexcept = 0;
+
+    /**
+     * If true, then this function holds that f(x) = vec3(f(x.r), f(x.g), f(x.b))
+     *
+     * This may be used to indicate that the color grading's LUT only requires a 1D texture instead
+     * of a 3D texture, potentially saving a significant amount of memory and generation time.
+     */
+    virtual bool isOneDimensional() const noexcept { return false; }
+
+    /**
+     * True if this tonemapper only works in low-dynamic-range.
+     *
+     * This may be used to indicate that the color grading's LUT doesn't need to be log encoded.
+     */
+    virtual bool isLDR() const noexcept { return false; }
 };
 
 /**
@@ -79,6 +94,8 @@ struct UTILS_PUBLIC LinearToneMapper final : public ToneMapper {
     ~LinearToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 c) const noexcept override;
+    bool isOneDimensional() const noexcept override { return true; }
+    bool isLDR() const noexcept override { return true; }
 };
 
 /**
@@ -91,6 +108,8 @@ struct UTILS_PUBLIC ACESToneMapper final : public ToneMapper {
     ~ACESToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 c) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
 };
 
 /**
@@ -104,6 +123,8 @@ struct UTILS_PUBLIC ACESLegacyToneMapper final : public ToneMapper {
     ~ACESLegacyToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 c) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
 };
 
 /**
@@ -117,6 +138,8 @@ struct UTILS_PUBLIC FilmicToneMapper final : public ToneMapper {
     ~FilmicToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 x) const noexcept override;
+    bool isOneDimensional() const noexcept override { return true; }
+    bool isLDR() const noexcept override { return false; }
 };
 
 /**
@@ -129,6 +152,8 @@ struct UTILS_PUBLIC PBRNeutralToneMapper final : public ToneMapper {
     ~PBRNeutralToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 x) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
 };
 
 /**
@@ -150,6 +175,8 @@ struct UTILS_PUBLIC AgxToneMapper final : public ToneMapper {
     ~AgxToneMapper() noexcept final;
 
     math::float3 operator()(math::float3 x) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
 
     AgxLook look;
 };
@@ -194,6 +221,8 @@ struct UTILS_PUBLIC GenericToneMapper final : public ToneMapper {
     GenericToneMapper& operator=(GenericToneMapper&& rhs) noexcept;
 
     math::float3 operator()(math::float3 x) const noexcept override;
+    bool isOneDimensional() const noexcept override { return true; }
+    bool isLDR() const noexcept override { return false; }
 
     /** Returns the contrast of the curve as a strictly positive value. */
     float getContrast() const noexcept;
@@ -256,6 +285,8 @@ struct UTILS_PUBLIC DisplayRangeToneMapper final : public ToneMapper {
     ~DisplayRangeToneMapper() noexcept override;
 
     math::float3 operator()(math::float3 c) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
 };
 
 } // namespace filament

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2649,7 +2649,7 @@ void PostProcessManager::configureTemporalAntiAliasingMaterial(
     setConstantParameter(ma, "varianceGamma", taaOptions.varianceGamma);
     if (dirty) {
         ma->invalidate();
-        // TODO: call Material::compile(), we can't si that now because it works only
+        // TODO: call Material::compile(), we can't do that now because it works only
         //       with surface materials
     }
 }
@@ -2676,7 +2676,7 @@ FMaterialInstance* PostProcessManager::configureColorGradingMaterial(
 
     if (dirty) {
         ma->invalidate();
-        // TODO: call Material::compile(), we can't si that now because it works only
+        // TODO: call Material::compile(), we can't do that now because it works only
         //       with surface materials
     }
 
@@ -2693,13 +2693,8 @@ FMaterialInstance* PostProcessManager::configureColorGradingMaterial(
             .wrapR = SamplerWrapMode::CLAMP_TO_EDGE,
             .anisotropyLog2 = 0
     };
-    if (colorGrading->isOneDimensional()) {
-        mi->setParameter("lut1d", colorGrading->getHwHandle(), params);
-        mi->setParameter("lut", mEngine.getZeroTexture(), params);
-    } else {
-        mi->setParameter("lut", colorGrading->getHwHandle(), params);
-        mi->setParameter("lut1d", mEngine.getZeroTexture(), params);
-    }
+
+    mi->setParameter("lut", colorGrading->getHwHandle(), params);
 
     const float lutDimension = float(colorGrading->getDimension());
     mi->setParameter("lutSize", float2{

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2306,36 +2306,11 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
         const FColorGrading* colorGrading, ColorGradingConfig const& colorGradingConfig,
         VignetteOptions const& vignetteOptions, uint32_t const width, uint32_t const height) noexcept {
 
-    float4 const vignetteParameters = getVignetteParameters(vignetteOptions, width, height);
-
-    auto const& material = getPostProcessMaterial("colorGradingAsSubpass");
-    FMaterialInstance* const mi = PostProcessMaterial::getMaterialInstance(mEngine, material);
-
-    mi->setParameter("lut", colorGrading->getHwHandle(), {
-            .filterMag = SamplerMagFilter::LINEAR,
-            .filterMin = SamplerMinFilter::LINEAR,
-            .wrapS = SamplerWrapMode::CLAMP_TO_EDGE,
-            .wrapT = SamplerWrapMode::CLAMP_TO_EDGE,
-            .wrapR = SamplerWrapMode::CLAMP_TO_EDGE,
-            .anisotropyLog2 = 0
-    });
-    const float lutDimension = float(colorGrading->getDimension());
-    mi->setParameter("lutSize", float2{
-        0.5f / lutDimension, (lutDimension - 1.0f) / lutDimension,
-    });
-
-    const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
-
-    mi->setParameter("vignette", vignetteParameters);
-    mi->setParameter("vignetteColor", vignetteOptions.color);
-    mi->setParameter("dithering", colorGradingConfig.dithering);
-    mi->setParameter("outputLuminance", colorGradingConfig.outputLuminance);
-    mi->setParameter("temporalNoise", temporalNoise);
+    auto& material = getPostProcessMaterial("colorGradingAsSubpass");
+    FMaterialInstance* const mi =
+            configureColorGradingMaterial(material, colorGrading, colorGradingConfig,
+                    vignetteOptions, width, height);
     mi->commit(driver);
-
-    // load both variants
-    material.getMaterial(mEngine, PostProcessVariant::OPAQUE);
-    material.getMaterial(mEngine, PostProcessVariant::TRANSLUCENT);
 }
 
 void PostProcessManager::colorGradingSubpass(DriverApi& driver,
@@ -2487,22 +2462,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
 
                 auto const& out = resources.getRenderPassInfo();
 
-                auto const& material = getPostProcessMaterial("colorGrading");
+                auto const& input = resources.getDescriptor(data.input);
+                auto const& output = resources.getDescriptor(data.output);
 
-                PostProcessVariant const variant = colorGradingConfig.translucent ?
-                        PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE;
-
+                auto& material = getPostProcessMaterial("colorGrading");
                 FMaterialInstance* const mi =
-                        PostProcessMaterial::getMaterialInstance(mEngine, material, variant);
+                        configureColorGradingMaterial(material, colorGrading, colorGradingConfig,
+                                vignetteOptions, output.width, output.height);
 
-                mi->setParameter("lut", colorGrading->getHwHandle(), {
-                        .filterMag = SamplerMagFilter::LINEAR,
-                        .filterMin = SamplerMinFilter::LINEAR
-                });
-                const float lutDimension = float(colorGrading->getDimension());
-                mi->setParameter("lutSize", float2{
-                        0.5f / lutDimension, (lutDimension - 1.0f) / lutDimension,
-                });
                 mi->setParameter("colorBuffer", colorTexture, { /* shader uses texelFetch */ });
                 mi->setParameter("bloomBuffer", bloomTexture, {
                         .filterMag = SamplerMagFilter::LINEAR,
@@ -2534,19 +2501,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                     bloomParameters.y = 1.0f - bloomParameters.x;
                 }
 
-                auto const& input = resources.getDescriptor(data.input);
-                auto const& output = resources.getDescriptor(data.output);
-                float4 const vignetteParameters = getVignetteParameters(
-                        vignetteOptions, output.width, output.height);
-
-                const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
-
-                mi->setParameter("dithering", colorGradingConfig.dithering);
                 mi->setParameter("bloom", bloomParameters);
-                mi->setParameter("vignette", vignetteParameters);
-                mi->setParameter("vignetteColor", vignetteOptions.color);
-                mi->setParameter("outputLuminance", colorGradingConfig.outputLuminance);
-                mi->setParameter("temporalNoise", temporalNoise);
                 mi->setParameter("viewport", float4{
                         float(vp.left)   / input.width,
                         float(vp.bottom) / input.height,
@@ -2554,7 +2509,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                         float(vp.height) / input.height
                 });
 
-                commitAndRenderFullScreenQuad(driver, out, mi, variant);
+                commitAndRenderFullScreenQuad(driver, out, mi,
+                        colorGradingConfig.translucent
+                        ? PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
             }
     );
 
@@ -2695,6 +2652,70 @@ void PostProcessManager::configureTemporalAntiAliasingMaterial(
         // TODO: call Material::compile(), we can't si that now because it works only
         //       with surface materials
     }
+}
+
+FMaterialInstance* PostProcessManager::configureColorGradingMaterial(
+        PostProcessMaterial& material, FColorGrading const* colorGrading,
+        ColorGradingConfig const& colorGradingConfig, VignetteOptions const& vignetteOptions,
+        uint32_t const width, uint32_t const height) noexcept {
+    FMaterial* const ma = material.getMaterial(mEngine);
+    bool dirty = false;
+
+    auto setConstantParameter =
+            [&dirty](FMaterial* const material, std::string_view const name, auto value) noexcept {
+        auto id = material->getSpecializationConstantId(name);
+        if (id.has_value()) {
+            if (material->setConstant(id.value(), value)) {
+                dirty = true;
+            }
+        }
+    };
+
+    setConstantParameter(ma, "isOneDimensional", colorGrading->isOneDimensional());
+    setConstantParameter(ma, "isLDR", colorGrading->isLDR());
+
+    if (dirty) {
+        ma->invalidate();
+        // TODO: call Material::compile(), we can't si that now because it works only
+        //       with surface materials
+    }
+
+    PostProcessVariant const variant = colorGradingConfig.translucent ?
+            PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE;
+    FMaterialInstance* const mi =
+            PostProcessMaterial::getMaterialInstance(mEngine, material, variant);
+
+    const SamplerParams params = {
+            .filterMag = SamplerMagFilter::LINEAR,
+            .filterMin = SamplerMinFilter::LINEAR,
+            .wrapS = SamplerWrapMode::CLAMP_TO_EDGE,
+            .wrapT = SamplerWrapMode::CLAMP_TO_EDGE,
+            .wrapR = SamplerWrapMode::CLAMP_TO_EDGE,
+            .anisotropyLog2 = 0
+    };
+    if (colorGrading->isOneDimensional()) {
+        mi->setParameter("lut1d", colorGrading->getHwHandle(), params);
+        mi->setParameter("lut", mEngine.getZeroTexture(), params);
+    } else {
+        mi->setParameter("lut", colorGrading->getHwHandle(), params);
+        mi->setParameter("lut1d", mEngine.getZeroTexture(), params);
+    }
+
+    const float lutDimension = float(colorGrading->getDimension());
+    mi->setParameter("lutSize", float2{
+        0.5f / lutDimension, (lutDimension - 1.0f) / lutDimension,
+    });
+
+    const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
+
+    float4 const vignetteParameters = getVignetteParameters(vignetteOptions, width, height);
+    mi->setParameter("vignette", vignetteParameters);
+    mi->setParameter("vignetteColor", vignetteOptions.color);
+    mi->setParameter("dithering", colorGradingConfig.dithering);
+    mi->setParameter("outputLuminance", colorGradingConfig.outputLuminance);
+    mi->setParameter("temporalNoise", temporalNoise);
+
+    return mi;
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -401,6 +401,13 @@ public:
             FMaterialInstance const* mi,
             PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept;
 
+    // Sets the necessary spec constants and uniforms common to both colorGrading.mat and
+    // colorGradingAsSubpass.mat.
+    FMaterialInstance* configureColorGradingMaterial(
+            PostProcessMaterial& material, FColorGrading const* colorGrading,
+            ColorGradingConfig const& colorGradingConfig, VignetteOptions const& vignetteOptions,
+            uint32_t const width, uint32_t const height) noexcept;
+
 private:
     backend::RenderPrimitiveHandle mFullScreenQuadRph;
     backend::VertexBufferInfoHandle mFullScreenQuadVbih;

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -812,11 +812,11 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
                 // Apply OETF
                 v = config.oetf(v);
 
-                *p++ = half{v.r};
+                *p++ = half(v.r);
             }
         } else {
             for (size_t rgb = 0; rgb < config.lutDimension; rgb++) {
-                *p = half{hdrColorAt(rgb, rgb, rgb).r};
+                *p = half(hdrColorAt(rgb, rgb, rgb).r);
             }
         }
     } else {

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -816,7 +816,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
             }
         } else {
             for (size_t rgb = 0; rgb < config.lutDimension; rgb++) {
-                *p = half(hdrColorAt(rgb, rgb, rgb).r);
+                *p++ = half(hdrColorAt(rgb, rgb, rgb).r);
             }
         }
     } else {

--- a/filament/src/details/ColorGrading.cpp
+++ b/filament/src/details/ColorGrading.cpp
@@ -35,7 +35,6 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <mutex>
 #include <tuple>
 
 namespace filament {
@@ -581,8 +580,11 @@ static float3 luminanceScaling(float3 x,
 // Quality
 //------------------------------------------------------------------------------
 
-static std::tuple<TextureFormat, PixelDataFormat, PixelDataType>
-        selectLutTextureParams(ColorGrading::LutFormat const lutFormat) noexcept {
+static std::tuple<TextureFormat, PixelDataFormat, PixelDataType> selectLutTextureParams(
+        ColorGrading::LutFormat const lutFormat, const bool isOneDimensional) noexcept {
+    if (isOneDimensional) {
+        return { TextureFormat::R8, PixelDataFormat::R, PixelDataType::UBYTE };
+    }
     // We use RGBA16F for high quality modes instead of RGB16F because RGB16F
     // is not supported everywhere
     switch (lutFormat) {
@@ -658,27 +660,28 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
 
     DriverApi& driver = engine.getDriverApi();
 
-    Config c;
-    // This lock protects the data inside Config, which is written to by the Filament thread,
-    // and read from multiple Job threads.
-    Mutex configLock;
-    {
-        std::lock_guard<Mutex> const lock(configLock);
-        c.lutDimension          = builder->dimension;
-        c.adaptationTransform   = adaptationTransform(builder->whiteBalance);
-        c.colorGradingIn        = selectColorGradingTransformIn(builder->toneMapping);
-        c.colorGradingOut       = selectColorGradingTransformOut(builder->toneMapping);
-        c.colorGradingLuminance = selectColorGradingLuminance(builder->toneMapping);
-        c.oetf                  = selectOETF(builder->outputColorSpace);
-    }
+    const Config config = {
+            builder->dimension,
+            adaptationTransform(builder->whiteBalance),
+            selectColorGradingTransformIn(builder->toneMapping),
+            selectColorGradingTransformOut(builder->toneMapping),
+            selectColorGradingLuminance(builder->toneMapping),
+            selectOETF(builder->outputColorSpace),
+    };
 
-    mDimension = c.lutDimension;
+    mDimension = config.lutDimension;
+    mIsOneDimensional = !builder->hasAdjustments && !builder->luminanceScaling
+            && builder->toneMapper->isOneDimensional();
+    mIsLDR = mIsOneDimensional && builder->toneMapper->isLDR();
 
-    size_t lutElementCount = c.lutDimension * c.lutDimension * c.lutDimension;
-    size_t elementSize = sizeof(half4);
+    size_t lutElementCount = mIsOneDimensional
+            ? config.lutDimension
+            : (config.lutDimension * config.lutDimension * config.lutDimension);
+    size_t elementSize = mIsOneDimensional ? sizeof(uint8_t) : sizeof(half4);
     void* data = malloc(lutElementCount * elementSize);
 
-    auto [textureFormat, format, type] = selectLutTextureParams(builder->format);
+    auto [textureFormat, format, type] =
+            selectLutTextureParams(builder->format, mIsOneDimensional);
     assert_invariant(FTexture::isTextureFormatSupported(engine, textureFormat));
     assert_invariant(FTexture::validatePixelFormatAndType(textureFormat, format, type));
 
@@ -688,155 +691,171 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
         converted = malloc(lutElementCount * sizeof(uint32_t));
     }
 
+    auto hdrColorAt = [builder, config](size_t r, size_t g, size_t b) {
+        float3 v = float3{r, g, b} * (1.0f / float(config.lutDimension - 1u));
+
+        // LogC encoding
+        v = LogC_to_linear(v);
+
+        // Kill negative values near 0.0f due to imprecision in the log conversion
+        v = max(v, 0.0f);
+
+        if (builder->hasAdjustments) {
+            // Exposure
+            v = adjustExposure(v, builder->exposure);
+
+            // Purkinje shift ("low-light" vision)
+            v = scotopicAdaptation(v, builder->nightAdaptation);
+        }
+
+        // Move to color grading color space
+        v = config.colorGradingIn * v;
+
+        if (builder->hasAdjustments) {
+            // White balance
+            v = chromaticAdaptation(v, config.adaptationTransform);
+
+            // Kill negative values before the next transforms
+            v = max(v, 0.0f);
+
+            // Channel mixer
+            v = channelMixer(v, builder->outRed, builder->outGreen, builder->outBlue);
+
+            // Shadows/mid-tones/highlights
+            v = tonalRanges(v, config.colorGradingLuminance,
+                    builder->shadows, builder->midtones, builder->highlights,
+                    builder->tonalRanges);
+
+            // The adjustments below behave better in log space
+            v = linear_to_LogC(v);
+
+            // ASC CDL
+            v = colorDecisionList(v, builder->slope, builder->offset, builder->power);
+
+            // Contrast in log space
+            v = contrast(v, builder->contrast);
+
+            // Back to linear space
+            v = LogC_to_linear(v);
+
+            // Vibrance in linear space
+            v = vibrance(v, config.colorGradingLuminance, builder->vibrance);
+
+            // Saturation in linear space
+            v = saturation(v, config.colorGradingLuminance, builder->saturation);
+
+            // Kill negative values before curves
+            v = max(v, 0.0f);
+
+            // RGB curves
+            v = curves(v,
+                    builder->shadowGamma, builder->midPoint, builder->highlightScale);
+        }
+
+        // Tone mapping
+        if (builder->luminanceScaling) {
+            v = luminanceScaling(v, *builder->toneMapper, config.colorGradingLuminance);
+        } else {
+            v = (*builder->toneMapper)(v);
+        }
+
+        // Go back to display color space
+        v = config.colorGradingOut * v;
+
+        // Apply gamut mapping
+        if (builder->gamutMapping) {
+            // TODO: This should depend on the output color space
+            v = gamutMapping_sRGB(v);
+        }
+
+        // TODO: We should convert to the output color space if we use a working
+        //       color space that's not sRGB
+        // TODO: Allow the user to customize the output color space
+
+        // We need to clamp for the output transfer function
+        v = saturate(v);
+
+        // Apply OETF
+        v = config.oetf(v);
+
+        return v;
+    };
+
     //auto now = std::chrono::steady_clock::now();
 
-    // Multithreadedly generate the tone mapping 3D look-up table using 32 jobs
-    // Slices are 8 KiB (128 cache lines) apart.
-    // This takes about 3-6ms on Android in Release
-    JobSystem& js = engine.getJobSystem();
-    auto *slices = js.createJob();
-    for (size_t b = 0; b < c.lutDimension; b++) {
-        auto *job = js.createJob(slices,
-                [data, converted, b, &c, &configLock, builder](JobSystem&, JobSystem::Job*) {
-            Config config;
-            {
-                std::lock_guard<Mutex> lock(configLock);
-                config = c;
+    if (mIsOneDimensional) {
+        uint8_t* UTILS_RESTRICT p = (uint8_t*) data;
+        for (size_t rgb = 0; rgb < config.lutDimension; rgb++) {
+            float s;
+            if (mIsLDR) {
+                float3 v = float3(rgb) * (1.0f / float(config.lutDimension - 1u));
+
+                v = (*builder->toneMapper)(float3(v));
+
+                // TODO: We should convert to the output color space if we use a working
+                //       color space that's not sRGB
+                // TODO: Allow the user to customize the output color space
+
+                // We need to clamp for the output transfer function
+                v = saturate(v);
+
+                // Apply OETF
+                v = config.oetf(v);
+
+                s = v.r;
+            } else {
+                s = hdrColorAt(rgb, rgb, rgb).r;
             }
-            half4* UTILS_RESTRICT p = (half4*) data + b * config.lutDimension * config.lutDimension;
-            for (size_t g = 0; g < config.lutDimension; g++) {
-                for (size_t r = 0; r < config.lutDimension; r++) {
-                    float3 v = float3{r, g, b} * (1.0f / float(config.lutDimension - 1u));
-
-                    // LogC encoding
-                    v = LogC_to_linear(v);
-
-                    // Kill negative values near 0.0f due to imprecision in the log conversion
-                    v = max(v, 0.0f);
-
-                    if (builder->hasAdjustments) {
-                        // Exposure
-                        v = adjustExposure(v, builder->exposure);
-
-                        // Purkinje shift ("low-light" vision)
-                        v = scotopicAdaptation(v, builder->nightAdaptation);
+            *p++ = uint8_t(std::floor(s * 255.0f + 0.5f));
+        }
+    } else {
+        // Multithreadedly generate the tone mapping 3D look-up table using 32 jobs
+        // Slices are 8 KiB (128 cache lines) apart.
+        // This takes about 3-6ms on Android in Release
+        JobSystem& js = engine.getJobSystem();
+        auto *slices = js.createJob();
+        for (size_t b = 0; b < config.lutDimension; b++) {
+            auto* job = js.createJob(slices,
+                    [data, converted, b, &config, builder, &hdrColorAt](
+                            JobSystem&, JobSystem::Job*) {
+                half4* UTILS_RESTRICT p =
+                        (half4*) data + b * config.lutDimension * config.lutDimension;
+                for (size_t g = 0; g < config.lutDimension; g++) {
+                    for (size_t r = 0; r < config.lutDimension; r++) {
+                        *p++ = half4{hdrColorAt(r, g, b), 0.0f};
                     }
-
-                    // Move to color grading color space
-                    v = c.colorGradingIn * v;
-
-                    if (builder->hasAdjustments) {
-                        // White balance
-                        v = chromaticAdaptation(v, config.adaptationTransform);
-
-                        // Kill negative values before the next transforms
-                        v = max(v, 0.0f);
-
-                        // Channel mixer
-                        v = channelMixer(v, builder->outRed, builder->outGreen, builder->outBlue);
-
-                        // Shadows/mid-tones/highlights
-                        v = tonalRanges(v, c.colorGradingLuminance,
-                                builder->shadows, builder->midtones, builder->highlights,
-                                builder->tonalRanges);
-
-                        // The adjustments below behave better in log space
-                        v = linear_to_LogC(v);
-
-                        // ASC CDL
-                        v = colorDecisionList(v, builder->slope, builder->offset, builder->power);
-
-                        // Contrast in log space
-                        v = contrast(v, builder->contrast);
-
-                        // Back to linear space
-                        v = LogC_to_linear(v);
-
-                        // Vibrance in linear space
-                        v = vibrance(v, c.colorGradingLuminance, builder->vibrance);
-
-                        // Saturation in linear space
-                        v = saturation(v, c.colorGradingLuminance, builder->saturation);
-
-                        // Kill negative values before curves
-                        v = max(v, 0.0f);
-
-                        // RGB curves
-                        v = curves(v,
-                                builder->shadowGamma, builder->midPoint, builder->highlightScale);
-                    }
-
-                    // Tone mapping
-                    if (builder->luminanceScaling) {
-                        v = luminanceScaling(v, *builder->toneMapper, c.colorGradingLuminance);
-                    } else {
-                        v = (*builder->toneMapper)(v);
-                    }
-
-                    // Go back to display color space
-                    v = c.colorGradingOut * v;
-
-                    // Apply gamut mapping
-                    if (builder->gamutMapping) {
-                        // TODO: This should depend on the output color space
-                        v = gamutMapping_sRGB(v);
-                    }
-
-                    // TODO: We should convert to the output color space if we use a working
-                    //       color space that's not sRGB
-                    // TODO: Allow the user to customize the output color space
-
-                    // We need to clamp for the output transfer function
-                    v = saturate(v);
-
-                    // Apply OETF
-                    v = c.oetf(v);
-
-                    *p++ = half4{v, 0.0f};
                 }
-            }
 
-            if (converted) {
-                uint32_t* const UTILS_RESTRICT dst = (uint32_t*) converted +
-                        b * config.lutDimension * config.lutDimension;
-                half4* UTILS_RESTRICT src = (half4*) data +
-                        b * config.lutDimension * config.lutDimension;
-                // we use a vectorize width of 8 because, on ARMv8 it allows the compiler to write eight
-                // 32-bits results in one go.
-                const size_t count = (config.lutDimension * config.lutDimension) & ~0x7u; // tell the compiler that we're a multiple of 8
+                if (converted) {
+                    uint32_t* const UTILS_RESTRICT dst = (uint32_t*) converted +
+                            b * config.lutDimension * config.lutDimension;
+                    half4* UTILS_RESTRICT src = (half4*) data +
+                            b * config.lutDimension * config.lutDimension;
+                    // we use a vectorize width of 8 because, on ARMv8 it allows the compiler to
+                    // write eight 32-bits results in one go.
+                    const size_t count = (config.lutDimension * config.lutDimension) & ~0x7u; // tell the compiler that we're a multiple of 8
 #if defined(__clang__)
-                #pragma clang loop vectorize_width(8)
+#pragma clang loop vectorize_width(8)
 #endif
-                for (size_t i = 0; i < count; ++i) {
-                    float4 v{src[i]};
-                    uint32_t pr = uint32_t(std::floor(v.x * 1023.0f + 0.5f));
-                    uint32_t pg = uint32_t(std::floor(v.y * 1023.0f + 0.5f));
-                    uint32_t pb = uint32_t(std::floor(v.z * 1023.0f + 0.5f));
-                    dst[i] = (pb << 20u) | (pg << 10u) | pr;
+                    for (size_t i = 0; i < count; ++i) {
+                        float4 v{src[i]};
+                        uint32_t pr = uint32_t(std::floor(v.x * 1023.0f + 0.5f));
+                        uint32_t pg = uint32_t(std::floor(v.y * 1023.0f + 0.5f));
+                        uint32_t pb = uint32_t(std::floor(v.z * 1023.0f + 0.5f));
+                        dst[i] = (pb << 20u) | (pg << 10u) | pr;
+                    }
                 }
-            }
+            });
+            js.run(job);
+        }
 
-        });
-        js.run(job);
+        // TODO: Should we do a runAndRetain() and defer the wait() + texture creation until
+        //       getHwHandle() is invoked?
+        js.runAndWait(slices);
     }
-
-    // TODO: Should we do a runAndRetain() and defer the wait() + texture creation until
-    //       getHwHandle() is invoked?
-    js.runAndWait(slices);
 
     //std::chrono::duration<float, std::milli> duration = std::chrono::steady_clock::now() - now;
     //slog.d << "LUT generation time: " << duration.count() << " ms" << io::endl;
-
-    mLutHandle = driver.createTexture(
-            SamplerType::SAMPLER_3D,
-            1,
-            textureFormat,
-            1,
-            c.lutDimension,
-            c.lutDimension,
-            c.lutDimension,
-            TextureUsage::DEFAULT
-    );
 
     if (converted) {
         free(data);
@@ -844,14 +863,34 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
         elementSize = sizeof(uint32_t);
     }
 
+    // Create texture.
+    backend::SamplerType target;
+    uint32_t width;
+    uint32_t height;
+    uint32_t depth;
+
+    if (mIsOneDimensional) {
+        target = SamplerType::SAMPLER_2D;
+        width = config.lutDimension;
+        height = 1;
+        depth = 1;
+    } else {
+        target = SamplerType::SAMPLER_3D;
+        width = config.lutDimension;
+        height = config.lutDimension;
+        depth = config.lutDimension;
+    }
+
+    mLutHandle = driver.createTexture(target, 1, textureFormat, 1,
+            width, height, depth, TextureUsage::DEFAULT);
+
     driver.update3DImage(mLutHandle, 0,
             0, 0, 0,
-            c.lutDimension, c.lutDimension, c.lutDimension,
+            width, height, depth,
             PixelBufferDescriptor{
-                    data, lutElementCount * elementSize,format, type,
-                    [](void* buffer, size_t, void*) { free(buffer); }
-            }
-    );
+                data, lutElementCount * elementSize, format, type,
+                        [](void* buffer, size_t, void*) { free(buffer); }
+                        });
 }
 
 FColorGrading::~FColorGrading() noexcept = default;

--- a/filament/src/details/ColorGrading.h
+++ b/filament/src/details/ColorGrading.h
@@ -42,12 +42,15 @@ public:
     void terminate(FEngine& engine);
 
     backend::TextureHandle getHwHandle() const noexcept { return mLutHandle; }
-
     uint32_t getDimension() const noexcept { return mDimension; }
+    bool isOneDimensional() const noexcept { return mIsOneDimensional; }
+    bool isLDR() const noexcept { return mIsLDR; }
 
 private:
     backend::TextureHandle mLutHandle;
     uint32_t mDimension;
+    bool mIsOneDimensional;
+    bool mIsLDR;
 };
 
 FILAMENT_DOWNCAST(ColorGrading)

--- a/filament/src/materials/colorGrading/colorGrading.fs
+++ b/filament/src/materials/colorGrading/colorGrading.fs
@@ -7,22 +7,23 @@ vec3 LogC_to_linear(const vec3 x) {
     return c * log2(a * x + b) + d;
 }
 
-vec3 colorGrade3D(const vec3 v) {
-    return textureLod(materialParams_lut, v, 0.0).rgb;
+vec3 colorGrade3D(mediump sampler3D lut, const vec3 v) {
+    return textureLod(lut, v, 0.0).rgb;
 }
 
-vec3 colorGrade1D(const vec3 v) {
+vec3 colorGrade1D(mediump sampler3D lut, const vec3 v) {
     return vec3(
-        textureLod(materialParams_lut1d, vec2(v.r, 0.5), 0.0).r,
-        textureLod(materialParams_lut1d, vec2(v.g, 0.5), 0.0).r,
-        textureLod(materialParams_lut1d, vec2(v.b, 0.5), 0.0).r);
+        textureLod(lut, vec3(v.r, 0.5, 0.5), 0.0).r,
+        textureLod(lut, vec3(v.g, 0.5, 0.5), 0.0).r,
+        textureLod(lut, vec3(v.b, 0.5, 0.5), 0.0).r);
 }
 
-vec3 colorGrade(vec3 v) {
+vec3 colorGrade(mediump sampler3D lut, vec3 v) {
     if (!materialConstants_isLDR) {
         v = LogC_to_linear(v);
     }
     // Remap to sample pixel centers.
     v = materialParams.lutSize.x + v * materialParams.lutSize.y;
-    return materialConstants_isOneDimensional ? colorGrade1D(v) : colorGrade3D(v);
+    return materialConstants_isOneDimensional
+            ? colorGrade1D(lut, v) : colorGrade3D(lut, v);
 }

--- a/filament/src/materials/colorGrading/colorGrading.fs
+++ b/filament/src/materials/colorGrading/colorGrading.fs
@@ -1,13 +1,28 @@
-vec3 colorGrade(mediump sampler3D lut, const vec3 x) {
+vec3 LogC_to_linear(const vec3 x) {
     // Alexa LogC EI 1000
     const float a = 5.555556;
     const float b = 0.047996;
     const float c = 0.244161 / log2(10.0);
     const float d = 0.386036;
-    vec3 logc = c * log2(a * x + b) + d;
+    return c * log2(a * x + b) + d;
+}
 
-    // Remap to sample pixel centers
-    logc = materialParams.lutSize.x + logc * materialParams.lutSize.y;
+vec3 colorGrade3D(const vec3 v) {
+    return textureLod(materialParams_lut, v, 0.0).rgb;
+}
 
-    return textureLod(lut, logc, 0.0).rgb;
+vec3 colorGrade1D(const vec3 v) {
+    return vec3(
+        textureLod(materialParams_lut1d, vec2(v.r, 0.5), 0.0).r,
+        textureLod(materialParams_lut1d, vec2(v.g, 0.5), 0.0).r,
+        textureLod(materialParams_lut1d, vec2(v.b, 0.5), 0.0).r);
+}
+
+vec3 colorGrade(vec3 v) {
+    if (!materialConstants_isLDR) {
+        v = LogC_to_linear(v);
+    }
+    // Remap to sample pixel centers.
+    v = materialParams.lutSize.x + v * materialParams.lutSize.y;
+    return materialConstants_isOneDimensional ? colorGrade1D(v) : colorGrade3D(v);
 }

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -12,6 +12,11 @@ material {
             precision: medium
         },
         {
+            type : sampler2d,
+            name : lut1d,
+            precision: medium
+        },
+        {
             type : float2,
             name : lutSize
         },
@@ -64,6 +69,16 @@ material {
             type : float4,
             name : viewport,
             precision : high
+        }
+    ],
+    constants : [
+        {
+            type : bool,
+            name : isOneDimensional
+        },
+        {
+            type : bool,
+            name : isLDR
         }
     ],
     variables : [
@@ -154,7 +169,7 @@ void postProcess(inout PostProcessInputs postProcess) {
     }
 
     // Color grading
-    color.rgb  = colorGrade(materialParams_lut, color.rgb);
+    color.rgb = colorGrade(color.rgb);
 
     // output in premultiplied alpha
 #if !POST_PROCESS_OPAQUE

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -12,11 +12,6 @@ material {
             precision: medium
         },
         {
-            type : sampler2d,
-            name : lut1d,
-            precision: medium
-        },
-        {
             type : float2,
             name : lutSize
         },
@@ -169,7 +164,7 @@ void postProcess(inout PostProcessInputs postProcess) {
     }
 
     // Color grading
-    color.rgb = colorGrade(color.rgb);
+    color.rgb = colorGrade(materialParams_lut, color.rgb);
 
     // output in premultiplied alpha
 #if !POST_PROCESS_OPAQUE

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -7,6 +7,11 @@ material {
             precision: medium
         },
         {
+            type : sampler2d,
+            name : lut1d,
+            precision: medium
+        },
+        {
             type : float2,
             name : lutSize
         },
@@ -30,6 +35,16 @@ material {
         {
             type : float4,
             name : vignetteColor
+        }
+    ],
+    constants : [
+        {
+            type : bool,
+            name : isOneDimensional
+        },
+        {
+            type : bool,
+            name : isLDR
         }
     ],
     subpasses : [
@@ -103,7 +118,7 @@ void postProcess(inout PostProcessInputs postProcess) {
     }
 
     // Color grading
-    color.rgb  = colorGrade(materialParams_lut, color.rgb);
+    color.rgb = colorGrade(color.rgb);
 
     // output in premultiplied alpha
 #if !POST_PROCESS_OPAQUE

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : sampler2d,
-            name : lut1d,
-            precision: medium
-        },
-        {
             type : float2,
             name : lutSize
         },
@@ -118,7 +113,7 @@ void postProcess(inout PostProcessInputs postProcess) {
     }
 
     // Color grading
-    color.rgb = colorGrade(color.rgb);
+    color.rgb = colorGrade(materialParams_lut, color.rgb);
 
     // output in premultiplied alpha
 #if !POST_PROCESS_OPAQUE


### PR DESCRIPTION
This introduces two new methods to `ToneMapper`: `isOneDimensional()` and `isLDR()`. `ColorGrading` references these values along with other parameters passed to the builder to determine if we can get away with only generating a one-dimensional LUT. Meanwhile, `PostProcessManager` takes care of setting the new spec constants and uniforms for `colorGrading.mat` and `colorGradingAsSubpass.mat`.

FIXES=[372037228]