### PR TITLE
Add debug messaging during OpenGL init phase for non-debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(FILAMENT_SUPPORTS_OSMESA "Enable OSMesa (headless GL context) for Filamen
 
 option(FILAMENT_ENABLE_FGVIEWER "Enable the frame graph viewer" OFF)
 
-option(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD "Enable GL error warnings during init in optimized builds" ON)
+option(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD "Enable GL error warnings during init in optimized builds" OFF)
 
 set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ option(FILAMENT_SUPPORTS_OSMESA "Enable OSMesa (headless GL context) for Filamen
 
 option(FILAMENT_ENABLE_FGVIEWER "Enable the frame graph viewer" OFF)
 
+option(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD "Enable GL error warnings during init in optimized builds" ON)
+
 set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
 )

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -318,6 +318,13 @@ if (WIN32 AND FILAMENT_SUPPORTS_WEBGPU)
     target_compile_definitions(${TARGET} PRIVATE "WGPU_IMPLEMENTATION")
 endif()
 
+# enable OpenGL init warnings for the optimized build
+if(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
+    target_compile_definitions(${TARGET} PRIVATE "FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD")
+endif()
+
+
+
 # ==================================================================================================
 # Expose a header-only target to minimize dependencies.
 # ==================================================================================================

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -50,6 +50,12 @@ void assertFramebufferStatus(utils::io::ostream& out, GLenum target, const char*
 #   define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __func__, __LINE__); }
 #endif
 
+#ifdef defined(NDEBUG) && defined(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
+#   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out) { GLUtils::assertGLError(out, __func__, __LINE__);}
+#else
+#   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out)
+#endif
+
 constexpr GLuint getComponentCount(ElementType const type) noexcept {
     using ElementType = ElementType;
     switch (type) {

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -50,7 +50,7 @@ void assertFramebufferStatus(utils::io::ostream& out, GLenum target, const char*
 #   define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __func__, __LINE__); }
 #endif
 
-#ifdef defined(NDEBUG) && defined(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
+#if defined(NDEBUG) && defined(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
 #   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out) { GLUtils::assertGLError(out, __func__, __LINE__);}
 #else
 #   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out)

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -50,9 +50,11 @@ void assertFramebufferStatus(utils::io::ostream& out, GLenum target, const char*
 #   define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __func__, __LINE__); }
 #endif
 
-#if defined(NDEBUG) && defined(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
+#ifndef NDEBUG
 #   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out) { GLUtils::assertGLError(out, __func__, __LINE__);}
-#else
+#elif defined(FILAMENT_ENABLE_INIT_GL_WARNINGS_FOR_OPTIMIZED_BUILD)
+#   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out) { GLUtils::checkGLError(out, __func__, __LINE__);}
+#else 
 #   define CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(out)
 #endif
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -59,6 +59,9 @@ bool OpenGLContext::queryOpenGLVersion(GLint* major, GLint* minor) noexcept {
     // OpenGL version
     glGetIntegerv(GL_MAJOR_VERSION, major);
     glGetIntegerv(GL_MINOR_VERSION, minor);
+
+    CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
+
     return (glGetError() == GL_NO_ERROR);
 #endif
 }
@@ -109,6 +112,8 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform,
     glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE,               &gets.max_3d_texture_size);
     glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS,          &gets.max_array_texture_layers);
 
+    CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
+
     mFeatureLevel = resolveFeatureLevel(state.major, state.minor, ext, gets, bugs);
 
 #ifdef BACKEND_OPENGL_VERSION_GLES
@@ -149,6 +154,7 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform,
         glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT,
                 &gets.uniform_buffer_offset_alignment);
 #endif
+        CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
     }
 
 #ifdef BACKEND_OPENGL_VERSION_GLES
@@ -235,6 +241,7 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform,
     }
 #endif
 #endif
+CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
 
     // in practice KHR_Debug has never been useful, and actually is confusing. We keep this
     // only for our own debugging, in case we need it some day.
@@ -269,6 +276,7 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform,
         glDebugMessageCallback(cb, nullptr);
     }
 #endif
+CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
 
     mTimerQueryFactory = TimerQueryFactory::init(platform, *this);
 }
@@ -384,6 +392,8 @@ void OpenGLContext::setDefaultState() noexcept {
         glEnable(GL_CLIP_DISTANCE0);
         glEnable(GL_CLIP_DISTANCE1);
     }
+
+    CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
 }
 
 
@@ -761,6 +771,8 @@ void OpenGLContext::initExtensionsGLES(Extensions* ext, GLint major, GLint minor
         ext->EXT_discard_framebuffer = true;
         ext->OES_vertex_array_object = true;
     }
+
+    CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
 }
 
 #endif // BACKEND_OPENGL_VERSION_GLES
@@ -831,6 +843,8 @@ void OpenGLContext::initExtensionsGL(Extensions* ext, GLint major, GLint minor) 
     if (major > 4 || (major == 4 && minor >= 5)) {
         ext->EXT_clip_control = true;
     }
+
+    CHECK_GL_INIT_ERROR_FOR_OPTIMIZED_BUILD(utils::slog.e)
 }
 
 #endif // BACKEND_OPENGL_VERSION_GL


### PR DESCRIPTION
Currently, in Filament's optimized builds, error-checking macros like `CHECK_GL_ERROR` are disabled, likely for performance or code size reasons. However, this poses a problem for developers who use Filament as a pre-built library. They find it difficult to detect initialization errors originating within Filament, even if their own application is a debug build.

This change proposes the addition of functionality to output warning messages when OpenGL errors occur during initialization, even in optimized (non-debug) builds. 

FIXES=[333130292]