### PR TITLE
Make decl/def of createDriver api consistent

### DIFF
--- a/filament/backend/src/noop/PlatformNoop.cpp
+++ b/filament/backend/src/noop/PlatformNoop.cpp
@@ -20,7 +20,7 @@
 
 namespace filament::backend {
 
-Driver* PlatformNoop::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformNoop::createDriver(void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     return NoopDriver::create();
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -148,8 +148,8 @@ using namespace utils;
 namespace filament::backend {
 
 Driver* OpenGLDriverFactory::create(
-        OpenGLPlatform* const platform,
-        void* const sharedGLContext,
+        OpenGLPlatform* platform,
+        void* sharedGLContext,
         const Platform::DriverConfig& driverConfig) noexcept {
     return OpenGLDriver::create(platform, sharedGLContext, driverConfig);
 }
@@ -159,10 +159,10 @@ using namespace GLUtils;
 // ------------------------------------------------------------------------------------------------
 
 UTILS_NOINLINE
-OpenGLDriver* OpenGLDriver::create(OpenGLPlatform* const platform,
-        void* const /*sharedGLContext*/, const Platform::DriverConfig& driverConfig) noexcept {
+OpenGLDriver* OpenGLDriver::create(OpenGLPlatform* platform,
+        void* /*sharedGLContext*/, const Platform::DriverConfig& driverConfig) noexcept {
     assert_invariant(platform);
-    OpenGLPlatform* const ec = platform;
+    OpenGLPlatform* ec = platform;
 
 #if 0
     // this is useful for development, but too verbose even for debug builds
@@ -230,7 +230,7 @@ OpenGLDriver* OpenGLDriver::create(OpenGLPlatform* const platform,
     constexpr size_t defaultSize = FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
     Platform::DriverConfig validConfig{ driverConfig };
     validConfig.handleArenaSize = std::max(driverConfig.handleArenaSize, defaultSize);
-    OpenGLDriver* const driver = new(std::nothrow) OpenGLDriver(ec, validConfig);
+    OpenGLDriver* driver = new(std::nothrow) OpenGLDriver(ec, validConfig);
     return driver;
 }
 

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
@@ -64,7 +64,7 @@ PlatformCocoaTouchGL::~PlatformCocoaTouchGL() noexcept {
     delete pImpl;
 }
 
-Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformCocoaTouchGL::createDriver(void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     EAGLSharegroup* sharegroup = (__bridge EAGLSharegroup*) sharedGLContext;
 
     EAGLContext *context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3 sharegroup:sharegroup];

--- a/filament/backend/src/opengl/platforms/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformGLX.cpp
@@ -128,7 +128,7 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformGLX::createDriver(void* const sharedGLContext,
+Driver* PlatformGLX::createDriver(void* sharedGLContext,
         const DriverConfig& driverConfig) noexcept {
     loadLibraries();
     // Get the display device

--- a/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
@@ -112,7 +112,7 @@ private:
 
 }// anonymous namespace
 
-Driver* PlatformOSMesa::createDriver(void* const sharedGLContext,
+Driver* PlatformOSMesa::createDriver(void* sharedGLContext,
         const DriverConfig& driverConfig) noexcept {
 
     OSMesaAPI* api = new OSMesaAPI();

--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -75,7 +75,7 @@ struct WGLSwapChain {
 
 static PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribs = nullptr;
 
-Driver* PlatformWGL::createDriver(void* const sharedGLContext,
+Driver* PlatformWGL::createDriver(void* sharedGLContext,
         const Platform::DriverConfig& driverConfig) noexcept {
     int result = 0;
     int pixelFormat = 0;

--- a/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
@@ -20,7 +20,7 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformWebGL::createDriver(void* const sharedGLContext,
+Driver* PlatformWebGL::createDriver(void* sharedGLContext,
         const Platform::DriverConfig& driverConfig) noexcept {
     return OpenGLPlatform::createDefaultDriver(this, sharedGLContext, driverConfig);
 }

--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -143,7 +143,7 @@ wgpu::Device WebGPUPlatform::requestDevice(wgpu::Adapter const& adapter) {
     return device;
 }
 
-Driver* WebGPUPlatform::createDriver(void* const sharedContext,
+Driver* WebGPUPlatform::createDriver(void* sharedContext,
         const Platform::DriverConfig& /*driverConfig*/) noexcept {
     if (sharedContext) {
         FWGPU_LOGW << "sharedContext is ignored/unused in the WebGPU backend. A non-null "


### PR DESCRIPTION
Replace "void* const" with "void*" as const here serves no purpose because of following reasons:
  1. void* const in function parameter has a limited and local effect on the code.
  2. clang tidy would complain and report error if const is added to the function declaration.
  3. const is dropped later in the call stack making the code incosistent.