### PR TITLE
attempt to fix external streams with protected context

### DIFF
--- a/filament/backend/src/opengl/GLDescriptorSet.cpp
+++ b/filament/backend/src/opengl/GLDescriptorSet.cpp
@@ -162,8 +162,11 @@ void GLDescriptorSet::update(OpenGLContext&,
     }, descriptors[binding].desc);
 }
 
-void GLDescriptorSet::update(OpenGLContext& gl,
-        descriptor_binding_t binding, GLTexture* t, SamplerParams params) noexcept {
+void GLDescriptorSet::update(OpenGLContext& gl, HandleAllocatorGL& handleAllocator,
+        descriptor_binding_t binding, TextureHandle th, SamplerParams params) noexcept {
+
+    GLTexture* t = th ? handleAllocator.handle_cast<GLTexture*>(th) : nullptr;
+
     assert_invariant(binding < descriptors.size());
     std::visit([=, &gl](auto&& arg) mutable {
         using T = std::decay_t<decltype(arg)>;
@@ -196,19 +199,11 @@ void GLDescriptorSet::update(OpenGLContext& gl,
                 }
             }
 
-            arg.target = t ? t->gl.target : 0;
-            arg.id = t ? t->gl.id : 0;
-            arg.external = t ? t->gl.external :  false;
+            arg.handle = th;
             if constexpr (std::is_same_v<T, Sampler> ||
                           std::is_same_v<T, SamplerWithAnisotropyWorkaround>) {
                 if constexpr (std::is_same_v<T, SamplerWithAnisotropyWorkaround>) {
                     arg.anisotropy = float(1u << params.anisotropyLog2);
-                }
-                if (t) {
-                    arg.ref = t->ref;
-                    arg.baseLevel = t->gl.baseLevel;
-                    arg.maxLevel = t->gl.maxLevel;
-                    arg.swizzle = t->gl.swizzle;
                 }
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
                 arg.sampler = gl.getSampler(params);
@@ -225,39 +220,39 @@ void GLDescriptorSet::update(OpenGLContext& gl,
     }, descriptors[binding].desc);
 }
 
-template<typename T>
 void GLDescriptorSet::updateTextureView(OpenGLContext& gl,
-        HandleAllocatorGL& handleAllocator, GLuint unit, T const& desc) noexcept {
+        HandleAllocatorGL& handleAllocator, GLuint unit, GLTexture const* t) noexcept {
     // The common case is that we don't have a ref handle (we only have one if
     // the texture ever had a View on it).
-    assert_invariant(desc.ref);
-    GLTextureRef* const ref = handleAllocator.handle_cast<GLTextureRef*>(desc.ref);
-    if (UTILS_UNLIKELY((desc.baseLevel != ref->baseLevel || desc.maxLevel != ref->maxLevel))) {
+    assert_invariant(t);
+    assert_invariant(t->ref);
+    GLTextureRef* const ref = handleAllocator.handle_cast<GLTextureRef*>(t->ref);
+    if (UTILS_UNLIKELY((t->gl.baseLevel != ref->baseLevel || t->gl.maxLevel != ref->maxLevel))) {
         // If we have views, then it's still uncommon that we'll switch often
         // handle the case where we reset to the original texture
-        GLint baseLevel = GLint(desc.baseLevel); // NOLINT(*-signed-char-misuse)
-        GLint maxLevel = GLint(desc.maxLevel); // NOLINT(*-signed-char-misuse)
+        GLint baseLevel = GLint(t->gl.baseLevel); // NOLINT(*-signed-char-misuse)
+        GLint maxLevel = GLint(t->gl.maxLevel); // NOLINT(*-signed-char-misuse)
         if (baseLevel > maxLevel) {
             baseLevel = 0;
             maxLevel = 1000; // per OpenGL spec
         }
         // that is very unfortunate that we have to call activeTexture here
         gl.activeTexture(unit);
-        glTexParameteri(desc.target, GL_TEXTURE_BASE_LEVEL, baseLevel);
-        glTexParameteri(desc.target, GL_TEXTURE_MAX_LEVEL,  maxLevel);
-        ref->baseLevel = desc.baseLevel;
-        ref->maxLevel = desc.maxLevel;
+        glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, baseLevel);
+        glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL,  maxLevel);
+        ref->baseLevel = t->gl.baseLevel;
+        ref->maxLevel = t->gl.maxLevel;
     }
-    if (UTILS_UNLIKELY(desc.swizzle != ref->swizzle)) {
+    if (UTILS_UNLIKELY(t->gl.swizzle != ref->swizzle)) {
         using namespace GLUtils;
         gl.activeTexture(unit);
 #if !defined(__EMSCRIPTEN__)  && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
-        glTexParameteri(desc.target, GL_TEXTURE_SWIZZLE_R, (GLint)getSwizzleChannel(desc.swizzle[0]));
-        glTexParameteri(desc.target, GL_TEXTURE_SWIZZLE_G, (GLint)getSwizzleChannel(desc.swizzle[1]));
-        glTexParameteri(desc.target, GL_TEXTURE_SWIZZLE_B, (GLint)getSwizzleChannel(desc.swizzle[2]));
-        glTexParameteri(desc.target, GL_TEXTURE_SWIZZLE_A, (GLint)getSwizzleChannel(desc.swizzle[3]));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_R, (GLint)getSwizzleChannel(t->gl.swizzle[0]));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_G, (GLint)getSwizzleChannel(t->gl.swizzle[1]));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_B, (GLint)getSwizzleChannel(t->gl.swizzle[2]));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_A, (GLint)getSwizzleChannel(t->gl.swizzle[3]));
 #endif
-        ref->swizzle = desc.swizzle;
+        ref->swizzle = t->gl.swizzle;
     }
 }
 
@@ -310,27 +305,31 @@ void GLDescriptorSet::bind(
                 }
             } else if constexpr (std::is_same_v<T, Sampler>) {
                 GLuint const unit = p.getTextureUnit(set, binding);
-                if (arg.target) {
-                    gl.bindTexture(unit, arg.target, arg.id, arg.external);
+
+
+                if (arg.handle) {
+                    GLTexture const* const t = handleAllocator.handle_cast<GLTexture*>(arg.handle);
+                    gl.bindTexture(unit, t->gl.target, t->gl.id, t->gl.external);
                     gl.bindSampler(unit, arg.sampler);
-                    if (UTILS_UNLIKELY(arg.ref)) {
-                        updateTextureView(gl, handleAllocator, unit, arg);
+                    if (UTILS_UNLIKELY(t->ref)) {
+                        updateTextureView(gl, handleAllocator, unit, t);
                     }
                 } else {
                     gl.unbindTextureUnit(unit);
                 }
             } else if constexpr (std::is_same_v<T, SamplerWithAnisotropyWorkaround>) {
                 GLuint const unit = p.getTextureUnit(set, binding);
-                if (arg.target) {
-                    gl.bindTexture(unit, arg.target, arg.id, arg.external);
+                if (arg.handle) {
+                    GLTexture const* const t = handleAllocator.handle_cast<GLTexture*>(arg.handle);
+                    gl.bindTexture(unit, t->gl.target, t->gl.id, t->gl.external);
                     gl.bindSampler(unit, arg.sampler);
-                    if (UTILS_UNLIKELY(arg.ref)) {
-                        updateTextureView(gl, handleAllocator, unit, arg);
+                    if (UTILS_UNLIKELY(t->ref)) {
+                        updateTextureView(gl, handleAllocator, unit, t);
                     }
 #if defined(GL_EXT_texture_filter_anisotropic)
                     // Driver claims to support anisotropic filtering, but it fails when set on
                     // the sampler, we have to set it on the texture instead.
-                    glTexParameterf(arg.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+                    glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
                             std::min(gl.gets.max_anisotropy, float(arg.anisotropy)));
 #endif
                 } else {
@@ -339,19 +338,20 @@ void GLDescriptorSet::bind(
             } else if constexpr (std::is_same_v<T, SamplerGLES2>) {
                 // in ES2 the sampler parameters need to be set on the texture itself
                 GLuint const unit = p.getTextureUnit(set, binding);
-                if (arg.target) {
-                    gl.bindTexture(unit, arg.target, arg.id, arg.external);
+                if (arg.handle) {
+                    GLTexture const* const t = handleAllocator.handle_cast<GLTexture*>(arg.handle);
+                    gl.bindTexture(unit, t->gl.target, t->gl.id, t->gl.external);
                     SamplerParams const params = arg.params;
-                    glTexParameteri(arg.target, GL_TEXTURE_MIN_FILTER,
+                    glTexParameteri(t->gl.target, GL_TEXTURE_MIN_FILTER,
                             (GLint)GLUtils::getTextureFilter(params.filterMin));
-                    glTexParameteri(arg.target, GL_TEXTURE_MAG_FILTER,
+                    glTexParameteri(t->gl.target, GL_TEXTURE_MAG_FILTER,
                             (GLint)GLUtils::getTextureFilter(params.filterMag));
-                    glTexParameteri(arg.target, GL_TEXTURE_WRAP_S,
+                    glTexParameteri(t->gl.target, GL_TEXTURE_WRAP_S,
                             (GLint)GLUtils::getWrapMode(params.wrapS));
-                    glTexParameteri(arg.target, GL_TEXTURE_WRAP_T,
+                    glTexParameteri(t->gl.target, GL_TEXTURE_WRAP_T,
                             (GLint)GLUtils::getWrapMode(params.wrapT));
 #if defined(GL_EXT_texture_filter_anisotropic)
-                    glTexParameterf(arg.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+                    glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
                             std::min(gl.gets.max_anisotropy, arg.anisotropy));
 #endif
                 } else {

--- a/filament/backend/src/opengl/GLDescriptorSet.h
+++ b/filament/backend/src/opengl/GLDescriptorSet.h
@@ -59,8 +59,8 @@ struct GLDescriptorSet : public HwDescriptorSet {
             descriptor_binding_t binding, GLBufferObject* bo, size_t offset, size_t size) noexcept;
 
     // update a sampler descriptor in the set
-    void update(OpenGLContext& gl,
-            descriptor_binding_t binding, GLTexture* t, SamplerParams params) noexcept;
+    void update(OpenGLContext& gl, HandleAllocatorGL& handleAllocator,
+            descriptor_binding_t binding, TextureHandle th, SamplerParams params) noexcept;
 
     // conceptually bind the set to the command buffer
     void bind(
@@ -111,46 +111,19 @@ private:
 
     // A sampler descriptor
     struct Sampler {
-        uint16_t target;                        // 2 (GLenum)
-        bool external = false;                  // 1
-        bool reserved = false;                  // 1
-        GLuint id = 0;                          // 4
+        TextureHandle handle;                   // 4
         GLuint sampler = 0;                     // 4
-        Handle<GLTextureRef> ref;               // 4
-        int8_t baseLevel = 0x7f;                // 1
-        int8_t maxLevel = -1;                   // 1
-        std::array<TextureSwizzle, 4> swizzle{  // 4
-                TextureSwizzle::CHANNEL_0,
-                TextureSwizzle::CHANNEL_1,
-                TextureSwizzle::CHANNEL_2,
-                TextureSwizzle::CHANNEL_3
-        };
     };
 
     struct SamplerWithAnisotropyWorkaround {
-        uint16_t target;                        // 2 (GLenum)
-        bool external = false;                  // 1
-        bool reserved = false;                  // 1
-        GLuint id = 0;                          // 4
+        TextureHandle handle;                   // 4
         GLuint sampler = 0;                     // 4
-        Handle<GLTextureRef> ref;               // 4
         math::half anisotropy = 1.0f;           // 2
-        int8_t baseLevel = 0x7f;                // 1
-        int8_t maxLevel = -1;                   // 1
-        std::array<TextureSwizzle, 4> swizzle{  // 4
-                TextureSwizzle::CHANNEL_0,
-                TextureSwizzle::CHANNEL_1,
-                TextureSwizzle::CHANNEL_2,
-                TextureSwizzle::CHANNEL_3
-        };
     };
 
     // A sampler descriptor for ES2
     struct SamplerGLES2 {
-        uint16_t target;                        // 2 (GLenum)
-        bool external = false;                  // 1
-        bool reserved = false;                  // 1
-        GLuint id = 0;                          // 4
+        TextureHandle handle;                   // 4
         SamplerParams params{};                 // 4
         float anisotropy = 1.0f;                // 4
     };
@@ -165,9 +138,8 @@ private:
     };
     static_assert(sizeof(Descriptor) <= 32);
 
-    template<typename T>
     static void updateTextureView(OpenGLContext& gl,
-            HandleAllocatorGL& handleAllocator, GLuint unit, T const& desc) noexcept;
+            HandleAllocatorGL& handleAllocator, GLuint unit, GLTexture const* t) noexcept;
 
     utils::FixedCapacityVector<Descriptor> descriptors;     // 16
     utils::bitset64 dynamicBuffers;                         // 8

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2531,10 +2531,28 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 
     mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain,
             [this]() {
+                for (auto t: mTexturesWithStreamsAttached) {
+                    if (t->hwStream->streamType == StreamType::NATIVE) {
+                        mPlatform.detach(t->hwStream->stream);
+                    }
+                }
                 // OpenGL context is about to change, unbind everything
                 mContext.unbindEverything();
             },
             [this](size_t index) {
+                for (auto t: mTexturesWithStreamsAttached) {
+                    if (t->hwStream->streamType == StreamType::NATIVE) {
+                        glGenTextures(1, &t->gl.id);
+                        mPlatform.attach(t->hwStream->stream, t->gl.id);
+                        mContext.updateTexImage(GL_TEXTURE_EXTERNAL_OES, t->gl.id);
+                    }
+                }
+
+                // force invalidation of all bound descriptor sets
+                decltype(mInvalidDescriptorSetBindings) changed;
+                changed.setValue((1 << MAX_DESCRIPTOR_SET_COUNT) - 1);
+                mInvalidDescriptorSetBindings |= changed;
+
                 // OpenGL context has changed, resynchronize the state with the cache
                 mContext.synchronizeStateAndCache(index);
                 slog.d << "*** OpenGL context change : " << (index ? "protected" : "default") << io::endl;
@@ -3725,8 +3743,7 @@ void OpenGLDriver::updateDescriptorSetTexture(
         TextureHandle th,
         SamplerParams params) {
     GLDescriptorSet* ds = handle_cast<GLDescriptorSet*>(dsh);
-    GLTexture* t = th ? handle_cast<GLTexture*>(th) : nullptr;
-    ds->update(mContext, binding, t, params);
+    ds->update(mContext, mHandleAllocator, binding, th, params);
 }
 
 void OpenGLDriver::flush(int) {


### PR DESCRIPTION
There was several issues:

1) when we're switching contexts (e.g. between protect and regular) we
   needed up reattach all SurfaceView (i.e. streams), because they need
   to be attached on currently active context.

2) reattaching, because it's implemented as detach + attach, would 
   destroy the current gl texture id and create a new one. However,
   because of the way descriptor-sets were implemented, that GL
   texture id was kept inside the descriptor, later leading to using
   a destroyed texture id.
   The fix here is to store texture handles in descriptors, so that
   we can update the id independently. 

3) we also needed to invalidate all bound descriptor sets because it's
   now possible for descriptor sets to have outdated descriptors