### PR TITLE
VK: Add a new platform method to check UMA

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -142,6 +142,10 @@ public:
         return mPortabilitySubsetFeatures.imageView2DOn3DImage == VK_TRUE;
     }
 
+    inline bool isUnifiedMemoryArchitecture() const noexcept {
+        return mIsUnifiedMemoryArchitecture;
+    }
+
 private:
     VkPhysicalDeviceMemoryProperties mMemoryProperties = {};
     VkPhysicalDeviceProperties2 mPhysicalDeviceProperties = {
@@ -164,6 +168,7 @@ private:
     bool mDebugUtilsSupported = false;
     bool mLazilyAllocatedMemorySupported = false;
     bool mProtectedMemorySupported = false;
+    bool mIsUnifiedMemoryArchitecture = false;
 
     fvkutils::VkFormatList mDepthStencilFormats;
     fvkutils::VkFormatList mBlittableDepthStencilFormats;

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -634,10 +634,7 @@ fvkutils::VkFormatList findBlittableDepthStencilFormats(VkPhysicalDevice device)
 /**
  *  Check if the GPU has a unified memory architecture.
  */
-bool hasUnifiedMemoryArchitecture(VkPhysicalDevice device) noexcept {
-    VkPhysicalDeviceMemoryProperties memoryProperties;
-    vkGetPhysicalDeviceMemoryProperties(device, &memoryProperties);
-
+bool hasUnifiedMemoryArchitecture(VkPhysicalDeviceMemoryProperties memoryProperties) noexcept {
     // Try to identify if the platform is running on a Unified Memory Architecture by inspecting the
     // memory heap flags, if they are all VK_MEMORY_HEAP_DEVICE_LOCAL_BIT it's UMA, otherwise not
     // enough information to make a decision, so default to false.
@@ -882,7 +879,7 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
         }
     }
 
-    context.mIsUnifiedMemoryArchitecture = hasUnifiedMemoryArchitecture(mImpl->mPhysicalDevice);
+    context.mIsUnifiedMemoryArchitecture = hasUnifiedMemoryArchitecture(context.mMemoryProperties);
 
 #ifdef NDEBUG
     // If we are in release build, we should not have turned on debug extensions

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -631,6 +631,24 @@ fvkutils::VkFormatList findBlittableDepthStencilFormats(VkPhysicalDevice device)
     return ret;
 }
 
+/**
+ *  Check if the GPU has a unified memory architecture.
+ */
+bool hasUnifiedMemoryArchitecture(VkPhysicalDevice device) noexcept {
+    VkPhysicalDeviceMemoryProperties memoryProperties;
+    vkGetPhysicalDeviceMemoryProperties(device, &memoryProperties);
+
+    // Try to identify if the platform is running on a Unified Memory Architecture by inspecting the
+    // memory heap flags, if they are all VK_MEMORY_HEAP_DEVICE_LOCAL_BIT it's UMA, otherwise not
+    // enough information to make a decision, so default to false.
+    for (uint32_t i = 0; i < memoryProperties.memoryHeapCount; ++i) {
+        if ((memoryProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }// anonymous namespace
 
 using SwapChainPtr = VulkanPlatform::SwapChainPtr;
@@ -863,6 +881,8 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
             break;
         }
     }
+
+    context.mIsUnifiedMemoryArchitecture = hasUnifiedMemoryArchitecture(mImpl->mPhysicalDevice);
 
 #ifdef NDEBUG
     // If we are in release build, we should not have turned on debug extensions


### PR DESCRIPTION
This heuristic should work on almost all android
devices, can be extended later as needed.

On non android platforms the default is always false.