### PR TITLE
webgpu: fix dummy bindings for bind groups that don't have resources corresponding to their layouts.

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -238,14 +238,6 @@ WebGPUDriver::WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfi
     printDeviceDetails(mDevice);
 #endif
     mQueue = mDevice.GetQueue();
-    bundle.sampler = mDevice.CreateSampler();
-    wgpu::BufferDescriptor bDesc{.label = "DummyBuff", .usage = wgpu::BufferUsage::Uniform, .size=1};
-    bundle.buffer = mDevice.CreateBuffer(&bDesc);
-    //Do we  need to keep a ref to this? If so into the bundle it goes
-    wgpu::TextureDescriptor texDesc{.label = "DummyTex",.usage=wgpu::TextureUsage::TextureBinding, .dimension = wgpu::TextureDimension::e2D, .size={1,1,1},.format=wgpu::TextureFormat::R8Unorm};
-    auto tempTex = mDevice.CreateTexture(&texDesc);
-    wgpu::TextureViewDescriptor texVDesc{.label = "DummyTex"};
-    bundle.textureView = tempTex.CreateView(&texVDesc);
 }
 
 WebGPUDriver::~WebGPUDriver() noexcept = default;
@@ -461,6 +453,8 @@ void WebGPUDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
     mSwapChain = constructHandle<WebGPUSwapChain>(sch, std::move(surface), surfaceSize, mAdapter,
             mDevice, flags);
     assert_invariant(mSwapChain);
+    WebGPUDescriptorSet::initializeDummyResourcesIfNotAlready(mDevice,
+            mSwapChain->getColorFormat());
     FWGPU_LOGW << "WebGPU support is still essentially a no-op at this point in development (only "
                   "background components have been instantiated/selected, such as surface/screen, "
                   "graphics device/GPU, etc.), thus nothing is being drawn to the screen."
@@ -582,7 +576,7 @@ void WebGPUDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh
 void WebGPUDriver::createDescriptorSetR(Handle<HwDescriptorSet> dsh,
         Handle<HwDescriptorSetLayout> dslh) {
     auto layout = handleCast<WebGPUDescriptorSetLayout>(dslh);
-    constructHandle<WebGPUDescriptorSet>(dsh, layout->getLayout(), layout->getLayoutSize(), layout->bindingToIndex, layout->typeVec, bundle);
+    constructHandle<WebGPUDescriptorSet>(dsh, layout->getLayout(), layout->getBindGroupEntries());
 }
 
 Handle<HwStream> WebGPUDriver::createStreamNative(void* nativeStream) {
@@ -985,7 +979,7 @@ void WebGPUDriver::updateDescriptorSetBuffer(Handle<HwDescriptorSet> dsh,
             .buffer = buffer->buffer,
             .offset = offset,
             .size = size };
-        bindGroup->addEntry(binding, std::move(entry));
+        bindGroup->addEntry(entry.binding, std::move(entry));
     }
 }
 
@@ -1001,11 +995,11 @@ void WebGPUDriver::updateDescriptorSetTexture(Handle<HwDescriptorSet> dsh,
         // TODO making assumptions that size and offset mean the same thing here.
         wgpu::BindGroupEntry tEntry{ .binding = static_cast<uint32_t>(binding * 2),
             .textureView = texture->getTexView() };
-        bindGroup->addEntry(binding, std::move(tEntry));
+        bindGroup->addEntry(tEntry.binding, std::move(tEntry));
 
         wgpu::BindGroupEntry sEntry{ .binding = static_cast<uint32_t>(binding * 2 + 1),
             .sampler = sampler };
-        bindGroup->addEntry(binding, std::move(sEntry));
+        bindGroup->addEntry(sEntry.binding, std::move(sEntry));
     }
 }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -53,7 +53,6 @@ public:
     [[nodiscard]] static Driver* create(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
 
 private:
-    dummyBundle bundle;
     explicit WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
     [[nodiscard]] ShaderModel getShaderModel() const noexcept final;
     [[nodiscard]] ShaderLanguage getShaderLanguage() const noexcept final;


### PR DESCRIPTION
This is more in line with what I believe we discussed yesterday regarding addressing the missing slots for bind groups.