### PR TITLE
Fix bug in FMaterialInstance::setParameterImpl() where mTextureParame…

### DIFF
--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -269,12 +269,14 @@ void FMaterialInstance::setParameterImpl(std::string_view const name,
     if (texture && texture->textureHandleCanMutate()) {
         mTextureParameters[binding] = { texture, sampler.getSamplerParams() };
     } else {
+        // Ensure to erase the binding from mTextureParameters since it will not
+        // be updated.
+        mTextureParameters.erase(binding);
+
         Handle<HwTexture> handle{};
         if (texture) {
             handle = texture->getHwHandleForSampling();
             assert_invariant(handle == texture->getHwHandle());
-        } else {
-            mTextureParameters.erase(binding);
         }
         mDescriptorSet.setSampler(binding, handle, sampler.getSamplerParams());
     }


### PR DESCRIPTION
Fix bug in FMaterialInstance::setParameterImpl() where mTextureParameters was not updated when a texture was reassigned if !texture->textureHandleCanMutate().
    
This could cause a crash in FMaterialInstance::commit() since the old texture binding was still in mTextureParameters but may have been destroyed.

BUG=406881511