### PR TITLE
Use Cleanup and RenderFrame helpers for better resource allocation and release.

### DIFF
--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -145,7 +145,6 @@ static void createFaces(DriverApi& dapi, Handle<HwTexture> texture, int baseWidt
 
 TEST_F(BlitTest, ColorMagnify) {
     auto& api = getDriverApi();
-    mCleanup.addPostCall([&]() { executeCommands(); });
 
     constexpr int kSrcTexWidth = 256;
     constexpr int kSrcTexHeight = 256;
@@ -207,7 +206,6 @@ TEST_F(BlitTest, ColorMagnify) {
 
 TEST_F(BlitTest, ColorMinify) {
     auto& api = getDriverApi();
-    mCleanup.addPostCall([&]() { executeCommands(); });
 
     constexpr int kSrcTexWidth = 1024;
     constexpr int kSrcTexHeight = 1024;
@@ -342,7 +340,6 @@ TEST_F(BlitTest, ColorResolve) {
 
 TEST_F(BlitTest, Blit2DTextureArray) {
     auto& api = getDriverApi();
-    mCleanup.addPostCall([&]() { executeCommands(); });
 
     api.startCapture(0);
     mCleanup.addPostCall([&]() { api.stopCapture(0); });
@@ -412,7 +409,6 @@ TEST_F(BlitTest, Blit2DTextureArray) {
 
 TEST_F(BlitTest, BlitRegion) {
     auto& api = getDriverApi();
-    mCleanup.addPostCall([&]() { executeCommands(); });
 
     constexpr int kSrcTexWidth = 1024;
     constexpr int kSrcTexHeight = 1024;
@@ -488,7 +484,6 @@ TEST_F(BlitTest, BlitRegion) {
 TEST_F(BlitTest, BlitRegionToSwapChain) {
     FAIL_IF(Backend::VULKAN, "Crashes due to not finding color attachment, see b/417481493");
     auto& api = getDriverApi();
-    mCleanup.addPostCall([&]() { executeCommands(); });
 
     constexpr int kSrcTexWidth = 1024;
     constexpr int kSrcTexHeight = 1024;
@@ -541,13 +536,13 @@ TEST_F(BlitTest, BlitRegionToSwapChain) {
                 dstRect, srcRenderTargets[srcLevel],
                 srcRect, SamplerMagFilter::LINEAR);
 
-        api.commit(swapChain);
-    }
+                api.commit(swapChain);
 
-    // TODO: for some reason, this test has been disabled. It needs to be tested on all
-    // machines.
-    // EXPECT_IMAGE(dstRenderTarget,
-    //         ScreenshotParams(kDstTexWidth, kDstTexHeight, "BlitRegionToSwapChain", 0x0));
+        // TODO: for some reason, this test has been disabled. It needs to be tested on all
+        // machines.
+        // EXPECT_IMAGE(dstRenderTarget,
+        //         ScreenshotParams(kDstTexWidth, kDstTexHeight, "BlitRegionToSwapChain", 0x0));
+    }
 }
 
 } // namespace test

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -29,58 +29,61 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     SKIP_IF(Backend::VULKAN, "Frame callbacks are unsupported in Vulkan, see b/417254479");
     SKIP_IF(Backend::WEBGPU, "Frame callbacks are unsupported in WebGPU");
 
-    auto& api = getDriverApi();
-    Cleanup cleanup(api);
-
-    // Create a SwapChain.
-    // In order for the frameScheduledCallback to be called, this must be a real SwapChain (not
-    // headless) so we obtain a drawable.
-    auto swapChain = cleanup.add(createSwapChain());
-
-    Handle<HwRenderTarget> renderTarget = cleanup.add(api.createDefaultRenderTarget());
-
     int callbackCountA = 0;
-    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
-        callable();
-        callbackCountA++;
-    }, 0);
-
-    // Render the first frame.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.beginRenderPass(renderTarget, {});
-    api.endRenderPass(0);
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    // Render the next frame. The same callback should be called.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.beginRenderPass(renderTarget, {});
-    api.endRenderPass(0);
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    // Now switch out the callback.
     int callbackCountB = 0;
-    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountB](PresentCallable callable) {
-        callable();
-        callbackCountB++;
-    }, 0);
+    {
+        auto& api = getDriverApi();
+        Cleanup cleanup(api);
+        cleanup.addPostCall([&]() { executeCommands(); });
+        cleanup.addPostCall([&]() { getDriver().purge(); });
 
-    // Render one final frame.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.beginRenderPass(renderTarget, {});
-    api.endRenderPass(0);
-    api.commit(swapChain);
-    api.endFrame(0);
+        // Create a SwapChain.
+        // In order for the frameScheduledCallback to be called, this must be a real SwapChain (not
+        // headless) so we obtain a drawable.
+        auto swapChain = cleanup.add(createSwapChain());
 
-    api.finish();
+        Handle<HwRenderTarget> renderTarget = cleanup.add(api.createDefaultRenderTarget());
 
-    executeCommands();
-    getDriver().purge();
+        api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
+            callable();
+            callbackCountA++;
+        }, 0);
 
+        // Render the first frame.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.beginRenderPass(renderTarget, {});
+            api.endRenderPass(0);
+            api.commit(swapChain);
+        }
+
+        // Render the next frame. The same callback should be called.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.beginRenderPass(renderTarget, {});
+            api.endRenderPass(0);
+            api.commit(swapChain);
+        }
+
+        // Now switch out the callback.
+        api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountB](PresentCallable callable) {
+            callable();
+            callbackCountB++;
+        }, 0);
+
+        // Render one final frame.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.beginRenderPass(renderTarget, {});
+            api.endRenderPass(0);
+            api.commit(swapChain);
+        }
+
+        api.finish();
+    }
     EXPECT_EQ(callbackCountA, 2);
     EXPECT_EQ(callbackCountB, 1);
 }
@@ -90,43 +93,47 @@ TEST_F(BackendTest, FrameCompletedCallback) {
     SKIP_IF(Backend::VULKAN, "Frame callbacks are unsupported in Vulkan, see b/417254479");
     SKIP_IF(Backend::WEBGPU, "Frame callbacks are unsupported in WebGPU");
 
-    auto& api = getDriverApi();
-    Cleanup cleanup(api);
-
-    // Create a SwapChain.
-    auto swapChain = cleanup.add(api.createSwapChainHeadless(256, 256, 0));
-
     int callbackCountA = 0;
-    api.setFrameCompletedCallback(swapChain, nullptr,
-            [&callbackCountA]() { callbackCountA++; });
-
-    // Render the first frame.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    // Render the next frame. The same callback should be called.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    // Now switch out the callback.
     int callbackCountB = 0;
-    api.setFrameCompletedCallback(swapChain, nullptr,
-            [&callbackCountB]() { callbackCountB++; });
+    {
+        auto& api = getDriverApi();
+        Cleanup cleanup(api);
+        cleanup.addPostCall([&]() { executeCommands(); });
+        cleanup.addPostCall([&]() { getDriver().purge(); });
 
-    // Render one final frame.
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
-    api.commit(swapChain);
-    api.endFrame(0);
+        // Create a SwapChain.
+        auto swapChain = cleanup.add(api.createSwapChainHeadless(256, 256, 0));
 
-    api.finish();
+        api.setFrameCompletedCallback(swapChain, nullptr,
+                [&callbackCountA]() { callbackCountA++; });
 
-    executeCommands();
-    getDriver().purge();
+        // Render the first frame.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.commit(swapChain);
+        }
+
+        // Render the next frame. The same callback should be called.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.commit(swapChain);
+        }
+
+        // Now switch out the callback.
+        api.setFrameCompletedCallback(swapChain, nullptr,
+                [&callbackCountB]() { callbackCountB++; });
+
+        // Render one final frame.
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
+            api.commit(swapChain);
+        }
+
+        api.finish();
+    }
 
     EXPECT_EQ(callbackCountA, 2);
     EXPECT_EQ(callbackCountB, 1);

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -108,28 +108,27 @@ TEST_F(BackendTest, MRT) {
         RenderPassParams params = getClearColorRenderPass();
         params.viewport = getFullViewport();
 
+        Cleanup captureCleanup(api);
         api.startCapture(0);
+        captureCleanup.addPostCall([&]() { api.stopCapture(0); });
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        {
+            RenderFrame frame(api);
 
-        // Draw a triangle.
-        api.beginRenderPass(renderTarget, params);
-        state.primitiveType = PrimitiveType::TRIANGLES;
-        state.vertexBufferInfo = triangle.getVertexBufferInfo();
-        api.bindPipeline(state);
-        api.bindRenderPrimitive(triangle.getRenderPrimitive());
-        api.draw2(0, 3, 1);
-        api.endRenderPass();
+            // Draw a triangle.
+            api.beginRenderPass(renderTarget, params);
+            state.primitiveType = PrimitiveType::TRIANGLES;
+            state.vertexBufferInfo = triangle.getVertexBufferInfo();
+            api.bindPipeline(state);
+            api.bindRenderPrimitive(triangle.getRenderPrimitive());
+            api.draw2(0, 3, 1);
+            api.endRenderPass();
 
-        api.flush();
-        api.commit(swapChain);
-        api.endFrame(0);
-
-        api.stopCapture(0);
+            api.flush();
+            api.commit(swapChain);
+        }
     }
-
-    executeCommands();
 }
 
 } // namespace test

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -56,8 +56,9 @@ using namespace filament::backend;
 
 TEST_F(BackendTest, TextureViewLod) {
     auto& api = getDriverApi();
-    api.startCapture(0);
     Cleanup cleanup(api);
+    api.startCapture(0);
+    cleanup.addPostCall([&]() { api.stopCapture(0); });
 
     // The test is executed within this block scope to force destructors to run before
     // executeCommands().
@@ -123,7 +124,7 @@ TEST_F(BackendTest, TextureViewLod) {
 
         TrianglePrimitive triangle(api);
 
-        api.beginFrame(0, 0, 0);
+        RenderFrame frame(api);
 
         // We set the base mip to 1, and the max mip to 3
         // Level 0: 128x128 (red)
@@ -211,15 +212,9 @@ TEST_F(BackendTest, TextureViewLod) {
         api.endRenderPass();
 
         api.commit(swapChain);
-        api.endFrame(0);
-
-        api.stopCapture(0);
     }
 
     api.finish();
-
-    executeCommands();
-    getDriver().purge();
 }
 
 } // namespace test

--- a/filament/backend/test/test_MissingRequiredAttributes.cpp
+++ b/filament/backend/test/test_MissingRequiredAttributes.cpp
@@ -59,10 +59,11 @@ using namespace filament::backend;
  * successfully.
  */
 TEST_F(BackendTest, MissingRequiredAttributes) {
+    DriverApi& api = getDriverApi();
+
     // The test is executed within this block scope to force destructors to run before
     // executeCommands().
     {
-        DriverApi& api = getDriverApi();
         Cleanup cleanup(api);
         // Create a platform-specific SwapChain and make it current.
         auto swapChain = cleanup.add(createSwapChain());
@@ -86,9 +87,10 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
         params.viewport = getFullViewport();
 
         api.startCapture(0);
+        cleanup.addPostCall([&]() { api.stopCapture(0); });
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        RenderFrame frame(api);
 
         // Render a triangle.
         api.beginRenderPass(defaultRenderTarget, params);
@@ -101,12 +103,7 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
 
         api.flush();
         api.commit(swapChain);
-        api.endFrame(0);
-
-        api.stopCapture(0);
     }
-
-    executeCommands();
 }
 
 } // namespace test

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -288,7 +288,7 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         params.viewport.height = t.getRenderTargetSize();
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        RenderFrame frame (api);
 
         // Render a white triangle over blue.
         api.beginRenderPass(renderTarget, params);
@@ -350,11 +350,7 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         api.endRenderPass();
 
         api.commit(swapChain);
-        api.endFrame(0);
     }
-
-    // This ensures all driver commands have finished before exiting the test.
-    flushAndWait();
 }
 
 TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
@@ -363,6 +359,7 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
 
     DriverApi& api = getDriverApi();
     Cleanup cleanup(api);
+    cleanup.addPostCall([&]() { executeCommands(); });
 
     // Create a platform-specific SwapChain and make it current.
     auto swapChain = cleanup.add(
@@ -416,28 +413,29 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
         }
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        {
+            RenderFrame frame(api);
 
-        // Render some content, just so we don't read back uninitialized data.
-        api.beginRenderPass(renderTarget, params);
-        state.primitiveType = PrimitiveType::TRIANGLES;
-        state.vertexBufferInfo = triangle.getVertexBufferInfo();
-        api.bindPipeline(state);
-        api.bindRenderPrimitive(triangle.getRenderPrimitive());
-        api.draw2(0, 3, 1);
-        api.endRenderPass();
+            // Render some content, just so we don't read back uninitialized data.
+            api.beginRenderPass(renderTarget, params);
+            state.primitiveType = PrimitiveType::TRIANGLES;
+            state.vertexBufferInfo = triangle.getVertexBufferInfo();
+            api.bindPipeline(state);
+            api.bindRenderPrimitive(triangle.getRenderPrimitive());
+            api.draw2(0, 3, 1);
+            api.endRenderPass();
 
-        PixelBufferDescriptor descriptor(buffer, renderTargetSize * renderTargetSize * 4,
-                PixelDataFormat::RGBA, PixelDataType::UBYTE, 1, 0, 0, renderTargetSize,
-                [](void* buffer, size_t size, void* user) {
-                    ReadPixelsTest* test = (ReadPixelsTest*)user;
-                    test->readPixelsFinished = true;
-                }, this);
+            PixelBufferDescriptor descriptor(buffer, renderTargetSize * renderTargetSize * 4,
+                    PixelDataFormat::RGBA, PixelDataType::UBYTE, 1, 0, 0, renderTargetSize,
+                    [](void* buffer, size_t size, void* user) {
+                        ReadPixelsTest* test = (ReadPixelsTest*) user;
+                        test->readPixelsFinished = true;
+                    }, this);
 
-        api.readPixels(renderTarget, 0, 0, renderTargetSize, renderTargetSize,
-                std::move(descriptor));
-        api.commit(swapChain);
-        api.endFrame(0);
+            api.readPixels(renderTarget, 0, 0, renderTargetSize, renderTargetSize,
+                    std::move(descriptor));
+            api.commit(swapChain);
+        }
 
         flushAndWait();
         getDriver().purge();
@@ -448,7 +446,6 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
     free(buffer);
 
     api.finish();
-    executeCommands();
 }
 
 } // namespace test

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -81,31 +81,31 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
 
     DescriptorSetHandle descriptorSet = shader.createDescriptorSet(api);
 
-    api.startCapture(0);
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
+    {
+        Cleanup cleanupCapture(api);
+        api.startCapture(0);
+        cleanup.addPostCall([&]() { api.stopCapture(0); });
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
 
-    api.updateDescriptorSetTexture(descriptorSet, 0, texture, {});
-    api.bindDescriptorSet(descriptorSet, 0, {});
+            api.updateDescriptorSetTexture(descriptorSet, 0, texture, {});
+            api.bindDescriptorSet(descriptorSet, 0, {});
 
-    // Render a triangle.
-    api.beginRenderPass(defaultRenderTarget, params);
-    state.primitiveType = PrimitiveType::TRIANGLES;
-    state.vertexBufferInfo = triangle.getVertexBufferInfo();
-    api.bindPipeline(state);
-    api.bindRenderPrimitive(triangle.getRenderPrimitive());
-    api.draw2(0, 3, 1);
-    api.endRenderPass();
+            // Render a triangle.
+            api.beginRenderPass(defaultRenderTarget, params);
+            state.primitiveType = PrimitiveType::TRIANGLES;
+            state.vertexBufferInfo = triangle.getVertexBufferInfo();
+            api.bindPipeline(state);
+            api.bindRenderPrimitive(triangle.getRenderPrimitive());
+            api.draw2(0, 3, 1);
+            api.endRenderPass();
 
-    api.flush();
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    api.stopCapture(0);
-
+            api.flush();
+            api.commit(swapChain);
+        }
+    }
     api.finish();
-
-    executeCommands();
 }
 
 TEST_F(BackendTest, RenderExternalImage) {
@@ -180,32 +180,32 @@ TEST_F(BackendTest, RenderExternalImage) {
     RenderPassParams params = getClearColorRenderPass();
     params.viewport = getFullViewport();
 
-    api.startCapture(0);
-    api.makeCurrent(swapChain, swapChain);
-    api.beginFrame(0, 0, 0);
+    {
+        Cleanup cleanupCapture(api);
+        api.startCapture(0);
+        cleanup.addPostCall([&]() { api.stopCapture(0); });
+        api.makeCurrent(swapChain, swapChain);
+        {
+            RenderFrame frame(api);
 
-    api.updateDescriptorSetTexture(descriptorSet, 0, texture, {});
-    api.bindDescriptorSet(descriptorSet, 0, {});
+            api.updateDescriptorSetTexture(descriptorSet, 0, texture, {});
+            api.bindDescriptorSet(descriptorSet, 0, {});
 
-    // Render a triangle.
-    api.beginRenderPass(defaultRenderTarget, params);
-    state.primitiveType = PrimitiveType::TRIANGLES;
-    state.vertexBufferInfo = triangle.getVertexBufferInfo();
-    api.bindPipeline(state);
-    api.bindRenderPrimitive(triangle.getRenderPrimitive());
-    api.draw2(0, 3, 1);
-    api.endRenderPass();
+            // Render a triangle.
+            api.beginRenderPass(defaultRenderTarget, params);
+            state.primitiveType = PrimitiveType::TRIANGLES;
+            state.vertexBufferInfo = triangle.getVertexBufferInfo();
+            api.bindPipeline(state);
+            api.bindRenderPrimitive(triangle.getRenderPrimitive());
+            api.draw2(0, 3, 1);
+            api.endRenderPass();
 
-    api.flush();
-    api.commit(swapChain);
-    api.endFrame(0);
-    EXPECT_IMAGE(defaultRenderTarget,
-            ScreenshotParams(screenWidth(), screenHeight(), "RenderExternalImage", 1206264951));
-
-    api.stopCapture(0);
-    api.finish();
-    flushAndWait();
-
+            api.flush();
+            api.commit(swapChain);
+        }
+        EXPECT_IMAGE(defaultRenderTarget,
+                ScreenshotParams(screenWidth(), screenHeight(), "RenderExternalImage", 1206264951));
+    }
 }
 
 } // namespace test

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -43,8 +43,9 @@ TEST_F(BackendTest, ScissorViewportRegion) {
     constexpr int kSrcRtWidth = 384;
     constexpr int kSrcRtHeight = 384;
 
-    api.startCapture(0);
     Cleanup cleanup(api);
+    api.startCapture(0);
+    cleanup.addPostCall([&]() { api.stopCapture(0); });
 
     //    color texture (mip level 1) 512x512           depth texture (mip level 0) 512x512
     // +----------------------------------------+   +------------------------------------------+
@@ -121,7 +122,7 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         shader.addProgramToPipelineState(ps);
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        RenderFrame frame(api);
 
         api.beginRenderPass(srcRenderTarget, params);
         api.scissor(scissor);
@@ -136,9 +137,6 @@ TEST_F(BackendTest, ScissorViewportRegion) {
                 ScreenshotParams(kSrcTexWidth >> 1, kSrcTexHeight >> 1, "scissor", 15842520));
 
         api.commit(swapChain);
-        api.endFrame(0);
-
-        api.stopCapture(0);
     }
 }
 
@@ -146,12 +144,11 @@ TEST_F(BackendTest, ScissorViewportRegion) {
 TEST_F(BackendTest, ScissorViewportEdgeCases) {
     auto& api = getDriverApi();
 
-    api.startCapture(0);
-    Cleanup cleanup(api);
-
     // The test is executed within this block scope to force destructors to run before
     // executeCommands().
     {
+        Cleanup cleanup(api);
+        api.startCapture(0);
         // Create a SwapChain and make it current. We don't really use it so the res doesn't matter.
         auto swapChain = cleanup.add(api.createSwapChainHeadless(256, 256, 0));
         api.makeCurrent(swapChain, swapChain);
@@ -201,7 +198,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         shader.addProgramToPipelineState(ps);
 
         api.makeCurrent(swapChain, swapChain);
-        api.beginFrame(0, 0, 0);
+        RenderFrame frame(api);
 
         api.beginRenderPass(renderTarget, params);
         api.scissor(scissor);
@@ -228,9 +225,6 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
                 ScreenshotParams(512, 512, "ScissorViewportEdgeCases", 2199186852));
 
         api.commit(swapChain);
-        api.endFrame(0);
-
-        api.stopCapture(0);
     }
 }
 


### PR DESCRIPTION
This builds on top of #8562 to continue test boilerplate removal.
For the distinct changes in this PR just check the last commit.
This falls into three groupings of changes.

1. RenderFrame usage to streamline the ubiquitous BeginFrame(0,0,0) and EndFrame(0) calls throughout the tests. This is a trivial refactor and needs little more than a glance.
2. Using Cleanup helper to handle pairing api.startCapture() calls with api.stopCapture() at the end of scope. The only question here is I may have overthought it a bit because I'm not clear *exactly* what the capture feature is doing. Does it matter if it is halted at test teardown time or at the specific locations it initially appeared in the tests? I assumed the latter, but if the former is the case then I can simplify a few places where I added additional scopes to have stopCapture() called in the same location it was previously.
3. Insuring BackendTest->flushAndWait() or similar calls occur at end of test. As far as I can tell every test case uses a BackendTest fixture, which calls flushAndWait() in its destructor.  As such, with a few exceptions such as tests where it was called before assertions in order to trigger work, I simply removed these calls as redundant.  I will look some more for reasons that this would not be safe, but so far I have failed to find any. Please let me know if I missed something here.