### PR TITLE
Fix Clang 20 compile error: invalid std type trait specializations

### DIFF
--- a/libs/math/include/math/compiler.h
+++ b/libs/math/include/math/compiler.h
@@ -122,6 +122,11 @@ struct is_arithmetic : std::integral_constant<bool,
         std::is_integral<T>::value || std::is_floating_point<T>::value> {
 };
 
+template<typename T>
+struct is_floating_point : std::integral_constant<bool,
+        std::is_floating_point<T>::value> {
+};
+
 } // filament::math
 
 #endif // TNT_MATH_COMPILER_H

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -166,17 +166,23 @@ inline constexpr half operator""_h(long double v) {
 
 template<> struct is_arithmetic<half> : public std::true_type {};
 
+template<> struct is_floating_point<half> : public std::true_type {};
+
 } // namespace math
 } // namespace filament
 
 namespace std {
 
+// Note: This code may work with non-Clang compilers or Clang versions older than Clang 20.
+// Clang 20 explicitly blocks to customizing standard type traits.
+#if !defined(__clang__) || (defined(__clang__) && __clang_major__ < 20)
 template<> struct is_floating_point<filament::math::half> : public std::true_type {};
 
 // note: this shouldn't be needed (is_floating_point<> is enough) but some version of msvc need it
 // This stopped working with MSVC 2019 16.4, so we specialize our own version of is_arithmetic in
 // the math::filament namespace (see above).
 template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
+#endif
 
 template<>
 class numeric_limits<filament::math::half> {

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -173,17 +173,11 @@ template<> struct is_floating_point<half> : public std::true_type {};
 
 namespace std {
 
-// Note: This code may work with non-Clang compilers or Clang versions older than Clang 20.
-// Clang 20 explicitly blocks to customizing standard type traits.
-#if !defined(__clang__) || (defined(__clang__) && __clang_major__ < 20)
-template<> struct is_floating_point<filament::math::half> : public std::true_type {};
-
-// note: this shouldn't be needed (is_floating_point<> is enough) but some version of msvc need it
-// This stopped working with MSVC 2019 16.4, so we specialize our own version of is_arithmetic in
+// Remove the standard template specializations for filament::math::half
+// Clang 20 explicitly blocks customizing standard type traits
+// Instead, use the traits defined in the math:: namespace
+// This avoids compatibility issues with Clang 20 and MSVC 2019 16.4+
 // the math::filament namespace (see above).
-template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
-#endif
-
 template<>
 class numeric_limits<filament::math::half> {
 public:


### PR DESCRIPTION
The desired at (https://github.com/google/filament/pull/8599) split operation has been applied 

Clang 20 does not allow customization of standard type_traits
Disabled template customization of standard is_floating_point and is_arithmetic for Clang 20.
Fix: (https://github.com/google/filament/issues/8598)