### PR TITLE
Add getter functions for settings to build ColorGrading object

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,4 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+- `ColorGrading::Builder::toneMapper` now takes a `shared_ptr<ToneMapper>`

--- a/android/filament-android/src/main/cpp/ColorGrading.cpp
+++ b/android/filament-android/src/main/cpp/ColorGrading.cpp
@@ -18,6 +18,7 @@
 
 #include <filament/ColorGrading.h>
 #include <filament/ToneMapper.h>
+#include <memory>
 
 #include <math/vec3.h>
 #include <math/vec4.h>
@@ -67,8 +68,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_ColorGrading_nBuilderToneMapper(JNIEnv*, jclass,
         jlong nativeBuilder, jlong toneMapper_) {
     ColorGrading::Builder* builder = (ColorGrading::Builder*) nativeBuilder;
-    const ToneMapper* toneMapper = (const ToneMapper*) toneMapper_;
-    builder->toneMapper(toneMapper);
+    ToneMapper* toneMapper = reinterpret_cast<ToneMapper*>(toneMapper_);
+    std::shared_ptr<ToneMapper> toneMapperCopy = std::make_shared<ToneMapper>(*toneMapper);
+    builder->toneMapper(toneMapperCopy);
 }
 
 #pragma clang diagnostic push

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -214,9 +214,9 @@ public class ColorGrading {
          *
          * The default tone mapping operator is {@link ToneMapper.ACESLegacy}.
          *
-         * The specified tone mapper must have a lifecycle that exceeds the lifetime of
-         * this builder. Since the build(Engine&) method is synchronous, it is safe to
-         * delete the tone mapper object after that finishes executing.
+         * The copy of the specified tone mapper is set to this builder. It is safe to delete
+         * the original tone mapper object while the copied one is held by the built ColorGrading
+         * object.
          *
          * @param toneMapper The tone mapping operator to apply to the HDR color buffer
          *

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -21,13 +21,17 @@
 
 #include <filament/FilamentAPI.h>
 #include <filament/ToneMapper.h>
+#include <filament/ColorSpace.h>
 
 #include <utils/compiler.h>
 
 #include <math/mathfwd.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
 
 #include <stdint.h>
 #include <stddef.h>
+#include <memory>
 
 namespace filament {
 
@@ -201,15 +205,14 @@ public:
          *
          * The default tone mapping operator is ACESLegacyToneMapper.
          *
-         * The specified tone mapper must have a lifecycle that exceeds the lifetime of
-         * this builder. Since the build(Engine&) method is synchronous, it is safe to
-         * delete the tone mapper object after that finishes executing.
+         * The ownership of the specified tone mapper is shared with the builder and built
+         * ColorGrading object.
          *
          * @param toneMapper The tone mapping operator to apply to the HDR color buffer
          *
          * @return This Builder, for chaining calls
          */
-        Builder& toneMapper(ToneMapper const* UTILS_NULLABLE toneMapper) noexcept;
+        Builder& toneMapper(std::shared_ptr<ToneMapper> toneMapper) noexcept;
 
         /**
          * Selects the tone mapping operator to apply to the HDR color buffer as the last
@@ -487,7 +490,118 @@ public:
         friend class FColorGrading;
     };
 
-protected:
+    /** Returns the quality level used to create this ColorGrading object. */
+    QualityLevel getQuality() const noexcept;
+
+    /** Returns the LUT format used to create this ColorGrading object. */
+    LutFormat getLutFormat() const noexcept;
+
+    /** Returns the LUT dimensions used to create this ColorGrading object. */
+    uint8_t getLutDimensions() const noexcept;
+
+    /** Returns the tone mapper used to create this ColorGrading object. */
+    const ToneMapper& getToneMapper() const noexcept;
+
+    /** Returns whether luminance scaling was enabled during creation. */
+    bool isLuminanceScalingEnabled() const noexcept;
+
+    /** Returns whether gamut mapping was enabled during creation. */
+    bool isGamutMappingEnabled() const noexcept;
+
+    /** Returns the exposure value used to create this ColorGrading object. */
+    float getExposure() const noexcept;
+
+    /** Returns the night adaptation value used to create this ColorGrading object. */
+    float getNightAdaptation() const noexcept;
+
+    /** Returns the white balance temperature used to create this ColorGrading object. */
+    float getWhiteBalanceTemperature() const noexcept;
+
+    /** Returns the white balance tint used to create this ColorGrading object. */
+    float getWhiteBalanceTint() const noexcept;
+
+    /** Returns the channel mixer output for the red channel. */
+    math::float3 getChannelMixerOutRed() const noexcept;
+
+    /** Returns the channel mixer output for the green channel. */
+    math::float3 getChannelMixerOutGreen() const noexcept;
+
+    /** Returns the channel mixer output for the blue channel. */
+    math::float3 getChannelMixerOutBlue() const noexcept;
+
+    /** Returns the shadows adjustment used to create this ColorGrading object. */
+    math::float3 getShadows() const noexcept;
+
+    /** Returns the midtones adjustment used to create this ColorGrading object. */
+    math::float3 getMidtones() const noexcept;
+
+    /** Returns the highlights adjustment used to create this ColorGrading object. */
+    math::float3 getHighlights() const noexcept;
+
+    /** Returns the shadow/midtones/highlights ranges used to create this ColorGrading object. */
+    math::float4 getShadowMidtonesHighlightsRanges() const noexcept;
+
+    /** Returns the slope adjustment used to create this ColorGrading object. */
+    math::float3 getSlope() const noexcept;
+
+    /** Returns the offset adjustment used to create this ColorGrading object. */
+    math::float3 getOffset() const noexcept;
+
+    /** Returns the power adjustment used to create this ColorGrading object. */
+    math::float3 getPower() const noexcept;
+
+    /** Returns the contrast value used to create this ColorGrading object. */
+    float getContrast() const noexcept;
+
+    /** Returns the vibrance value used to create this ColorGrading object. */
+    float getVibrance() const noexcept;
+
+    /** Returns the saturation value used to create this ColorGrading object. */
+    float getSaturation() const noexcept;
+
+    /** Returns the shadow gamma curve adjustment used to create this ColorGrading object. */
+    math::float3 getCurvesShadowGamma() const noexcept;
+
+    /** Returns the mid-point curve adjustment used to create this ColorGrading object. */
+    math::float3 getCurvesMidPoint() const noexcept;
+
+    /** Returns the highlight scale curve adjustment used to create this ColorGrading object. */
+    math::float3 getCurvesHighlightScale() const noexcept;
+
+    /** Returns the output color space used to create this ColorGrading object. */
+    const color::ColorSpace& getOutputColorSpace() const noexcept;
+
+protected :
+    struct Settings {
+        LutFormat lutFormat = LutFormat::INTEGER;
+        uint8_t lutDimensions = 32;
+        std::shared_ptr<ToneMapper> toneMapper = std::make_shared<ACESLegacyToneMapper>();
+        bool luminanceScaling = false;
+        bool gummapMapping = false;
+        float exposure = 0.0f;
+        float nightAdaptation = 0.0f;
+        float whiteBalanceTemperature = 0.0f;
+        float whiteBalanceTint = 0.0f;
+        math::float3 channelMixerOutRed{1.0f, 0.0f, 0.0f};
+        math::float3 channelMixerOutGreen{0.0f, 1.0f, 0.0f};
+        math::float3 channelMixerOutBlue{0.0f, 0.0f, 1.0f};
+        math::float3 shadows{1.0f, 1.0f, 1.0f};
+        math::float3 midtones{1.0f, 1.0f, 1.0f};
+        math::float3 highlights{1.0f, 1.0f, 1.0f};
+        math::float4 ShadowMidtonesHighlightsRanges{0.0f, 0.333f, 0.55f, 1.0f};
+        math::float3 slope{1.0f};
+        math::float3 offset{0.0f};
+        math::float3 power{1.0f};
+        float contrast = 1.0f;
+        float vibrance = 1.0f;
+        float saturation = 1.0f;
+        math::float3 curvesShadowGamma{1.0f, 1.0f, 1.0f};
+        math::float3 curvesMidPoint{1.0f, 1.0f, 1.0f};
+        math::float3 curvesHighlightScale{1.0f, 1.0f, 1.0f};
+        color::ColorSpace colorSpace = color::Rec709 - color::sRGB - color::D65;
+    };
+    Settings mSettings;
+
     // prevent heap allocation
     ~ColorGrading() = default;
 };

--- a/filament/src/details/ColorGrading.h
+++ b/filament/src/details/ColorGrading.h
@@ -51,6 +51,8 @@ private:
     uint32_t mDimension;
     bool mIsOneDimensional;
     bool mIsLDR;
+
+    void initializeSettings(Settings& settings, const Builder& builder) noexcept;
 };
 
 FILAMENT_DOWNCAST(ColorGrading)

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -700,7 +700,8 @@ constexpr ToneMapper* createToneMapper(const ColorGradingSettings& settings) noe
 }
 
 ColorGrading* createColorGrading(const ColorGradingSettings& settings, Engine* engine) {
-    ToneMapper* toneMapper = createToneMapper(settings);
+    ToneMapper* toneMapperRaw = createToneMapper(settings);
+    std::shared_ptr<ToneMapper> toneMapper(toneMapperRaw);
     ColorGrading *colorGrading = ColorGrading::Builder()
             .quality(settings.quality)
             .exposure(settings.exposure)
@@ -723,7 +724,6 @@ ColorGrading* createColorGrading(const ColorGradingSettings& settings, Engine* e
             .gamutMapping(settings.gamutMapping)
             .outputColorSpace(settings.colorspace)
             .build(*engine);
-    delete toneMapper;
     return colorGrading;
 }
 


### PR DESCRIPTION
Currently, ColorGrading is created using a builder API, but there's no way to retrieve the settings that were used to build it after the fact. As the most simple and robust solution, this change make the `ColorGrading` object storing its creation parameters internally and providing their getter functions.

This change also involves changing changing the interface of the existing `ToneMapper` setter of the builder so that it takes tone mapper as `shared_ptr` instead of the raw pointer. For JNI function impl, to avoid the risk of the double free between C++ codes and JVM GC, the `ToneMapper` instance is just copied and passed.

FIXES=[364901658]