### PR TITLE
utils: Fix FixedCircularBufferTest.Exceptions

### DIFF
--- a/libs/utils/test/test_FixedCircularBuffer.cpp
+++ b/libs/utils/test/test_FixedCircularBuffer.cpp
@@ -86,7 +86,7 @@ TEST(FixedCircularBufferTest, Exceptions) {
 
     EXPECT_DEATH({
         circularBuffer.pop();  // should assert
-    }, "failed assertion");
+    }, "failed");
 
     circularBuffer.push(1);
     circularBuffer.push(2);


### PR DESCRIPTION
Switching from assert_invariant to assert produced a different error message.