### PR TITLE
VK: Introduce VulkanMemoryPool

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -202,6 +202,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanHandles.h
             src/vulkan/VulkanMemory.cpp
             src/vulkan/VulkanMemory.h
+            src/vulkan/VulkanMemoryPool.h
+            src/vulkan/VulkanMemoryPool.cpp
             src/vulkan/VulkanPipelineCache.cpp
             src/vulkan/VulkanPipelineCache.h
             src/vulkan/VulkanPipelineLayoutCache.cpp

--- a/filament/backend/src/vulkan/VulkanBuffer.h
+++ b/filament/backend/src/vulkan/VulkanBuffer.h
@@ -18,31 +18,32 @@
 #define TNT_FILAMENT_BACKEND_VULKANBUFFER_H
 
 #include "VulkanContext.h"
-#include "VulkanStagePool.h"
 #include "VulkanMemory.h"
+#include "VulkanMemoryPool.h"
+#include "VulkanStagePool.h"
 
 namespace filament::backend {
 
 // Encapsulates a Vulkan buffer, its attached DeviceMemory and a staging area.
 class VulkanBuffer {
 public:
-    VulkanBuffer(VmaAllocator allocator, VulkanStagePool& stagePool, VkBufferUsageFlags usage,
-            uint32_t numBytes);
-    ~VulkanBuffer();
+    VulkanBuffer(VmaAllocator allocator, VulkanStagePool& stagePool, VulkanMemoryPool& memoryPool,
+            VulkanBufferUsage usage, uint32_t numBytes);
+
     void loadFromCpu(VkCommandBuffer cmdbuf, const void* cpuData, uint32_t byteOffset,
             uint32_t numBytes);
-    VkBuffer getGpuBuffer() const {
-        return mGpuBuffer;
-    }
+
+    VkBuffer getGpuBuffer() const noexcept;
+
+    VulkanBufferUsage getUsage() const noexcept;
 
 private:
     VmaAllocator mAllocator;
     VulkanStagePool& mStagePool;
+    VulkanMemoryPool& mMemoryPool;
 
-    VmaAllocation mGpuMemory = VK_NULL_HANDLE;
-    VkBuffer mGpuBuffer = VK_NULL_HANDLE;
-    VkBufferUsageFlags mUsage = {};
-	uint32_t mUpdatedOffset = 0;
+    fvkmemory::resource_ptr<VulkanBufferMemory> mGpuMemory;
+    uint32_t mUpdatedOffset = 0;
     uint32_t mUpdatedBytes = 0;
 };
 

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -81,6 +81,8 @@
 // All other debug features must be disabled.
 #define FVK_DEBUG_PROFILING               0x00040000
 
+#define FVK_DEBUG_MEMORY_POOL_ALLOCATION  0x00080000
+
 // Useful default combinations
 #define FVK_DEBUG_EVERYTHING              (0xFFFFFFFF & ~FVK_DEBUG_PROFILING)
 #define FVK_DEBUG_PERFORMANCE     \

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -22,11 +22,13 @@
 #include "VulkanContext.h"
 #include "VulkanFboCache.h"
 #include "VulkanHandles.h"
+#include "VulkanMemory.h"
+#include "VulkanMemoryPool.h"
 #include "VulkanPipelineCache.h"
+#include "VulkanQueryManager.h"
 #include "VulkanReadPixels.h"
 #include "VulkanSamplerCache.h"
 #include "VulkanStagePool.h"
-#include "VulkanQueryManager.h"
 #include "VulkanYcbcrConversionCache.h"
 #include "vulkan/VulkanDescriptorSetCache.h"
 #include "vulkan/VulkanDescriptorSetLayoutCache.h"
@@ -138,6 +140,7 @@ private:
     VulkanPipelineLayoutCache mPipelineLayoutCache;
     VulkanPipelineCache mPipelineCache;
     VulkanStagePool mStagePool;
+    VulkanMemoryPool mMemoryPool;
     VulkanFboCache mFramebufferCache;
     VulkanYcbcrConversionCache mYcbcrConversionCache;
     VulkanSamplerCache mSamplerCache;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -590,15 +590,15 @@ void VulkanVertexBuffer::setBuffer(fvkmemory::resource_ptr<VulkanBufferObject> b
 }
 
 VulkanBufferObject::VulkanBufferObject(VmaAllocator allocator, VulkanStagePool& stagePool,
-        uint32_t byteCount, BufferObjectBinding bindingType)
+        VulkanMemoryPool& memoryPool, uint32_t byteCount, BufferObjectBinding bindingType)
     : HwBufferObject(byteCount),
-      buffer(allocator, stagePool, getBufferObjectUsage(bindingType), byteCount),
+      buffer(allocator, stagePool, memoryPool, getBufferObjectUsage(bindingType), byteCount),
       bindingType(bindingType) {}
 
 VulkanRenderPrimitive::VulkanRenderPrimitive(PrimitiveType pt,
         fvkmemory::resource_ptr<VulkanVertexBuffer> vb,
         fvkmemory::resource_ptr<VulkanIndexBuffer> ib)
-    : HwRenderPrimitive{.type = pt},
+    : HwRenderPrimitive{ .type = pt },
       vertexBuffer(vb),
       indexBuffer(ib) {}
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -23,18 +23,19 @@
 #include "VulkanAsyncHandles.h"
 #include "VulkanBuffer.h"
 #include "VulkanFboCache.h"
+#include "VulkanMemoryPool.h"
 #include "VulkanSwapChain.h"
 #include "VulkanTexture.h"
 #include "vulkan/memory/Resource.h"
-#include "vulkan/utils/StaticVector.h"
 #include "vulkan/utils/Definitions.h"
+#include "vulkan/utils/StaticVector.h"
 
 #include <backend/Program.h>
 
-#include <utils/bitset.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Mutex.h>
 #include <utils/StructureOfArrays.h>
+#include <utils/bitset.h>
 
 #include <array>
 
@@ -428,10 +429,11 @@ private:
 };
 
 struct VulkanIndexBuffer : public HwIndexBuffer, fvkmemory::Resource {
-    VulkanIndexBuffer(VmaAllocator allocator, VulkanStagePool& stagePool, uint8_t elementSize,
-            uint32_t indexCount)
+    VulkanIndexBuffer(VmaAllocator allocator, VulkanStagePool& stagePool,
+            VulkanMemoryPool& memoryPool, uint8_t elementSize, uint32_t indexCount)
         : HwIndexBuffer(elementSize, indexCount),
-          buffer(allocator, stagePool, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount),
+          buffer(allocator, stagePool, memoryPool, VulkanBufferUsage::INDEX,
+                  elementSize * indexCount),
           indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32) {}
 
     VulkanBuffer buffer;
@@ -439,8 +441,8 @@ struct VulkanIndexBuffer : public HwIndexBuffer, fvkmemory::Resource {
 };
 
 struct VulkanBufferObject : public HwBufferObject, fvkmemory::Resource {
-    VulkanBufferObject(VmaAllocator allocator, VulkanStagePool& stagePool, uint32_t byteCount,
-            BufferObjectBinding bindingType);
+    VulkanBufferObject(VmaAllocator allocator, VulkanStagePool& stagePool,
+            VulkanMemoryPool& memoryPool, uint32_t byteCount, BufferObjectBinding bindingType);
 
     VulkanBuffer buffer;
     const BufferObjectBinding bindingType;
@@ -455,18 +457,19 @@ struct VulkanRenderPrimitive : public HwRenderPrimitive, fvkmemory::Resource {
     fvkmemory::resource_ptr<VulkanIndexBuffer> indexBuffer;
 };
 
-inline constexpr VkBufferUsageFlagBits getBufferObjectUsage(
-        BufferObjectBinding bindingType) noexcept {
-    switch(bindingType) {
+inline constexpr VulkanBufferUsage getBufferObjectUsage(BufferObjectBinding bindingType) noexcept {
+    switch (bindingType) {
         case BufferObjectBinding::VERTEX:
-            return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+            return VulkanBufferUsage::VERTEX;
         case BufferObjectBinding::UNIFORM:
-            return VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+            return VulkanBufferUsage::UNIFORM;
         case BufferObjectBinding::SHADER_STORAGE:
-            return VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        // when adding more buffer-types here, make sure to update VulkanBuffer::loadFromCpu()
-        // if necessary.
+            return VulkanBufferUsage::SHADER_STORAGE;
+            // when adding more buffer-types here, make sure to update VulkanBuffer::loadFromCpu()
+            // if necessary.
     }
+
+    return VulkanBufferUsage::UNKNOWN;
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanMemoryPool.cpp
+++ b/filament/backend/src/vulkan/VulkanMemoryPool.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanMemoryPool.h"
+
+#include "VulkanConstants.h"
+#include "VulkanMemory.h"
+#include "memory/Resource.h"
+#include "memory/ResourceManager.h"
+
+#include <utility>
+
+namespace filament::backend {
+
+namespace {
+
+VkBufferUsageFlags getVkBufferUsage(VulkanBufferUsage usage) {
+    switch (usage) {
+        case VulkanBufferUsage::VERTEX:
+            return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+        case VulkanBufferUsage::INDEX:
+            return VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+        case VulkanBufferUsage::UNIFORM:
+            return VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+        case VulkanBufferUsage::SHADER_STORAGE:
+            return VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        case VulkanBufferUsage::UNKNOWN:
+            return 0;
+    }
+
+    return 0;
+}
+
+} // namespace
+
+VulkanMemoryPool::VulkanMemoryPool(VulkanContext const& context,
+        fvkmemory::ResourceManager& resourceManager, VmaAllocator allocator)
+    : mContext(context),
+      mResourceManager(resourceManager),
+      mAllocator(allocator) {}
+
+fvkmemory::resource_ptr<VulkanBufferMemory> VulkanMemoryPool::acquire(VulkanBufferUsage usage,
+        uint32_t numBytes) noexcept {
+    assert_invariant(usage != VulkanBufferUsage::UNKNOWN);
+
+    if (usage != VulkanBufferUsage::UNIFORM) {
+        // Allocate memory for vertex, index or storage buffer won't be recycled.
+        VulkanMemoryPoolAllocation const* poolAllocation = allocateMemory(usage, numBytes);
+        return fvkmemory::resource_ptr<VulkanBufferMemory>::construct(&mResourceManager,
+                poolAllocation, [this](VulkanMemoryPoolAllocation const* poolAllocation) {
+                    this->yield(poolAllocation);
+                });
+    }
+
+    // First check if an allocation exists whose capacity is greater than or equal to the requested
+    // size.
+    auto iter = mFreeUniformAllocations.lower_bound(numBytes);
+    if (iter != mFreeUniformAllocations.end()) {
+        VulkanMemoryPoolAllocation const* poolAllocation = iter->second.poolAllocation;
+        mFreeUniformAllocations.erase(iter);
+        return fvkmemory::resource_ptr<VulkanBufferMemory>::construct(&mResourceManager,
+                poolAllocation, [this](VulkanMemoryPoolAllocation const* poolAllocation) {
+                    this->yield(poolAllocation);
+                });
+    }
+
+    // We were not able to find a sufficiently large allocation, so create a new one that is
+    // recycled after being yielded.
+    VulkanMemoryPoolAllocation const* uniformPoolAllocation = allocateMemory(usage, numBytes);
+    return fvkmemory::resource_ptr<VulkanBufferMemory>::construct(&mResourceManager,
+            uniformPoolAllocation, [this](VulkanMemoryPoolAllocation const* poolAllocation) {
+                this->yield(poolAllocation);
+            });
+}
+
+void VulkanMemoryPool::yield(VulkanMemoryPoolAllocation const* poolAllocation) noexcept {
+    if (!poolAllocation) {
+        return;
+    }
+
+    if (poolAllocation->usage == VulkanBufferUsage::UNIFORM) {
+        mFreeUniformAllocations.insert(
+                std::make_pair(poolAllocation->numBytes, FreeMemoryPoolAllocation{
+                                                             .lastAccessed = mCurrentFrame,
+                                                             .poolAllocation = poolAllocation,
+                                                         }));
+        return;
+    }
+
+    releaseMemory(poolAllocation);
+}
+
+void VulkanMemoryPool::gc() noexcept {
+    FVK_SYSTRACE_CONTEXT();
+    FVK_SYSTRACE_START("VulkanMemoryPool::gc");
+
+    // If this is one of the first few frames, return early to avoid wrapping unsigned integers.
+    constexpr uint32_t TIME_BEFORE_EVICTION = 3;
+    if (++mCurrentFrame <= TIME_BEFORE_EVICTION) {
+        return;
+    }
+    const uint64_t evictionTime = mCurrentFrame - TIME_BEFORE_EVICTION;
+
+    // Destroy buffers that have not been used for several frames.
+    for (auto iter = mFreeUniformAllocations.begin(); iter != mFreeUniformAllocations.end();) {
+        if (iter->second.lastAccessed < evictionTime) {
+#if FVK_ENABLED(FVK_DEBUG_MEMORY_POOL_ALLOCATION)
+            FVK_LOGD << "Memory pool destroyed vkBuffer " << iter->second.poolAllocation->vkbuffer
+                     << utils::io::endl;
+#endif // FVK_DEBUG_MEMORY_POOL_ALLOCATION
+
+            releaseMemory(iter->second.poolAllocation);
+            iter = mFreeUniformAllocations.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
+
+    FVK_SYSTRACE_END();
+}
+
+void VulkanMemoryPool::terminate() noexcept {
+    for (auto& entry: mFreeUniformAllocations) {
+        releaseMemory(entry.second.poolAllocation);
+    }
+    mFreeUniformAllocations.clear();
+}
+
+VulkanMemoryPoolAllocation const* VulkanMemoryPool::allocateMemory(VulkanBufferUsage usage,
+        uint32_t numBytes) noexcept {
+    VkBufferCreateInfo const bufferInfo{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = numBytes,
+        // `VK_BUFFER_USAGE_TRANSFER_DST_BIT` is needed to allow updating the buffer through
+        // a staging using `vkCmdCopyBuffer`.
+        .usage = getVkBufferUsage(usage) | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+    };
+
+    VmaAllocationCreateFlags vmaFlags = 0;
+    if (usage == VulkanBufferUsage::UNIFORM) {
+        // In the case of UMA, the uniform buffers will always be mappable
+        if (mContext.isUnifiedMemoryArchitecture()) {
+            vmaFlags |= VMA_ALLOCATION_CREATE_MAPPED_BIT |
+                        VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+        }
+    }
+
+    VulkanMemoryPoolAllocation* poolAllocation = new VulkanMemoryPoolAllocation{
+        .numBytes = numBytes,
+        .usage = usage,
+    };
+    VmaAllocationCreateInfo const allocInfo{
+        .flags = vmaFlags,
+        .requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+    };
+    UTILS_UNUSED_IN_RELEASE VkResult result =
+            vmaCreateBuffer(mAllocator, &bufferInfo, &allocInfo, &poolAllocation->vkbuffer,
+                    &poolAllocation->vmaAllocation, &poolAllocation->allocationInfo);
+
+#if FVK_ENABLED(FVK_DEBUG_MEMORY_POOL_ALLOCATION)
+    if (result != VK_SUCCESS) {
+        FVK_LOGE << "Memory pool failed to allocate a new vkBuffer, error: " << result
+                 << utils::io::endl;
+    } else {
+        FVK_LOGD << "Memory pool allocated a vkBuffer " << poolAllocation->vkbuffer << " of size "
+                 << numBytes << "and usage = " << (int) usage << "  successfully"
+                 << utils::io::endl;
+    }
+#endif // FVK_DEBUG_MEMORY_POOL_ALLOCATION
+
+    return poolAllocation;
+}
+
+void VulkanMemoryPool::releaseMemory(VulkanMemoryPoolAllocation const* poolAllocation) noexcept {
+    vmaDestroyBuffer(mAllocator, poolAllocation->vkbuffer, poolAllocation->vmaAllocation);
+    delete poolAllocation;
+    poolAllocation = nullptr;
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanMemoryPool.h
+++ b/filament/backend/src/vulkan/VulkanMemoryPool.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKANMEMORYPOOL_H
+#define TNT_FILAMENT_BACKEND_VULKANMEMORYPOOL_H
+
+#include "VulkanContext.h"
+#include "VulkanMemory.h"
+#include "memory/Resource.h"
+#include "memory/ResourceManager.h"
+
+#include <map>
+
+namespace filament::backend {
+
+class VulkanMemoryPool {
+public:
+    VulkanMemoryPool(VulkanContext const& context, fvkmemory::ResourceManager& resourceManager,
+            VmaAllocator allocator);
+
+    // `VulkanMemoryPool` is not copyable.
+    VulkanMemoryPool(const VulkanMemoryPool&) = delete;
+    VulkanMemoryPool& operator=(const VulkanMemoryPool&) = delete;
+
+    fvkmemory::resource_ptr<VulkanBufferMemory> acquire(VulkanBufferUsage usage,
+            uint32_t numBytes) noexcept;
+
+    // Return an allocation back to the pool
+    void yield(VulkanMemoryPoolAllocation const* poolAllocation) noexcept;
+
+    // Evicts old unused allocations and bumps the current frame number
+    void gc() noexcept;
+
+    // Destroys all unused allocations.
+    // This should be called while the context's VkDevice is still alive.
+    void terminate() noexcept;
+
+private:
+    VulkanMemoryPoolAllocation const* allocateMemory(VulkanBufferUsage usage,
+            uint32_t numBytes) noexcept;
+
+    void releaseMemory(VulkanMemoryPoolAllocation const* poolAllocation) noexcept;
+
+    struct FreeMemoryPoolAllocation {
+        uint64_t lastAccessed;
+        VulkanMemoryPoolAllocation const* poolAllocation;
+    };
+
+    VulkanContext const& mContext;
+    fvkmemory::ResourceManager& mResourceManager;
+    VmaAllocator mAllocator;
+
+    // Allocation for uniform buffers are kept for a few of frames so they can be recycled,
+    // otherwise they are destroyed.
+    std::multimap<uint32_t, FreeMemoryPoolAllocation> mFreeUniformAllocations;
+
+    // Store the current "time" (really just a frame count) and LRU eviction parameters.
+    uint64_t mCurrentFrame = 0;
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_VULKANMEMORYPOOL_H

--- a/filament/backend/src/vulkan/memory/Resource.cpp
+++ b/filament/backend/src/vulkan/memory/Resource.cpp
@@ -35,6 +35,7 @@ template ResourceType getTypeEnum<VulkanVertexBufferInfo>() noexcept;
 template ResourceType getTypeEnum<VulkanDescriptorSetLayout>() noexcept;
 template ResourceType getTypeEnum<VulkanDescriptorSet>() noexcept;
 template ResourceType getTypeEnum<VulkanFence>() noexcept;
+template ResourceType getTypeEnum<VulkanBufferMemory>() noexcept;
 
 template<typename D>
 ResourceType getTypeEnum() noexcept {
@@ -80,6 +81,9 @@ ResourceType getTypeEnum() noexcept {
     if constexpr (std::is_same_v<D, VulkanFence>) {
         return ResourceType::FENCE;
     }
+    if constexpr (std::is_same_v<D, VulkanBufferMemory>) {
+        return ResourceType::VULKAN_BUFFER_MEMORY;
+    }
     return ResourceType::UNDEFINED_TYPE;
 }
 
@@ -113,6 +117,8 @@ std::string getTypeStr(ResourceType type) {
             return "DescriptorSet";
         case ResourceType::FENCE:
             return "Fence";
+        case ResourceType::VULKAN_BUFFER_MEMORY:
+            return "VulkanBufferMemory";
         case ResourceType::UNDEFINED_TYPE:
             return "";
     }

--- a/filament/backend/src/vulkan/memory/Resource.h
+++ b/filament/backend/src/vulkan/memory/Resource.h
@@ -49,7 +49,8 @@ enum class ResourceType : uint8_t {
     DESCRIPTOR_SET_LAYOUT = 11,
     DESCRIPTOR_SET = 12,
     FENCE = 13,
-    UNDEFINED_TYPE = 14,    // Must be the last enum because we use it for iterating over the enums.
+    VULKAN_BUFFER_MEMORY = 14,
+    UNDEFINED_TYPE = 15,    // Must be the last enum because we use it for iterating over the enums.
 };
 
 template<typename D>

--- a/filament/backend/src/vulkan/memory/ResourceManager.cpp
+++ b/filament/backend/src/vulkan/memory/ResourceManager.cpp
@@ -104,6 +104,9 @@ void ResourceManager::destroyWithType(ResourceType type, HandleId id) {
         case ResourceType::FENCE:
             destruct<VulkanFence>(Handle<VulkanFence>(id));
             break;
+        case ResourceType::VULKAN_BUFFER_MEMORY:
+            destruct<VulkanBufferMemory>(Handle<VulkanBufferMemory>(id));
+            break;
         case ResourceType::UNDEFINED_TYPE:
             break;
     }


### PR DESCRIPTION
This class will allow better tracking of memory
allocations and recycling of buffers. Currently
only the uniform buffers are recycled.

It will eventually allow us to dynamically change
the underlying GPU buffer of a VulkanBuffer when
updating an UBO for uniforms and also keep track
which of those buffers are still inflight and which ones are ready to be reuse for an UBO.

Its the first step on moving towards by passing
the staging buffer in UMA.