### PR TITLE
vk: preparing for Ycbcr conversion

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -177,29 +177,6 @@ endif()
 if (FILAMENT_SUPPORTS_VULKAN)
     list(APPEND SRCS
             include/backend/platforms/VulkanPlatform.h
-            src/vulkan/VulkanDescriptorSetCache.cpp
-            src/vulkan/VulkanDescriptorSetCache.h
-            src/vulkan/VulkanDescriptorSetLayoutCache.cpp
-            src/vulkan/VulkanDescriptorSetLayoutCache.h
-            src/vulkan/VulkanPipelineLayoutCache.cpp
-            src/vulkan/VulkanPipelineLayoutCache.h
-            src/vulkan/memory/ResourceManager.cpp
-            src/vulkan/memory/ResourceManager.h
-            src/vulkan/memory/ResourcePointer.h
-            src/vulkan/memory/Resource.cpp
-            src/vulkan/memory/Resource.h
-            src/vulkan/platform/VulkanPlatform.cpp
-            src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
-            src/vulkan/platform/VulkanPlatformSwapChainImpl.h
-            src/vulkan/utils/Conversion.cpp
-            src/vulkan/utils/Conversion.h
-            src/vulkan/utils/Definitions.h
-            src/vulkan/utils/Helper.h
-            src/vulkan/utils/Image.h
-            src/vulkan/utils/Image.cpp
-            src/vulkan/utils/Spirv.h
-            src/vulkan/utils/Spirv.cpp
-            src/vulkan/utils/StaticVector.h
             src/vulkan/VulkanAsyncHandles.h
             src/vulkan/VulkanBlitter.cpp
             src/vulkan/VulkanBlitter.h
@@ -210,6 +187,10 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanConstants.h
             src/vulkan/VulkanContext.cpp
             src/vulkan/VulkanContext.h
+            src/vulkan/VulkanDescriptorSetCache.cpp
+            src/vulkan/VulkanDescriptorSetCache.h
+            src/vulkan/VulkanDescriptorSetLayoutCache.cpp
+            src/vulkan/VulkanDescriptorSetLayoutCache.h
             src/vulkan/VulkanDriver.cpp
             src/vulkan/VulkanDriver.h
             src/vulkan/VulkanDriverFactory.h
@@ -217,24 +198,43 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanFboCache.h
             src/vulkan/VulkanHandles.cpp
             src/vulkan/VulkanHandles.h
-            src/vulkan/VulkanMemory.h
             src/vulkan/VulkanMemory.cpp
+            src/vulkan/VulkanMemory.h
             src/vulkan/VulkanPipelineCache.cpp
             src/vulkan/VulkanPipelineCache.h
+            src/vulkan/VulkanPipelineLayoutCache.cpp
+            src/vulkan/VulkanPipelineLayoutCache.h
             src/vulkan/VulkanQueryManager.cpp
             src/vulkan/VulkanQueryManager.h
+            src/vulkan/VulkanReadPixels.cpp
+            src/vulkan/VulkanReadPixels.h
             src/vulkan/VulkanSamplerCache.cpp
             src/vulkan/VulkanSamplerCache.h
             src/vulkan/VulkanStagePool.cpp
             src/vulkan/VulkanStagePool.h
             src/vulkan/VulkanSwapChain.cpp
             src/vulkan/VulkanSwapChain.h
-            src/vulkan/VulkanReadPixels.cpp
-            src/vulkan/VulkanReadPixels.h
             src/vulkan/VulkanTexture.cpp
             src/vulkan/VulkanTexture.h
             src/vulkan/VulkanYcbcrConversionCache.cpp
             src/vulkan/VulkanYcbcrConversionCache.h
+            src/vulkan/memory/Resource.cpp
+            src/vulkan/memory/Resource.h
+            src/vulkan/memory/ResourceManager.cpp
+            src/vulkan/memory/ResourceManager.h
+            src/vulkan/memory/ResourcePointer.h
+            src/vulkan/platform/VulkanPlatform.cpp
+            src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+            src/vulkan/platform/VulkanPlatformSwapChainImpl.h
+            src/vulkan/utils/Conversion.cpp
+            src/vulkan/utils/Conversion.h
+            src/vulkan/utils/Definitions.h
+            src/vulkan/utils/Helper.h
+            src/vulkan/utils/Image.cpp
+            src/vulkan/utils/Image.h
+            src/vulkan/utils/Spirv.cpp
+            src/vulkan/utils/Spirv.h
+            src/vulkan/utils/StaticVector.h
     )
     if (LINUX OR WIN32)
         list(APPEND SRCS src/vulkan/platform/VulkanPlatformLinuxWindows.cpp)

--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -41,6 +41,8 @@ public:
             VulkanDescriptorSetLayout::UNIQUE_DESCRIPTOR_SET_COUNT;
 
     using DescriptorSetLayoutArray = VulkanDescriptorSetLayout::DescriptorSetLayoutArray;
+    using DescriptorSetArray =
+            std::array<fvkmemory::resource_ptr<VulkanDescriptorSet>, UNIQUE_DESCRIPTOR_SET_COUNT>;
 
     VulkanDescriptorSetCache(VkDevice device, fvkmemory::ResourceManager* resourceManager);
     ~VulkanDescriptorSetCache();
@@ -68,13 +70,20 @@ public:
     fvkmemory::resource_ptr<VulkanDescriptorSet> createSet(Handle<HwDescriptorSet> handle,
             fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
 
+    // This method is only meant to be used with external samplers (or internally within this
+    // class).
+    VkDescriptorSet getVkSet(fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
+
+    // This method is only meant to be used with external samplers.
+    void manualRecyle(VulkanDescriptorSetLayout::Count const& count, VkDescriptorSetLayout vklayout,
+            VkDescriptorSet vkSet);
+
+    DescriptorSetArray const& getBoundSets() const { return mStashedSets; }
+
     void gc();
 
 private:
     class DescriptorInfinitePool;
-
-    using DescriptorSetArray =
-            std::array<fvkmemory::resource_ptr<VulkanDescriptorSet>, UNIQUE_DESCRIPTOR_SET_COUNT>;
 
     VkDevice mDevice;
     fvkmemory::ResourceManager* mResourceManager;

--- a/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
@@ -18,6 +18,8 @@
 
 #include "VulkanHandles.h"
 
+#include <utils/Hash.h>
+
 namespace filament::backend {
 
 namespace {
@@ -58,6 +60,56 @@ uint32_t appendBindings(VkDescriptorSetLayoutBinding* toBind, VkDescriptorType t
     return count;
 }
 
+uint32_t appendSamplerBindings(VkDescriptorSetLayoutBinding* toBind,
+        fvkutils::SamplerBitmask const& mask, fvkutils::SamplerBitmask const& external,
+        utils::FixedCapacityVector<VkSampler> const& immutableSamplers) {
+    using Bitmask = fvkutils::SamplerBitmask;
+    uint32_t count = 0;
+    Bitmask alreadySeen;
+    uint8_t immutableIndex = 0;
+    size_t const immutableSamplerCount = immutableSamplers.size();
+    mask.forEachSetBit([&](size_t index) {
+        VkShaderStageFlags stages = 0;
+        uint32_t binding = 0;
+        if (index < fvkutils::getFragmentStageShift<Bitmask>()) {
+            binding = (uint32_t) index;
+            stages |= VK_SHADER_STAGE_VERTEX_BIT;
+            auto fragIndex = index + fvkutils::getFragmentStageShift<Bitmask>();
+            if (mask.test(fragIndex)) {
+                stages |= VK_SHADER_STAGE_FRAGMENT_BIT;
+                alreadySeen.set(fragIndex);
+            }
+        } else if (!alreadySeen.test(index)) {
+            // We are in fragment stage bits
+            binding = (uint32_t) (index - fvkutils::getFragmentStageShift<Bitmask>());
+            stages |= VK_SHADER_STAGE_FRAGMENT_BIT;
+        }
+
+        if (stages) {
+            toBind[count++] = {
+                .binding = binding,
+                .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                .descriptorCount = 1,
+                .stageFlags = stages,
+                .pImmutableSamplers = external[index] && immutableSamplerCount > immutableIndex
+                                              ? &immutableSamplers[immutableIndex++]
+                                              : nullptr,
+            };
+        }
+    });
+    return count;
+}
+
+uint64_t computeImmutableSamplerHash(utils::FixedCapacityVector<VkSampler> const& samplers) {
+    size_t const size = samplers.size();
+    if (size == 0) {
+        return 0;
+    } else if (size == 1) {
+        return (uint64_t) samplers[0];
+    }
+    return utils::hash::murmur3((uint32_t*) samplers.data(), samplers.size() * 2, 0);
+}
+
 } // anonymous namespace
 
 VulkanDescriptorSetLayoutCache::VulkanDescriptorSetLayoutCache(VkDevice device,
@@ -73,37 +125,44 @@ void VulkanDescriptorSetLayoutCache::terminate() noexcept {
     }
 }
 
+VkDescriptorSetLayout VulkanDescriptorSetLayoutCache::getVkLayout(
+        VulkanDescriptorSetLayout::Bitmask const& bitmasks,
+        utils::FixedCapacityVector<VkSampler> immutableSamplers) {
+    LayoutKey key = {
+        .bitmask = bitmasks,
+        .immutableSamplerHash = computeImmutableSamplerHash(immutableSamplers),
+    };
+    if (auto itr = mVkLayouts.find(key); itr != mVkLayouts.end()) {
+        return itr->second;
+    }
+
+    VkDescriptorSetLayoutBinding toBind[VulkanDescriptorSetLayout::MAX_BINDINGS];
+    uint32_t count = 0;
+    count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+            bitmasks.dynamicUbo);
+    count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, bitmasks.ubo);
+    count += appendSamplerBindings(&toBind[count], bitmasks.sampler, bitmasks.externalSampler,
+            immutableSamplers);
+    count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
+            bitmasks.inputAttachment);
+
+    assert_invariant(count != 0 && "Need at least one binding for descriptor set layout.");
+    VkDescriptorSetLayoutCreateInfo dlinfo = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .bindingCount = count,
+        .pBindings = toBind,
+    };
+    VkDescriptorSetLayout vklayout;
+    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &vklayout);
+    mVkLayouts[key] = vklayout;
+    return vklayout;
+}
+
 fvkmemory::resource_ptr<VulkanDescriptorSetLayout> VulkanDescriptorSetLayoutCache::createLayout(
         Handle<HwDescriptorSetLayout> handle, backend::DescriptorSetLayout&& info) {
     auto layout = fvkmemory::resource_ptr<VulkanDescriptorSetLayout>::make(mResourceManager, handle,
             info);
-    VkDescriptorSetLayout vklayout = VK_NULL_HANDLE;
-    auto const& bitmasks = layout->bitmask;
-    if (auto itr = mVkLayouts.find(bitmasks); itr != mVkLayouts.end()) {
-        vklayout = itr->second;
-    } else {
-        VkDescriptorSetLayoutBinding toBind[VulkanDescriptorSetLayout::MAX_BINDINGS];
-        uint32_t count = 0;
-        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-                bitmasks.dynamicUbo);
-        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, bitmasks.ubo);
-        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                bitmasks.sampler);
-        count += appendBindings(&toBind[count], VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
-                bitmasks.inputAttachment);
-
-        assert_invariant(count != 0 && "Need at least one binding for descriptor set layout.");
-        VkDescriptorSetLayoutCreateInfo dlinfo = {
-            .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-            .pNext = nullptr,
-            .bindingCount = count,
-            .pBindings = toBind,
-        };
-
-        vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &vklayout);
-        mVkLayouts[bitmasks] = vklayout;
-    }
-    layout->setVkLayout(vklayout);
+    layout->setVkLayout(getVkLayout(layout->bitmask));
     return layout;
 }
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -30,6 +30,7 @@
 
 #include <backend/platforms/VulkanPlatform.h>
 
+#include <utils/compiler.h> // UTILS_FALLTHROUGH
 #include <utils/Panic.h>    // ASSERT_POSTCONDITION
 
 using namespace bluevk;
@@ -89,8 +90,9 @@ BitmaskGroup fromBackendLayout(DescriptorSetLayout const& layout) {
                 }
                 break;
             }
-            // TODO: properly handle external sampler
             case DescriptorType::SAMPLER_EXTERNAL:
+                fromStageFlags(binding.stageFlags, binding.binding, mask.externalSampler);
+                UTILS_FALLTHROUGH;
             case DescriptorType::SAMPLER: {
                 fromStageFlags(binding.stageFlags, binding.binding, mask.sampler);
                 break;

--- a/filament/backend/src/vulkan/VulkanSamplerCache.cpp
+++ b/filament/backend/src/vulkan/VulkanSamplerCache.cpp
@@ -33,8 +33,15 @@ VkSampler VulkanSamplerCache::getSampler(Params params) noexcept {
     if (UTILS_LIKELY(iter != mCache.end())) {
         return iter->second;
     }
+    VkSamplerYcbcrConversionInfo ycbcrConversion = {
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+        .conversion = params.conversion,
+    };
+
     auto const& samplerParams = params.sampler;
-    VkSamplerCreateInfo samplerInfo{ .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+    VkSamplerCreateInfo samplerInfo{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .pNext = params.conversion != VK_NULL_HANDLE ? &ycbcrConversion : VK_NULL_HANDLE,
         .magFilter = fvkutils::getFilter(samplerParams.filterMag),
         .minFilter = fvkutils::getFilter(samplerParams.filterMin),
         .mipmapMode = fvkutils::getMipmapMode(samplerParams.filterMin),
@@ -48,7 +55,8 @@ VkSampler VulkanSamplerCache::getSampler(Params params) noexcept {
         .minLod = 0.0f,
         .maxLod = fvkutils::getMaxLod(samplerParams.filterMin),
         .borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK,
-        .unnormalizedCoordinates = VK_FALSE };
+        .unnormalizedCoordinates = VK_FALSE,
+    };
     VkSampler sampler;
     VkResult result = vkCreateSampler(mDevice, &samplerInfo, VKALLOC, &sampler);
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "Unable to create sampler."

--- a/filament/backend/src/vulkan/VulkanYcbcrConversionCache.cpp
+++ b/filament/backend/src/vulkan/VulkanYcbcrConversionCache.cpp
@@ -43,7 +43,7 @@ VkSamplerYcbcrConversion VulkanYcbcrConversionCache::getConversion(
     TextureSwizzle const swizzleArray[] = { chroma.r, chroma.g, chroma.b, chroma.a };
     VkSamplerYcbcrConversionCreateInfo conversionInfo = {
         .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
-        .format = VK_FORMAT_UNDEFINED,
+        .format = fvkutils::getVkFormat(params.format),
         .ycbcrModel = fvkutils::getYcbcrModelConversion(chroma.ycbcrModel),
         .ycbcrRange = fvkutils::getYcbcrRange(chroma.ycbcrRange),
         .components = fvkutils::getSwizzleMap(swizzleArray),
@@ -52,6 +52,7 @@ VkSamplerYcbcrConversion VulkanYcbcrConversionCache::getConversion(
         .chromaFilter = fvkutils::getFilter(chroma.chromaFilter),
     };
 
+    // We could put this in the platform class, but that seems like a bit of an overkill
 #if defined(__ANDROID__)
     VkExternalFormatANDROID externalFormat = {
         .sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID,
@@ -59,6 +60,7 @@ VkSamplerYcbcrConversion VulkanYcbcrConversionCache::getConversion(
     };
     if (params.externalFormat) {
         conversionInfo.pNext = &externalFormat;
+        conversionInfo.format = VK_FORMAT_UNDEFINED;
     }
 #endif
 

--- a/filament/backend/src/vulkan/VulkanYcbcrConversionCache.h
+++ b/filament/backend/src/vulkan/VulkanYcbcrConversionCache.h
@@ -31,7 +31,8 @@ class VulkanYcbcrConversionCache {
 public:
     struct Params {
         SamplerYcbcrConversion conversion = {};
-        uint32_t padding = 0;
+        TextureFormat format = {};
+        uint16_t padding = 0;
         uint64_t externalFormat = 0;
     };
     static_assert(sizeof(Params) == 16);

--- a/filament/backend/src/vulkan/utils/Conversion.cpp
+++ b/filament/backend/src/vulkan/utils/Conversion.cpp
@@ -668,4 +668,111 @@ VkShaderStageFlags getShaderStageFlags(ShaderStageFlags stageFlags) {
     return flags;
 }
 
+VkSamplerYcbcrModelConversion getYcbcrModelConversion(
+    SamplerYcbcrModelConversion model) {
+    switch (model) {
+    case SamplerYcbcrModelConversion::RGB_IDENTITY:
+        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
+    case SamplerYcbcrModelConversion::YCBCR_IDENTITY:
+        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY;
+    case SamplerYcbcrModelConversion::YCBCR_709:
+        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
+    case SamplerYcbcrModelConversion::YCBCR_601:
+        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601;
+    case SamplerYcbcrModelConversion::YCBCR_2020:
+        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
+    default:
+        assert_invariant(false &&
+            "Unknown data type, conversion is not supported.");
+    }
+}
+
+VkSamplerYcbcrRange getYcbcrRange(SamplerYcbcrRange range) {
+    switch (range) {
+    case SamplerYcbcrRange::ITU_FULL:
+        return VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
+    case SamplerYcbcrRange::ITU_NARROW:
+        return VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+    default:
+        assert_invariant(false &&
+            "Unknown data type, conversion is not supported.");
+    }
+}
+
+VkChromaLocation getChromaLocation(ChromaLocation loc) {
+    switch (loc) {
+    case ChromaLocation::COSITED_EVEN:
+        return VK_CHROMA_LOCATION_COSITED_EVEN;
+    case ChromaLocation::MIDPOINT:
+        return VK_CHROMA_LOCATION_MIDPOINT;
+    default:
+        assert_invariant(false &&
+            "Unknown data type, conversion is not supported.");
+    }
+}
+
+SamplerYcbcrModelConversion getYcbcrModelConversionFilament(VkSamplerYcbcrModelConversion model) {
+    switch (model) {
+        case VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY:
+            return SamplerYcbcrModelConversion::RGB_IDENTITY;
+        case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY:
+            return SamplerYcbcrModelConversion::YCBCR_IDENTITY;
+        case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709:
+            return SamplerYcbcrModelConversion::YCBCR_709;
+        case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601:
+            return SamplerYcbcrModelConversion::YCBCR_601;
+        case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020:
+            return SamplerYcbcrModelConversion::YCBCR_2020;
+        default:
+            assert_invariant(false && "Unknown data type, conversion is not supported.");
+            return {};
+    }
+}
+
+SamplerYcbcrRange getYcbcrRangeFilament(VkSamplerYcbcrRange range) {
+    switch (range) {
+        case VK_SAMPLER_YCBCR_RANGE_ITU_FULL:
+            return SamplerYcbcrRange::ITU_FULL;
+        case VK_SAMPLER_YCBCR_RANGE_ITU_NARROW:
+            return SamplerYcbcrRange::ITU_NARROW;
+        default:
+            assert_invariant(false && "Unknown data type, conversion is not supported.");
+            return {};
+    }
+}
+
+ChromaLocation getChromaLocationFilament(VkChromaLocation loc) {
+    switch (loc) {
+        case VK_CHROMA_LOCATION_COSITED_EVEN:
+            return ChromaLocation::COSITED_EVEN;
+        case VK_CHROMA_LOCATION_MIDPOINT:
+            return ChromaLocation::MIDPOINT;
+        default:
+            assert_invariant(false && "Unknown data type, conversion is not supported.");
+            return {};
+    }
+}
+
+TextureSwizzle getSwizzleFilament(VkComponentSwizzle c, uint8_t rgbaIndex) {
+    switch (c) {
+        case VK_COMPONENT_SWIZZLE_ZERO:
+            return TextureSwizzle::SUBSTITUTE_ZERO;
+        case VK_COMPONENT_SWIZZLE_ONE:
+            return TextureSwizzle::SUBSTITUTE_ONE;
+        case VK_COMPONENT_SWIZZLE_IDENTITY:
+            return (TextureSwizzle) (((uint8_t) TextureSwizzle::CHANNEL_0) + rgbaIndex);
+        case VK_COMPONENT_SWIZZLE_R:
+            return TextureSwizzle::CHANNEL_0;
+        case VK_COMPONENT_SWIZZLE_G:
+            return TextureSwizzle::CHANNEL_1;
+        case VK_COMPONENT_SWIZZLE_B:
+            return TextureSwizzle::CHANNEL_2;
+        case VK_COMPONENT_SWIZZLE_A:
+            return TextureSwizzle::CHANNEL_3;
+        default:
+            assert_invariant(false && "Unknown data type, conversion is not supported.");
+            return {};
+    }
+}
+
 } // namespace filament::backend::fvkutils

--- a/filament/backend/src/vulkan/utils/Conversion.h
+++ b/filament/backend/src/vulkan/utils/Conversion.h
@@ -69,6 +69,12 @@ VkSamplerYcbcrModelConversion getYcbcrModelConversion(SamplerYcbcrModelConversio
 VkSamplerYcbcrRange getYcbcrRange(SamplerYcbcrRange range);
 VkChromaLocation getChromaLocation(ChromaLocation loc);
 
+// Ycbcr related functions
+SamplerYcbcrModelConversion getYcbcrModelConversionFilament(VkSamplerYcbcrModelConversion model);
+SamplerYcbcrRange getYcbcrRangeFilament(VkSamplerYcbcrRange range);
+ChromaLocation getChromaLocationFilament(VkChromaLocation loc);
+TextureSwizzle getSwizzleFilament(VkComponentSwizzle c, uint8_t rgbaIndex);
+
 inline VkImageViewType getViewType(SamplerType target) {
     switch (target) {
         case SamplerType::SAMPLER_CUBEMAP:

--- a/filament/backend/src/vulkan/utils/Definitions.h
+++ b/filament/backend/src/vulkan/utils/Definitions.h
@@ -348,6 +348,10 @@ using SamplerBitmask = utils::bitset64;
 // general.
 using InputAttachmentBitmask = utils::bitset64;
 
+constexpr uint8_t MAX_DESCRIPTOR_SET_BITMASK_BITS =
+        std::max(std::max(sizeof(UniformBufferBitmask), sizeof(SamplerBitmask)),
+                sizeof(InputAttachmentBitmask)) * 8;
+
 template<typename Bitmask>
 static constexpr uint8_t getVertexStageShift() noexcept {
     // We assume the bottom half of bits are for vertex stages.

--- a/filament/backend/src/vulkan/utils/Image.cpp
+++ b/filament/backend/src/vulkan/utils/Image.cpp
@@ -193,49 +193,6 @@ uint8_t reduceSampleCount(uint8_t sampleCount, VkSampleCountFlags mask) {
     return mostSignificantBit((sampleCount - 1) & mask);
 }
 
-VkSamplerYcbcrModelConversion getYcbcrModelConversion(
-    SamplerYcbcrModelConversion model) {
-    switch (model) {
-    case SamplerYcbcrModelConversion::RGB_IDENTITY:
-        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
-    case SamplerYcbcrModelConversion::YCBCR_IDENTITY:
-        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY;
-    case SamplerYcbcrModelConversion::YCBCR_709:
-        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
-    case SamplerYcbcrModelConversion::YCBCR_601:
-        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601;
-    case SamplerYcbcrModelConversion::YCBCR_2020:
-        return VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    default:
-        assert_invariant(false &&
-            "Unknown data type, conversion is not supported.");
-    }
-}
-
-VkSamplerYcbcrRange getYcbcrRange(SamplerYcbcrRange range) {
-    switch (range) {
-    case SamplerYcbcrRange::ITU_FULL:
-        return VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
-    case SamplerYcbcrRange::ITU_NARROW:
-        return VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    default:
-        assert_invariant(false &&
-            "Unknown data type, conversion is not supported.");
-    }
-}
-
-VkChromaLocation getChromaLocation(ChromaLocation loc) {
-    switch (loc) {
-    case ChromaLocation::COSITED_EVEN:
-        return VK_CHROMA_LOCATION_COSITED_EVEN;
-    case ChromaLocation::MIDPOINT:
-        return VK_CHROMA_LOCATION_MIDPOINT;
-    default:
-        assert_invariant(false &&
-            "Unknown data type, conversion is not supported.");
-    }
-}
-
 } // namespace filament::backend::fvkutils
 
 bool operator<(const VkImageSubresourceRange& a, const VkImageSubresourceRange& b) {


### PR DESCRIPTION
 - Move utils functions to the right files
 - Add conversion from vk formats to filament
 - Refactor how to enable multiview and external sampler in VulkanPlatform
 - Make VuklanDescriptorSet and VuklanDescriptorSetLayout more general to allow for mutability
 - Reorder vulkan files in CMakeLists.txt to be sorted in alphabetical order.