### PR TITLE
Materials can now specify a shadow attenuation factor

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -78,26 +78,27 @@ in table [standardProperties].
         Property        |      Definition
 -----------------------:|:---------------------
 **baseColor**           | Diffuse albedo for non-metallic surfaces, and specular color for metallic surfaces
-**metallic**            | Whether a surface appears to be dielectric (0.0) or conductor (1.0). Often used as a binary value (0 or 1)
 **roughness**           | Perceived smoothness (1.0) or roughness (0.0) of a surface. Smooth surfaces exhibit sharp reflections
+**metallic**            | Whether a surface appears to be dielectric (0.0) or conductor (1.0). Often used as a binary value (0 or 1)
 **reflectance**         | Fresnel reflectance at normal incidence for dielectric surfaces. This directly controls the strength of the reflections
-**sheenColor**          | Strength of the sheen layer
-**sheenRoughness**      | Perceived smoothness or roughness of the sheen layer
+**ambientOcclusion**    | Defines how much of the ambient light is accessible to a surface point. It is a per-pixel shadowing factor between 0.0 and 1.0
 **clearCoat**           | Strength of the clear coat layer
 **clearCoatRoughness**  | Perceived smoothness or roughness of the clear coat layer
+**clearCoatNormal**     | A detail normal used to perturb the clear coat layer using _bump mapping_ (_normal mapping_)
 **anisotropy**          | Amount of anisotropy in either the tangent or bitangent direction
 **anisotropyDirection** | Local surface direction in tangent space
-**ambientOcclusion**    | Defines how much of the ambient light is accessible to a surface point. It is a per-pixel shadowing factor between 0.0 and 1.0
-**normal**              | A detail normal used to perturb the surface using _bump mapping_ (_normal mapping_)
-**bentNormal**          | A normal pointing in the average unoccluded direction. Can be used to improve indirect lighting quality
-**clearCoatNormal**     | A detail normal used to perturb the clear coat layer using _bump mapping_ (_normal mapping_)
-**emissive**            | Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass
-**postLightingColor**   | Additional color that can be blended with the result of the lighting computations. See `postLightingBlending`
-**ior**                 | Index of refraction, either for refractive objects or as an alternative to reflectance
-**transmission**        | Defines how much of the diffuse light of a dielectric is transmitted through the object, in other words this defines how transparent an object is
-**absorption**          | Absorption factor for refractive objects
-**microThickness**      | Thickness of the thin layer of refractive objects
 **thickness**           | Thickness of the solid volume of refractive objects
+**sheenColor**          | Strength of the sheen layer
+**sheenRoughness**      | Perceived smoothness or roughness of the sheen layer
+**emissive**            | Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass
+**normal**              | A detail normal used to perturb the surface using _bump mapping_ (_normal mapping_)
+**postLightingColor**   | Additional color that can be blended with the result of the lighting computations. See `postLightingBlending`
+**absorption**          | Absorption factor for refractive objects
+**transmission**        | Defines how much of the diffuse light of a dielectric is transmitted through the object, in other words this defines how transparent an object is
+**ior**                 | Index of refraction, either for refractive objects or as an alternative to reflectance
+**microThickness**      | Thickness of the thin layer of refractive objects
+**bentNormal**          | A normal pointing in the average unoccluded direction. Can be used to improve indirect lighting quality
+**shadowStrength**      | Strength factor between 0 and 1 for all shadows received by this material
 [Table [standardProperties]: Properties of the standard model]
 
 The type and range of each property is described in table [standardPropertiesTypes].

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -203,7 +203,7 @@ enum class ReflectionMode : uint8_t {
 // can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t
 using AttributeBitset = utils::bitset32;
 
-static constexpr size_t MATERIAL_PROPERTIES_COUNT = 29;
+static constexpr size_t MATERIAL_PROPERTIES_COUNT = 30;
 enum class Property : uint8_t {
     BASE_COLOR,              //!< float4, all shading models
     ROUGHNESS,               //!< float,  lit shading models only
@@ -234,6 +234,7 @@ enum class Property : uint8_t {
     BENT_NORMAL,             //!< float3, all shading models only, except unlit
     SPECULAR_FACTOR,         //!< float, lit shading models only, except subsurface and cloth
     SPECULAR_COLOR_FACTOR,   //!< float3, lit shading models only, except subsurface and cloth
+    SHADOW_STRENGTH,         //!< float, [0, 1] strength of shadows received by this material
 
     // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
 };

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -50,7 +50,7 @@ std::unordered_map<std::string, Property> Enums::mStringToProperty = {
         { "bentNormal",          Property::BENT_NORMAL },
         { "specularFactor",      Property::SPECULAR_FACTOR },
         { "specularColorFactor", Property::SPECULAR_COLOR_FACTOR },
-        { "shadowStrength",   Property::SHADOW_STRENGTH }
+        { "shadowStrength",       Property::SHADOW_STRENGTH }
 };
 
 template <>

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -49,7 +49,8 @@ std::unordered_map<std::string, Property> Enums::mStringToProperty = {
         { "microThickness",      Property::MICRO_THICKNESS },
         { "bentNormal",          Property::BENT_NORMAL },
         { "specularFactor",      Property::SPECULAR_FACTOR },
-        { "specularColorFactor",  Property::SPECULAR_COLOR_FACTOR }
+        { "specularColorFactor", Property::SPECULAR_COLOR_FACTOR },
+        { "shadowStrength",   Property::SHADOW_STRENGTH }
 };
 
 template <>

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -1218,6 +1218,7 @@ char const* CodeGenerator::getConstantName(MaterialBuilder::Property property) n
         case Property::BENT_NORMAL:                 return "BENT_NORMAL";
         case Property::SPECULAR_FACTOR:             return "SPECULAR_FACTOR";
         case Property::SPECULAR_COLOR_FACTOR:       return "SPECULAR_COLOR_FACTOR";
+        case Property::SHADOW_STRENGTH:             return "SHADOW_STRENGTH";
     }
 }
 

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -696,6 +696,25 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerBentNormal) {
     EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
+TEST_F(MaterialCompiler, StaticCodeAnalyzerShadowStrength) {
+    std::string fragmentCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.shadowStrength = 0.1;
+        }
+    )");
+
+    std::string shaderCode = shaderWithAllProperties(*jobSystem, ShaderStage::FRAGMENT,
+            fragmentCode);
+
+    GLSLTools glslTools;
+    MaterialBuilder::PropertyList properties{ false };
+    glslTools.findProperties(ShaderStage::FRAGMENT, shaderCode, properties);
+    MaterialBuilder::PropertyList expected{ false };
+    expected[size_t(filamat::MaterialBuilder::Property::SHADOW_STRENGTH)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
 TEST_F(MaterialCompiler, StaticCodeAnalyzerOutputFactor) {
     std::string fragmentCode(R"(
         void material(inout MaterialInputs material) {

--- a/shaders/src/surface_light_directional.fs
+++ b/shaders/src/surface_light_directional.fs
@@ -58,6 +58,9 @@ void evaluateDirectionalLight(const MaterialInputs material,
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             highp vec4 shadowPosition = getShadowPosition(cascade);
             visibility = shadow(true, sampler0_shadowMap, cascade, shadowPosition, 0.0);
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+            applyShadowStrength(visibility, material.shadowStrength);
+#endif
             // shadow far attenuation
             highp vec3 v = getWorldPosition() - getWorldCameraPosition();
             // (viewFromWorld * v).z == dot(transpose(viewFromWorld), v)

--- a/shaders/src/surface_light_punctual.fs
+++ b/shaders/src/surface_light_punctual.fs
@@ -222,6 +222,9 @@ void evaluatePunctualLights(const MaterialInputs material,
                 highp vec4 shadowPosition = getShadowPosition(shadowIndex, light.direction, light.zLight);
                 visibility = shadow(false, sampler0_shadowMap, shadowIndex,
                         shadowPosition, light.zLight);
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+                applyShadowStrength(visibility, material.shadowStrength);
+#endif
             }
             if (light.contactShadows && visibility > 0.0) {
                 if ((object_uniforms_flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {

--- a/shaders/src/surface_material_inputs.fs
+++ b/shaders/src/surface_material_inputs.fs
@@ -98,6 +98,10 @@ struct MaterialInputs {
     vec3 specularColorFactor;
 #endif
 
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+    float shadowStrength;
+#endif
+
 };
 
 void initMaterial(out MaterialInputs material) {
@@ -195,6 +199,9 @@ void initMaterial(out MaterialInputs material) {
     material.specularColorFactor = vec3(1.0);
 #endif
 
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+    material.shadowStrength = 0.0;
+#endif
 }
 
 #if defined(MATERIAL_HAS_CUSTOM_SURFACE_SHADING)

--- a/shaders/src/surface_shading_unlit.fs
+++ b/shaders/src/surface_shading_unlit.fs
@@ -47,6 +47,9 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     if (hasDirectionalShadows && cascadeHasVisibleShadows) {
         highp vec4 shadowPosition = getShadowPosition(cascade);
         visibility = shadow(true, sampler0_shadowMap, cascade, shadowPosition, 0.0);
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+        applyShadowStrength(visibility, material.shadowStrength);
+#endif
         // shadow far attenuation
         highp vec3 v = getWorldPosition() - getWorldCameraPosition();
         // (viewFromWorld * v).z == dot(transpose(viewFromWorld), v)

--- a/shaders/src/surface_shadowing.fs
+++ b/shaders/src/surface_shadowing.fs
@@ -511,6 +511,12 @@ int getPointLightFace(const highp vec3 r) {
     }
 }
 
+#if defined(MATERIAL_HAS_SHADOW_STRENGTH)
+void applyShadowStrength(inout float visibility, float strength) {
+    visibility = 1.0 - (1.0 - visibility) * strength;
+}
+#endif
+
 // PCF sampling
 float shadow(const bool DIRECTIONAL,
         const mediump sampler2DArrayShadow shadowMap,


### PR DESCRIPTION
Materials have a new property: shadowStrength that can be used to attenuate all shadows received by this material. e.g.:

```
void material(inout MaterialInputs material) {
  prepareMaterial(material);
  material.shadowStrength = 0.1;
}
```

FIXES=[391663042]