### PR TITLE
Upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -40,7 +40,7 @@ jobs:
 
   build-android:
     name: build-android
-    runs-on: ubuntu-22.04-16core
+    runs-on: 'ubuntu-24.04-6core'
 
     steps:
       - uses: actions/checkout@v4.1.6
@@ -69,7 +69,7 @@ jobs:
 
   build-web:
     name: build-web
-    runs-on: ubuntu-22.04-16core
+    runs-on: 'ubuntu-24.04-6core'
 
     steps:
       - uses: actions/checkout@v4.1.6
@@ -79,7 +79,7 @@ jobs:
 
   validate-docs:
     name: validate-docs
-    runs-on: ubuntu-22.04-4core
+    runs-on: 'ubuntu-24.04-4core'
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -114,7 +114,7 @@ jobs:
 
   validate-wgsl-webgpu:
     name: validate-wgsl-webgpu
-    runs-on: ubuntu-22.04-8core
+    runs-on: 'ubuntu-24.04-8core'
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -40,7 +40,7 @@ jobs:
 
   build-android:
     name: build-android
-    runs-on: 'ubuntu-24.04-6core'
+    runs-on: 'ubuntu-24.04-16core'
 
     steps:
       - uses: actions/checkout@v4.1.6
@@ -69,7 +69,7 @@ jobs:
 
   build-web:
     name: build-web
-    runs-on: 'ubuntu-24.04-6core'
+    runs-on: 'ubuntu-24.04-16core'
 
     steps:
       - uses: actions/checkout@v4.1.6


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

This is a courtesy PR to help you upgrade to the latest release of ubuntu runners, it is not mandatory at this time.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it.

More context and feedback: http://b/406537467
