### PR TITLE
Fix ASAN use-after-stack-free in VulkanPlatform

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -926,7 +926,7 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
     // Keep a copy of context for swapchains.
     mImpl->mContext = context;
 
-    return VulkanDriver::create(this, context, driverConfig);
+    return VulkanDriver::create(this, mImpl->mContext, driverConfig);
 }
 
 // This needs to be explictly written for


### PR DESCRIPTION
`context` is a stack variable, but it is captured by reference.