### PR TITLE
vertex buffer info hardening.

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -1012,14 +1012,11 @@ void WebGPUDriver::bindPipeline(PipelineState const& pipelineState) {
 
 void WebGPUDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     auto* renderPrimitive = handleCast<WGPURenderPrimitive>(rph);
-
-    // This *must* match the WGPUVertexBufferInfo that was bound in bindPipeline(). But we want
-    // to allow to call this before bindPipeline(), so the validation can only happen in draw()
     auto vbi = handleCast<WGPUVertexBufferInfo>(renderPrimitive->vertexBuffer->vbih);
-    assert_invariant(
-            vbi->getVertexBufferLayoutSize() == renderPrimitive->vertexBuffer->buffers.size());
-    for (uint32_t i = 0; i < vbi->getVertexBufferLayoutSize(); i++) {
-        mRenderPassEncoder.SetVertexBuffer(i, renderPrimitive->vertexBuffer->buffers[i]);
+    for (const auto& webGPUSlotBindings: vbi->getWebGPUSlotBindingInfos()) {
+        mRenderPassEncoder.SetVertexBuffer(webGPUSlotBindings.slot,
+                renderPrimitive->vertexBuffer->buffers[webGPUSlotBindings.sourceBuffer],
+                webGPUSlotBindings.bufferOffset);
     }
 
     mRenderPassEncoder.SetIndexBuffer(renderPrimitive->indexBuffer->getBuffer(),

--- a/filament/backend/src/webgpu/WebGPUPipelineCreation.cpp
+++ b/filament/backend/src/webgpu/WebGPUPipelineCreation.cpp
@@ -191,8 +191,8 @@ wgpu::RenderPipeline createWebGPURenderPipeline(wgpu::Device const& device,
             .entryPoint = "main",
             .constantCount = program.constants.size(),
             .constants = program.constants.data(),
-            .bufferCount = vertexBufferInfo.getVertexBufferLayoutSize(),
-            .buffers = vertexBufferInfo.getVertexBufferLayout()
+            .bufferCount = vertexBufferInfo.getVertexBufferLayoutCount(),
+            .buffers = vertexBufferInfo.getVertexBufferLayouts()
         },
         .primitive = {
             .topology = toWebGPU(primitiveType),


### PR DESCRIPTION
Implement vertexbufferinfo taking both interleaved and block attributes into account. Handle the unused buffers by dedicating a slot for that. Update the usage of vertexbufferinfo for setVertexBuffer call