### PR TITLE
webgpu: Ebridgewater/fix dawn hack

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -64,6 +64,7 @@ private:
     WebGPUPlatform& mPlatform;
     wgpu::Adapter mAdapter = nullptr;
     wgpu::Device mDevice = nullptr;
+    uint32_t mMinUniformBufferOffsetAlignment;
     wgpu::Queue mQueue = nullptr;
     void* mNativeWindow = nullptr;
     WebGPUSwapChain* mSwapChain = nullptr;

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -58,26 +58,6 @@ private:
     [[nodiscard]] ShaderLanguage getShaderLanguage() const noexcept final;
     [[nodiscard]] wgpu::Sampler makeSampler(SamplerParams const& params);
     [[nodiscard]] static wgpu::AddressMode fWrapModeToWAddressMode(const filament::backend::SamplerWrapMode& fUsage);
-    template<typename GPUBufferObject>
-    void updateGPUBuffer(GPUBufferObject* gpuBufferObject, BufferDescriptor&& bufferDescriptor,
-            uint32_t byteOffset) {
-        FILAMENT_CHECK_PRECONDITION(bufferDescriptor.buffer)
-                << "copyIntoBuffer called with a null buffer";
-        FILAMENT_CHECK_PRECONDITION(
-                bufferDescriptor.size + byteOffset <= gpuBufferObject->buffer.GetSize())
-                << "Attempting to copy " << bufferDescriptor.size << " bytes into a buffer of size "
-                << gpuBufferObject->buffer.GetSize() << " at offset " << byteOffset;
-
-        // TODO: All buffer objects are created with CopyDst usage.
-        // This may have some performance implications. That should be investigated later.
-        assert_invariant(gpuBufferObject->buffer.GetUsage() & wgpu::BufferUsage::CopyDst);
-
-        // WriteBuffer is an async call. But cpu buffer data is already written to the staging
-        // buffer on return from the WriteBuffer.
-        mQueue.WriteBuffer(gpuBufferObject->buffer, byteOffset, bufferDescriptor.buffer,
-                bufferDescriptor.size);
-        scheduleDestroy(std::move(bufferDescriptor));
-    }
 
     // the platform (e.g. OS) specific aspects of the WebGPU backend are strictly only
     // handled in the WebGPUPlatform

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -172,6 +172,8 @@ void WGPUBufferBase::updateGPUBuffer(BufferDescriptor& bufferDescriptor, uint32_
     FILAMENT_CHECK_PRECONDITION(bufferDescriptor.size + byteOffset <= buffer.GetSize())
             << "Attempting to copy " << bufferDescriptor.size << " bytes into a buffer of size "
             << buffer.GetSize() << " at offset " << byteOffset;
+    FILAMENT_CHECK_PRECONDITION(byteOffset % 4 == 0)
+            << "Byte offset must be a multiple of 4 but is " << byteOffset;
 
     // TODO: All buffer objects are created with CopyDst usage.
     // This may have some performance implications. That should be investigated later.

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -41,15 +41,6 @@ constexpr wgpu::BufferUsage getBufferObjectUsage(
     }
 }
 
-wgpu::Buffer createBuffer(wgpu::Device const& device, wgpu::BufferUsage usage, uint32_t size,
-        char const* label) {
-    wgpu::BufferDescriptor descriptor{ .label = label,
-        .usage = usage,
-        .size = size,
-        .mappedAtCreation = false };
-    return device.CreateBuffer(&descriptor);
-}
-
 wgpu::VertexFormat getVertexFormat(filament::backend::ElementType type, bool normalized, bool integer) {
     using ElementType = filament::backend::ElementType;
     using VertexFormat = wgpu::VertexFormat;
@@ -162,6 +153,47 @@ wgpu::StringView getUserTextureViewLabel(filament::backend::SamplerType target) 
 
 namespace filament::backend {
 
+void WGPUBufferBase::createBuffer(const wgpu::Device& device, wgpu::BufferUsage usage,
+        uint32_t size, const char* label) {
+    // Write size must be divisible by 4. If the whole buffer is written to as is common, so must
+    // the buffer size.
+    size += (4 - (size % 4)) % 4;
+    wgpu::BufferDescriptor descriptor{ .label = label,
+        .usage = usage,
+        .size = size,
+        .mappedAtCreation = false };
+    buffer = device.CreateBuffer(&descriptor);
+}
+
+void WGPUBufferBase::updateGPUBuffer(BufferDescriptor& bufferDescriptor, uint32_t byteOffset,
+        wgpu::Queue queue) {
+    FILAMENT_CHECK_PRECONDITION(bufferDescriptor.buffer)
+            << "copyIntoBuffer called with a null buffer";
+    FILAMENT_CHECK_PRECONDITION(bufferDescriptor.size + byteOffset <= buffer.GetSize())
+            << "Attempting to copy " << bufferDescriptor.size << " bytes into a buffer of size "
+            << buffer.GetSize() << " at offset " << byteOffset;
+
+    // TODO: All buffer objects are created with CopyDst usage.
+    // This may have some performance implications. That should be investigated later.
+    assert_invariant(buffer.GetUsage() & wgpu::BufferUsage::CopyDst);
+
+    size_t remainder = bufferDescriptor.size % 4;
+
+    // WriteBuffer is an async call. But cpu buffer data is already written to the staging
+    // buffer on return from the WriteBuffer.
+    auto legalSize = bufferDescriptor.size - remainder;
+    queue.WriteBuffer(buffer, byteOffset, bufferDescriptor.buffer, legalSize);
+    if (remainder != 0) {
+        const uint8_t* remainderStart =
+                static_cast<const uint8_t*>(bufferDescriptor.buffer) + legalSize;
+        memcpy(mRemainderChunk.data(), remainderStart, remainder);
+        // Pad the remainder with zeros to ensure deterministic behavior, though GPU shouldn't
+        // access this
+        std::memset(mRemainderChunk.data() + remainder, 0, 4 - remainder);
+
+        queue.WriteBuffer(buffer, byteOffset + legalSize, &mRemainderChunk, 4);
+    }
+}
 WGPUVertexBufferInfo::WGPUVertexBufferInfo(uint8_t bufferCount, uint8_t attributeCount,
         AttributeArray const& attributes)
     : HwVertexBufferInfo(bufferCount, attributeCount),
@@ -204,9 +236,10 @@ WGPUVertexBufferInfo::WGPUVertexBufferInfo(uint8_t bufferCount, uint8_t attribut
 
 WGPUIndexBuffer::WGPUIndexBuffer(wgpu::Device const& device, uint8_t elementSize,
         uint32_t indexCount)
-    : buffer(createBuffer(device, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Index,
-              elementSize * indexCount, "index_buffer")),
-      indexFormat(elementSize == 2 ? wgpu::IndexFormat::Uint16 : wgpu::IndexFormat::Uint32) {}
+    : indexFormat(elementSize == 2 ? wgpu::IndexFormat::Uint16 : wgpu::IndexFormat::Uint32) {
+    createBuffer(device, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Index,
+            elementSize * indexCount, "index_buffer");
+}
 
 
 WGPUVertexBuffer::WGPUVertexBuffer(wgpu::Device const& device, uint32_t vertexCount,
@@ -217,10 +250,10 @@ WGPUVertexBuffer::WGPUVertexBuffer(wgpu::Device const& device, uint32_t vertexCo
 
 WGPUBufferObject::WGPUBufferObject(wgpu::Device const& device, BufferObjectBinding bindingType,
         uint32_t byteCount)
-    : HwBufferObject(byteCount),
-      buffer(createBuffer(device, wgpu::BufferUsage::CopyDst | getBufferObjectUsage(bindingType),
-              byteCount, "buffer_object")),
-      bufferObjectBinding(bindingType) {}
+    : HwBufferObject(byteCount) {
+    createBuffer(device, wgpu::BufferUsage::CopyDst | getBufferObjectUsage(bindingType), byteCount,
+            "buffer_object");
+}
 
 wgpu::ShaderStage WebGPUDescriptorSetLayout::filamentStageToWGPUStage(ShaderStageFlags fFlags) {
     wgpu::ShaderStage retStages = wgpu::ShaderStage::None;

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -44,7 +44,6 @@ public:
     std::vector<wgpu::ConstantEntry> constants;
 };
 
-struct WGPUBufferObject;
 
 // VertexBufferInfo contains layout info for Vertex Buffer based on WebGPU structs. In WebGPU each
 // VertexBufferLayout is associated with a single vertex buffer. So number of mVertexBufferLayout
@@ -86,19 +85,30 @@ struct WGPUVertexBuffer : public HwVertexBuffer {
     utils::FixedCapacityVector<wgpu::Buffer> buffers;
 };
 
-struct WGPUIndexBuffer : public HwIndexBuffer {
+class WGPUBufferBase {
+public:
+    void createBuffer(wgpu::Device const& device, wgpu::BufferUsage usage, uint32_t size,
+            char const* label);
+    void updateGPUBuffer(BufferDescriptor& bufferDescriptor, uint32_t byteOffset,
+            wgpu::Queue queue);
+    const wgpu::Buffer& getBuffer() const { return buffer; }
+protected:
+    wgpu::Buffer buffer;
+private:
+    // 4 bytes to hold any extra chunk we need.
+    std::array<uint8_t,4> mRemainderChunk;
+};
+
+class WGPUIndexBuffer : public HwIndexBuffer, public WGPUBufferBase {
+public:
     WGPUIndexBuffer(wgpu::Device const &device, uint8_t elementSize,
                     uint32_t indexCount);
-
-    wgpu::Buffer buffer;
     wgpu::IndexFormat indexFormat;
 };
 
-struct WGPUBufferObject : HwBufferObject {
+class WGPUBufferObject : public HwBufferObject, public WGPUBufferBase {
+public:
     WGPUBufferObject(wgpu::Device const &device, BufferObjectBinding bindingType, uint32_t byteCount);
-
-    wgpu::Buffer buffer = nullptr;
-    const BufferObjectBinding bufferObjectBinding;
 };
 
 class WebGPUDescriptorSetLayout final : public HwDescriptorSetLayout {

--- a/third_party/dawn/src/dawn/native/CommandValidation.cpp
+++ b/third_party/dawn/src/dawn/native/CommandValidation.cpp
@@ -229,10 +229,10 @@ MaybeError ValidateWriteBuffer(const DeviceBase* device,
                                uint64_t size) {
     DAWN_TRY(device->ValidateObject(buffer));
 
-    // DAWN_INVALID_IF(bufferOffset % 4 != 0, "BufferOffset (%u) is not a multiple of 4.",
-    //                 bufferOffset);
-    //
-    // DAWN_INVALID_IF(size % 4 != 0, "Size (%u) is not a multiple of 4.", size);
+    DAWN_INVALID_IF(bufferOffset % 4 != 0, "BufferOffset (%u) is not a multiple of 4.",
+                    bufferOffset);
+
+    DAWN_INVALID_IF(size % 4 != 0, "Size (%u) is not a multiple of 4.", size);
 
     uint64_t bufferSize = buffer->GetSize();
     DAWN_INVALID_IF(bufferOffset > bufferSize || size > (bufferSize - bufferOffset),


### PR DESCRIPTION
BUGS=["416091729"]
Revert our Dawn hack, and both handle sizes that are different than Dawn enforces, but also enforce offset rules which don't have a workaround (At least for now).