### PR TITLE
webgpu: update pipeline cache key to include render target

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -81,7 +81,7 @@ private:
     WebGPURenderPassMipmapGenerator mRenderPassMipmapGenerator;
     spd::MipmapGenerator mSpdComputePassMipmapGenerator;
 
-    tsl::robin_map<uint32_t, wgpu::RenderPipeline> mPipelineMap;
+    tsl::robin_map<size_t, wgpu::RenderPipeline> mPipelineMap;
 
     struct DescriptorSetBindingInfo{
         wgpu::BindGroup bindGroup;
@@ -89,6 +89,9 @@ private:
         backend::DescriptorSetOffsetArray offsets;
     };
     std::array<DescriptorSetBindingInfo,MAX_DESCRIPTOR_SET_COUNT> mCurrentDescriptorSets;
+
+    [[nodiscard]] size_t computePipelineKey(PipelineState const&, WebGPURenderTarget const*) const;
+
     /*
      * Driver interface
      */


### PR DESCRIPTION
Currently, we simply hash on the Filament PipelineState _(utils::hash::MurmurHashFn<filament::backend::PipelineState>())_, but when we create our pipeline we also use the mCurrentRenderTarget, as it contains color attachment info we use to define our pipeline. If we return/use a pipeline built for a different render target _(but with the same pipeline state)_ than is currently being used we can easily get mismatches on attachment states, which we see here. Indeed, I temporarily added some debug logs and was able to see evidence of this happening:

```
...
BIND PIPELINE bilateralBlur with pipeline HASH 3467939382 and render target 0x1203d8448
...
BIND PIPELINE bilateralBlur with pipeline HASH 3467939382 and render target 0x1203d8678
...
```

Thus, we need to use the render target as part of the pipeline hash.

BUGS = [427709441]