### PR TITLE
fix MSAA custom resolve

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2341,6 +2341,9 @@ void PostProcessManager::customResolvePrepareSubpass(DriverApi& driver, CustomRe
 }
 
 void PostProcessManager::customResolveSubpass(DriverApi& driver) noexcept {
+
+    bindPostProcessDescriptorSet(driver);
+
     FEngine const& engine = mEngine;
     Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine.getFullScreenRenderPrimitive();
     auto const& material = getPostProcessMaterial("customResolveAsSubpass");


### PR DESCRIPTION
we were not binding the proper descriptor set. on gl this is only an assert, on vulkan it would be a problem if we supported subpasses, on metal there is no assert.