### PR TITLE
Optional CMake flag for enabling ASAN for backend and its tests.

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -6,6 +6,18 @@ set(PUBLIC_HDR_DIR include)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 
 # ==================================================================================================
+# Compilation options
+# ==================================================================================================
+#
+set(BACKEND_SANITIZATION "" CACHE STRING "Sanitization option")
+set_property(CACHE BACKEND_SANITIZATION PROPERTY STRINGS ";ASAN")
+
+set(BACKEND_SANITIZERS)
+if (BACKEND_SANITIZATION STREQUAL "ASAN")
+    set(BACKEND_SANITIZERS -fsanitize=address)
+endif()
+
+# ==================================================================================================
 # Sources and headers
 # ==================================================================================================
 set(PUBLIC_HDRS
@@ -472,6 +484,7 @@ target_compile_options(${TARGET} PRIVATE
         ${OSMESA_COMPILE_FLAGS}
         $<$<CONFIG:Release>:${OPTIMIZATION_FLAGS}>
         $<$<AND:$<PLATFORM_ID:Darwin>,$<CONFIG:Release>>:${DARWIN_OPTIMIZATION_FLAGS}>
+        ${BACKEND_SANITIZERS}
 )
 
 if (FILAMENT_SUPPORTS_METAL)
@@ -481,6 +494,8 @@ endif()
 if (FILAMENT_SUPPORTS_WEBGPU)
     target_compile_definitions(${TARGET} PRIVATE $<$<BOOL:${FILAMENT_WEBGPU_IMMEDIATE_ERROR_HANDLING}>:FILAMENT_WEBGPU_IMMEDIATE_ERROR_HANDLING>)
 endif()
+
+target_link_options(${TARGET} PRIVATE ${BACKEND_SANITIZERS})
 
 target_link_libraries(${TARGET} PRIVATE
         ${OSMESA_LINKER_FLAGS}
@@ -551,6 +566,8 @@ if (APPLE AND NOT IOS)
          test/test_RenderExternalImage.cpp)
     add_library(backend_test STATIC ${BACKEND_TEST_SRC})
     target_link_libraries(backend_test PUBLIC ${BACKEND_TEST_LIBS})
+    target_compile_options(backend_test PRIVATE ${BACKEND_SANITIZERS})
+    target_link_options(backend_test PRIVATE ${BACKEND_SANITIZERS})
 
     set(BACKEND_TEST_DEPS
             OSDependent
@@ -589,6 +606,7 @@ if (APPLE AND NOT IOS)
        # linker from removing "unused" symbols.
        target_link_libraries(backend_test_mac PRIVATE -force_load backend_test)
        set_target_properties(backend_test_mac PROPERTIES FOLDER Tests)
+       target_link_options(backend_test_mac PRIVATE ${BACKEND_SANITIZERS})
 
        # This is needed after XCode 15.3
        set_target_properties(backend_test_mac PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
@@ -598,6 +616,8 @@ endif()
 
 if (LINUX)
     add_executable(backend_test_linux test/linux_runner.cpp ${BACKEND_TEST_SRC})
+    target_compile_options(backend_test_linux PRIVATE ${BACKEND_SANITIZERS})
+    target_link_options(backend_test_linux PRIVATE ${BACKEND_SANITIZERS})
     target_link_libraries(backend_test_linux PRIVATE ${BACKEND_TEST_LIBS})
     set_target_properties(backend_test_linux PROPERTIES FOLDER Tests)
 endif()


### PR DESCRIPTION
Add -DSANITIZATION=ASAN as an argument to CMake to enable.