### PR TITLE
webgpu: remove float filterable requirement

### DIFF
--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -56,10 +56,8 @@ namespace {
 // The SPD Algorithm can make use of up to 12 storage texture attachments
 constexpr uint32_t MAX_MIPMAP_STORAGE_TEXTURES_PER_STAGE = 12u;
 
-constexpr std::array REQUIRED_FEATURES = { wgpu::FeatureName::TransientAttachments,
-    /*To make filtering assumptions like we want while waiting for Filament to provide that info,
-       float 32 needs to be filterable*/
-    wgpu::FeatureName::Float32Filterable,
+constexpr std::array REQUIRED_FEATURES = {
+    wgpu::FeatureName::TransientAttachments,
     // Qualcomm 500 and 600 GPUs do not support this so it is not part of core webgpu spec. To
     // support such devices, we will either need Filament to not attempt this, or find another
     // workaround. https://github.com/gpuweb/gpuweb/issues/2648

--- a/libs/filabridge/src/DescriptorSets.cpp
+++ b/libs/filabridge/src/DescriptorSets.cpp
@@ -96,7 +96,7 @@ static constexpr std::initializer_list<DescriptorSetLayoutBinding> perRenderable
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::OBJECT_UNIFORMS, DescriptorFlags::DYNAMIC_OFFSET },
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::BONES_UNIFORMS,  DescriptorFlags::DYNAMIC_OFFSET },
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::MORPHING_UNIFORMS         },
-    { DescriptorType::SAMPLER_2D_ARRAY_FLOAT,   ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::MORPH_TARGET_POSITIONS    },
+    { DescriptorType::SAMPLER_2D_ARRAY_FLOAT,   ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::MORPH_TARGET_POSITIONS, DescriptorFlags::UNFILTERABLE },
     { DescriptorType::SAMPLER_2D_ARRAY_INT,     ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::MORPH_TARGET_TANGENTS     },
     { DescriptorType::SAMPLER_2D_ARRAY_FLOAT,   ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS },
 };


### PR DESCRIPTION
This will enable webgpu for devices such as pixel 4, which does not support this feature.