### PR TITLE
Upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

### DIFF
--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -12,7 +12,7 @@ jobs:
     name: build-android
     # We intentially use a larger runner here to enable larger disk space
     # (standard linux runner will fail on disk space and faster build time).
-    runs-on: 'ubuntu-24.04-2core'
+    runs-on: 'ubuntu-24.04-32core'
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -12,7 +12,7 @@ jobs:
     name: build-android
     # We intentially use a larger runner here to enable larger disk space
     # (standard linux runner will fail on disk space and faster build time).
-    runs-on: ubuntu-22.04-32core
+    runs-on: 'ubuntu-24.04-2core'
 
     steps:
       - uses: actions/checkout@v4.1.6


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

This is a courtesy PR to help you upgrade to the latest release of ubuntu runners, it is not mandatory at this time.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it.

More context and feedback: http://b/406537467
