### PR TITLE
Fix Vulkan protected memory support

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1057,7 +1057,7 @@ bool VulkanDriver::isDepthStencilBlitSupported(TextureFormat format) {
            formats.end();
 }
 
-bool VulkanDriver::isProtectedTexturesSupported() { return false; }
+bool VulkanDriver::isProtectedTexturesSupported() { return isProtectedContentSupported(); }
 
 bool VulkanDriver::isDepthClampSupported() {
     return mContext.isDepthClampSupported();

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -736,10 +736,6 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
     chainStruct(&context.mPhysicalDeviceFeatures, &queryProtectedMemoryFeatures);
     chainStruct(&context.mPhysicalDeviceProperties, &protectedMemoryProperties);
 
-    // We know we need to allocate the protected version of the VK objects
-    context.mProtectedMemorySupported =
-            static_cast<bool>(queryProtectedMemoryFeatures.protectedMemory);
-
     // Initialize the following fields: physicalDeviceProperties, memoryProperties,
     // physicalDeviceFeatures, graphicsQueueFamilyIndex.
     vkGetPhysicalDeviceProperties2(mImpl->mPhysicalDevice, &context.mPhysicalDeviceProperties);
@@ -758,6 +754,10 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
     if (mImpl->mGraphicsQueueIndex == INVALID_VK_INDEX) {
         mImpl->mGraphicsQueueIndex = 0;
     }
+
+    // We know we need to allocate the protected version of the VK objects
+    context.mProtectedMemorySupported =
+            static_cast<bool>(queryProtectedMemoryFeatures.protectedMemory);
 
     if (context.mProtectedMemorySupported) {
         mImpl->mProtectedGraphicsQueueFamilyIndex = identifyGraphicsQueueFamilyIndex(


### PR DESCRIPTION
Set the support for isProtectedTexturesSupported depending if the context supports protected content or not.

- This will allow creating protected textures and importing protected external images in Vulkan.
- Fix checking if the protected feature is supported on the host after retrieving the results from querying the Physical Device otherwise it will always be false.
