### PR TITLE
vk: split layout cache from descriptorSet cache

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -179,6 +179,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             include/backend/platforms/VulkanPlatform.h
             src/vulkan/VulkanDescriptorSetCache.cpp
             src/vulkan/VulkanDescriptorSetCache.h
+            src/vulkan/VulkanDescriptorSetLayoutCache.cpp
+            src/vulkan/VulkanDescriptorSetLayoutCache.h
             src/vulkan/VulkanPipelineLayoutCache.cpp
             src/vulkan/VulkanPipelineLayoutCache.h
             src/vulkan/memory/ResourceManager.cpp

--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -34,7 +34,7 @@
 
 namespace filament::backend {
 
-// Abstraction over the pool and the layout cache.
+// Abstraction over the descriptor set pool.
 class VulkanDescriptorSetCache {
 public:
     static constexpr uint8_t UNIQUE_DESCRIPTOR_SET_COUNT =
@@ -68,12 +68,9 @@ public:
     fvkmemory::resource_ptr<VulkanDescriptorSet> createSet(Handle<HwDescriptorSet> handle,
             fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
 
-    void initVkLayout(fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
-
     void clearHistory();
 
 private:
-    class DescriptorSetLayoutManager;
     class DescriptorInfinitePool;
 
     using DescriptorSetArray =
@@ -81,7 +78,6 @@ private:
 
     VkDevice mDevice;
     fvkmemory::ResourceManager* mResourceManager;
-    std::unique_ptr<DescriptorSetLayoutManager> mLayoutManager;
     std::unique_ptr<DescriptorInfinitePool> mDescriptorPool;
     std::pair<VulkanAttachment, VkDescriptorImageInfo> mInputAttachment;
     DescriptorSetArray mStashedSets = {};

--- a/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanDescriptorSetLayoutCache.h"
+
+#include "VulkanHandles.h"
+
+namespace filament::backend {
+
+namespace {
+
+using BitmaskGroup = VulkanDescriptorSetLayout::Bitmask;
+
+template<typename Bitmask>
+uint32_t appendBindings(VkDescriptorSetLayoutBinding* toBind, VkDescriptorType type,
+        Bitmask const& mask) {
+    uint32_t count = 0;
+    Bitmask alreadySeen;
+    mask.forEachSetBit([&](size_t index) {
+        VkShaderStageFlags stages = 0;
+        uint32_t binding = 0;
+        if (index < fvkutils::getFragmentStageShift<Bitmask>()) {
+            binding = (uint32_t) index;
+            stages |= VK_SHADER_STAGE_VERTEX_BIT;
+            auto fragIndex = index + fvkutils::getFragmentStageShift<Bitmask>();
+            if (mask.test(fragIndex)) {
+                stages |= VK_SHADER_STAGE_FRAGMENT_BIT;
+                alreadySeen.set(fragIndex);
+            }
+        } else if (!alreadySeen.test(index)) {
+            // We are in fragment stage bits
+            binding = (uint32_t) (index - fvkutils::getFragmentStageShift<Bitmask>());
+            stages |= VK_SHADER_STAGE_FRAGMENT_BIT;
+        }
+
+        if (stages) {
+            toBind[count++] = {
+                .binding = binding,
+                .descriptorType = type,
+                .descriptorCount = 1,
+                .stageFlags = stages,
+            };
+        }
+    });
+    return count;
+}
+
+} // anonymous namespace
+
+VulkanDescriptorSetLayoutCache::VulkanDescriptorSetLayoutCache(VkDevice device,
+        fvkmemory::ResourceManager* resourceManager)
+    : mDevice(device),
+      mResourceManager(resourceManager) {}
+
+VulkanDescriptorSetLayoutCache::~VulkanDescriptorSetLayoutCache() = default;
+
+void VulkanDescriptorSetLayoutCache::terminate() noexcept {
+    for (auto& itr: mVkLayouts) {
+        vkDestroyDescriptorSetLayout(mDevice, itr.second, VKALLOC);
+    }
+}
+
+fvkmemory::resource_ptr<VulkanDescriptorSetLayout> VulkanDescriptorSetLayoutCache::createLayout(
+        Handle<HwDescriptorSetLayout> handle, backend::DescriptorSetLayout&& info) {
+    auto layout = fvkmemory::resource_ptr<VulkanDescriptorSetLayout>::make(mResourceManager, handle,
+            info);
+    VkDescriptorSetLayout vklayout = VK_NULL_HANDLE;
+    auto const& bitmasks = layout->bitmask;
+    if (auto itr = mVkLayouts.find(bitmasks); itr != mVkLayouts.end()) {
+        vklayout = itr->second;
+    } else {
+        VkDescriptorSetLayoutBinding toBind[VulkanDescriptorSetLayout::MAX_BINDINGS];
+        uint32_t count = 0;
+        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+                bitmasks.dynamicUbo);
+        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, bitmasks.ubo);
+        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                bitmasks.sampler);
+        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
+                bitmasks.inputAttachment);
+
+        assert_invariant(count != 0 && "Need at least one binding for descriptor set layout.");
+        VkDescriptorSetLayoutCreateInfo dlinfo = {
+            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+            .pNext = nullptr,
+            .bindingCount = count,
+            .pBindings = toBind,
+        };
+
+        vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &vklayout);
+        mVkLayouts[bitmasks] = vklayout;
+    }
+    layout->setVkLayout(vklayout);
+    return layout;
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_CACHING_VULKANDESCRIPTORSETLAYOUTCACHE_H
+#define TNT_FILAMENT_BACKEND_CACHING_VULKANDESCRIPTORSETLAYOUTCACHE_H
+
+#include "VulkanHandles.h"
+
+#include "vulkan/memory/ResourcePointer.h"
+
+#include <backend/DriverEnums.h>
+#include <backend/Program.h>
+#include <backend/TargetBufferInfo.h>
+
+#include <utils/bitset.h>
+
+#include <bluevk/BlueVK.h>
+#include <tsl/robin_map.h>
+
+#include <memory>
+
+namespace filament::backend {
+
+class VulkanDescriptorSetLayoutCache {
+public:
+    VulkanDescriptorSetLayoutCache(VkDevice device, fvkmemory::ResourceManager* resourceManager);
+    ~VulkanDescriptorSetLayoutCache();
+
+    void terminate() noexcept;
+
+    fvkmemory::resource_ptr<VulkanDescriptorSetLayout> createLayout(
+            Handle<HwDescriptorSetLayout> handle, backend::DescriptorSetLayout&& info);
+
+private:
+    VkDevice mDevice;
+    fvkmemory::ResourceManager* mResourceManager;
+
+    using BitmaskGroup = VulkanDescriptorSetLayout::Bitmask;
+    using BitmaskGroupHashFn = utils::hash::MurmurHashFn<BitmaskGroup>;
+    struct BitmaskGroupEqual {
+        bool operator()(BitmaskGroup const& k1, BitmaskGroup const& k2) const { return k1 == k2; }
+    };
+
+    tsl::robin_map<BitmaskGroup, VkDescriptorSetLayout, BitmaskGroupHashFn, BitmaskGroupEqual>
+            mVkLayouts;
+};
+
+} // namespace filament::backend
+
+#endif// TNT_FILAMENT_BACKEND_CACHING_VULKANDESCRIPTORSETLAYOUTCACHE_H

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -28,6 +28,7 @@
 #include "VulkanStagePool.h"
 #include "VulkanQueryManager.h"
 #include "vulkan/VulkanDescriptorSetCache.h"
+#include "vulkan/VulkanDescriptorSetLayoutCache.h"
 #include "vulkan/VulkanPipelineLayoutCache.h"
 #include "vulkan/memory/ResourceManager.h"
 #include "vulkan/memory/ResourcePointer.h"
@@ -137,6 +138,7 @@ private:
     VulkanSamplerCache mSamplerCache;
     VulkanBlitter mBlitter;
     VulkanReadPixels mReadPixels;
+    VulkanDescriptorSetLayoutCache mDescriptorSetLayoutCache;
     VulkanDescriptorSetCache mDescriptorSetCache;
     VulkanQueryManager mQueryManager;
 


### PR DESCRIPTION
This is just splitting the layout cache into its own class and files.