### PR TITLE
webgpu: Use level and layer in textureViews

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -431,18 +431,6 @@ void WebGPUDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 void WebGPUDriver::createRenderTargetR(Handle<HwRenderTarget> rth, TargetBufferFlags targets,
         uint32_t width, uint32_t height, uint8_t samples, uint8_t layerCount, MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
-    // The `targets` flags indicate which of the `color`, `depth`, `stencil` TargetBufferInfo
-    // are actually active for this render target.
-    // We'll pass all TargetBufferInfo to WGPURenderTarget; it will use them if their handles are valid.
-
-    // Ensure that textures intended for use as attachments were created with
-    // wgpu::TextureUsage::RenderAttachment. This check should ideally be in createTextureR
-    // or validated here if possible.
-
-    // The `layerCount` parameter might be for creating array textures that this RT targets.
-    // Individual attachments (color[i].layer, depth.layer, stencil.layer) specify which layer
-    // of an array texture to bind. For now, we assume textures are pre-configured.
-
     constructHandle<WGPURenderTarget>(rth, width, height, samples, layerCount, color, depth, stencil);
 }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -809,13 +809,15 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
             if (colorInfos[i].handle) {
                 auto* hwTexture = handleCast<WGPUTexture>(colorInfos[i].handle);
                 if (hwTexture) {
-                    FILAMENT_CHECK_POSTCONDITION(colorInfos[i].layer < renderTarget->getLayerCount())
-                    << "Color attachment " << i << " requests layer "
-                    << colorInfos[i].layer << " but render target has only "
-                    << renderTarget->getLayerCount() << ".";
+                    FILAMENT_CHECK_POSTCONDITION(
+                            colorInfos[i].layer < renderTarget->getLayerCount())
+                            << "Color attachment " << i << " requests layer " << colorInfos[i].layer
+                            << " but render target has only " << renderTarget->getLayerCount()
+                            << ".";
                     const uint8_t mipLevel = colorInfos[i].level;
                     const uint32_t arrayLayer = colorInfos[i].layer;
-                    customColorViews[customColorViewCount++] = hwTexture->getOrMakeTextureView(mipLevel, arrayLayer);
+                    customColorViews[customColorViewCount++] =
+                            hwTexture->getOrMakeTextureView(mipLevel, arrayLayer);
                 }
             }
         }
@@ -823,13 +825,13 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
         const auto& depthInfo = renderTarget->getDepthAttachmentInfo();
         if (depthInfo.handle) {
             FILAMENT_CHECK_POSTCONDITION(depthInfo.layer < renderTarget->getLayerCount())
-            << "Depth attachment requests layer " << depthInfo.layer
-            << "but render target has only " << renderTarget->getLayerCount() << ".";
+                    << "Depth attachment requests layer " << depthInfo.layer
+                    << "but render target has only " << renderTarget->getLayerCount() << ".";
             auto* hwTexture = handleCast<WGPUTexture>(depthInfo.handle);
             if (hwTexture) {
                 const uint8_t depthMipLevel = depthInfo.level;
                 const uint32_t depthArrayLayer = depthInfo.layer;
-                customDepthView = hwTexture->getOrMakeTextureView(depthMipLevel,depthArrayLayer);
+                customDepthView = hwTexture->getOrMakeTextureView(depthMipLevel, depthArrayLayer);
                 customDepthFormat = hwTexture->getFormat();
             }
         }
@@ -845,7 +847,8 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
                         << " layers.";
                 const uint8_t stencilMipLevel = stencilInfo.level;
                 const uint32_t stencilArrayLayer = stencilInfo.layer;
-                customStencilView = hwTexture->getOrMakeTextureView(stencilMipLevel,stencilArrayLayer );
+                customStencilView =
+                        hwTexture->getOrMakeTextureView(stencilMipLevel, stencilArrayLayer);
                 customStencilFormat = hwTexture->getFormat();
             }
         }
@@ -1165,7 +1168,7 @@ void WebGPUDriver::updateDescriptorSetTexture(Handle<HwDescriptorSet> dsh,
         auto sampler = makeSampler(params);
         // TODO making assumptions that size and offset mean the same thing here.
         wgpu::BindGroupEntry tEntry{ .binding = static_cast<uint32_t>(binding * 2),
-            .textureView = texture->getTextureView() };
+            .textureView = texture->getDefaultTextureView() };
         bindGroup->addEntry(tEntry.binding, std::move(tEntry));
 
         wgpu::BindGroupEntry sEntry{ .binding = static_cast<uint32_t>(binding * 2 + 1),

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -813,9 +813,9 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
                     << "Color attachment " << i << " requests layer "
                     << colorInfos[i].layer << " but render target has only "
                     << renderTarget->getLayerCount() << ".";
-                    uint8_t mipLevel = colorInfos[i].level;
-                    uint32_t arrayLayer = colorInfos[i].layer;
-                    customColorViews[customColorViewCount++] = hwTexture->getTextureView(mipLevel, arrayLayer);
+                    const uint8_t mipLevel = colorInfos[i].level;
+                    const uint32_t arrayLayer = colorInfos[i].layer;
+                    customColorViews[customColorViewCount++] = hwTexture->getOrMakeTextureView(mipLevel, arrayLayer);
                 }
             }
         }
@@ -827,9 +827,9 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
             << "but render target has only " << renderTarget->getLayerCount() << ".";
             auto* hwTexture = handleCast<WGPUTexture>(depthInfo.handle);
             if (hwTexture) {
-                uint8_t depthMipLevel = depthInfo.level;
-                uint32_t depthArrayLayer = depthInfo.layer;
-                customDepthView = hwTexture->getTextureView(depthMipLevel, depthArrayLayer);
+                const uint8_t depthMipLevel = depthInfo.level;
+                const uint32_t depthArrayLayer = depthInfo.layer;
+                customDepthView = hwTexture->getOrMakeTextureView(depthMipLevel,depthArrayLayer);
                 customDepthFormat = hwTexture->getFormat();
             }
         }
@@ -843,9 +843,9 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
                         << "Stencil attachment requests layer " << stencilInfo.layer
                         << " but render target has only " << renderTarget->getLayerCount()
                         << " layers.";
-                uint8_t stencilMipLevel = stencilInfo.level;
-                uint32_t stencilArrayLayer = stencilInfo.layer;
-                customStencilView = hwTexture->getTextureView(stencilMipLevel, stencilArrayLayer);
+                const uint8_t stencilMipLevel = stencilInfo.level;
+                const uint32_t stencilArrayLayer = stencilInfo.layer;
+                customStencilView = hwTexture->getOrMakeTextureView(stencilMipLevel,stencilArrayLayer );
                 customStencilFormat = hwTexture->getFormat();
             }
         }

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -845,7 +845,7 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
                         << " layers.";
                 uint8_t stencilMipLevel = stencilInfo.level;
                 uint32_t stencilArrayLayer = stencilInfo.layer;
-                customStencilView = hwTexture->getTextureView(stencilMipLevel,stencilArrayLayer);
+                customStencilView = hwTexture->getTextureView(stencilMipLevel, stencilArrayLayer);
                 customStencilFormat = hwTexture->getFormat();
             }
         }

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -809,35 +809,27 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
             if (colorInfos[i].handle) {
                 auto* hwTexture = handleCast<WGPUTexture>(colorInfos[i].handle);
                 if (hwTexture) {
-                    FILAMENT_CHECK_POSTCONDITION(colorInfos[i].layer < renderTarget->mLayerCount)
+                    FILAMENT_CHECK_POSTCONDITION(colorInfos[i].layer < renderTarget->getLayerCount())
                     << "Color attachment " << i << " requests layer "
                     << colorInfos[i].layer << " but render target has only "
-                    << renderTarget->mLayerCount << ".";
+                    << renderTarget->getLayerCount() << ".";
                     uint8_t mipLevel = colorInfos[i].level;
                     uint32_t arrayLayer = colorInfos[i].layer;
-                    customColorViews[customColorViewCount++] = hwTexture->makeTextureView(mipLevel,
-                            1, arrayLayer, 1, hwTexture->mSamplerType);
-
+                    customColorViews[customColorViewCount++] = hwTexture->getTextureView(mipLevel, arrayLayer);
                 }
             }
         }
 
         const auto& depthInfo = renderTarget->getDepthAttachmentInfo();
         if (depthInfo.handle) {
-            FILAMENT_CHECK_POSTCONDITION(depthInfo.layer < renderTarget->mLayerCount)
+            FILAMENT_CHECK_POSTCONDITION(depthInfo.layer < renderTarget->getLayerCount())
             << "Depth attachment requests layer " << depthInfo.layer
-            << "but render target has only " << renderTarget->mLayerCount << ".";
+            << "but render target has only " << renderTarget->getLayerCount() << ".";
             auto* hwTexture = handleCast<WGPUTexture>(depthInfo.handle);
             if (hwTexture) {
                 uint8_t depthMipLevel = depthInfo.level;
                 uint32_t depthArrayLayer = depthInfo.layer;
-                customDepthView = hwTexture->makeTextureView(
-                    depthMipLevel,
-                    1,
-                    depthArrayLayer,
-                    1,
-                    hwTexture->mSamplerType
-                );
+                customDepthView = hwTexture->getTextureView(depthMipLevel, depthArrayLayer);
                 customDepthFormat = hwTexture->getFormat();
             }
         }
@@ -847,14 +839,13 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> rth, RenderPassParams 
             // If depth and stencil use the same texture handle, this will re-cast but that's fine.
             auto* hwTexture = handleCast<WGPUTexture>(stencilInfo.handle);
             if (hwTexture) {
-                FILAMENT_CHECK_POSTCONDITION(stencilInfo.layer < renderTarget->mLayerCount)
+                FILAMENT_CHECK_POSTCONDITION(stencilInfo.layer < renderTarget->getLayerCount())
                         << "Stencil attachment requests layer " << stencilInfo.layer
-                        << " but render target has only " << renderTarget->mLayerCount
+                        << " but render target has only " << renderTarget->getLayerCount()
                         << " layers.";
                 uint8_t stencilMipLevel = stencilInfo.level;
                 uint32_t stencilArrayLayer = stencilInfo.layer;
-                customStencilView = hwTexture->makeTextureView(stencilMipLevel, 1,
-                        stencilArrayLayer, 1, hwTexture->mSamplerType);
+                customStencilView = hwTexture->getTextureView(stencilMipLevel,stencilArrayLayer);
                 customStencilFormat = hwTexture->getFormat();
             }
         }

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -579,7 +579,7 @@ size_t WebGPUDescriptorSet::countEntitiesWithDynamicOffsets() const {
     return mEntriesWithDynamicOffsetsCount;
 }
 
-WGPUTexture::WGPUTexture(SamplerType target, uint8_t levels, TextureFormat format,
+WGPUTexture::WGPUTexture(SamplerType samplerType, uint8_t levels, TextureFormat format,
         uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage,
         wgpu::Device const& device) noexcept {
     assert_invariant(
@@ -593,12 +593,12 @@ WGPUTexture::WGPUTexture(SamplerType target, uint8_t levels, TextureFormat forma
     mFormat = fToWGPUTextureFormat(format);
     mUsage = fToWGPUTextureUsage(usage);
     mAspect = fToWGPUTextureViewAspect(usage, format);
-    mSamplerType = target;
+    mSamplerType = samplerType;
     mBlockWidth = filament::backend::getBlockWidth(format);
     mBlockHeight = filament::backend::getBlockHeight(format);
 
     wgpu::TextureDescriptor textureDescriptor{
-        .label = getUserTextureLabel(target),
+        .label = getUserTextureLabel(samplerType),
         .usage = mUsage,
         .dimension = target == SamplerType::SAMPLER_3D ? wgpu::TextureDimension::e3D
                                                        : wgpu::TextureDimension::e2D,
@@ -612,7 +612,7 @@ WGPUTexture::WGPUTexture(SamplerType target, uint8_t levels, TextureFormat forma
         .viewFormats = nullptr,
     };
 
-    switch (target) {
+    switch (samplerType) {
         case SamplerType::SAMPLER_2D:
             mArrayLayerCount = 1;
             break;
@@ -638,7 +638,7 @@ WGPUTexture::WGPUTexture(SamplerType target, uint8_t levels, TextureFormat forma
     FILAMENT_CHECK_POSTCONDITION(mTexture)
             << "Failed to create texture for " << textureDescriptor.label;
 
-    mTextureView = makeTextureView(0, levels, 0, mArrayLayerCount, target);
+    mTextureView = makeTextureView(0, levels, 0, mArrayLayerCount, samplerType);
 }
 
 WGPUTexture::WGPUTexture(WGPUTexture* src, uint8_t baseLevel, uint8_t levelCount) noexcept {
@@ -651,8 +651,6 @@ WGPUTexture::WGPUTexture(WGPUTexture* src, uint8_t baseLevel, uint8_t levelCount
 
     mTextureView = makeTextureView(baseLevel, levelCount, 0, src->mArrayLayerCount, mSamplerType);
 }
-
-
 
 wgpu::TextureUsage WGPUTexture::fToWGPUTextureUsage(TextureUsage const& fUsage) {
     wgpu::TextureUsage retUsage = wgpu::TextureUsage::None;
@@ -982,7 +980,6 @@ wgpu::TextureAspect WGPUTexture::fToWGPUTextureViewAspect(TextureUsage const& fU
 wgpu::TextureView WGPUTexture::getTextureView(uint8_t mipLevel, uint32_t arrayLayer) const {
     return makeTextureView(mipLevel, 1, arrayLayer, 1, mSamplerType);
 }
-
 
 wgpu::TextureView WGPUTexture::makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
         const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -579,7 +579,7 @@ size_t WebGPUDescriptorSet::countEntitiesWithDynamicOffsets() const {
     return mEntriesWithDynamicOffsetsCount;
 }
 
-WGPUTexture::WGPUTexture(SamplerType samplerTargetType, uint8_t levels, TextureFormat format,
+WGPUTexture::WGPUTexture(SamplerType target, uint8_t levels, TextureFormat format,
         uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage,
         wgpu::Device const& device) noexcept {
     assert_invariant(
@@ -596,7 +596,6 @@ WGPUTexture::WGPUTexture(SamplerType samplerTargetType, uint8_t levels, TextureF
     mSamplerType = target;
     mBlockWidth = filament::backend::getBlockWidth(format);
     mBlockHeight = filament::backend::getBlockHeight(format);
-    target = samplerTargetType;
 
     wgpu::TextureDescriptor textureDescriptor{
         .label = getUserTextureLabel(target),

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -638,18 +638,18 @@ WGPUTexture::WGPUTexture(SamplerType samplerType, uint8_t levels, TextureFormat 
     FILAMENT_CHECK_POSTCONDITION(mTexture)
             << "Failed to create texture for " << textureDescriptor.label;
 
-    mTextureView = makeTextureView(0, levels, 0, mArrayLayerCount, samplerType);
+    mDefaultTextureView = makeTextureView(0, levels, 0, mArrayLayerCount, samplerType);
 }
 
-WGPUTexture::WGPUTexture(WGPUTexture* src, uint8_t baseLevel, uint8_t levelCount) noexcept :
-      mTexture(src->mTexture),
+WGPUTexture::WGPUTexture(WGPUTexture* src, uint8_t baseLevel, uint8_t levelCount) noexcept
+    : mTexture(src->mTexture),
       mAspect(src->mAspect),
       mArrayLayerCount(src->mArrayLayerCount),
       mBlockWidth(src->mBlockWidth),
       mBlockHeight(src->mBlockHeight),
       mSamplerType(src->mSamplerType),
-      mTextureView(makeTextureView(baseLevel, levelCount, 0, src->mArrayLayerCount, mSamplerType))
-    {}
+      mDefaultTextureView(
+              makeTextureView(baseLevel, levelCount, 0, src->mArrayLayerCount, mSamplerType)) {}
 
 wgpu::TextureUsage WGPUTexture::fToWGPUTextureUsage(TextureUsage const& fUsage) {
     wgpu::TextureUsage retUsage = wgpu::TextureUsage::None;

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -638,7 +638,8 @@ WGPUTexture::WGPUTexture(SamplerType samplerType, uint8_t levels, TextureFormat 
     FILAMENT_CHECK_POSTCONDITION(mTexture)
             << "Failed to create texture for " << textureDescriptor.label;
 
-    mDefaultTextureView = makeTextureView(0, levels, 0, mArrayLayerCount, samplerType);
+    mDefaultTextureView = makeTextureView(mDefaultMipLevel, levels, mDefaultBaseArrayLayer,
+            mArrayLayerCount, samplerType);
 }
 
 WGPUTexture::WGPUTexture(WGPUTexture* src, uint8_t baseLevel, uint8_t levelCount) noexcept
@@ -977,7 +978,10 @@ wgpu::TextureAspect WGPUTexture::fToWGPUTextureViewAspect(TextureUsage const& fU
 }
 
 wgpu::TextureView WGPUTexture::getOrMakeTextureView(uint8_t mipLevel, uint32_t arrayLayer) const {
-//    TODO: just return mTextureView if redundant
+    //TODO: there's an optimization to be made here to return mDefaultTextureView.
+    // Problem: mDefaultTextureView is a view of the entire texture,
+    // but this function (and its callers) expects a single-slice view.
+    // Returning the whole texture view for a single-slice request seems wrong.
 
     return makeTextureView(mipLevel, 1, arrayLayer, 1, mSamplerType);
 }

--- a/filament/backend/src/webgpu/WebGPUHandles.cpp
+++ b/filament/backend/src/webgpu/WebGPUHandles.cpp
@@ -983,7 +983,7 @@ wgpu::TextureView WGPUTexture::getTextureView(uint8_t mipLevel, uint32_t arrayLa
 
 wgpu::TextureView WGPUTexture::makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
         const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,
-        SamplerType samplerType) const {
+        SamplerType samplerType) const noexcept{
 
     wgpu::TextureViewDescriptor textureViewDescriptor{
         .label = getUserTextureViewLabel(target),

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -208,7 +208,8 @@ private:
     size_t mBlockHeight;
     SamplerType mSamplerType;
     wgpu::TextureView mDefaultTextureView = nullptr;
-
+    uint32_t mDefaultMipLevel = 0;
+    uint32_t mDefaultBaseArrayLayer = 0;
 
     [[nodiscard]] wgpu::TextureUsage fToWGPUTextureUsage(
             filament::backend::TextureUsage const& fUsage);

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -181,6 +181,10 @@ public:
     size_t getBlockWidth() const { return mBlockWidth; }
     size_t getBlockHeight() const { return mBlockHeight; }
 
+    wgpu::TextureView makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
+            const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,
+            SamplerType target);
+
     [[nodiscard]] const wgpu::Texture& getTexture() const { return mTexture; }
     [[nodiscard]] const wgpu::TextureView& getTextureView() const { return mTexureView; }
     [[nodiscard]] wgpu::TextureFormat getFormat() const { return mFormat; }
@@ -192,21 +196,23 @@ public:
             filament::backend::TextureUsage const& fUsage,
             filament::backend::TextureFormat const& fFormat);
 
+    SamplerType mSamplerType;
+
 private:
-    wgpu::TextureView makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
-            SamplerType target);
     // CreateTextureR has info for a texture and sampler. Texture Views are needed for binding,
     // along with a sampler Current plan: Inherit the sampler and Texture to always exist (It is a
     // ref counted pointer) when making views. View is optional
     wgpu::Texture mTexture = nullptr;
-    wgpu::TextureUsage mUsage = wgpu::TextureUsage::None;
+    wgpu::TextureView mTexureView = nullptr;
     wgpu::TextureFormat mFormat = wgpu::TextureFormat::Undefined;
     wgpu::TextureAspect mAspect = wgpu::TextureAspect::Undefined;
+    wgpu::TextureUsage mUsage = wgpu::TextureUsage::None;
     uint32_t mArrayLayerCount = 1;
-    wgpu::TextureView mTexureView = nullptr;
-    wgpu::TextureUsage fToWGPUTextureUsage(filament::backend::TextureUsage const& fUsage);
     size_t mBlockWidth;
     size_t mBlockHeight;
+
+    wgpu::TextureUsage fToWGPUTextureUsage(filament::backend::TextureUsage const& fUsage);
+
 };
 
 struct WGPURenderPrimitive : public HwRenderPrimitive {
@@ -219,7 +225,7 @@ class WGPURenderTarget : public HwRenderTarget {
 public:
     using Attachment = TargetBufferInfo; // Using TargetBufferInfo directly for attachments
 
-    WGPURenderTarget(uint32_t width, uint32_t height, uint8_t samples,
+    WGPURenderTarget(uint32_t width, uint32_t height, uint8_t samples, uint8_t layerCount,
             const MRT& colorAttachments,
             const Attachment& depthAttachment,
             const Attachment& stencilAttachment);
@@ -257,6 +263,8 @@ public:
     // Static helpers for load/store operations
     static wgpu::LoadOp getLoadOperation(const RenderPassParams& params, TargetBufferFlags buffer);
     static wgpu::StoreOp getStoreOperation(const RenderPassParams& params, TargetBufferFlags buffer);
+
+    uint8_t mLayerCount = 1;
 
 private:
     bool defaultRenderTarget = false;

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -214,9 +214,9 @@ private:
 
     wgpu::TextureUsage fToWGPUTextureUsage(filament::backend::TextureUsage const& fUsage);
 
-    wgpu::TextureView makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
+    [[nodiscard]] wgpu::TextureView makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
             const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,
-            SamplerType samplerType) const;
+            SamplerType samplerType) const noexcept;
 };
 
 struct WGPURenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -267,7 +267,7 @@ public:
     // Static helpers for load/store operations
     static wgpu::LoadOp getLoadOperation(const RenderPassParams& params, TargetBufferFlags buffer);
     static wgpu::StoreOp getStoreOperation(const RenderPassParams& params, TargetBufferFlags buffer);
-    
+
 private:
     bool mDefaultRenderTarget = false;
     uint8_t mSamples = 1;

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -183,7 +183,7 @@ public:
 
     [[nodiscard]] const wgpu::Texture& getTexture() const { return mTexture; }
 
-    [[nodiscard]] wgpu::TextureView getTextureView() const {return mTextureView;}
+    [[nodiscard]] wgpu::TextureView getDefaultTextureView() const {return mDefaultTextureView;}
     [[nodiscard]] wgpu::TextureView getOrMakeTextureView(uint8_t mipLevel, uint32_t arrayLayer) const;
 
     [[nodiscard]] wgpu::TextureFormat getFormat() const { return mFormat; }
@@ -207,10 +207,11 @@ private:
     size_t mBlockWidth;
     size_t mBlockHeight;
     SamplerType mSamplerType;
-    wgpu::TextureView mTextureView = nullptr;
+    wgpu::TextureView mDefaultTextureView = nullptr;
 
 
-    [[nodiscard]] wgpu::TextureUsage fToWGPUTextureUsage(filament::backend::TextureUsage const& fUsage);
+    [[nodiscard]] wgpu::TextureUsage fToWGPUTextureUsage(
+            filament::backend::TextureUsage const& fUsage);
 
     [[nodiscard]] wgpu::TextureView makeTextureView(const uint8_t& baseLevel,
             const uint8_t& levelCount, const uint32_t& baseArrayLayer,

--- a/filament/backend/src/webgpu/WebGPUHandles.h
+++ b/filament/backend/src/webgpu/WebGPUHandles.h
@@ -198,7 +198,6 @@ public:
             filament::backend::TextureUsage const& fUsage,
             filament::backend::TextureFormat const& fFormat);
 
-
 private:
     // CreateTextureR has info for a texture and sampler. Texture Views are needed for binding,
     // along with a sampler Current plan: Inherit the sampler and Texture to always exist (It is a
@@ -213,13 +212,11 @@ private:
     size_t mBlockHeight;
     SamplerType mSamplerType;
 
-
     wgpu::TextureUsage fToWGPUTextureUsage(filament::backend::TextureUsage const& fUsage);
 
     wgpu::TextureView makeTextureView(const uint8_t& baseLevel, const uint8_t& levelCount,
             const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,
             SamplerType samplerType) const;
-
 };
 
 struct WGPURenderPrimitive : public HwRenderPrimitive {
@@ -258,7 +255,6 @@ public:
             wgpu::TextureFormat customDepthFormat,
             wgpu::TextureFormat customStencilFormat);
 
-
     bool isDefaultRenderTarget() const { return defaultRenderTarget; }
     uint8_t getSamples() const { return mSamples; }
     uint8_t getLayerCount() const { return mLayerCount; }
@@ -271,9 +267,7 @@ public:
     // Static helpers for load/store operations
     static wgpu::LoadOp getLoadOperation(const RenderPassParams& params, TargetBufferFlags buffer);
     static wgpu::StoreOp getStoreOperation(const RenderPassParams& params, TargetBufferFlags buffer);
-
-
-
+    
 private:
     bool defaultRenderTarget = false;
     uint8_t mSamples = 1;


### PR DESCRIPTION
This PR addresses an issue where level and layer values were not consistently applied when creating wgpu::TextureViews for render pass attachments.