### PR TITLE
webgpu:   Handle WebGPUDescriptorSetLayout creation

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -344,6 +344,9 @@ void WebGPUDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 
 void WebGPUDriver::destroyDescriptorSetLayout(Handle<HwDescriptorSetLayout> tqh) {
+    if (tqh) {
+        destructHandle<WebGPUDescriptorSetLayout>(tqh);
+    }
 }
 
 void WebGPUDriver::destroyDescriptorSet(Handle<HwDescriptorSet> tqh) {
@@ -418,8 +421,7 @@ Handle<HwRenderTarget> WebGPUDriver::createDefaultRenderTargetS() noexcept {
 }
 
 Handle<HwDescriptorSetLayout> WebGPUDriver::createDescriptorSetLayoutS() noexcept {
-    return Handle<HwDescriptorSetLayout>(
-            (Handle<HwDescriptorSetLayout>::HandleId) mNextFakeHandle++);
+    return allocHandle<WebGPUDescriptorSetLayout>();
 }
 
 Handle<HwTexture> WebGPUDriver::createTextureExternalImageS() noexcept {
@@ -520,7 +522,9 @@ void WebGPUDriver::createFenceR(Handle<HwFence> fh, int) {}
 void WebGPUDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, int) {}
 
 void WebGPUDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh,
-        backend::DescriptorSetLayout&& info) {}
+        backend::DescriptorSetLayout&& info) {
+    constructHandle<WebGPUDescriptorSetLayout>(dslh, std::move(info), &mDevice);
+}
 
 void WebGPUDriver::createDescriptorSetR(Handle<HwDescriptorSet> dsh,
         Handle<HwDescriptorSetLayout> dslh) {}

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -229,6 +229,14 @@ WebGPUDriver::WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfi
 #if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
     printInstanceDetails(mPlatform.getInstance());
 #endif
+    mAdapter = mPlatform.requestAdapter(nullptr);
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
+    printAdapterDetails(mAdapter);
+#endif
+    mDevice = mPlatform.requestDevice(mAdapter);
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
+    printDeviceDetails(mDevice);
+#endif
 }
 
 WebGPUDriver::~WebGPUDriver() noexcept = default;
@@ -430,14 +438,7 @@ void WebGPUDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
     mNativeWindow = nativeWindow;
     assert_invariant(!mSwapChain);
     wgpu::Surface surface = mPlatform.createSurface(nativeWindow, flags);
-    mAdapter = mPlatform.requestAdapter(surface);
-#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
-    printAdapterDetails(mAdapter);
-#endif
-    mDevice = mPlatform.requestDevice(mAdapter);
-#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
-    printDeviceDetails(mDevice);
-#endif
+
     mQueue = mDevice.GetQueue();
     wgpu::Extent2D surfaceSize = mPlatform.getSurfaceExtent(mNativeWindow);
     mSwapChain = constructHandle<WebGPUSwapChain>(sch, std::move(surface), surfaceSize, mAdapter,

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -60,4 +60,94 @@ void WGPUVertexBuffer::setBuffer(WGPUBufferObject* bufferObject, uint32_t index)
 WGPUBufferObject::WGPUBufferObject(BufferObjectBinding bindingType, uint32_t byteCount)
     : HwBufferObject(byteCount),
       bufferObjectBinding(bindingType) {}
+
+wgpu::ShaderStage WebGPUDescriptorSetLayout::filamentStageToWGPUStage(ShaderStageFlags fFlags) {
+    wgpu::ShaderStage retStages = wgpu::ShaderStage::None;
+    if (any(ShaderStageFlags::VERTEX & fFlags)) {
+        retStages |= wgpu::ShaderStage::Vertex;
+    }
+    if (any(ShaderStageFlags::FRAGMENT & fFlags)) {
+        retStages |= wgpu::ShaderStage::Fragment;
+    }
+    if (any(ShaderStageFlags::COMPUTE & fFlags)) {
+        retStages |= wgpu::ShaderStage::Compute;
+    }
+    return retStages;
+}
+
+WebGPUDescriptorSetLayout::WebGPUDescriptorSetLayout(DescriptorSetLayout const& layout,
+        wgpu::Device const* device) {
+    assert_invariant(device->Get());
+
+    // TODO: layoutDescriptor has a "Label". Ideally we can get info on what this layout is for
+    // debugging. For now, hack an incrementing value.
+    static int layoutNum = 0;
+
+
+    uint samplerCount =
+            std::count_if(layout.bindings.begin(), layout.bindings.end(), [](auto& fEntry) {
+                return fEntry.type == DescriptorType::SAMPLER ||
+                       fEntry.type == DescriptorType::SAMPLER_EXTERNAL;
+            });
+
+
+    std::vector<wgpu::BindGroupLayoutEntry> wEntries;
+    wEntries.reserve(layout.bindings.size() + samplerCount);
+
+    for (auto fEntry: layout.bindings) {
+        auto& wEntry = wEntries.emplace_back();
+        wEntry.visibility = filamentStageToWGPUStage(fEntry.stageFlags);
+        wEntry.binding = fEntry.binding * 2;
+
+        switch (fEntry.type) {
+            // TODO Metal treats these the same. Is this fine?
+            case DescriptorType::SAMPLER_EXTERNAL:
+            case DescriptorType::SAMPLER: {
+                // Sampler binding is 2n+1 due to split.
+                auto& samplerEntry = wEntries.emplace_back();
+                samplerEntry.binding = fEntry.binding * 2 + 1;
+                samplerEntry.visibility = wEntry.visibility;
+                // We are simply hoping that undefined and defaults suffices here.
+                samplerEntry.sampler.type = wgpu::SamplerBindingType::Undefined;
+                wEntry.texture.sampleType = wgpu::TextureSampleType::Undefined;
+                break;
+            }
+            case DescriptorType::UNIFORM_BUFFER: {
+                wEntry.buffer.hasDynamicOffset =
+                        any(fEntry.flags & DescriptorFlags::DYNAMIC_OFFSET);
+                wEntry.buffer.type = wgpu::BufferBindingType::Uniform;
+                // TODO: Ideally we fill minBindingSize
+                break;
+            }
+
+            case DescriptorType::INPUT_ATTACHMENT: {
+                // TODO: support INPUT_ATTACHMENT. Metal does not currently.
+                PANIC_POSTCONDITION("Input Attachment is not supported");
+                break;
+            }
+
+            case DescriptorType::SHADER_STORAGE_BUFFER: {
+                // TODO: Vulkan does not support this, can we?
+                PANIC_POSTCONDITION("Shader storage is not supported");
+                break;
+            }
+        }
+
+        // Currently flags are only used to specify dynamic offset.
+
+        // UNUSED
+        // fEntry.count
+    }
+
+    wgpu::BindGroupLayoutDescriptor layoutDescriptor{
+        // TODO: layoutDescriptor has a "Label". Ideally we can get info on what this layout is for
+        // debugging. For now, hack an incrementing value.
+        .label{ "layout_" + std::to_string(++layoutNum) },
+        .entryCount = wEntries.size(),
+        .entries = wEntries.data()
+    };
+    // TODO Do we need to defer this until we have more info on textures and samplers??
+    mLayout = device->CreateBindGroupLayout(&layoutDescriptor);
+}
+WebGPUDescriptorSetLayout::~WebGPUDescriptorSetLayout() {}
 }// namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -67,6 +67,18 @@ struct WGPUBufferObject : HwBufferObject {
     wgpu::Buffer buffer;
     const BufferObjectBinding bufferObjectBinding;
 };
+class WebGPUDescriptorSetLayout : public HwDescriptorSetLayout {
+public:
+    WebGPUDescriptorSetLayout(DescriptorSetLayout const& layout, wgpu::Device const* device);
+    ~WebGPUDescriptorSetLayout();
+
+private:
+    // TODO: If this is useful elsewhere, remove it from this class
+    // Convert Filament Shader Stage Flags bitmask to webgpu equivilant
+    static wgpu::ShaderStage filamentStageToWGPUStage(ShaderStageFlags fFlags);
+
+    wgpu::BindGroupLayout mLayout;
+};
 
 // TODO: Currently WGPUTexture is not used by WebGPU for useful task.
 // Update the struct when used by WebGPU driver.


### PR DESCRIPTION
Adds the ability to create a webgpu descriptor layout when Filament requests it.

BUGS = [403532779]
