### PR TITLE
webgpu: support auto-resolve render passes (render target samples != attached texture samples)

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -273,6 +273,8 @@ if (FILAMENT_SUPPORTS_WEBGPU)
             src/webgpu/WebGPUFence.h
             src/webgpu/WebGPUIndexBuffer.cpp
             src/webgpu/WebGPUIndexBuffer.h
+            src/webgpu/WebGPUMsaaTextureResolver.cpp
+            src/webgpu/WebGPUMsaaTextureResolver.h
             src/webgpu/WebGPUPipelineCreation.cpp
             src/webgpu/WebGPUPipelineCreation.h
             src/webgpu/WebGPUProgram.cpp

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -19,6 +19,7 @@
 
 #include "WebGPURenderTarget.h"
 #include "webgpu/WebGPUConstants.h"
+#include "webgpu/WebGPUMsaaTextureResolver.h"
 #include "webgpu/WebGPURenderPassMipmapGenerator.h"
 #include <backend/platforms/WebGPUPlatform.h>
 
@@ -56,7 +57,7 @@ public:
     [[nodiscard]] static Driver* create(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
 
 private:
-    explicit WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
+    WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
     [[nodiscard]] ShaderModel getShaderModel() const noexcept final;
     [[nodiscard]] ShaderLanguage getShaderLanguage() const noexcept final;
     [[nodiscard]] wgpu::Sampler makeSampler(SamplerParams const& params);
@@ -80,6 +81,7 @@ private:
     WebGPURenderTarget* mCurrentRenderTarget = nullptr;
     WebGPURenderPassMipmapGenerator mRenderPassMipmapGenerator;
     spd::MipmapGenerator mSpdComputePassMipmapGenerator;
+    WebGPUMsaaTextureResolver mMsaaTextureResolver{};
 
     tsl::robin_map<size_t, wgpu::RenderPipeline> mPipelineMap;
 

--- a/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.cpp
+++ b/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "WebGPUMsaaTextureResolver.h"
+
+#include "WebGPUTexture.h"
+
+#include <utils/Panic.h>
+
+#include <webgpu/webgpu_cpp.h>
+
+namespace filament::backend {
+
+namespace {
+
+void resolveColorTextures(wgpu::CommandEncoder const& commandEncoder,
+        wgpu::TextureView const& sourceTextureView,
+        wgpu::TextureView const& destinationTextureView) {
+    const wgpu::RenderPassColorAttachment colorAttachment{
+        .view = sourceTextureView,
+        .depthSlice = wgpu::kDepthSliceUndefined, // being explicit for consistent behavior
+        .resolveTarget = destinationTextureView,
+        .loadOp = wgpu::LoadOp::Load,
+        .storeOp = wgpu::StoreOp::Store,
+        .clearValue = {}, // being explicit for consistent behavior
+    };
+    const wgpu::RenderPassDescriptor renderPassDescriptor{
+        .label = "resolve_render_pass",
+        .colorAttachmentCount = 1,
+        .colorAttachments = &colorAttachment,
+        .depthStencilAttachment = nullptr, // being explicit for consistent behavior
+        .occlusionQuerySet = nullptr,      // being explicit for consistent behavior
+        .timestampWrites = nullptr,        // being explicit for consistent behavior
+    };
+    const wgpu::RenderPassEncoder renderPassEncoder{ commandEncoder.BeginRenderPass(
+            &renderPassDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(renderPassEncoder)
+            << "Failed to create wgpu::RenderPassEncoder for WebGPUDriver::resolve";
+    renderPassEncoder.End(); // only the implicit resolve is happening in the pass
+}
+
+} // namespace
+
+void WebGPUMsaaTextureResolver::resolve(ResolveRequest const& request) {
+    ResolveRequest::TextureInfo const& source{ request.source };
+    ResolveRequest::TextureInfo const& destination{ request.destination };
+    FILAMENT_CHECK_PRECONDITION(destination.texture.GetWidth() == source.texture.GetWidth() &&
+                                destination.texture.GetHeight() == source.texture.GetHeight())
+            << "invalid resolve: source and destination sizes don't match";
+
+    FILAMENT_CHECK_PRECONDITION(
+            source.texture.GetSampleCount() > 1 && destination.texture.GetSampleCount() == 1)
+            << "invalid resolve: source.samples=" << source.texture.GetSampleCount()
+            << ", destination.samples=" << destination.texture.GetSampleCount();
+
+    FILAMENT_CHECK_PRECONDITION(source.texture.GetFormat() == destination.texture.GetFormat())
+            << "source and destination texture format don't match";
+    const wgpu::TextureFormat format{ source.texture.GetFormat() };
+
+    FILAMENT_CHECK_PRECONDITION(!hasDepth(format)) << "can't resolve depth formats";
+
+    FILAMENT_CHECK_PRECONDITION(!hasStencil(format)) << "can't resolve stencil formats";
+
+    FILAMENT_CHECK_PRECONDITION(source.texture.GetUsage() & wgpu::TextureUsage::RenderAttachment)
+            << "source texture usage doesn't have wgpu::TextureUsage::RenderAttachment";
+
+    FILAMENT_CHECK_PRECONDITION(
+            destination.texture.GetUsage() & wgpu::TextureUsage::RenderAttachment)
+            << "destination texture usage doesn't have wgpu::TextureUsage::RenderAttachment";
+
+    FILAMENT_CHECK_PRECONDITION(destination.texture.GetUsage() & wgpu::TextureUsage::TextureBinding)
+            << "destination texture usage doesn't have wgpu::TextureUsage::TextureBinding";
+
+    const wgpu::TextureViewDescriptor sourceTextureViewDescriptor{
+        .label = "resolve_source_texture_view",
+        .format = request.viewFormat,
+        .dimension = source.viewDimension,
+        .baseMipLevel = source.mipLevel,
+        .mipLevelCount = 1,
+        .baseArrayLayer = source.layer,
+        .arrayLayerCount = 1,
+        .aspect = source.aspect,
+        .usage = source.texture.GetUsage(),
+    };
+    const wgpu::TextureView sourceTextureView{ source.texture.CreateView(
+            &sourceTextureViewDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(sourceTextureView)
+            << "Failed to create wgpu::TextureView sourceTextureView";
+    const wgpu::TextureViewDescriptor destinationTextureViewDescriptor{
+        .label = "resolve_destination_texture_view",
+        .format = request.viewFormat,
+        .dimension = destination.viewDimension,
+        .baseMipLevel = destination.mipLevel,
+        .mipLevelCount = 1,
+        .baseArrayLayer = destination.layer,
+        .arrayLayerCount = 1,
+        .aspect = destination.aspect,
+        .usage = destination.texture.GetUsage(),
+    };
+    const wgpu::TextureView destinationTextureView{ destination.texture.CreateView(
+            &destinationTextureViewDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(destinationTextureView)
+            << "Failed to create wgpu::TextureView destinationTextureView.";
+
+    if (hasDepth(format)) {
+        PANIC_PRECONDITION("DEPTH RESOLVE NOT IMPLEMENTED YET");
+    } else {
+        resolveColorTextures(request.commandEncoder, sourceTextureView, destinationTextureView);
+    }
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.h
+++ b/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_WEBGPUMSAATEXTURERESOLVER_H
+#define TNT_FILAMENT_BACKEND_WEBGPUMSAATEXTURERESOLVER_H
+
+#include <cstdint>
+
+namespace wgpu {
+class CommandEncoder;
+class Texture;
+enum class TextureAspect : uint32_t;
+enum class TextureFormat : uint32_t;
+enum class TextureViewDimension : uint32_t;
+} // namespace wgpu
+
+namespace filament::backend {
+
+class WebGPUTexture;
+
+class WebGPUMsaaTextureResolver final {
+public:
+    struct ResolveRequest final {
+        struct TextureInfo final {
+            wgpu::Texture const& texture;
+            wgpu::TextureViewDimension viewDimension;
+            uint8_t mipLevel;
+            uint8_t layer;
+            wgpu::TextureAspect aspect;
+        };
+        wgpu::CommandEncoder const& commandEncoder;
+        wgpu::TextureFormat viewFormat;
+        TextureInfo source;
+        TextureInfo destination;
+    };
+
+    void resolve(ResolveRequest const&);
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_WEBGPUMSAATEXTURERESOLVER_H

--- a/filament/backend/src/webgpu/WebGPURenderTarget.cpp
+++ b/filament/backend/src/webgpu/WebGPURenderTarget.cpp
@@ -16,7 +16,11 @@
 
 #include "WebGPURenderTarget.h"
 
+#include "WebGPUTexture.h"
+
+#include "DriverBase.h"
 #include <backend/DriverEnums.h>
+#include <backend/Handle.h>
 #include <backend/TargetBufferInfo.h>
 
 #include <private/backend/BackendUtils.h>
@@ -26,14 +30,97 @@
 
 #include <webgpu/webgpu_cpp.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <functional>
+#include <string_view>
 
 namespace filament::backend {
+
+namespace {
+
+/**
+ * Panics if the number of samples in the original attachment textures do not match.
+ * @return The number of samples in the original attachment textures (the number/count in each one).
+ *         Returns 0 if there are no attachments.
+ */
+[[nodiscard]] uint8_t createMsaaSidecarTextures(const uint8_t renderTargetSampleCount,
+        const TargetBufferFlags targetFlags, MRT const& colorAttachments,
+        TargetBufferInfo const& depthAttachment, TargetBufferInfo const& stencilAttachment,
+        std::function<WebGPUTexture*(const Handle<HwTexture>)> const& getWebGPUTexture,
+        wgpu::Device const& device) {
+    struct Target final {
+        std::string_view name;
+        TargetBufferFlags flag{ TargetBufferFlags::NONE };
+        size_t colorIndex{ 0 };
+    };
+    // assuming 8 colors. hopefully the following static_assert will get tripped if another
+    // color ever gets added
+    static_assert(
+            (TargetBufferFlags::COLOR0 | TargetBufferFlags::COLOR1 | TargetBufferFlags::COLOR2 |
+                    TargetBufferFlags::COLOR3 | TargetBufferFlags::COLOR4 |
+                    TargetBufferFlags::COLOR5 | TargetBufferFlags::COLOR6 |
+                    TargetBufferFlags::COLOR7) == TargetBufferFlags::COLOR_ALL);
+    const static std::array TARGETS{
+        Target{ .name = "COLOR0", .flag = TargetBufferFlags::COLOR0, .colorIndex = 0 },
+        Target{ .name = "COLOR1", .flag = TargetBufferFlags::COLOR1, .colorIndex = 1 },
+        Target{ .name = "COLOR2", .flag = TargetBufferFlags::COLOR2, .colorIndex = 2 },
+        Target{ .name = "COLOR3", .flag = TargetBufferFlags::COLOR3, .colorIndex = 3 },
+        Target{ .name = "COLOR4", .flag = TargetBufferFlags::COLOR4, .colorIndex = 4 },
+        Target{ .name = "COLOR5", .flag = TargetBufferFlags::COLOR5, .colorIndex = 5 },
+        Target{ .name = "COLOR6", .flag = TargetBufferFlags::COLOR6, .colorIndex = 6 },
+        Target{ .name = "COLOR7", .flag = TargetBufferFlags::COLOR7, .colorIndex = 7 },
+        Target{ .name = "DEPTH", .flag = TargetBufferFlags::DEPTH },
+        Target{ .name = "STENCIL", .flag = TargetBufferFlags::STENCIL },
+    };
+#ifndef NDEBUG
+    for (auto const& target: TARGETS) {
+        assert_invariant(target.colorIndex <= MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT &&
+                         "color index is >= MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT, which should "
+                         "not be possible and could lead to us indexing into the colorAttachments "
+                         "array beyond its bounds.");
+    }
+#endif
+    bool firstAttachment{ true };
+    uint8_t sampleCountPerAttachment{ 0 };
+    for (auto const& target: TARGETS) {
+        if (any(targetFlags & target.flag)) {
+            const Handle<HwTexture> textureHandle{
+                target.flag == TargetBufferFlags::DEPTH
+                        ? depthAttachment.handle
+                        : (target.flag == TargetBufferFlags::STENCIL
+                                          ? stencilAttachment.handle
+                                          : colorAttachments[target.colorIndex].handle)
+            };
+            WebGPUTexture* const texture{ getWebGPUTexture(textureHandle) };
+            assert_invariant(texture != nullptr && "target flag indicate the use of an attachment "
+                                                   "for which we do not have a texture?");
+            if (firstAttachment) {
+                sampleCountPerAttachment = texture->samples;
+                firstAttachment = false;
+            }
+            FILAMENT_CHECK_PRECONDITION(texture->samples == sampleCountPerAttachment)
+                    << target.name << " attachment texture has " << +texture->samples
+                    << " but the other attachment(s) have " << +sampleCountPerAttachment;
+            if (renderTargetSampleCount > 1 && sampleCountPerAttachment == 1) {
+                texture->createMsaaSidecarTextureIfNotAlreadyCreated(renderTargetSampleCount,
+                        device);
+            }
+        }
+    }
+    assert_invariant(sampleCountPerAttachment);
+    return sampleCountPerAttachment;
+}
+
+}  // namespace
 
 WebGPURenderTarget::WebGPURenderTarget(const uint32_t width, const uint32_t height,
         const uint8_t samples, const uint8_t layerCount, MRT const& colorAttachmentsMRT,
         Attachment const& depthAttachmentInfo, Attachment const& stencilAttachmentInfo,
-        TargetBufferFlags const& targetFlags)
+        TargetBufferFlags const& targetFlags,
+        std::function<WebGPUTexture*(const Handle<HwTexture>)> const& getWebGPUTexture,
+        wgpu::Device const& device)
     : HwRenderTarget{ width, height },
       mDefaultRenderTarget{ false },
       mTargetFlags{ targetFlags },
@@ -41,8 +128,11 @@ WebGPURenderTarget::WebGPURenderTarget(const uint32_t width, const uint32_t heig
       mLayerCount{ layerCount },
       mColorAttachments{ colorAttachmentsMRT },
       mDepthAttachment{ depthAttachmentInfo },
-      mStencilAttachment{ stencilAttachmentInfo } {
-    // TODO consider making this an array
+      mStencilAttachment{ stencilAttachmentInfo },
+      mSampleCountPerAttachment{ createMsaaSidecarTextures(mSamples, mTargetFlags,
+              mColorAttachments, mDepthAttachment, mStencilAttachment, getWebGPUTexture, device) } {
+    // TODO consider possibly making this an array (that would avoid a heap allocation, but the
+    //      concern is the size limitation on the handle itself)
     mColorAttachmentDesc.reserve(MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT);
 }
 
@@ -52,8 +142,8 @@ WebGPURenderTarget::WebGPURenderTarget()
       mDefaultRenderTarget{ true },
       mTargetFlags{ TargetBufferFlags::NONE },
       mSamples{ 1 },
-      mLayerCount{ 1 }
-     {}
+      mLayerCount{ 1 },
+      mSampleCountPerAttachment{ 1 } {}
 
 wgpu::LoadOp WebGPURenderTarget::getLoadOperation(RenderPassParams const& params,
         const TargetBufferFlags bufferToOperateOn) {
@@ -77,8 +167,35 @@ wgpu::StoreOp WebGPURenderTarget::getStoreOperation(RenderPassParams const& para
 void WebGPURenderTarget::setUpRenderPassAttachments(wgpu::RenderPassDescriptor& outDescriptor,
         RenderPassParams const& params, wgpu::TextureView const& defaultColorTextureView,
         wgpu::TextureView const& defaultDepthStencilTextureView,
-        wgpu::TextureView const* customColorTextureViews, uint32_t customColorTextureViewCount,
-        wgpu::TextureView const& customDepthStencilTextureView) {
+        wgpu::TextureView const* customColorTextureViews,
+        wgpu::TextureView const* customColorMsaaSidecarTextureViews,
+        uint32_t customColorTextureViewCount,
+        wgpu::TextureView const& customDepthStencilTextureView,
+        wgpu::TextureView const& customDepthStencilMsaaSidecarTextureView) {
+    const bool hasMsaaSidecars{ (customColorTextureViewCount > 0 &&
+                                        customColorMsaaSidecarTextureViews[0]) ||
+                                customDepthStencilMsaaSidecarTextureView };
+    // either all the textures have MSAA sidecars or none of them do
+    if (hasMsaaSidecars) {
+        FILAMENT_CHECK_PRECONDITION(std::all_of(customColorMsaaSidecarTextureViews,
+                customColorMsaaSidecarTextureViews + customColorTextureViewCount,
+                [](wgpu::TextureView const& msaaView) { return msaaView != nullptr; }))
+                << "A color or depth/stencil attachment texture has a MSAA sidecar but at least "
+                   "one other color attachment texture does not.";
+        FILAMENT_CHECK_PRECONDITION(customDepthStencilMsaaSidecarTextureView != nullptr)
+                << "The color attachment texture(s) have MSAA sidecar(s) but the depth/stencil "
+                   "texture does not.";
+    } else {
+        FILAMENT_CHECK_PRECONDITION(std::all_of(customColorMsaaSidecarTextureViews,
+                customColorMsaaSidecarTextureViews + customColorTextureViewCount,
+                [](wgpu::TextureView const& msaaView) { return msaaView == nullptr; }))
+                << "A color or depth/stencil attachment texture does not have a MSAA sidecar but "
+                   "at least one color attachment texture does.";
+        FILAMENT_CHECK_PRECONDITION(customDepthStencilMsaaSidecarTextureView == nullptr)
+                << "Custom color textures for the render target do not have MSAA sidecar(s) but "
+                   "the depth/stencil texture does.";
+    }
+
     mColorAttachmentDesc.clear();
 
     const bool hasDepth = any(mTargetFlags & TargetBufferFlags::DEPTH);
@@ -104,9 +221,10 @@ void WebGPURenderTarget::setUpRenderPassAttachments(wgpu::RenderPassDescriptor& 
     } else {
         for (uint32_t i = 0; i < customColorTextureViewCount; ++i) {
             if (customColorTextureViews[i]) {
-                mColorAttachmentDesc.push_back({ .view = customColorTextureViews[i],
-                    .resolveTarget =
-                            nullptr, // We handle MSAA on the WebGPU driver's resolve function
+                const wgpu::TextureView msaaSidecar{ customColorMsaaSidecarTextureViews[i] };
+                mColorAttachmentDesc.push_back({
+                    .view = hasMsaaSidecars ? msaaSidecar : customColorTextureViews[i],
+                    .resolveTarget = hasMsaaSidecars ? customColorTextureViews[i] : nullptr,
                     .loadOp =
                             WebGPURenderTarget::getLoadOperation(params, getTargetBufferFlagsAt(i)),
                     .storeOp = WebGPURenderTarget::getStoreOperation(params,
@@ -132,7 +250,8 @@ void WebGPURenderTarget::setUpRenderPassAttachments(wgpu::RenderPassDescriptor& 
             assert_invariant(depthStencilViewToUse);
         } else {
             if (customDepthStencilTextureView) {
-                depthStencilViewToUse = customDepthStencilTextureView;
+                depthStencilViewToUse = hasMsaaSidecars ? customDepthStencilMsaaSidecarTextureView
+                                                        : customDepthStencilTextureView;
             }
         }
 

--- a/filament/backend/src/webgpu/WebGPUTexture.h
+++ b/filament/backend/src/webgpu/WebGPUTexture.h
@@ -26,6 +26,20 @@
 
 namespace filament::backend {
 
+[[nodiscard]] constexpr bool hasStencil(const wgpu::TextureFormat textureFormat) {
+    return textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
+           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8 ||
+           textureFormat == wgpu::TextureFormat::Stencil8;
+}
+
+[[nodiscard]] constexpr bool hasDepth(const wgpu::TextureFormat textureFormat) {
+    return textureFormat == wgpu::TextureFormat::Depth16Unorm ||
+           textureFormat == wgpu::TextureFormat::Depth32Float ||
+           textureFormat == wgpu::TextureFormat::Depth24Plus ||
+           textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
+           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8;
+}
+
 class WebGPUTexture : public HwTexture {
 public:
     enum class MipmapGenerationStrategy : uint8_t {
@@ -47,6 +61,8 @@ public:
 
     [[nodiscard]] wgpu::Texture const& getTexture() const { return mTexture; }
 
+    [[nodiscard]] wgpu::Texture const& getMsaaSidecarTexture(uint8_t sampleCount) const;
+
     [[nodiscard]] wgpu::TextureView const& getDefaultTextureView() const {
         return mDefaultTextureView;
     }
@@ -61,6 +77,33 @@ public:
     [[nodiscard]] MipmapGenerationStrategy getMipmapGenerationStrategy() const {
         return mMipmapGenerationStrategy;
     }
+
+    /**
+     * Creates the MSAA sidecar texture if it has not already been created.
+     * If the sidecar already exists with a different number of samples this will panic
+     * (at the time of writing this WebGPU only supports MSAA with 4 samples. If this changes, then
+     * multiple sidecars with different number of samples could be supported if needed, but that
+     * level of complexity is not warranted at this time).
+     * Additionally, if samples is <= 1 this will panic as well, as that is not an MSAA texture.
+     * @param samples The number of samples the texture will have
+     */
+    void createMsaaSidecarTextureIfNotAlreadyCreated(uint8_t samples, wgpu::Device const&);
+
+    /**
+     * @param samples The number of samples the underlying texture supports
+     * @param mipLevel The mip level into the underyling texture for which this view will reference
+     * (this view will only have one mip level)
+     * @param arrayLayer The layer into the underyling texture for which this view will reference
+     * (this view will only have one layer)
+     * @return A texture view for the MSAA sidecar texture
+     */
+    wgpu::TextureView makeMsaaSidecarTextureViewIfTextureSidecarExists(uint8_t samples,
+            uint8_t mipLevel, uint32_t arrayLayer) const;
+
+    /**
+     * @return nullptr if a MSAA sidecar texture is not appliable, otherwise a view to one
+     */
+    [[nodiscard]] wgpu::TextureView makeMsaaSidecarTextureView(wgpu::Texture const&, uint8_t mipLevel, uint32_t arrayLayer) const;
 
     [[nodiscard]] static wgpu::TextureFormat fToWGPUTextureFormat(
             filament::backend::TextureFormat const& fFormat);
@@ -96,6 +139,11 @@ private:
     uint32_t mDefaultMipLevel = 0;
     uint32_t mDefaultBaseArrayLayer = 0;
     wgpu::TextureView mDefaultTextureView = nullptr;
+    // At the time of writing this, WebGPU only supported 4 samples in a multi-sampled texture.
+    // If that has changed, then consider updating the implementation to have a map of msaa textures
+    // by sampleCount or something like that.
+    // For now that complexity and cost is not warranted due to WebGPU's restrictions.
+    wgpu::Texture mMsaaSidecarTexture = nullptr;
 
     [[nodiscard]] wgpu::TextureView makeTextureView(const uint8_t& baseLevel,
             const uint8_t& levelCount, const uint32_t& baseArrayLayer,


### PR DESCRIPTION
The solution resembles that of the other backends, to implement msaa sidecar textures.

Note: this solution does not resolve depth/stencil textures

BUGS = [427709441]