### PR TITLE
Fix test breaking changes with workarounds

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -256,16 +256,18 @@ struct DescriptorSetLayoutBinding {
     DescriptorFlags flags = DescriptorFlags::NONE;
     uint16_t count = 0;
 
-    uint8_t externalSamplerDataIndex = EXTERNAL_SAMPLER_DATA_INDEX_UNUSED;
+    //  TODO: uncomment when needed.  Note that this class is used as hash key.  We need to ensure
+    //  no uninitialized padding bytes.
+    //    uint8_t externalSamplerDataIndex = EXTERNAL_SAMPLER_DATA_INDEX_UNUSED;
 
-    friend inline bool operator==(
-            DescriptorSetLayoutBinding const& lhs,
+    friend inline bool operator==(DescriptorSetLayoutBinding const& lhs,
             DescriptorSetLayoutBinding const& rhs) noexcept {
         return lhs.type == rhs.type &&
                lhs.flags == rhs.flags &&
                lhs.count == rhs.count &&
-               lhs.stageFlags == rhs.stageFlags &&
-               lhs.externalSamplerDataIndex == rhs.externalSamplerDataIndex;
+               lhs.stageFlags == rhs.stageFlags;
+//               lhs.stageFlags == rhs.stageFlags &&
+//               lhs.externalSamplerDataIndex == rhs.externalSamplerDataIndex;
     }
 };
 
@@ -1138,7 +1140,9 @@ static_assert(sizeof(ExternalSamplerDatum) == 12);
 
 struct DescriptorSetLayout {
     utils::FixedCapacityVector<DescriptorSetLayoutBinding> bindings;
-    utils::FixedCapacityVector<ExternalSamplerDatum> externalSamplerData;
+
+//  TODO: uncomment when needed
+//    utils::FixedCapacityVector<ExternalSamplerDatum> externalSamplerData;
 };
 
 //! blending equation function

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -241,7 +241,7 @@ size_t NoopDriver::getMaxUniformBufferSize() {
 }
 
 size_t NoopDriver::getMaxTextureSize(SamplerType target) {
-    return 2048u;
+    return 4096u;
 }
 
 size_t NoopDriver::getMaxArrayTextureLayers() {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1146,7 +1146,7 @@ size_t VulkanDriver::getMaxUniformBufferSize() {
 
 size_t VulkanDriver::getMaxTextureSize(SamplerType) {
     // TODO: return the actual size instead of hardcoded value
-    return 2048;
+    return 4096;
 }
 
 size_t VulkanDriver::getMaxArrayTextureLayers() {


### PR DESCRIPTION
- Some tests require textures larger than 2048. Change the minimum to 4096 for now, and file proper bugs for tests.
- The introduction of uint8_t to DescriptorSetLayoutBinding caused unintended padding with using this struct as a hash key. We comment out the relevent code for now.