### PR TITLE
Upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

### DIFF
--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-linux:
     name: build-linux
-    runs-on: ubuntu-22.04-16core
+    runs-on: 'ubuntu-24.04-16core'
 
     steps:
       - uses: actions/checkout@v4.1.6


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

This is a courtesy PR to help you upgrade to the latest release of ubuntu runners, it is not mandatory at this time.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it.

More context and feedback: http://b/406537467
