### PR TITLE
Fix: Prevent deadlock when loading programs from cache

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -133,7 +133,7 @@ struct ShaderCompilerService::OpenGLProgramToken : ProgramToken {
     bool signaled = false;
 
     // Indicate this program was created from the cache blob.
-    bool retrieved = false;
+    bool retrievedFromBlobCache = false;
 };
 
 ShaderCompilerService::OpenGLProgramToken::~OpenGLProgramToken() {
@@ -265,7 +265,7 @@ ShaderCompilerService::program_token_t ShaderCompilerService::createProgram(
     // Try retrieving the cached program blob if available.
     token->gl.program = mBlobCache.retrieve(&token->key, mDriver.mPlatform, program);
     if (token->gl.program) {
-        token->retrieved = true;
+        token->retrievedFromBlobCache = true;
         return token;
     }
 
@@ -345,7 +345,7 @@ GLuint ShaderCompilerService::getProgram(program_token_t& token) {
     assert_invariant(token);// This function should be called when the token is still alive.
 
     // Finalize any pending shader compilation tasks only when the token was created without cache.
-    if (!token->retrieved) {
+    if (!token->retrievedFromBlobCache) {
         if (token->compiler.mMode == Mode::THREAD_POOL) {
             auto const job = token->compiler.mCompilerThreadPool.dequeue(token);
             if (!job) {


### PR DESCRIPTION
When a program was created directly from a cached blob in `ShaderCompilerService`, its associated token was not signaled as ready in the THREAD_POOL mode. This oversight caused a deadlock at the `token->wait()` call during program destruction.
    
This commit resolves the issue by skipping the token's readiness check upon destruction if the program was created from the cache blob.

BUGS=[423221474]