### PR TITLE
Add defines to strip unused default materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ option(FILAMENT_ENABLE_FEATURE_LEVEL_0 "Enable Feature Level 0" ON)
 
 option(FILAMENT_ENABLE_MULTIVIEW "Enable multiview for Filament" OFF)
 
+option(FILAMENT_TRIM_DEFAULT_MATERIAL "Trim default material for Filament" OFF)
+
+option(FILAMENT_TRIM_SKYBOX_MATERIAL "Trim skybox material for Filament" OFF)
+
 option(FILAMENT_SUPPORTS_OSMESA "Enable OSMesa (headless GL context) for Filament" OFF)
 
 option(FILAMENT_ENABLE_FGVIEWER "Enable the frame graph viewer" OFF)

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -237,7 +237,6 @@ set(MATERIAL_SRCS
         src/materials/colorGrading/colorGradingAsSubpass.mat
         src/materials/colorGrading/customResolveAsSubpass.mat
         src/materials/debugShadowCascades.mat
-        src/materials/defaultMaterial.mat
         src/materials/dof/dof.mat
         src/materials/dof/dofCoc.mat
         src/materials/dof/dofCombine.mat
@@ -255,7 +254,6 @@ set(MATERIAL_SRCS
         src/materials/sgsr/sgsr1.mat
         src/materials/resolveDepth.mat
         src/materials/separableGaussianBlur.mat
-        src/materials/skybox.mat
         src/materials/shadowmap.mat
         src/materials/ssao/bilateralBlur.mat
         src/materials/ssao/bilateralBlurBentNormals.mat
@@ -265,15 +263,13 @@ set(MATERIAL_SRCS
         src/materials/vsmMipmap.mat
 )
 
-set(MATERIAL_FL0_SRCS
-        src/materials/defaultMaterial.mat
-        src/materials/skybox.mat
-)
-
-set(MATERIAL_MULTIVIEW_SRCS
-        src/materials/defaultMaterial.mat
-        src/materials/skybox.mat
-)
+set(BASIC_MATERIAL_SRCS)
+if (NOT FILAMENT_TRIM_DEFAULT_MATERIAL)
+    list(APPEND BASIC_MATERIAL_SRCS src/materials/defaultMaterial.mat)
+endif()
+if (NOT FILAMENT_TRIM_SKYBOX_MATERIAL)
+    list(APPEND BASIC_MATERIAL_SRCS src/materials/skybox.mat)
+endif()
 
 # Embed the binary resource blob for materials.
 get_resgen_vars(${RESOURCE_DIR} materials)
@@ -307,6 +303,16 @@ endif()
 # Whether to include MULTIVIEW materials.
 if (FILAMENT_ENABLE_MULTIVIEW)
     add_definitions(-DFILAMENT_ENABLE_MULTIVIEW)
+endif()
+
+# Whether to trim default material.
+if (FILAMENT_TRIM_DEFAULT_MATERIAL)
+    add_definitions(-DFILAMENT_TRIM_DEFAULT_MATERIAL)
+endif()
+
+# Whether to trim skybox material.
+if (FILAMENT_TRIM_SKYBOX_MATERIAL)
+    add_definitions(-DFILAMENT_TRIM_SKYBOX_MATERIAL)
 endif()
 
 # Whether to force the profiling mode.
@@ -352,9 +358,22 @@ foreach (mat_src ${MATERIAL_SRCS})
             COMMENT "Compiling material ${fullname} to ${output_path}"
     )
     list(APPEND MATERIAL_BINS ${output_path})
+endforeach()
 
-    list(FIND MATERIAL_FL0_SRCS ${mat_src} index)
-    if (${index} GREATER -1 AND FILAMENT_ENABLE_FEATURE_LEVEL_0)
+foreach (mat_src ${BASIC_MATERIAL_SRCS})
+    get_filename_component(localname "${mat_src}" NAME_WE)
+    get_filename_component(fullname "${mat_src}" ABSOLUTE)
+    set(output_path "${MATERIAL_DIR}/${localname}.filamat")
+    add_custom_command(
+            OUTPUT ${output_path}
+            COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${fullname}
+            MAIN_DEPENDENCY ${fullname}
+            DEPENDS matc
+            COMMENT "Compiling material ${fullname} to ${output_path}"
+    )
+    list(APPEND MATERIAL_BINS ${output_path})
+
+    if (FILAMENT_ENABLE_FEATURE_LEVEL_0)
         string(REGEX REPLACE "[.]filamat$" "_fl0.filamat" output_path_fl0 ${output_path})
         add_custom_command(
                 OUTPUT ${output_path_fl0}
@@ -366,8 +385,7 @@ foreach (mat_src ${MATERIAL_SRCS})
         list(APPEND MATERIAL_BINS ${output_path_fl0})
     endif ()
 
-    list(FIND MATERIAL_MULTIVIEW_SRCS ${mat_src} index)
-    if (${index} GREATER -1 AND FILAMENT_ENABLE_MULTIVIEW)
+    if (FILAMENT_ENABLE_MULTIVIEW)
         string(REGEX REPLACE "[.]filamat$" "_multiview.filamat" output_path_multiview ${output_path})
         add_custom_command(
                 OUTPUT ${output_path_multiview}
@@ -378,7 +396,6 @@ foreach (mat_src ${MATERIAL_SRCS})
         )
         list(APPEND MATERIAL_BINS ${output_path_multiview})
     endif ()
-
 endforeach()
 
 # Additional dependencies on included files for materials

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -35,9 +35,14 @@ namespace filament {
 void FRenderPrimitive::init(HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
         FRenderableManager::Entry const& entry) noexcept {
 
+#if !defined(FILAMENT_TRIM_DEFAULT_MATERIAL)
     assert_invariant(entry.materialInstance);
-
     mMaterialInstance = downcast(entry.materialInstance);
+#else
+    if (entry.materialInstance) {
+        mMaterialInstance = downcast(entry.materialInstance);
+    }
+#endif
     mBlendOrder = entry.blendOrder;
 
     if (entry.indices && entry.vertices) {

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -468,12 +468,16 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
         auto& entry = mImpl->mEntries[i];
 
         // entry.materialInstance must be set to something even if indices/vertices are null
-        FMaterial const* material;
-        if (!entry.materialInstance) {
+        FMaterial const* material = nullptr;
+        if (entry.materialInstance) {
+            material = downcast(entry.materialInstance->getMaterial());
+        } else {
+#if defined(FILAMENT_TRIM_DEFAULT_MATERIAL)
+            continue;
+#else
             material = downcast(engine.getDefaultMaterial());
             entry.materialInstance = material->getDefaultInstance();
-        } else {
-            material = downcast(entry.materialInstance->getMaterial());
+#endif
         }
 
         // primitives without indices or vertices will be ignored
@@ -700,7 +704,7 @@ void FRenderableManager::create(
                     primitives[i].setMorphingBufferOffset(morphing.offset);
                 }
             }
-            
+
             // When targetCount equal 0, boneCount>0 in this case, do an initialization for the
             // morphWeights uniform array to avoid crash on adreno gpu.
             if (UTILS_UNLIKELY(targetCount == 0 &&

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -416,15 +416,18 @@ void FEngine::init() {
 
 #ifdef FILAMENT_ENABLE_FEATURE_LEVEL_0
     if (UTILS_UNLIKELY(mActiveFeatureLevel == FeatureLevel::FEATURE_LEVEL_0)) {
+#if !defined(FILAMENT_TRIM_DEFAULT_MATERIAL)
         FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
         defaultMaterialBuilder.package(
                 MATERIALS_DEFAULTMATERIAL_FL0_DATA, MATERIALS_DEFAULTMATERIAL_FL0_SIZE);
         mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
+#endif
     } else
 #endif
     {
         mDefaultColorGrading = downcast(ColorGrading::Builder().build(*this));
 
+#if !defined(FILAMENT_TRIM_DEFAULT_MATERIAL)
         FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
         switch (mConfig.stereoscopicType) {
             case StereoscopicType::NONE:
@@ -442,6 +445,7 @@ void FEngine::init() {
                 break;
         }
         mDefaultMaterial = downcast(defaultMaterialBuilder.build(*this));
+#endif
 
         constexpr float3 dummyPositions[1] = {};
         constexpr short4 dummyTangents[1] = {};
@@ -794,9 +798,9 @@ int FEngine::loop() {
 #if FILAMENT_ENABLE_MATDBG
     if(debug.server) {
         delete debug.server;
-    } 
+    }
 #endif
-#if FILAMENT_ENABLE_FGVIEWER 
+#if FILAMENT_ENABLE_FGVIEWER
     if(debug.fgviewerServer) {
         delete debug.fgviewerServer;
     }

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -1126,6 +1126,7 @@ void FMaterial::precacheDepthVariants(FEngine& engine) {
         return;
     }
 
+#if !defined(FILAMENT_TRIM_DEFAULT_MATERIAL)
     // if possible pre-cache all depth variants from the default material
     if (mMaterialDomain == MaterialDomain::SURFACE &&
             !mIsDefaultMaterial &&
@@ -1138,6 +1139,7 @@ void FMaterial::precacheDepthVariants(FEngine& engine) {
             mCachedPrograms[variant.key] = pDefaultMaterial->mCachedPrograms[variant.key];
         }
     }
+#endif
 }
 
 void FMaterial::processDescriptorSets(FEngine& engine, MaterialParser const* const parser) {

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -88,7 +88,11 @@ Skybox* Skybox::Builder::build(Engine& engine) {
     FILAMENT_CHECK_PRECONDITION(!cubemap || cubemap->isCubemap())
             << "environment maps must be a cubemap";
 
+#if defined(FILAMENT_TRIM_SKYBOX_MATERIAL)
+    return nullptr;
+#else
     return downcast(engine).createSkybox(*this);
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -124,6 +128,9 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
 }
 
 FMaterial const* FSkybox::createMaterial(FEngine& engine) {
+#ifdef FILAMENT_TRIM_SKYBOX_MATERIAL
+    return nullptr;
+#else
     Material::Builder builder;
 #ifdef FILAMENT_ENABLE_FEATURE_LEVEL_0
     if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == Engine::FeatureLevel::FEATURE_LEVEL_0)) {
@@ -148,6 +155,7 @@ FMaterial const* FSkybox::createMaterial(FEngine& engine) {
     }
     auto material = builder.build(engine);
     return downcast(material);
+#endif
 }
 
 void FSkybox::terminate(FEngine& engine) noexcept {

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -571,7 +571,7 @@ void FilamentApp::loadIBL(std::string_view path) {
         }
     }
 
-    if (mIBL != nullptr) {
+    if (mIBL != nullptr && mIBL->getSkybox()) {
         mIBL->getSkybox()->setLayerMask(0x7, 0x4);
         mScene->setSkybox(mIBL->getSkybox());
         mScene->setIndirectLight(mIBL->getIndirectLight());


### PR DESCRIPTION
Add defines for trimming default materials. These enable binary size reduction by omitting them. Referencing the trimmed material will cause associated renderables to be skipped from rendering.

BUG=[415840223]