### PR TITLE
Add glFramebufferTextureMultisampleMultiviewOVR for multiview MSAA

### DIFF
--- a/libs/bluegl/include/GL/glext.h
+++ b/libs/bluegl/include/GL/glext.h
@@ -11125,6 +11125,14 @@ GLAPI void APIENTRY glFramebufferTextureMultiviewOVR (GLenum target, GLenum atta
 #define GL_OVR_multiview2 1
 #endif /* GL_OVR_multiview2 */
 
+#ifndef GL_OVR_multiview_multisampled_render_to_texture
+#define GL_OVR_multiview_multisampled_render_to_texture 1
+typedef void (APIENTRYP PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glFramebufferTextureMultisampleMultiviewOVR (GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
+#endif
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
+
 #ifndef GL_PGI_misc_hints
 #define GL_PGI_misc_hints 1
 #define GL_PREFER_DOUBLEBUFFER_HINT_PGI   0x1A1F8

--- a/libs/bluegl/include/bluegl/BlueGL.h
+++ b/libs/bluegl/include/bluegl/BlueGL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/bluegl/include/bluegl/BlueGLDefines.h
+++ b/libs/bluegl/include/bluegl/BlueGLDefines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2460,6 +2460,7 @@
 #define glVideoCaptureStreamParameterfvNV bluegl_glVideoCaptureStreamParameterfvNV
 #define glVideoCaptureStreamParameterdvNV bluegl_glVideoCaptureStreamParameterdvNV
 #define glFramebufferTextureMultiviewOVR bluegl_glFramebufferTextureMultiviewOVR
+#define glFramebufferTextureMultisampleMultiviewOVR bluegl_glFramebufferTextureMultisampleMultiviewOVR
 #define glHintPGI bluegl_glHintPGI
 #define glDetailTexFuncSGIS bluegl_glDetailTexFuncSGIS
 #define glGetDetailTexFuncSGIS bluegl_glGetDetailTexFuncSGIS

--- a/libs/bluegl/src/BlueGLCoreDarwinAArch64Impl.S
+++ b/libs/bluegl/src/BlueGLCoreDarwinAArch64Impl.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19519,6 +19519,14 @@ _bluegl_glVideoCaptureStreamParameterdvNV:
 _bluegl_glFramebufferTextureMultiviewOVR:
 	adrp	x16, ___blue_glCore_glFramebufferTextureMultiviewOVR@GOTPAGE
 	ldr	x16, [x16, ___blue_glCore_glFramebufferTextureMultiviewOVR@GOTPAGEOFF]
+	ldr	x16, [x16]
+	br	x16
+
+.private_extern _bluegl_glFramebufferTextureMultisampleMultiviewOVR
+	.align	2
+_bluegl_glFramebufferTextureMultisampleMultiviewOVR:
+	adrp	x16, ___blue_glCore_glFramebufferTextureMultisampleMultiviewOVR@GOTPAGE
+	ldr	x16, [x16, ___blue_glCore_glFramebufferTextureMultisampleMultiviewOVR@GOTPAGEOFF]
 	ldr	x16, [x16]
 	br	x16
 

--- a/libs/bluegl/src/BlueGLCoreDarwinImpl.S
+++ b/libs/bluegl/src/BlueGLCoreDarwinImpl.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12206,6 +12206,11 @@ _bluegl_glVideoCaptureStreamParameterdvNV:
 .private_extern _bluegl_glFramebufferTextureMultiviewOVR
 _bluegl_glFramebufferTextureMultiviewOVR:
     mov ___blue_glCore_glFramebufferTextureMultiviewOVR@GOTPCREL(%rip), %r11
+    jmp *(%r11)
+
+.private_extern _bluegl_glFramebufferTextureMultisampleMultiviewOVR
+_bluegl_glFramebufferTextureMultisampleMultiviewOVR:
+    mov ___blue_glCore_glFramebufferTextureMultisampleMultiviewOVR@GOTPCREL(%rip), %r11
     jmp *(%r11)
 
 .private_extern _bluegl_glHintPGI

--- a/libs/bluegl/src/BlueGLCoreLinuxAArch64Impl.S
+++ b/libs/bluegl/src/BlueGLCoreLinuxAArch64Impl.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24397,6 +24397,16 @@ bluegl_glFramebufferTextureMultiviewOVR:
 	ldr	x16, [x16]
 	br	x16
 	.size	bluegl_glFramebufferTextureMultiviewOVR, .-bluegl_glFramebufferTextureMultiviewOVR
+
+	.align	2
+	.global	bluegl_glFramebufferTextureMultisampleMultiviewOVR
+	.type	bluegl_glFramebufferTextureMultisampleMultiviewOVR, %function
+bluegl_glFramebufferTextureMultisampleMultiviewOVR:
+	adrp	x16, :got:__blue_glCore_glFramebufferTextureMultisampleMultiviewOVR
+	ldr	x16, [x16, #:got_lo12:__blue_glCore_glFramebufferTextureMultisampleMultiviewOVR]
+	ldr	x16, [x16]
+	br	x16
+	.size	bluegl_glFramebufferTextureMultisampleMultiviewOVR, .-bluegl_glFramebufferTextureMultisampleMultiviewOVR
 
 	.align	2
 	.global	bluegl_glHintPGI

--- a/libs/bluegl/src/BlueGLCoreLinuxImpl.S
+++ b/libs/bluegl/src/BlueGLCoreLinuxImpl.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14644,6 +14644,12 @@ bluegl_glVideoCaptureStreamParameterdvNV:
 .type bluegl_glFramebufferTextureMultiviewOVR, %function
 bluegl_glFramebufferTextureMultiviewOVR:
     mov __blue_glCore_glFramebufferTextureMultiviewOVR@GOTPCREL(%rip), %r11
+    jmp *(%r11)
+
+.global bluegl_glFramebufferTextureMultisampleMultiviewOVR
+.type bluegl_glFramebufferTextureMultisampleMultiviewOVR, %function
+bluegl_glFramebufferTextureMultisampleMultiviewOVR:
+    mov __blue_glCore_glFramebufferTextureMultisampleMultiviewOVR@GOTPCREL(%rip), %r11
     jmp *(%r11)
 
 .global bluegl_glHintPGI

--- a/libs/bluegl/src/BlueGLCoreWindows32Impl.cpp
+++ b/libs/bluegl/src/BlueGLCoreWindows32Impl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14651,6 +14651,12 @@ extern void* __blue_glCore_glFramebufferTextureMultiviewOVR;
 void APIENTRY bluegl_glFramebufferTextureMultiviewOVR (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews) {
     typedef void (APIENTRYP PFN_glFramebufferTextureMultiviewOVR) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
     return ((PFN_glFramebufferTextureMultiviewOVR)__blue_glCore_glFramebufferTextureMultiviewOVR)(target, attachment, texture, level, baseViewIndex, numViews);
+}
+
+extern void* __blue_glCore_glFramebufferTextureMultisampleMultiviewOVR;
+void APIENTRY bluegl_glFramebufferTextureMultisampleMultiviewOVR (GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews) {
+    typedef void (APIENTRYP PFN_glFramebufferTextureMultisampleMultiviewOVR) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
+    return ((PFN_glFramebufferTextureMultisampleMultiviewOVR)__blue_glCore_glFramebufferTextureMultisampleMultiviewOVR)(target, attachment, texture, level, samples, baseViewIndex, numViews);
 }
 
 extern void* __blue_glCore_glHintPGI;

--- a/libs/bluegl/src/BlueGLCoreWindowsImpl.S
+++ b/libs/bluegl/src/BlueGLCoreWindowsImpl.S
@@ -1,5 +1,5 @@
 ;
-; Copyright (C) 2023 The Android Open Source Project
+; Copyright (C) 2025 The Android Open Source Project
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -14646,6 +14646,12 @@ bluegl_glFramebufferTextureMultiviewOVR proc
     mov r11, __blue_glCore_glFramebufferTextureMultiviewOVR
     jmp r11
 bluegl_glFramebufferTextureMultiviewOVR endp
+
+extrn __blue_glCore_glFramebufferTextureMultisampleMultiviewOVR: qword
+bluegl_glFramebufferTextureMultisampleMultiviewOVR proc
+    mov r11, __blue_glCore_glFramebufferTextureMultisampleMultiviewOVR
+    jmp r11
+bluegl_glFramebufferTextureMultisampleMultiviewOVR endp
 
 extrn __blue_glCore_glHintPGI: qword
 bluegl_glHintPGI proc

--- a/libs/bluegl/src/private_BlueGL.h
+++ b/libs/bluegl/src/private_BlueGL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The Android Open Source Project
+ * Copyright (C) 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2458,6 +2458,7 @@ void* __blue_glCore_glVideoCaptureStreamParameterivNV;
 void* __blue_glCore_glVideoCaptureStreamParameterfvNV;
 void* __blue_glCore_glVideoCaptureStreamParameterdvNV;
 void* __blue_glCore_glFramebufferTextureMultiviewOVR;
+void* __blue_glCore_glFramebufferTextureMultisampleMultiviewOVR;
 void* __blue_glCore_glHintPGI;
 void* __blue_glCore_glDetailTexFuncSGIS;
 void* __blue_glCore_glGetDetailTexFuncSGIS;
@@ -5044,6 +5045,7 @@ struct {
     { &__blue_glCore_glVideoCaptureStreamParameterfvNV, "glVideoCaptureStreamParameterfvNV" },
     { &__blue_glCore_glVideoCaptureStreamParameterdvNV, "glVideoCaptureStreamParameterdvNV" },
     { &__blue_glCore_glFramebufferTextureMultiviewOVR, "glFramebufferTextureMultiviewOVR" },
+    { &__blue_glCore_glFramebufferTextureMultisampleMultiviewOVR, "glFramebufferTextureMultisampleMultiviewOVR" },
     { &__blue_glCore_glHintPGI, "glHintPGI" },
     { &__blue_glCore_glDetailTexFuncSGIS, "glDetailTexFuncSGIS" },
     { &__blue_glCore_glGetDetailTexFuncSGIS, "glGetDetailTexFuncSGIS" },
@@ -5181,5 +5183,5 @@ struct {
     { &__blue_glCore_glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fSUN, "glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fSUN" },
     { &__blue_glCore_glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN, "glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN" },
 };
-size_t blueCoreNumFunctions = 2574;
+size_t blueCoreNumFunctions = 2575;
 } // namespace bluegl


### PR DESCRIPTION
This commit adds the `glFramebufferTextureMultisampleMultiviewOVR` function, enabling MSAA to work in conjunction with the multiview extension.

The function's declaration is present in the latest main branch of the Khronos GLES2 API headers. While directly pulling these updated headers is the ideal approach, it would necessitate a significant reorganization of Filament's current header file structure and incorporate more files than currently needed.

To minimize immediate changes and limit scope, this change adopts only the necessary function declaration by copying it directly.

BUGS=[417311684]