### PR TITLE
Fix INVALID_OPERATION error for WebGL

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -570,22 +570,13 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
             bugs->disable_invalidate_framebuffer = true;
         }
 
-        if (strstr(vendor, "Mesa") ||
-            strstr(vendor, "Mozilla")) {
+        if (strstr(vendor, "Mesa")) {
             // Seen on
             //  [Mesa],
             //  [llvmpipe (LLVM 17.0.6, 256 bits)],
             //  [4.5 (Core Profile) Mesa 24.0.6-1],
             //  [4.50]
-            // or
-            //  [Mozilla],
-            //  [GeForce GTX 980, or similar],
-            //  [OpenGL ES 3.0 (WebGL 2.0)],
-            //  [OpenGL ES GLSL ES 3.00 (WebGL GLSL ES 3.00)]
-            // not known which version are affected.
-            // For Mozilla, the issue seems to be observed regardless of which
-            // renderer it comes with.
-
+            // not known which version are affected
             bugs->rebind_buffer_after_deletion = true;
         }
     } else {
@@ -596,6 +587,19 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
             // (that should be regardless of ANGLE, but we should double-check)
             bugs->split_easu = true;
         }
+    }
+
+    if (strstr(vendor, "Mozilla")) {
+        // Seen on
+        //  [Mozilla],
+        //  [GeForce GTX 980, or similar]
+        //    or [ANGLE (NVIDIA, NVIDIA GeForce GTX 980 Direct3D11 vs_5_0 ps_5_0), or similar]
+        //    or anything else,
+        //  [OpenGL ES 3.0 (WebGL 2.0)],
+        //  [OpenGL ES GLSL ES 3.00 (WebGL GLSL ES 3.00)]
+        // For Mozilla, the issue appears to be observed regardless of whether the renderer is
+        // ANGLE or not. (b/376125497)
+        bugs->rebind_buffer_after_deletion = true;
     }
 
 #ifdef BACKEND_OPENGL_VERSION_GLES

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -566,16 +566,27 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
         } else if (strstr(renderer, "AMD") ||
                    strstr(renderer, "ATI")) {
             // AMD/ATI GPU
-        } else if (strstr(vendor, "Mesa")) {
+        } else if (strstr(renderer, "Mozilla")) {
+            bugs->disable_invalidate_framebuffer = true;
+        }
+
+        if (strstr(vendor, "Mesa") ||
+            strstr(vendor, "Mozilla")) {
             // Seen on
             //  [Mesa],
             //  [llvmpipe (LLVM 17.0.6, 256 bits)],
             //  [4.5 (Core Profile) Mesa 24.0.6-1],
             //  [4.50]
-            // not known which version are affected
+            // or
+            //  [Mozilla],
+            //  [GeForce GTX 980, or similar],
+            //  [OpenGL ES 3.0 (WebGL 2.0)],
+            //  [OpenGL ES GLSL ES 3.00 (WebGL GLSL ES 3.00)]
+            // not known which version are affected.
+            // For Mozilla, the issue seems to be observed regardless of which
+            // renderer it comes with.
+
             bugs->rebind_buffer_after_deletion = true;
-        } else if (strstr(renderer, "Mozilla")) {
-            bugs->disable_invalidate_framebuffer = true;
         }
     } else {
         // When running under ANGLE, it's a different set of workaround that we need.

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -320,8 +320,8 @@ public:
         // a glFinish. So we must delay the destruction until we know the GPU is finished.
         bool delay_fbo_destruction;
 
-        // Mesa sometimes clears the generic buffer binding when *another* buffer is destroyed,
-        // if that other buffer is bound on an *indexed* buffer binding.
+        // Mesa and Mozilla(web) sometimes clear the generic buffer binding when *another* buffer
+        // is destroyed, if that other buffer is bound on an *indexed* buffer binding.
         bool rebind_buffer_after_deletion;
 
         // Force feature level 0. Typically used for low end ES3 devices with significant driver


### PR DESCRIPTION
Mozilla sometimes clears the generic buffer binding when another buffer is destroyed, if that other buffer is bound on an indexed buffer binding.

The fix makes sure the generic buffer binding is unbound from the context when being destroyed.

BUGS=[376125497]