### PR TITLE
Clean-up build.sh android

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -463,16 +463,6 @@ function ensure_android_build {
         echo "Error: Android NDK side-by-side version ${FILAMENT_NDK_VERSION} or compatible must be installed, exiting"
         exit 1
     fi
-
-    local cmake_version=$(cmake --version)
-    if [[ "${cmake_version}" =~ ([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
-        if [[ "${BASH_REMATCH[1]}" -lt "${CMAKE_MAJOR}" ]] || \
-           [[ "${BASH_REMATCH[2]}" -lt "${CMAKE_MINOR}" ]]; then
-            echo "Error: cmake version ${CMAKE_MAJOR}.${CMAKE_MINOR}+ is required," \
-                 "${BASH_REMATCH[1]}.${BASH_REMATCH[2]} installed, exiting"
-            exit 1
-        fi
-    fi
 }
 
 function build_android {


### PR DESCRIPTION
Failed to build android when using CMake >= 4.0.

Remove a no longer required check for the android build. This check should be covered by the cmake_minimum_required() call, which is present in relevant CMakeLists.txts.