### PR TITLE
VK: Reuse renderpasses after swapchain resize

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -327,7 +327,7 @@ void VulkanDriver::terminate() {
 
     mStagePool.terminate();
     mPipelineCache.terminate();
-    mFramebufferCache.reset();
+    mFramebufferCache.terminate();
     mSamplerCache.terminate();
     mDescriptorSetLayoutCache.terminate();
     mDescriptorSetCache.terminate();
@@ -1523,7 +1523,7 @@ void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
     swapChain->acquire(resized);
 
     if (resized) {
-        mFramebufferCache.reset();
+        mFramebufferCache.resetFramebuffers();
     }
 
     if (UTILS_LIKELY(mDefaultRenderTarget)) {

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -340,15 +340,24 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey const& config) noexcept
     return renderPass;
 }
 
-void VulkanFboCache::reset() noexcept {
-    for (auto pair : mFramebufferCache) {
+void VulkanFboCache::resetFramebuffers() noexcept {
+    for (const auto& pair: mFramebufferCache) {
         mRenderPassRefCount[pair.first.renderPass]--;
         vkDestroyFramebuffer(mDevice, pair.second.handle, VKALLOC);
     }
     mFramebufferCache.clear();
-    for (auto pair : mRenderPassCache) {
+}
+
+void VulkanFboCache::terminate() noexcept {
+    for (const auto& pair: mFramebufferCache) {
+        mRenderPassRefCount[pair.first.renderPass]--;
+        vkDestroyFramebuffer(mDevice, pair.second.handle, VKALLOC);
+    }
+    mFramebufferCache.clear();
+    for (const auto& pair: mRenderPassCache) {
         vkDestroyRenderPass(mDevice, pair.second.handle, VKALLOC);
     }
+    mRenderPassRefCount.clear();
     mRenderPassCache.clear();
 }
 

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -349,11 +349,8 @@ void VulkanFboCache::resetFramebuffers() noexcept {
 }
 
 void VulkanFboCache::terminate() noexcept {
-    for (const auto& pair: mFramebufferCache) {
-        mRenderPassRefCount[pair.first.renderPass]--;
-        vkDestroyFramebuffer(mDevice, pair.second.handle, VKALLOC);
-    }
-    mFramebufferCache.clear();
+    resetFramebuffers();
+
     for (const auto& pair: mRenderPassCache) {
         vkDestroyRenderPass(mDevice, pair.second.handle, VKALLOC);
     }

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -106,8 +106,11 @@ public:
     // Evicts old unused Vulkan objects. Call this once per frame.
     void gc() noexcept;
 
+    // Frees all Framebuffer objects. Call this every time a the swapchain is resized
+    void resetFramebuffers() noexcept;
+
     // Frees all Vulkan objects. Call this during shutdown before the device is destroyed.
-    void reset() noexcept;
+    void terminate() noexcept;
 
 private:
     VkDevice mDevice;


### PR DESCRIPTION
When a swapchain is resized the FBO cache gets resets which includes the framebuffer and renderpass objects. This causes pipelines to be recreated instead of being reused from the previous frames, causing stalls.

In the case of renderpasses there's no need to clear these objects, since the state of the renderpass is the same, only their refcount should be adjusted, fixing the issue mentioned above.