### PR TITLE
Add `UTILS_VERY_[UN]LIKELY` macros

### DIFF
--- a/filament/backend/src/opengl/GLUtils.cpp
+++ b/filament/backend/src/opengl/GLUtils.cpp
@@ -58,7 +58,7 @@ const char* getGLError(GLenum error) noexcept {
 UTILS_NOINLINE
 GLenum checkGLError(io::ostream& out, const char* function, size_t line) noexcept {
     GLenum const error = glGetError();
-    if (error != GL_NO_ERROR) {
+    if (UTILS_VERY_UNLIKELY(error != GL_NO_ERROR)) {
         const char* string = getGLError(error);
         out << "OpenGL error " << io::hex << error << " (" << string << ") in \""
             << function << "\" at line " << io::dec << line << io::endl;
@@ -69,7 +69,7 @@ GLenum checkGLError(io::ostream& out, const char* function, size_t line) noexcep
 UTILS_NOINLINE
 void assertGLError(io::ostream& out, const char* function, size_t line) noexcept {
     GLenum const err = checkGLError(out, function, line);
-    if (err != GL_NO_ERROR) {
+    if (UTILS_VERY_UNLIKELY(err != GL_NO_ERROR)) {
         debug_trap();
     }
 }
@@ -107,7 +107,7 @@ const char* getFramebufferStatus(GLenum status) noexcept {
 UTILS_NOINLINE
 GLenum checkFramebufferStatus(io::ostream& out, GLenum target, const char* function, size_t line) noexcept {
     GLenum const status = glCheckFramebufferStatus(target);
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
+    if (UTILS_VERY_UNLIKELY(status != GL_FRAMEBUFFER_COMPLETE)) {
         const char* string = getFramebufferStatus(status);
         out << "OpenGL framebuffer error " << io::hex << status << " (" << string << ") in \""
             << function << "\" at line " << io::dec << line << io::endl;
@@ -118,7 +118,7 @@ GLenum checkFramebufferStatus(io::ostream& out, GLenum target, const char* funct
 UTILS_NOINLINE
 void assertFramebufferStatus(io::ostream& out, GLenum target, const char* function, size_t line) noexcept {
     GLenum const status = checkFramebufferStatus(out, target, function, line);
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
+    if (UTILS_VERY_UNLIKELY(status != GL_FRAMEBUFFER_COMPLETE)) {
         debug_trap();
     }
 }

--- a/libs/utils/include/utils/Panic.h
+++ b/libs/utils/include/utils/Panic.h
@@ -560,7 +560,7 @@ public:
     switch (0)                                                                                     \
     case 0:                                                                                        \
     default:                                                                                       \
-        UTILS_LIKELY(cond) ? (void)0 : ::utils::details::Voidify()&&
+        UTILS_VERY_LIKELY(cond) ? (void)0 : ::utils::details::Voidify()&&
 
 #define FILAMENT_PANIC_IMPL(message, TYPE)                                                         \
         ::utils::details::TPanicStream<::utils::TYPE>(PANIC_FUNCTION, PANIC_FILE(__FILE__), __LINE__, message)
@@ -629,14 +629,14 @@ public:
  * @param format printf-style string describing the error in more details
  */
 #define ASSERT_PRECONDITION(cond, format, ...)                                                     \
-    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_PRECONDITION_NON_FATAL(cond, format, ...)                                           \
-    (!UTILS_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_PRECONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_PRECONDITION_NON_FATAL(cond, format, ...)                                           \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 
@@ -657,14 +657,14 @@ public:
  * @endcode
  */
 #define ASSERT_POSTCONDITION(cond, format, ...)                                                    \
-    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_POSTCONDITION_NON_FATAL(cond, format, ...)                                          \
-    (!UTILS_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_POSTCONDITION_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_POSTCONDITION_NON_FATAL(cond, format, ...)                                          \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 /**
@@ -689,10 +689,10 @@ public:
 
 #if defined(UTILS_EXCEPTIONS) || !defined(NDEBUG)
 #define ASSERT_ARITHMETIC_NON_FATAL(cond, format, ...)                                             \
-    (!UTILS_LIKELY(cond) ? PANIC_ARITHMETIC_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_ARITHMETIC_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #else
 #define ASSERT_ARITHMETIC_NON_FATAL(cond, format, ...)                                             \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__), false : true)
 #endif
 
 /**
@@ -717,6 +717,6 @@ public:
  * @endcode
  */
 #define ASSERT_DESTRUCTOR(cond, format, ...)                                                       \
-    (!UTILS_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
+    (!UTILS_VERY_LIKELY(cond) ? PANIC_LOG_IMPL(cond, format, ##__VA_ARGS__) : (void)0)
 
 #endif  // TNT_UTILS_PANIC_H

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -104,6 +104,19 @@
 #   define UTILS_UNLIKELY( exp )  (!!(exp))
 #endif
 
+#if __has_builtin(__builtin_expect_with_probability)
+#   ifdef __cplusplus
+#      define UTILS_VERY_LIKELY( exp )    (__builtin_expect_with_probability( !!(exp), true, 0.995 ))
+#      define UTILS_VERY_UNLIKELY( exp )  (__builtin_expect_with_probability( !!(exp), false, 0.995 ))
+#   else
+#      define UTILS_VERY_LIKELY( exp )    (__builtin_expect_with_probability( !!(exp), 1, 0.995 ))
+#      define UTILS_VERY_UNLIKELY( exp )  (__builtin_expect_with_probability( !!(exp), 0, 0.995 ))
+#   endif
+#else
+#   define UTILS_VERY_LIKELY( exp )    (!!(exp))
+#   define UTILS_VERY_UNLIKELY( exp )  (!!(exp))
+#endif
+
 #if __has_builtin(__builtin_prefetch)
 #   define UTILS_PREFETCH( exp ) (__builtin_prefetch(exp))
 #else

--- a/libs/utils/include/utils/debug.h
+++ b/libs/utils/include/utils/debug.h
@@ -28,7 +28,7 @@ void panic(const char *func, const char * file, int line, const char *assertion)
 #   define	assert_invariant(e)	((void)0)
 #else
 #   define	assert_invariant(e) \
-            (UTILS_LIKELY(e) ? ((void)0) : utils::panic(__func__, __FILE__, __LINE__, #e))
+            (UTILS_VERY_LIKELY(e) ? ((void)0) : utils::panic(__func__, __FILE__, __LINE__, #e))
 #endif // NDEBUG
 
 #endif // TNT_UTILS_DEBUG_H


### PR DESCRIPTION
clang optimizes code differently with very likely or unlikely  conditions, so we add a `VERY` version of these macros, and we make use of it for assertions.