### PR TITLE
vk: add YcbcrConversion to VulkanTexture

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -56,9 +56,9 @@ VkImageView VulkanAttachment::getImageView() {
     assert_invariant(texture);
     VkImageSubresourceRange range = getSubresourceRange();
     if (range.layerCount > 1) {
-        return texture->getMultiviewAttachmentView(range);
+        return texture->getAttachmentView(range, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
     }
-    return texture->getAttachmentView(range);
+    return texture->getAttachmentView(range, VK_IMAGE_VIEW_TYPE_2D);
 }
 
 bool VulkanAttachment::isDepth() const {
@@ -68,11 +68,11 @@ bool VulkanAttachment::isDepth() const {
 VkImageSubresourceRange VulkanAttachment::getSubresourceRange() const {
     assert_invariant(texture);
     return {
-            .aspectMask = texture->getImageAspect(),
-            .baseMipLevel = uint32_t(level),
-            .levelCount = 1,
-            .baseArrayLayer = uint32_t(layer),
-            .layerCount = layerCount,
+        .aspectMask = texture->getImageAspect(),
+        .baseMipLevel = uint32_t(level),
+        .levelCount = 1,
+        .baseArrayLayer = uint32_t(layer),
+        .layerCount = layerCount,
     };
 }
 

--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -68,7 +68,7 @@ public:
     fvkmemory::resource_ptr<VulkanDescriptorSet> createSet(Handle<HwDescriptorSet> handle,
             fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
 
-    void clearHistory();
+    void gc();
 
 private:
     class DescriptorInfinitePool;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -366,7 +366,7 @@ void VulkanDriver::collectGarbage() {
     FVK_SYSTRACE_SCOPE();
     // Command buffers need to be submitted and completed before other resources can be gc'd.
     mCommands.gc();
-    mDescriptorSetCache.clearHistory();
+    mDescriptorSetCache.gc();
     mStagePool.gc();
     mFramebufferCache.gc();
     mPipelineCache.gc();
@@ -594,10 +594,10 @@ void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::S
     std::tie(vkimg, deviceMemory) =
             mPlatform->createExternalImageData(externalImage, metadata, memoryTypeIndex, vkUsage);
 
-    auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mPlatform->getDevice(),
-            mAllocator, &mResourceManager, &mCommands, vkimg, deviceMemory, metadata.format,
-            metadata.samples, metadata.width, metadata.height, metadata.layerCount, usage,
-            mStagePool);
+    auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mContext,
+            mPlatform->getDevice(), mAllocator, &mResourceManager, &mCommands, vkimg, deviceMemory,
+            metadata.format, VK_NULL_HANDLE, metadata.samples, metadata.width, metadata.height,
+            metadata.layerCount, usage, mStagePool);
 
     texture.inc();
 }

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -32,6 +32,7 @@ VulkanSwapChain::VulkanSwapChain(VulkanPlatform* platform, VulkanContext const& 
         VulkanCommands* commands, VulkanStagePool& stagePool, void* nativeWindow, uint64_t flags,
         VkExtent2D extent)
     : mPlatform(platform),
+      mContext(context),
       mResourceManager(resourceManager),
       mCommands(commands),
       mAllocator(allocator),
@@ -77,16 +78,16 @@ void VulkanSwapChain::update() {
     }
     for (auto const color: bundle.colors) {
         auto colorTexture = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager,
-                device, mAllocator, mResourceManager, mCommands, color, VK_NULL_HANDLE,
-                bundle.colorFormat, 1, bundle.extent.width, bundle.extent.height, bundle.layerCount, colorUsage,
-                mStagePool);
+                mContext, device, mAllocator, mResourceManager, mCommands, color, VK_NULL_HANDLE,
+                bundle.colorFormat, VK_NULL_HANDLE /*ycrcb */, 1, bundle.extent.width,
+                bundle.extent.height, bundle.layerCount, colorUsage, mStagePool);
         mColors.push_back(colorTexture);
     }
 
-    mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, device,
-        mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
-        bundle.depthFormat, 1, bundle.extent.width, bundle.extent.height, bundle.layerCount, depthUsage,
-        mStagePool);
+    mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, mContext, device,
+            mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
+            bundle.depthFormat, VK_NULL_HANDLE /*ycrcb */, 1, bundle.extent.width,
+            bundle.extent.height, bundle.layerCount, depthUsage, mStagePool);
 
     mExtent = bundle.extent;
     mLayerCount = bundle.layerCount;

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -83,6 +83,7 @@ private:
     void update();
 
     VulkanPlatform* mPlatform;
+    VulkanContext const& mContext;
     fvkmemory::ResourceManager* mResourceManager;
     VulkanCommands* mCommands;
     VmaAllocator mAllocator;

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -55,7 +55,6 @@ VkComponentMapping composeSwizzle(VkComponentMapping const& prev, VkComponentMap
         VK_COMPONENT_SWIZZLE_B,
         VK_COMPONENT_SWIZZLE_A,
     };
-
     auto const compose = [](VkComponentMapping const& prev,
                                  VkComponentMapping const& next) -> VkComponentMapping {
         VkComponentSwizzle vals[4] = { next.r, next.g, next.b, next.a };
@@ -152,35 +151,152 @@ uint8_t getLayerCountFromDepth(uint32_t const depth) {
     return getLayerCount(getSamplerTypeFromDepth(depth), depth);
 }
 
+VkImageUsageFlags getUsage(VulkanContext const& context, uint8_t samples,
+        VkPhysicalDevice physicalDevice, VkFormat vkFormat, TextureUsage tusage) {
+    VkImageUsageFlags usage = {};
+    if (any(tusage & TextureUsage::BLIT_SRC)) {
+        usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    }
+    if (any(tusage & TextureUsage::BLIT_DST)) {
+        usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    }
+
+    // Determine if we can use the transient usage flag combined with lazily allocated memory.
+    const bool useTransientAttachment =
+            // Lazily allocated memory is available.
+            context.isLazilyAllocatedMemorySupported() &&
+            // Usage consists of attachment flags only.
+            none(tusage & ~TextureUsage::ALL_ATTACHMENTS) &&
+            // Usage contains at least one attachment flag.
+            any(tusage & TextureUsage::ALL_ATTACHMENTS) &&
+            // Depth resolve cannot use transient attachment because it uses a custom shader.
+            // TODO: see VulkanDriver::isDepthStencilResolveSupported() to know when to remove this
+            // restriction.
+            // Note that the custom shader does not resolve stencil. We do need to move to vk 1.2
+            // and above to be able to support stencil resolve (along with depth).
+            !(any(tusage & TextureUsage::DEPTH_ATTACHMENT) && samples > 1);
+
+    const VkImageUsageFlags transientFlag =
+       useTransientAttachment ? VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT : 0U;
+
+    if (any(tusage & TextureUsage::SAMPLEABLE)) {
+
+#if FVK_ENABLED(FVK_DEBUG_TEXTURE)
+        if (physicalDevice != VK_NULL_HANDLE) {
+            // Validate that the format is actually sampleable.
+            VkFormatProperties props;
+            vkGetPhysicalDeviceFormatProperties(physicalDevice, vkFormat, &props);
+            if (!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+                FVK_LOGW << "Texture usage is SAMPLEABLE but format " << mState->mVkFormat << " is not "
+                        "sampleable with optimal tiling." << utils::io::endl;
+            }
+        }
+#endif
+
+        usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+    }
+    if (any(tusage & TextureUsage::COLOR_ATTACHMENT)) {
+        usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | transientFlag;
+        if (any(tusage & TextureUsage::SUBPASS_INPUT)) {
+            usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+        }
+    }
+    if (any(tusage & TextureUsage::STENCIL_ATTACHMENT)) {
+        usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | transientFlag;
+    }
+    if (any(tusage & TextureUsage::UPLOADABLE)) {
+        usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    }
+    if (any(tusage & TextureUsage::DEPTH_ATTACHMENT)) {
+        usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | transientFlag;
+
+        // Depth resolves uses a custom shader and therefore needs to be sampleable.
+        if (samples > 1) {
+            usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+        }
+    }
+    return usage;
+}
+
 } // anonymous namespace
 
-VulkanTextureState::VulkanTextureState(VkDevice device, VmaAllocator allocator,
-        VulkanCommands* commands, VulkanStagePool& stagePool, VkFormat format,
-        VkImageViewType viewType, uint8_t levels, uint8_t layerCount, VulkanLayout defaultLayout,
+VulkanTextureState::VulkanTextureState(VulkanStagePool& stagePool, VulkanCommands* commands,
+        VmaAllocator allocator, VkDevice device, VkImage image, VkDeviceMemory deviceMemory,
+        VkFormat format, VkImageViewType viewType, uint8_t levels, uint8_t layerCount,
+        VkSamplerYcbcrConversion ycbcrConversion, bool isExternalFormat, VkImageUsageFlags usage,
         bool isProtected)
-    : mVkFormat(format),
-      mViewType(viewType),
-      mFullViewRange{fvkutils::getImageAspect(format), 0, levels, 0, layerCount},
-      mDefaultLayout(defaultLayout),
-      mIsProtected(isProtected),
-      mStagePool(stagePool),
-      mDevice(device),
-      mAllocator(allocator),
+    : mStagePool(stagePool),
       mCommands(commands),
-      mIsTransientAttachment(false) {}
+      mAllocator(allocator),
+      mDevice(device),
+      mTextureImage(image),
+      mTextureImageMemory(deviceMemory),
+      mVkFormat(format),
+      mViewType(viewType),
+      mFullViewRange{ fvkutils::getImageAspect(format), 0, levels, 0, layerCount },
+      mYcbcr{ ycbcrConversion, isExternalFormat },
+      mDefaultLayout(getDefaultLayoutImpl(usage)),
+      mUsage(usage),
+      mIsProtected(isProtected) {}
 
-// Constructor for internally passed VkImage
-VulkanTexture::VulkanTexture(VkDevice device, VmaAllocator allocator,
+VulkanTextureState::~VulkanTextureState() {
+    if (mTextureImageMemory != VK_NULL_HANDLE) {
+        vkDestroyImage(mDevice, mTextureImage, VKALLOC);
+        vkFreeMemory(mDevice, mTextureImageMemory, VKALLOC);
+    }
+    clearCachedImageViews();
+}
+
+void VulkanTextureState::clearCachedImageViews() noexcept {
+    for (auto entry: mCachedImageViews) {
+        vkDestroyImageView(mDevice, entry.second, VKALLOC);
+    }
+    mCachedImageViews.clear();
+}
+
+VkImageView VulkanTextureState::getImageView(VkImageSubresourceRange range, VkImageViewType viewType,
+        VkComponentMapping swizzle) {
+    ImageViewKey const key{ range, viewType, swizzle };
+    if (auto iter = mCachedImageViews.find(key); iter != mCachedImageViews.end()) {
+        return iter->second;
+    }
+
+    VkSamplerYcbcrConversionInfo conversionInfo = {
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+        .conversion = mYcbcr.conversion,
+    };
+
+    VkImageViewCreateInfo viewInfo = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = mYcbcr.conversion != VK_NULL_HANDLE ? &conversionInfo : nullptr,
+        .flags = 0,
+        .image = mTextureImage,
+        .viewType = viewType,
+        .format = mYcbcr.isExternalFormat ? VK_FORMAT_UNDEFINED : mVkFormat,
+        .components = swizzle,
+        .subresourceRange = range,
+    };
+    VkImageView imageView;
+    vkCreateImageView(mDevice, &viewInfo, VKALLOC, &imageView);
+    mCachedImageViews.emplace(key, imageView);
+    return imageView;
+}
+
+// Constructor for internally passed VkImage - including swapchain images and external images.
+VulkanTexture::VulkanTexture(VulkanContext const& context, VkDevice device, VmaAllocator allocator,
         fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
-        VkDeviceMemory memory, VkFormat format, uint8_t samples, uint32_t width,
-        uint32_t height, uint32_t depth, TextureUsage tusage, VulkanStagePool& stagePool)
-    : HwTexture(getSamplerTypeFromDepth(depth), 1, samples, width, height, depth, TextureFormat::UNUSED,
-              tusage),
-      mState(fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, device,
-              allocator, commands, stagePool, format, fvkutils::getViewType(SamplerType::SAMPLER_2D),
-              /*mipLevels=*/1, getLayerCountFromDepth(depth), getDefaultLayoutImpl(tusage), any(usage & TextureUsage::PROTECTED))) {
-    mState->mTextureImage = image;
-    mState->mTextureImageMemory = memory;
+        VkDeviceMemory memory, VkFormat format, VkSamplerYcbcrConversion conversion,
+        uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage tusage,
+        VulkanStagePool& stagePool)
+    : HwTexture(getSamplerTypeFromDepth(depth), 1, samples, width, height, depth,
+              TextureFormat::UNUSED, tusage),
+      mState(fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, stagePool,
+              commands, allocator, device, image, memory, format,
+              fvkutils::getViewType(SamplerType::SAMPLER_2D),
+              /*mipLevels=*/1, getLayerCountFromDepth(depth), conversion,
+              /*isExternalFormat=*/false,
+              getUsage(context, samples, VK_NULL_HANDLE, format, tusage),
+              any(usage & TextureUsage::PROTECTED))) {
     mPrimaryViewRange = mState->mFullViewRange;
 }
 
@@ -190,21 +306,19 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, SamplerType target,
         uint8_t levels, TextureFormat tformat, uint8_t samples, uint32_t w, uint32_t h,
         uint32_t depth, TextureUsage tusage, VulkanStagePool& stagePool)
-    : HwTexture(target, levels, samples, w, h, depth, tformat, tusage),
-      mState(fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, device,
-              allocator, commands, stagePool, fvkutils::getVkFormat(tformat),
-              fvkutils::getViewType(target), levels, getLayerCount(target, depth),
-              VulkanLayout::UNDEFINED, any(usage & TextureUsage::PROTECTED))) {
+     : HwTexture(target, levels, samples, w, h, depth, tformat, tusage) {
     // Create an appropriately-sized device-only VkImage, but do not fill it yet.
+    VkFormat const vkFormat = fvkutils::getVkFormat(tformat);
+    bool const isProtected = any(tusage & TextureUsage::PROTECTED);
     VkImageCreateInfo imageInfo{
         .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
         .imageType = target == SamplerType::SAMPLER_3D ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D,
-        .format = mState->mVkFormat,
+        .format = vkFormat,
         .extent = {w, h, depth},
         .mipLevels = levels,
         .arrayLayers = 1,
         .tiling = VK_IMAGE_TILING_OPTIMAL,
-        .usage = 0,
+        .usage = getUsage(context, samples, physicalDevice, vkFormat, tusage),
     };
     if (target == SamplerType::SAMPLER_3D && any(tusage & TextureUsage::ALL_ATTACHMENTS)) {
         if (context.isImageView2DOn3DImageSupported()) {
@@ -234,79 +348,17 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         imageInfo.arrayLayers = depth * 6;
         imageInfo.extent.depth = 1;
     }
-    if (any(usage & TextureUsage::PROTECTED)) {
+    if (isProtected) {
         imageInfo.flags |= VK_IMAGE_CREATE_PROTECTED_BIT;
-    }
-
-    if (any(usage & TextureUsage::BLIT_SRC)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    }
-    if (any(usage & TextureUsage::BLIT_DST)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    }
-
-    // Determine if we can use the transient usage flag combined with lazily allocated memory.
-    const bool useTransientAttachment =
-            // Lazily allocated memory is available.
-            context.isLazilyAllocatedMemorySupported() &&
-            // Usage consists of attachment flags only.
-            none(tusage & ~TextureUsage::ALL_ATTACHMENTS) &&
-            // Usage contains at least one attachment flag.
-            any(tusage & TextureUsage::ALL_ATTACHMENTS) &&
-            // Depth resolve cannot use transient attachment because it uses a custom shader.
-            // TODO: see VulkanDriver::isDepthStencilResolveSupported() to know when to remove this
-            // restriction.
-            // Note that the custom shader does not resolve stencil. We do need to move to vk 1.2
-            // and above to be able to support stencil resolve (along with depth).
-            !(any(usage & TextureUsage::DEPTH_ATTACHMENT) && samples > 1);
-
-    mState->mIsTransientAttachment = useTransientAttachment;
-
-    const VkImageUsageFlags transientFlag =
-       useTransientAttachment ? VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT : 0U;
-
-    if (any(usage & TextureUsage::SAMPLEABLE)) {
-
-#if FVK_ENABLED(FVK_DEBUG_TEXTURE)
-        // Validate that the format is actually sampleable.
-        VkFormatProperties props;
-        vkGetPhysicalDeviceFormatProperties(physicalDevice, mState->mVkFormat, &props);
-        if (!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
-            FVK_LOGW << "Texture usage is SAMPLEABLE but format " << mState->mVkFormat << " is not "
-                    "sampleable with optimal tiling." << utils::io::endl;
-        }
-#endif
-
-        imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
-    }
-    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | transientFlag;
-        if (any(usage & TextureUsage::SUBPASS_INPUT)) {
-            imageInfo.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
-        }
-    }
-    if (any(usage & TextureUsage::STENCIL_ATTACHMENT)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | transientFlag;
-    }
-    if (any(usage & TextureUsage::UPLOADABLE)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    }
-    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
-        imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | transientFlag;
-
-        // Depth resolves uses a custom shader and therefore needs to be sampleable.
-        if (samples > 1) {
-            imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
-        }
     }
 
     // Constrain the sample count according to the sample count masks in VkPhysicalDeviceProperties.
     // Note that VulkanRenderTarget holds a single MSAA count, so we play it safe if this is used as
     // any kind of attachment (color or depth).
-    const auto& limits = context.getPhysicalDeviceLimits();
+    auto const& limits = context.getPhysicalDeviceLimits();
     if (imageInfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) {
         samples = fvkutils::reduceSampleCount(samples,
-                fvkutils::isVkDepthFormat(mState->mVkFormat)
+                fvkutils::isVkDepthFormat(vkFormat)
                         ? limits.sampledImageDepthSampleCounts
                         : limits.sampledImageColorSampleCounts);
     }
@@ -320,33 +372,36 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
     this->samples = samples;
     imageInfo.samples = (VkSampleCountFlagBits) samples;
 
-    VkResult result = vkCreateImage(mState->mDevice, &imageInfo, VKALLOC, &mState->mTextureImage);
+    VkImage textureImage;
+    VkResult result = vkCreateImage(device, &imageInfo, VKALLOC, &textureImage);
     if (result != VK_SUCCESS || FVK_ENABLED(FVK_DEBUG_TEXTURE)) {
         FVK_LOGD << "vkCreateImage: "
-            << "image = " << mState->mTextureImage << ", "
+            << "image = " << textureImage << ", "
             << "result = " << result << ", "
-            << "handle = " << utils::io::hex << mState->mTextureImage << utils::io::dec << ", "
+            << "handle = " << utils::io::hex << textureImage << utils::io::dec << ", "
             << "extent = " << w << "x" << h << "x"<< depth << ", "
             << "mipLevels = " << int(levels) << ", "
-            << "TextureUsage = " << static_cast<int>(usage) << ", "
+            << "TextureUsage = " << static_cast<int>(tusage) << ", "
             << "usage = " << imageInfo.usage << ", "
             << "samples = " << imageInfo.samples << ", "
             << "type = " << imageInfo.imageType << ", "
             << "flags = " << imageInfo.flags << ", "
             << "target = " << static_cast<int>(target) <<", "
-            << "format = " << mState->mVkFormat << utils::io::endl;
+            << "format = " << vkFormat << utils::io::endl;
     }
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Unable to create image."
                                                        << " error=" << static_cast<int32_t>(result);
 
     // Allocate memory for the VkImage and bind it.
-    VkMemoryRequirements memReqs = {};
-    vkGetImageMemoryRequirements(mState->mDevice, mState->mTextureImage, &memReqs);
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(device, textureImage, &memReqs);
 
-    const VkFlags requiredMemoryFlags =
+    bool const useTransientAttachment = imageInfo.usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+
+    VkFlags const requiredMemoryFlags =
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
         (useTransientAttachment ? VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT : 0U) |
-        (mState->mIsProtected ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0U);
+        (isProtected ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0U);
     uint32_t memoryTypeIndex
             = context.selectMemoryType(memReqs.memoryTypeBits, requiredMemoryFlags);
 
@@ -358,21 +413,22 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         .allocationSize = memReqs.size,
         .memoryTypeIndex = memoryTypeIndex,
     };
-    result = vkAllocateMemory(mState->mDevice, &allocInfo, nullptr, &mState->mTextureImageMemory);
+    VkDeviceMemory textureImageMemory;
+    result = vkAllocateMemory(device, &allocInfo, nullptr, &textureImageMemory);
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Unable to allocate image memory."
                                                        << " error=" << static_cast<int32_t>(result);
-    result = vkBindImageMemory(mState->mDevice, mState->mTextureImage, mState->mTextureImageMemory,
-            0);
+    result = vkBindImageMemory(device, textureImage, textureImageMemory, 0);
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Unable to bind image."
                                                        << " error=" << static_cast<int32_t>(result);
 
+    mState = fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, stagePool,
+            commands, allocator, device, textureImage, textureImageMemory, vkFormat,
+            fvkutils::getViewType(target), levels, getLayerCount(target, depth),
+            VK_NULL_HANDLE /* ycbcrConversion */, false /*isExternalFormat*/, imageInfo.usage,
+            isProtected);
+
     // Spec out the "primary" VkImageView that shaders use to sample from the image.
     mPrimaryViewRange = mState->mFullViewRange;
-
-    // Go ahead and create the primary image view.
-    getImageView(mPrimaryViewRange, mState->mViewType, mSwizzle);
-
-    mState->mDefaultLayout = getDefaultLayoutImpl(imageInfo.usage);
 }
 
 // Constructor for creating a texture view
@@ -381,8 +437,8 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         fvkmemory::resource_ptr<VulkanTexture> src, uint8_t baseLevel,
         uint8_t levelCount)
     : HwTexture(src->target, src->levels, src->samples, src->width, src->height, src->depth,
-            src->format, src->usage) {
-    mState = src->mState;
+            src->format, src->usage),
+      mState(src->mState) {
     mPrimaryViewRange = src->mPrimaryViewRange;
     mPrimaryViewRange.baseMipLevel = src->mPrimaryViewRange.baseMipLevel + baseLevel;
     mPrimaryViewRange.levelCount = levelCount;
@@ -393,21 +449,10 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         VulkanContext const& context, VmaAllocator allocator, VulkanCommands* commands,
         fvkmemory::resource_ptr<VulkanTexture> src, VkComponentMapping swizzle)
     : HwTexture(src->target, src->levels, src->samples, src->width, src->height, src->depth,
-              src->format, src->usage) {
-    mState = src->mState;
-    mPrimaryViewRange = src->mPrimaryViewRange;
-    mSwizzle = composeSwizzle(src->mSwizzle, swizzle);
-}
-
-VulkanTextureState::~VulkanTextureState() {
-    if (mTextureImageMemory != VK_NULL_HANDLE) {
-        vkDestroyImage(mDevice, mTextureImage, VKALLOC);
-        vkFreeMemory(mDevice, mTextureImageMemory, VKALLOC);
-    }
-    for (auto entry: mCachedImageViews) {
-        vkDestroyImageView(mDevice, entry.second, VKALLOC);
-    }
-}
+              src->format, src->usage),
+      mState(src->mState),
+      mPrimaryViewRange(src->mPrimaryViewRange),
+      mSwizzle(composeSwizzle(src->mSwizzle, swizzle)) {}
 
 void VulkanTexture::updateImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
         uint32_t depth, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset, uint32_t miplevel) {
@@ -514,20 +559,20 @@ void VulkanTexture::updateImageWithBlit(const PixelBufferDescriptor& hostData, u
     commands.acquire(fvkmemory::resource_ptr<VulkanTexture>::cast(this));
 
     // TODO: support blit-based format conversion for 3D images and cubemaps.
-    const int layer = 0;
+    constexpr int layer = 0;
 
-    const VkOffset3D rect[2] { {0, 0, 0}, {int32_t(width), int32_t(height), 1} };
+    VkOffset3D const rect[2] { {0, 0, 0}, {int32_t(width), int32_t(height), 1} };
 
-    const VkImageAspectFlags aspect = getImageAspect();
+    VkImageAspectFlags const aspect = getImageAspect();
 
-    const VkImageBlit blitRegions[1] = {{
+    VkImageBlit const blitRegions[1] = {{
         .srcSubresource = { aspect, 0, 0, 1 },
         .srcOffsets = { rect[0], rect[1] },
         .dstSubresource = { aspect, uint32_t(miplevel), layer, 1 },
         .dstOffsets = { rect[0], rect[1] }
     }};
 
-    const VkImageSubresourceRange range = { aspect, miplevel, 1, layer, 1 };
+    VkImageSubresourceRange const range = { aspect, miplevel, 1, layer, 1 };
 
     VulkanLayout const newLayout = VulkanLayout::TRANSFER_DST;
     VulkanLayout const oldLayout = getLayout(layer, miplevel);
@@ -543,41 +588,21 @@ VulkanLayout VulkanTexture::getDefaultLayout() const {
     return mState->mDefaultLayout;
 }
 
-VkImageView VulkanTexture::getAttachmentView(VkImageSubresourceRange range) {
-    range.levelCount = 1;
-    range.layerCount = 1;
-    return getImageView(range, VK_IMAGE_VIEW_TYPE_2D, {});
-}
-
-VkImageView VulkanTexture::getMultiviewAttachmentView(VkImageSubresourceRange range) {
-    return getImageView(range, VK_IMAGE_VIEW_TYPE_2D_ARRAY, {});
-}
-
-VkImageView VulkanTexture::getViewForType(VkImageSubresourceRange const& range, VkImageViewType type) {
-    return getImageView(range, type, mSwizzle);
-}
-
-VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, VkImageViewType viewType,
-        VkComponentMapping swizzle) {
-    VulkanTextureState::ImageViewKey const key{ range, viewType, swizzle };
-    auto iter = mState->mCachedImageViews.find(key);
-    if (iter != mState->mCachedImageViews.end()) {
-        return iter->second;
+VkImageView VulkanTexture::getAttachmentView(VkImageSubresourceRange const& range, VkImageViewType type) {
+    assert_invariant(mState->mYcbcr.conversion == VK_NULL_HANDLE &&
+                     "We are not yet supporting external image as attachments.");
+    if (type == VK_IMAGE_VIEW_TYPE_2D) {
+        VkImageSubresourceRange copy = range;
+        copy.levelCount = 1;
+        copy.layerCount = 1;
+        return mState->getImageView(copy, type, {});
+    } else {
+        return mState->getImageView(range, type, {});
     }
-    VkImageViewCreateInfo viewInfo = {
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-        .image = mState->mTextureImage,
-        .viewType = viewType,
-        .format = mState->mVkFormat,
-        .components = swizzle,
-        .subresourceRange = range,
-    };
-    VkImageView imageView;
-    vkCreateImageView(mState->mDevice, &viewInfo, VKALLOC, &imageView);
-    mState->mCachedImageViews.emplace(key, imageView);
-    return imageView;
+}
+
+VkImageView VulkanTexture::getView(VkImageSubresourceRange const& range) {
+    return mState->getImageView(range, mState->mViewType, mSwizzle);
 }
 
 VkImageAspectFlags VulkanTexture::getImageAspect() const {
@@ -736,6 +761,21 @@ void VulkanTexture::setLayout(VkImageSubresourceRange const& range, VulkanLayout
             uint32_t const last = (layer << 16) | lastLevel;
             mState->mSubresourceLayouts.add(first, last, newLayout);
         }
+    }
+}
+
+void VulkanTexture::setYcbcrConversion(VkSamplerYcbcrConversion conversion, bool isExternalFormat) {
+    // Note that this comparison is valid because we only ever create VkSamplerYcbcrConversion from
+    // a cache.  So for each set of parameters, there is exactly one conversion (similar to
+    // samplers).
+    VulkanTextureState::Ycbcr ycbcr = {
+        .conversion = conversion,
+        .isExternalFormat = isExternalFormat,
+    };
+
+    if (mState->mYcbcr != ycbcr) {
+        mState->mYcbcr = ycbcr;
+        mState->clearCachedImageViews();
     }
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -34,10 +34,14 @@
 
 namespace filament::backend {
 
+struct VulkanTexture;
+
 struct VulkanTextureState : public fvkmemory::Resource {
-    VulkanTextureState(VkDevice device, VmaAllocator allocator, VulkanCommands* commands,
-            VulkanStagePool& stagePool, VkFormat format, VkImageViewType viewType, uint8_t levels,
-            uint8_t layerCount, VulkanLayout defaultLayout, bool isProtected);
+    VulkanTextureState(VulkanStagePool& stagePool, VulkanCommands* commands, VmaAllocator allocator,
+            VkDevice device, VkImage image, VkDeviceMemory deviceMemory, VkFormat format,
+            VkImageViewType viewType, uint8_t levels, uint8_t layerCount,
+            VkSamplerYcbcrConversion ycbcrConversion, bool isExternalFormat,
+            VkImageUsageFlags usage, bool isProtected);
 
     ~VulkanTextureState();
 
@@ -60,29 +64,50 @@ struct VulkanTextureState : public fvkmemory::Resource {
     // No implicit padding allowed due to it being a hash key.
     static_assert(sizeof(ImageViewKey) == 40);
 
-    using ImageViewHash = utils::hash::MurmurHashFn<ImageViewKey>;
+    VkImageView getImageView(VkImageSubresourceRange range, VkImageViewType viewType,
+            VkComponentMapping swizzle);
+private:
+    void clearCachedImageViews() noexcept;
+    VulkanStagePool& mStagePool;
+    VulkanCommands* const mCommands;
+    VmaAllocator const mAllocator;
+    VkDevice const mDevice;
 
     // The texture with the sidecar owns the sidecar.
     fvkmemory::resource_ptr<VulkanTexture> mSidecarMSAA;
-    VkDeviceMemory mTextureImageMemory = VK_NULL_HANDLE;
 
+    VkImage const mTextureImage;
+    VkDeviceMemory const mTextureImageMemory;
     VkFormat const mVkFormat;
     VkImageViewType const mViewType;
     VkImageSubresourceRange const mFullViewRange;
-    VkImage mTextureImage = VK_NULL_HANDLE;
-    VulkanLayout mDefaultLayout;
 
-    bool mIsProtected = false;
+    // Note that this parameter is not constant due to the fact that AHB can force a change in the
+    // conversion matrix per-frame.
+    struct Ycbcr {
+        VkSamplerYcbcrConversion conversion;
+        bool isExternalFormat;
+
+        bool operator==(Ycbcr const& other) const {
+            return conversion == other.conversion && isExternalFormat == other.isExternalFormat;
+        }
+
+        bool operator!=(Ycbcr const& other) const {
+            return !((*this) == other);
+        }
+
+    } mYcbcr;
+
+    VulkanLayout const mDefaultLayout;
+    VkImageUsageFlags const mUsage;
+    bool const mIsProtected;
 
     // Track the image layout of each subresource using a sparse range map.
     utils::RangeMap<uint32_t, VulkanLayout> mSubresourceLayouts;
-
+    using ImageViewHash = utils::hash::MurmurHashFn<ImageViewKey>;
     std::unordered_map<ImageViewKey, VkImageView, ImageViewHash> mCachedImageViews;
-    VulkanStagePool& mStagePool;
-    VkDevice mDevice;
-    VmaAllocator mAllocator;
-    VulkanCommands* mCommands;
-    bool mIsTransientAttachment;
+
+    friend struct VulkanTexture;
 };
 
 struct VulkanTexture : public HwTexture, fvkmemory::Resource {
@@ -94,10 +119,10 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
             VulkanStagePool& stagePool);
 
     // Specialized constructor for internally created textures (e.g. from a swap chain)
-    // The texture will never destroy the given VkImage, but it does manages its subresources.
-    VulkanTexture(VkDevice device, VmaAllocator allocator,
+    VulkanTexture(VulkanContext const& context, VkDevice device, VmaAllocator allocator,
             fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
-            VkDeviceMemory memory, VkFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
+            VkDeviceMemory memory, VkFormat format, VkSamplerYcbcrConversion conversion,
+            uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
             TextureUsage tusage, VulkanStagePool& stagePool);
 
     // Constructor for creating a texture view for wrt specific mip range
@@ -116,11 +141,6 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     void updateImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
             uint32_t depth, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset, uint32_t miplevel);
 
-    // Returns the primary image view, which is used for shader sampling.
-    VkImageView getPrimaryImageView() {
-        return getImageView(mPrimaryViewRange, mState->mViewType, mSwizzle);
-    }
-
     VkImageViewType getViewType() const {
         return mState->mViewType;
     }
@@ -135,20 +155,11 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     // time of the call.
     VulkanLayout getDefaultLayout() const;
 
-    // Gets or creates a cached VkImageView for a single subresource that can be used as a render
-    // target attachment.  Unlike the primary image view, this always has type VK_IMAGE_VIEW_TYPE_2D
-    // and the identity swizzle.
-    VkImageView getAttachmentView(VkImageSubresourceRange range);
+    // Gets or creates a cached VkImageView for a subresource that can be used as a render
+    // target attachment.  Unlike the primary image view, this always the identity swizzle.
+    VkImageView getAttachmentView(VkImageSubresourceRange const& range, VkImageViewType type);
 
-    // Gets or creates a cached VkImageView for a single subresource that can be used as a render
-    // target attachment when rendering with multiview.
-    VkImageView getMultiviewAttachmentView(VkImageSubresourceRange range);
-
-    // This is a workaround for the first few frames where we're waiting for the texture to actually
-    // be uploaded.  In that case, we bind the sampler to an empty texture, but the corresponding
-    // imageView needs to be of the right type. Hence, we provide an option to indicate the
-    // view type. Swizzle option does not matter in this case.
-    VkImageView getViewForType(VkImageSubresourceRange const& range, VkImageViewType type);
+    VkImageView getView(VkImageSubresourceRange const& range);
 
     VkFormat getVkFormat() const {
         return mState->mVkFormat;
@@ -168,7 +179,7 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     }
 
     bool isTransientAttachment() const {
-        return mState->mIsTransientAttachment;
+        return mState->mUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
     }
 
     bool getIsProtected() const {
@@ -194,6 +205,11 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     // For implicit transition like the end of a render pass, we need to be able to set the layout
     // manually (outside of calls to transitionLayout).
     void setLayout(VkImageSubresourceRange const& range, VulkanLayout newLayout);
+
+    // This is used in the case of external images and external samplers. AHB might update the
+    // conversion per-frame. This implies that we need to invalidate the view cache when that
+    // happens.
+    void setYcbcrConversion(VkSamplerYcbcrConversion conversion, bool isExternal);
 
 #if FVK_ENABLED(FVK_DEBUG_TEXTURE)
     void print() const;


### PR DESCRIPTION
- Refactor VulkanTextureState and VulkanTexture so that most state fields are consts.
- Add a field for VkYcbcrConversion.
- Clear the image view cache when YcbcrConversion changes
- Make sure that getAttachmentView and getView are better defined and called.