### PR TITLE
webgpu: Relocate calling mRenderPassEncoder.SetBindGroup to draw call, deferring it to handle non-default render targets being used.

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -196,6 +196,19 @@ void WebGPUDriver::destroyDescriptorSetLayout(Handle<HwDescriptorSetLayout> tqh)
 }
 
 void WebGPUDriver::destroyDescriptorSet(Handle<HwDescriptorSet> tqh) {
+    auto* bindGroup = handleCast<WebGPUDescriptorSet>(tqh);
+    assert_invariant(bindGroup);
+    if (bindGroup->getBindGroup() != nullptr) {
+        for (size_t i = 0; i < MAX_DESCRIPTOR_SET_COUNT; i++) {
+            if (mCurrentDescriptorSets[i].bindGroup != nullptr &&
+                    bindGroup->getBindGroup().Get() == mCurrentDescriptorSets[i].bindGroup.Get()) {
+                // Clear this from our current entries
+                mCurrentDescriptorSets[i].bindGroup = nullptr;
+                mCurrentDescriptorSets[i].offsets.clear();
+                mCurrentDescriptorSets[i].offsetCount = 0;
+            }
+        }
+    }
     if (tqh) {
         destructHandle<WebGPUDescriptorSet>(tqh);
     }
@@ -858,6 +871,15 @@ void WebGPUDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 }
 
 void WebGPUDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
+    // We defer actually binding until we actually draw
+    for (size_t i = 0; i < MAX_DESCRIPTOR_SET_COUNT; i++) {
+        auto& binding = mCurrentDescriptorSets[i];
+        if (binding.bindGroup) {
+            mRenderPassEncoder.SetBindGroup(i, binding.bindGroup, binding.offsetCount,
+                    binding.offsets.data());
+        }
+    }
+
     mRenderPassEncoder.DrawIndexed(indexCount, instanceCount, indexOffset, 0, 0);
 }
 
@@ -922,11 +944,13 @@ void WebGPUDriver::updateDescriptorSetTexture(Handle<HwDescriptorSet> dsh,
 
 void WebGPUDriver::bindDescriptorSet(Handle<HwDescriptorSet> dsh,
         backend::descriptor_set_t setIndex, backend::DescriptorSetOffsetArray&& offsets) {
+    assert_invariant(setIndex < MAX_DESCRIPTOR_SET_COUNT);
     const auto bindGroup = handleCast<WebGPUDescriptorSet>(dsh);
     const auto wbg = bindGroup->lockAndReturn(mDevice);
-    assert_invariant(mRenderPassEncoder);
-    const size_t dynamicOffsetCount = bindGroup->countEntitiesWithDynamicOffsets();
-    mRenderPassEncoder.SetBindGroup(setIndex, wbg, dynamicOffsetCount, offsets.data());
+
+    mCurrentDescriptorSets[setIndex] = { .bindGroup = wbg,
+        .offsetCount = bindGroup->countEntitiesWithDynamicOffsets(),
+        .offsets = std::move(offsets) };
 }
 
 void WebGPUDriver::setDebugTag(HandleBase::HandleId handleId, utils::CString tag) {

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -76,6 +76,13 @@ private:
     WGPURenderTarget* mDefaultRenderTarget = nullptr;
 
     tsl::robin_map<uint32_t, wgpu::RenderPipeline> mPipelineMap;
+
+    struct DescriptorSetBindingInfo{
+        wgpu::BindGroup bindGroup;
+        size_t offsetCount;
+        backend::DescriptorSetOffsetArray offsets;
+    };
+    std::array<DescriptorSetBindingInfo,MAX_DESCRIPTOR_SET_COUNT> mCurrentDescriptorSets;
     /*
      * Driver interface
      */

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -155,6 +155,9 @@ public:
     [[nodiscard]] bool getIsLocked() const { return mBindGroup != nullptr; }
     [[nodiscard]] size_t countEntitiesWithDynamicOffsets() const;
 
+    // May be nullptr. Use lockAndReturn to create the bind group when appropriate
+    [[nodiscard]] const wgpu::BindGroup& getBindGroup() const { return mBindGroup; }
+
 private:
     wgpu::BindGroupLayout mLayout = nullptr;
     static constexpr uint8_t INVALID_INDEX = MAX_DESCRIPTOR_COUNT + 1;


### PR DESCRIPTION
BUGS = [397432947]