### PR TITLE
Optimize slerp for quaternions.

### DIFF
--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -246,7 +246,7 @@ public:
         const T nq(norm(q));
         const T cos_theta = q.w / nq;
         const T sin_theta = std::sqrt(T(1) - cos_theta * cos_theta);
-        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta), cos_theta);
+        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta), cos_theta;
     }
 
     friend inline

--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -244,9 +244,8 @@ public:
     QUATERNION<T> MATH_PURE pow(const QUATERNION<T>& q, T a) {
         // could also be computed as: exp(a*log(q));
         const T nq(norm(q));
-        const T cos_theta = q.w / nq;
-        const T sin_theta = std::sqrt(T(1) - cos_theta * cos_theta);
-        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta, cos_theta);
+        const T theta(a * std::acos(q.w / nq));
+        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * std::sin(theta), std::cos(theta));
     }
 
     friend inline

--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -246,7 +246,7 @@ public:
         const T nq(norm(q));
         const T cos_theta = q.w / nq;
         const T sin_theta = std::sqrt(T(1) - cos_theta * cos_theta);
-        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta), cos_theta;
+        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta, cos_theta);
     }
 
     friend inline

--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -244,8 +244,9 @@ public:
     QUATERNION<T> MATH_PURE pow(const QUATERNION<T>& q, T a) {
         // could also be computed as: exp(a*log(q));
         const T nq(norm(q));
-        const T theta(a * std::acos(q.w / nq));
-        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * std::sin(theta), std::cos(theta));
+        const T cos_theta = q.w / nq;
+        const T sin_theta = std::sqrt(T(1) - cos_theta * cos_theta);
+        return std::pow(nq, a) * QUATERNION<T>(normalize(q.xyz) * sin_theta), cos_theta);
     }
 
     friend inline
@@ -259,10 +260,11 @@ public:
             return normalize(lerp(d < 0 ? -p : p, q, t));
         }
         const T npq = std::sqrt(dot(p, p) * dot(q, q));  // ||p|| * ||q||
-        const T a = std::acos(math::clamp(absd / npq, T(-1), T(1)));
+        const T cos_a = math::clamp(absd / npq, T(-1), T(1));
+        const T a = std::acos(cos_a);
         const T a0 = a * (1 - t);
         const T a1 = a * t;
-        const T sina = sin(a);
+        const T sina = std::sqrt(T(1) - cos_a * cos_a);
         if (sina < value_eps) {
             return normalize(lerp(p, q, t));
         }


### PR DESCRIPTION
Optimize pow and slerp for quaternions by using the identies sin(acos(x)) = sqrt(1-x^2)
