### PR TITLE
make createExternalImage UTILS_PUBLIC across platforms for future proofing

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformCocoaGL.h
+++ b/filament/backend/include/backend/platforms/PlatformCocoaGL.h
@@ -33,7 +33,7 @@ public:
     PlatformCocoaGL();
     ~PlatformCocoaGL() noexcept override;
 
-    ExternalImageHandle createExternalImage(void* cvPixelBuffer) noexcept;
+    ExternalImageHandle UTILS_PUBLIC createExternalImage(void* cvPixelBuffer) noexcept;
 
 protected:
     // --------------------------------------------------------------------------------------------

--- a/filament/backend/include/backend/platforms/PlatformCocoaTouchGL.h
+++ b/filament/backend/include/backend/platforms/PlatformCocoaTouchGL.h
@@ -32,7 +32,7 @@ public:
     PlatformCocoaTouchGL();
     ~PlatformCocoaTouchGL() noexcept override;
 
-    ExternalImageHandle createExternalImage(void* cvPixelBuffer) noexcept;
+    ExternalImageHandle UTILS_PUBLIC createExternalImage(void* cvPixelBuffer) noexcept;
 
     // --------------------------------------------------------------------------------------------
     // Platform Interface

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -50,7 +50,7 @@ public:
     /**
      * Creates an ExternalImage from a EGLImageKHR
      */
-    ExternalImageHandle createExternalImage(EGLImageKHR eglImage) noexcept;
+    ExternalImageHandle UTILS_PUBLIC createExternalImage(EGLImageKHR eglImage) noexcept;
 
 protected:
     // --------------------------------------------------------------------------------------------

--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -47,16 +47,16 @@ public:
     /**
      * Creates an ExternalImage from a EGLImageKHR
      */
-    ExternalImageHandle createExternalImage(AHardwareBuffer const* buffer, bool sRGB) noexcept;
+    ExternalImageHandle UTILS_PUBLIC createExternalImage(AHardwareBuffer const* buffer, bool sRGB) noexcept;
 
-    struct ExternalImageDescAndroid {
+    struct UTILS_PUBLIC ExternalImageDescAndroid {
         uint32_t width;      // Texture width
         uint32_t height;     // Texture height
         TextureFormat format;// Texture format
         TextureUsage usage;  // Texture usage flags
     };
 
-    ExternalImageDescAndroid getExternalImageDesc(ExternalImageHandle externalImage) noexcept;
+    ExternalImageDescAndroid UTILS_PUBLIC getExternalImageDesc(ExternalImageHandle externalImage) noexcept;
 
 protected:
     // --------------------------------------------------------------------------------------------

--- a/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
@@ -35,7 +35,7 @@ protected:
     ~ExternalImageVulkanAndroid() override;
 };
 
-Platform::ExternalImageHandle createExternalImage(AHardwareBuffer const* buffer,
+Platform::ExternalImageHandle UTILS_PUBLIC createExternalImage(AHardwareBuffer const* buffer,
         bool sRGB) noexcept;
 
 } // namespace filament::backend::fvkandroid

--- a/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
@@ -35,7 +35,7 @@ protected:
     ~ExternalImageVulkanAndroid() override;
 };
 
-Platform::ExternalImageHandle UTILS_PUBLIC createExternalImage(AHardwareBuffer const* buffer,
+Platform::ExternalImageHandle createExternalImage(AHardwareBuffer const* buffer,
         bool sRGB) noexcept;
 
 } // namespace filament::backend::fvkandroid


### PR DESCRIPTION
createExternalImagedepends on the user calling into this function directly - by adding UTILS_PUBLIC, we future proof setExternalImage functionality for clients who don't have innate awareness of Filament 