### PR TITLE
utils: add additional guards for Tracing

### DIFF
--- a/libs/utils/include/private/utils/Tracing.h
+++ b/libs/utils/include/private/utils/Tracing.h
@@ -30,9 +30,9 @@
 #   define FILAMENT_APPLE_SYSTRACE 0
 #endif
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) && FILAMENT_TRACING_ENABLED
 #    include <private/utils/android/Tracing.h>
-#elif defined(__APPLE__) && FILAMENT_APPLE_SYSTRACE
+#elif defined(__APPLE__) && FILAMENT_APPLE_SYSTRACE && FILAMENT_TRACING_ENABLED
 #    include <private/utils/darwin/Tracing.h>
 #else
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+// TODO: Clean-up. We shouldn't need this #ifndef here, but a client has requested that perfetto be
+// disabled due to size increase.  In their case, this flag would be defined across targets. Hence
+// we guard below with an #ifndef.
+#ifndef FILAMENT_TRACING_ENABLED
 // Note: The overhead of TRACING is not negligible especially with parallel_for().
 #define FILAMENT_TRACING_ENABLED false
+#endif
 
 // when FILAMENT_TRACING_ENABLED is true, enables even heavier tracing
 #define HEAVY_TRACING  0


### PR DESCRIPTION
The addition JobSystem.cpp allows for defining
FILAMENT_TRACING_ENABLED across targets.

Addingin FILAMENT_TRACING_ENABLED to the #if in Tracing.h prevents perfetto from being included.