### PR TITLE
Fix WebGPU compilation error

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -651,11 +651,11 @@ uint8_t WebGPUDriver::getMaxDrawBuffers() {
     return MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
 }
 
-size_t WebGPUDriver::getMaxUniformBufferSize(SamplerType) {
+size_t WebGPUDriver::getMaxUniformBufferSize() {
     return 16384u;
 }
 
-size_t WebGPUDriver::getMaxTextureSize() {
+size_t WebGPUDriver::getMaxTextureSize(SamplerType target) {
     return 2048u;
 }
 


### PR DESCRIPTION
WebGPU is broken because of 3abddc4584d63ce72bb8e2ccb11d41af490c0cc8 change