### PR TITLE
Adjust matc targets and flags for WebGPU

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -518,8 +518,13 @@ void GLSLPostProcessor::spirvToMsl(const SpirvBlob* spirv, std::string* outMsl,
     }
 }
 
-bool GLSLPostProcessor::spirvToWgsl(const SpirvBlob *spirv, std::string *outWsl) {
+bool GLSLPostProcessor::spirvToWgsl(SpirvBlob *spirv, std::string *outWsl) {
 #if FILAMENT_SUPPORTS_WEBGPU
+    // We need to remove dead code for our variant-filter workaround for WebGPU to work
+    // This is especially relevant for removing the push constants that morphing uses when not disabled
+    spv::spirvbin_t remapper(0);
+    remapper.remap(*spirv, spv::spirvbin_base_t::DCE_ALL);
+
     //Currently no options we want to use
     const tint::spirv::reader::Options readerOpts{};
     tint::wgsl::writer::Options writerOpts{};

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -90,7 +90,7 @@ public:
             bool useFramebufferFetch, const DescriptorSets& descriptorSets,
             const ShaderMinifier* minifier);
 
-    static bool spirvToWgsl(const SpirvBlob* spirv, std::string* outWsl);
+    static bool spirvToWgsl(SpirvBlob* spirv, std::string* outWsl);
 
 private:
     struct InternalConfig {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -20,7 +20,6 @@ set(MATERIAL_SRCS
         materials/aiDefaultMat.mat
         materials/bakedColor.mat
         materials/bakedTexture.mat
-        materials/pointSprites.mat
         materials/aoPreview.mat
         materials/arrayTexture.mat
         materials/groundShadow.mat
@@ -41,6 +40,12 @@ set(MATERIAL_SRCS
         materials/sandboxUnlit.mat
         materials/texturedLit.mat
 )
+
+# Tint does not support setting gl_PointSize, disable the relevant sample if using WebGPU
+# https://github.com/gpuweb/gpuweb/issues/1190
+if (NOT FILAMENT_SUPPORTS_WEBGPU)
+    set(MATERIAL_SRCS ${MATERIAL_SRCS} materials/pointSprites.mat)
+endif ()
 
 if (CMAKE_CROSSCOMPILING)
     include(${IMPORT_EXECUTABLES})
@@ -258,7 +263,11 @@ if (NOT ANDROID)
     add_demo(lightbulb)
     add_demo(material_sandbox)
     add_demo(multiple_windows)
-    add_demo(point_sprites)
+    # Tint does not support setting gl_PointSize, disable the relevant sample if using WebGPU
+    # https://github.com/gpuweb/gpuweb/issues/1190
+    if (NOT FILAMENT_SUPPORTS_WEBGPU)
+        add_demo(point_sprites)
+    endif ()
     add_demo(rendertarget)
     add_demo(sample_cloth)
     add_demo(sample_full_pbr)


### PR DESCRIPTION
We may need to improve the modularity of `matc` invocations as a custom tool, as this logic fully changes how matc works if WebGPU is enabled, even if someone theoretically wants to test other targets. Until we are enabled by default though that is a minor problem