### PR TITLE
fix a buffer overflow during init

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -370,13 +370,16 @@ void FEngine::init() {
             .sampler(Texture::Sampler::SAMPLER_CUBEMAP)
             .build(*this));
 
-    static constexpr std::array<uint8_t, 6> zeroCubemap{};
-    static constexpr std::array<uint8_t, 4> zeroRGBA{};
-    static constexpr std::array<uint8_t, 4> oneRGBA{ 0xff, 0xff, 0xff, 0xff };
-    static constexpr std::array<float, 1> oneFloat{ 1.0f };
+    static constexpr std::array<uint32_t, 6> zeroCubemap{};
+    static constexpr std::array<uint32_t, 1> zeroRGBA{};
+    static constexpr std::array<uint32_t, 1> oneRGBA{ 0xffffffff };
+    static constexpr std::array<float   , 1> oneFloat{ 1.0f };
+    auto const size = [](auto&& array) {
+        return array.size() * sizeof(decltype(array[0]));
+    };
 
     driverApi.update3DImage(mDefaultIblTexture->getHwHandle(), 0, 0, 0, 0, 1, 1, 6,
-            { zeroCubemap.data(), 6, Texture::Format::RGBA, Texture::Type::UBYTE });
+            { zeroCubemap.data(), size(zeroCubemap), Texture::Format::RGBA, Texture::Type::UBYTE });
 
     // 3 bands = 9 float3
     constexpr float sh[9 * 3] = { 0.0f };
@@ -398,10 +401,10 @@ void FEngine::init() {
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     driverApi.update3DImage(mDummyOneTexture, 0, 0, 0, 0, 1, 1, 1,
-            { oneRGBA.data(), 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+            { oneRGBA.data(), size(oneRGBA), Texture::Format::RGBA, Texture::Type::UBYTE });
 
     driverApi.update3DImage(mDummyZeroTexture, 0, 0, 0, 0, 1, 1, 1,
-            { zeroRGBA.data(), 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+            { zeroRGBA.data(), size(zeroRGBA), Texture::Format::RGBA, Texture::Type::UBYTE });
 
 
     mPerViewDescriptorSetLayoutSsrVariant = {
@@ -466,13 +469,13 @@ void FEngine::init() {
                 TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
         driverApi.update3DImage(mDummyOneTextureArray, 0, 0, 0, 0, 1, 1, 1,
-                { oneRGBA.data(), 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+                { oneRGBA.data(), size(oneRGBA), Texture::Format::RGBA, Texture::Type::UBYTE });
 
         driverApi.update3DImage(mDummyOneTextureArrayDepth, 0, 0, 0, 0, 1, 1, 1,
-                { oneFloat.data(), 4, Texture::Format::DEPTH_COMPONENT, Texture::Type::FLOAT });
+                { oneFloat.data(), size(oneFloat), Texture::Format::DEPTH_COMPONENT, Texture::Type::FLOAT });
 
         driverApi.update3DImage(mDummyZeroTextureArray, 0, 0, 0, 0, 1, 1, 1,
-                { zeroRGBA.data(), 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+                { zeroRGBA.data(), size(zeroRGBA), Texture::Format::RGBA, Texture::Type::UBYTE });
 
         mDummyUniformBuffer = driverApi.createBufferObject(CONFIG_MINSPEC_UBO_SIZE,
                 BufferObjectBinding::UNIFORM, BufferUsage::STATIC);


### PR DESCRIPTION
the default cubemap has RGBA pixels (4 bytes per pixel).