### PR TITLE
webgpu: Headless Swapchain 

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -361,7 +361,7 @@ void WebGPUDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 
 void WebGPUDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t width,
         uint32_t height, uint64_t flags) {
-     wgpu::Extent2D extent = { width, height};
+     wgpu::Extent2D extent = { .width = width, .height = height };
      mSwapChain = constructHandle<WebGPUSwapChain>(sch, extent, mAdapter,
             mDevice, flags);
      assert_invariant(mSwapChain);
@@ -999,7 +999,7 @@ void WebGPUDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
          wgpu::Extent2D extent = mPlatform.getSurfaceExtent(mNativeWindow);
          mTextureView = mSwapChain->getCurrentTextureView(extent);
     } else {
-        mTextureView = mSwapChain->getCurrentTextureView();
+        mTextureView = mSwapChain->getCurrentHeadlessTextureView();
     }
 
     assert_invariant(mTextureView);

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -995,8 +995,13 @@ void WebGPUDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
     auto swapChain = handleCast<WebGPUSwapChain>(drawSch);
     mSwapChain = swapChain;
     assert_invariant(mSwapChain);
-    wgpu::Extent2D surfaceSize = mPlatform.getSurfaceExtent(mNativeWindow);
-    mTextureView = mSwapChain->getCurrentTextureView(surfaceSize, mDevice);
+    if(!mSwapChain->isHeadless()){
+         wgpu::Extent2D extent = mPlatform.getSurfaceExtent(mNativeWindow);
+         mTextureView = mSwapChain->getCurrentTextureView(extent);
+    } else {
+        mTextureView = mSwapChain->getCurrentTextureView();
+    }
+
     assert_invariant(mTextureView);
 
     assert_invariant(mDefaultRenderTarget);

--- a/filament/backend/src/webgpu/WebGPUSwapChain.h
+++ b/filament/backend/src/webgpu/WebGPUSwapChain.h
@@ -41,7 +41,7 @@ public:
     [[nodiscard]] wgpu::TextureFormat getDepthFormat() const { return mDepthFormat; }
 
     [[nodiscard]] wgpu::TextureView getCurrentTextureView(wgpu::Extent2D const& extent);
-    [[nodiscard]] wgpu::TextureView getCurrentTextureView();
+    [[nodiscard]] wgpu::TextureView getCurrentHeadlessTextureView();
 
     [[nodiscard]] wgpu::TextureView getDepthTextureView() const { return mDepthTextureView; }
 
@@ -69,11 +69,10 @@ private:
     const uint32_t mHeadlessWidth;
     const uint32_t mHeadlessHeight;
 
-    ///TODO: eventually config for double or triple buffering
     static constexpr uint32_t mHeadlessBufferCount = 3;
-    uint32_t mHeadlessBufferIndex = 0;
-    std::array<wgpu::Texture, 3> mRenderTargetTextures;
-    std::array<wgpu::TextureView, 3> mRenderTargetViews;
+    uint8_t mHeadlessBufferIndex = 0;
+    std::array<wgpu::Texture, mHeadlessBufferCount> mRenderTargetTextures;
+    std::array<wgpu::TextureView, mHeadlessBufferCount> mRenderTargetViews;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUSwapChain.h
+++ b/filament/backend/src/webgpu/WebGPUSwapChain.h
@@ -40,17 +40,16 @@ public:
 
     [[nodiscard]] wgpu::TextureFormat getDepthFormat() const { return mDepthFormat; }
 
-    [[nodiscard]] wgpu::TextureView getCurrentTextureView(wgpu::Extent2D const& extent, wgpu::Device const& device );
-
-    [[nodiscard]] wgpu::TextureDescriptor createRenderTargetDescriptor(uint32_t width, uint32_t height, wgpu::TextureFormat format);
+    [[nodiscard]] wgpu::TextureView getCurrentTextureView(wgpu::Extent2D const& extent);
+    [[nodiscard]] wgpu::TextureView getCurrentTextureView();
 
     [[nodiscard]] wgpu::TextureView getDepthTextureView() const { return mDepthTextureView; }
+
+    [[nodiscard]] bool isHeadless() const { return mType == SwapChainType::HEADLESS; }
 
     void present();
 
 private:
-
-    [[nodiscard]] bool isHeadless() const { return mType == SwapChainType::HEADLESS; }
 
     void setExtent(wgpu::Extent2D const&);
 
@@ -71,7 +70,7 @@ private:
     const uint32_t mHeadlessHeight;
 
     ///TODO: eventually config for double or triple buffering
-    const uint32_t mHeadlessBufferCount = 3;
+    static constexpr uint32_t mHeadlessBufferCount = 3;
     uint32_t mHeadlessBufferIndex = 0;
     std::array<wgpu::Texture, 3> mRenderTargetTextures;
     std::array<wgpu::TextureView, 3> mRenderTargetViews;


### PR DESCRIPTION
Provides a separate constructor to create a headless swapchain. 
Provisions textures and textureViews on initialization and reuses them.