### PR TITLE
Mark utils::ashmem_create_region with UTILS_PUBLIC

### DIFF
--- a/libs/utils/include/utils/ashmem.h
+++ b/libs/utils/include/utils/ashmem.h
@@ -16,11 +16,14 @@
 
 #ifndef TNT_UTILS_ASHMEM_H
 #define TNT_UTILS_ASHMEM_H
+ 
+#include <utils/compiler.h>
 
 #include <stddef.h>
 
 namespace utils {
 
+UTILS_PUBLIC
 int ashmem_create_region(const char *name, size_t size);
 
 } // namespace utils


### PR DESCRIPTION
`utils::ashmem_create_region` provides a cross-platform way to create shared memory region and very useful not only in production, but in unit tests as well.

This patch marks `utils::ashmem_create_region` with UTILS_PUBLIC to make sure this function remains visible by default.