### PR TITLE
Backend tests using webgpu

### DIFF
--- a/filament/backend/test/Arguments.cpp
+++ b/filament/backend/test/Arguments.cpp
@@ -46,6 +46,8 @@ Backend parseArgumentsForBackend(int argc, char* argv[]) {
                     backend = Backend::VULKAN;
                 } else if (arg == "metal") {
                     backend = Backend::METAL;
+                } else if (arg == "webgpu") {
+                    backend = Backend::WEBGPU;
                 } else {
                     std::cerr << "Unrecognized target API. Must be 'opengl'|'vulkan'|'metal'."
                               << std::endl

--- a/filament/backend/test/mac_runner.mm
+++ b/filament/backend/test/mac_runner.mm
@@ -49,6 +49,9 @@ test::NativeView getNativeView() {
     if (self.backend == test::Backend::VULKAN) {
         nativeView.ptr = (void*) view;
     }
+    if (self.backend == test::Backend::WEBGPU) {
+        nativeView.ptr = (void*) view.layer;
+    }
     CGSize drawableSize = ((CAMetalLayer*) view.layer).drawableSize;
     nativeView.width = static_cast<size_t>(drawableSize.width);
     nativeView.height = static_cast<size_t>(drawableSize.height);

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -27,6 +27,7 @@ namespace test {
 TEST_F(BackendTest, FrameScheduledCallback) {
     SKIP_IF(Backend::OPENGL, "Frame callbacks are unsupported in OpenGL");
     SKIP_IF(Backend::VULKAN, "Frame callbacks are unsupported in Vulkan, see b/417254479");
+    SKIP_IF(Backend::WEBGPU, "Frame callbacks are unsupported in WebGPU");
 
     auto& api = getDriverApi();
     Cleanup cleanup(api);
@@ -87,6 +88,7 @@ TEST_F(BackendTest, FrameScheduledCallback) {
 TEST_F(BackendTest, FrameCompletedCallback) {
     SKIP_IF(Backend::OPENGL, "Frame callbacks are unsupported in OpenGL");
     SKIP_IF(Backend::VULKAN, "Frame callbacks are unsupported in Vulkan, see b/417254479");
+    SKIP_IF(Backend::WEBGPU, "Frame callbacks are unsupported in WebGPU");
 
     auto& api = getDriverApi();
     Cleanup cleanup(api);

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -104,6 +104,7 @@ TEST_F(BackendTest, FeedbackLoops) {
     SKIP_IF(SkipEnvironment(OperatingSystem::APPLE, Backend::OPENGL),
             "OpenGL image is upside down due to readPixels failing for texture with uploaded image "
             "data");
+    FAIL_IF(Backend::WEBGPU, "BUG");
     auto& api = getDriverApi();
     Cleanup cleanup(api);
 

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -453,7 +453,6 @@ TEST_F(LoadImageTest, UpdateImageSRGB) {
     RenderPassParams params = getClearColorRenderPass();
     params.viewport.width = kTexSize;
     params.viewport.height = kTexSize;
-    api.makeCurrent(swapChain, swapChain);
     PipelineState state = getColorWritePipelineState();
     shader.addProgramToPipelineState(state);
     state.primitiveType = PrimitiveType::TRIANGLES;
@@ -529,7 +528,6 @@ TEST_F(LoadImageTest, UpdateImageMipLevel) {
         RenderPassParams params = getClearColorRenderPass();
         params.viewport.width = kTexSize;
         params.viewport.height = kTexSize;
-        api.makeCurrent(swapChain, swapChain);
         PipelineState state = getColorWritePipelineState();
         shader.addProgramToPipelineState(state);
         state.primitiveType = PrimitiveType::TRIANGLES;
@@ -617,7 +615,6 @@ TEST_F(LoadImageTest, UpdateImage3D) {
         RenderPassParams params = getClearColorRenderPass();
         params.viewport.width = kTexSize;
         params.viewport.height = kTexSize;
-        api.makeCurrent(swapChain, swapChain);
         PipelineState state = getColorWritePipelineState();
         shader.addProgramToPipelineState(state);
         state.primitiveType = PrimitiveType::TRIANGLES;

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -453,6 +453,7 @@ TEST_F(LoadImageTest, UpdateImageSRGB) {
     RenderPassParams params = getClearColorRenderPass();
     params.viewport.width = kTexSize;
     params.viewport.height = kTexSize;
+    api.makeCurrent(swapChain, swapChain);
     PipelineState state = getColorWritePipelineState();
     shader.addProgramToPipelineState(state);
     state.primitiveType = PrimitiveType::TRIANGLES;
@@ -528,6 +529,7 @@ TEST_F(LoadImageTest, UpdateImageMipLevel) {
         RenderPassParams params = getClearColorRenderPass();
         params.viewport.width = kTexSize;
         params.viewport.height = kTexSize;
+        api.makeCurrent(swapChain, swapChain);
         PipelineState state = getColorWritePipelineState();
         shader.addProgramToPipelineState(state);
         state.primitiveType = PrimitiveType::TRIANGLES;
@@ -615,6 +617,7 @@ TEST_F(LoadImageTest, UpdateImage3D) {
         RenderPassParams params = getClearColorRenderPass();
         params.viewport.width = kTexSize;
         params.viewport.height = kTexSize;
+        api.makeCurrent(swapChain, swapChain);
         PipelineState state = getColorWritePipelineState();
         shader.addProgramToPipelineState(state);
         state.primitiveType = PrimitiveType::TRIANGLES;


### PR DESCRIPTION
Add "Web GPU" as one of the supported backends for the unit tests. At this time this is just the initial implementation as the tests are currently not running 