### PR TITLE
VK: Remove explicitImageReadyWait callback

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -104,10 +104,6 @@ public:
 
         // Semaphore to be signaled once the image is available.
         VkSemaphore imageReadySemaphore = VK_NULL_HANDLE;
-
-        // A function called right before vkQueueSubmit. After this call, the image must be 
-        // available. This pointer can be null if imageReadySemaphore is not VK_NULL_HANDLE.
-        std::function<void(SwapChainPtr handle)> explicitImageReadyWait = nullptr;
     };
 
     VulkanPlatform();

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -108,11 +108,6 @@ void VulkanSwapChain::present() {
 
     mCommands->flush();
 
-    // call the image ready wait function
-    if (mExplicitImageReadyWait != nullptr) {
-        mExplicitImageReadyWait(swapChain);
-    }
-
     // We only present if it is not headless. No-op for headless.
     if (!mHeadless) {
         VkSemaphore const finishedDrawing = mCommands->acquireFinishedSignal();
@@ -146,7 +141,6 @@ void VulkanSwapChain::acquire(bool& resized) {
     VulkanPlatform::ImageSyncData imageSyncData;
     VkResult const result = mPlatform->acquire(swapChain, &imageSyncData);
     mCurrentSwapIndex = imageSyncData.imageIndex;
-    mExplicitImageReadyWait = imageSyncData.explicitImageReadyWait;
     FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR)
             << "Cannot acquire in swapchain. error=" << static_cast<int32_t>(result);
     if (imageSyncData.imageReadySemaphore != VK_NULL_HANDLE) {

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -49,7 +49,9 @@ struct VulkanSwapChain : public HwSwapChain, fvkmemory::Resource {
 
     void present();
 
-    void acquire(bool& reized);
+    // Acquire a new image from the swapchain. If the image is not available it would wait until it
+    // is.
+    void acquire(bool& resized);
 
     fvkmemory::resource_ptr<VulkanTexture> getCurrentColor() const noexcept {
         uint32_t const imageIndex = mCurrentSwapIndex;
@@ -99,7 +101,6 @@ private:
     VkExtent2D mExtent;
     uint32_t mLayerCount;
     uint32_t mCurrentSwapIndex;
-    std::function<void(Platform::SwapChain* handle)> mExplicitImageReadyWait = nullptr;
     bool mAcquired;
     bool mIsFirstRenderPass;
 };


### PR DESCRIPTION
This function was created to make sure the swapchain image was available before submitting the work to the GPU.

This function is currently not in use so its safe to remove it.

So the order of the process looked like

| Acquire | Begin | Record | Wait | Present | End |

After this change the expectation is that when the swapchain acquires a new image it will also wait until is actually available from the platform.

| Acquire | Begin | Record | Present | End |

In the case the image is not available, the expectation is that the acquire will wait until it is and then start processing the frame.