### PR TITLE
Fix GTAO artifacts on mobile devices

### DIFF
--- a/filament/src/materials/ssao/gtaoImpl.fs
+++ b/filament/src/materials/ssao/gtaoImpl.fs
@@ -116,7 +116,7 @@ void groundTruthAmbientOcclusion(out float obscurance, out vec3 bentNormal,
 
             highp vec3 sampleDelta0 = (samplePos0 - origin);
             highp vec3 sampleDelta1 = (samplePos1 - origin);
-            vec2 sqSampleDist = vec2(dot(sampleDelta0, sampleDelta0), dot(sampleDelta1, sampleDelta1));
+            highp vec2 sqSampleDist = vec2(dot(sampleDelta0, sampleDelta0), dot(sampleDelta1, sampleDelta1));
             vec2 invSampleDist = rsqrt(sqSampleDist);
 
             // Use the view space radius to calculate the fallOff


### PR DESCRIPTION
It is possible that `sqSampleDist` becomes very large in a deep scene, and in this case `mediump` might not be enough for storing this value.