### PR TITLE
Fix SSR when postfx and msaa are disabled.

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -82,8 +82,6 @@ RenderPassBuilder& RenderPassBuilder::customCommand(
 
 RenderPass RenderPassBuilder::build(FEngine const& engine, DriverApi& driver) const {
     assert_invariant(mRenderableSoa);
-    assert_invariant(mScissorViewport.width  <= std::numeric_limits<int32_t>::max());
-    assert_invariant(mScissorViewport.height <= std::numeric_limits<int32_t>::max());
     return RenderPass{ engine, driver, *this };
 }
 
@@ -107,8 +105,7 @@ void RenderPass::DescriptorSetHandleDeleter::operator()(
 RenderPass::RenderPass(FEngine const& engine, DriverApi& driver,
         RenderPassBuilder const& builder) noexcept
         : mRenderableSoa(*builder.mRenderableSoa),
-          mColorPassDescriptorSet(builder.mColorPassDescriptorSet),
-          mScissorViewport(builder.mScissorViewport) {
+          mColorPassDescriptorSet(builder.mColorPassDescriptorSet) {
 
     // compute the number of commands we need
     updateSummedPrimitiveCounts(

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -306,6 +306,12 @@ public:
     // allocated commands ARE NOT freed, they're owned by the Arena
     ~RenderPass() noexcept;
 
+    // Specifies the viewport for the scissor rectangle, that is, the final scissor rect is
+    // offset by the viewport's left-top and clipped to the viewport's width/height.
+    void setScissorViewport(backend::Viewport const viewport) noexcept {
+        mScissorViewport = viewport;
+    }
+
     Command const* begin() const noexcept { return mCommandBegin; }
     Command const* end() const noexcept { return mCommandEnd; }
     bool empty() const noexcept { return begin() == end(); }
@@ -461,7 +467,7 @@ private:
 
     FScene::RenderableSoa const& mRenderableSoa;
     ColorPassDescriptorSet const* const mColorPassDescriptorSet;
-    backend::Viewport const mScissorViewport{ 0, 0, INT32_MAX, INT32_MAX };
+    backend::Viewport mScissorViewport{ 0, 0, INT32_MAX, INT32_MAX };
     Command const* /* const */ mCommandBegin = nullptr;   // Pointer to the first command
     Command const* /* const */ mCommandEnd = nullptr;     // Pointer to one past the last command
     mutable BufferObjectSharedHandle mInstancedUboHandle; // ubo for instanced primitives
@@ -476,7 +482,6 @@ class RenderPassBuilder {
 
     RenderPass::Arena& mArena;
     RenderPass::CommandTypeFlags mCommandTypeFlags{};
-    backend::Viewport mScissorViewport{ 0, 0, INT32_MAX, INT32_MAX };
     FScene::RenderableSoa const* mRenderableSoa = nullptr;
     utils::Range<uint32_t> mVisibleRenderables{};
     math::float3 mCameraPosition{};
@@ -504,13 +509,6 @@ public:
 
     RenderPassBuilder& commandTypeFlags(RenderPass::CommandTypeFlags const commandTypeFlags) noexcept {
         mCommandTypeFlags = commandTypeFlags;
-        return *this;
-    }
-
-    // Specifies the viewport for the scissor rectangle, that is, the final scissor rect is
-    // offset by the viewport's left-top and clipped to the viewport's width/height.
-    RenderPassBuilder& scissorViewport(backend::Viewport const viewport) noexcept {
-        mScissorViewport = viewport;
         return *this;
     }
 

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -40,7 +40,6 @@
 #include <utils/Panic.h>
 
 #include <algorithm>
-#include <optional>
 #include <utility>
 
 #include <stddef.h>
@@ -270,87 +269,94 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
     };
 }
 
-std::optional<RendererUtils::ColorPassOutput> RendererUtils::refractionPass(
+
+RenderPass::Command const* RendererUtils::getFirstRefractionCommand(
+    RenderPass const& pass) noexcept {
+
+    // find the first refractive object in channel 2
+    RenderPass::Command const* const refraction = std::partition_point(pass.begin(), pass.end(),
+        [](auto const& command) {
+            constexpr uint64_t mask  = RenderPass::CHANNEL_MASK | RenderPass::PASS_MASK;
+            constexpr uint64_t channel = uint64_t(RenderableManager::Builder::DEFAULT_CHANNEL) << RenderPass::CHANNEL_SHIFT;
+            constexpr uint64_t value = channel | uint64_t(RenderPass::Pass::REFRACT);
+            return (command.key & mask) < value;
+        });
+
+    const bool hasScreenSpaceRefraction =
+            (refraction->key & RenderPass::PASS_MASK) == uint64_t(RenderPass::Pass::REFRACT);
+
+    return hasScreenSpaceRefraction ? refraction : nullptr;
+
+}
+
+RendererUtils::ColorPassOutput RendererUtils::refractionPass(
         FrameGraph& fg, FEngine& engine, FView const& view,
         ColorPassInput colorPassInput,
         ColorPassConfig config,
         PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,
         PostProcessManager::ColorGradingConfig const colorGradingConfig,
-        RenderPass const& pass) noexcept {
+        RenderPass const& pass, RenderPass::Command const* const firstRefractionCommand) noexcept {
 
-    // find the first refractive object in channel 2
-    RenderPass::Command const* const refraction = std::partition_point(pass.begin(), pass.end(),
-            [](auto const& command) {
-                constexpr uint64_t mask  = RenderPass::CHANNEL_MASK | RenderPass::PASS_MASK;
-                constexpr uint64_t channel = uint64_t(RenderableManager::Builder::DEFAULT_CHANNEL) << RenderPass::CHANNEL_SHIFT;
-                constexpr uint64_t value = channel | uint64_t(RenderPass::Pass::REFRACT);
-                return (command.key & mask) < value;
-            });
-
-    const bool hasScreenSpaceRefraction =
-            (refraction->key & RenderPass::PASS_MASK) == uint64_t(RenderPass::Pass::REFRACT);
+    assert_invariant(firstRefractionCommand);
+    RenderPass::Command const* const refraction = firstRefractionCommand;
 
     // if there wasn't any refractive object, just skip everything below.
-    if (UTILS_UNLIKELY(hasScreenSpaceRefraction)) {
-        assert_invariant(!colorPassInput.linearColor);
-        assert_invariant(!colorPassInput.depth);
-        config.hasScreenSpaceReflectionsOrRefractions = true;
+    assert_invariant(!colorPassInput.linearColor);
+    assert_invariant(!colorPassInput.depth);
+    config.hasScreenSpaceReflectionsOrRefractions = true;
 
-        PostProcessManager& ppm = engine.getPostProcessManager();
-        auto const opaquePassOutput = colorPass(fg,
-                "Color Pass (opaque)", engine, view, colorPassInput, {
-                        // When rendering the opaques, we need to conserve the sample buffer,
-                        // so create a config that specifies the sample count.
-                        .width = config.physicalViewport.width,
-                        .height = config.physicalViewport.height,
-                        .samples = config.msaa,
-                        .format = config.hdrFormat
-                },
-                config, { .asSubpass = false, .customResolve = false },
-                pass.getExecutor(pass.begin(), refraction));
+    PostProcessManager& ppm = engine.getPostProcessManager();
+    auto const opaquePassOutput = colorPass(fg,
+            "Color Pass (opaque)", engine, view, colorPassInput, {
+                    // When rendering the opaques, we need to conserve the sample buffer,
+                    // so create a config that specifies the sample count.
+                    .width = config.physicalViewport.width,
+                    .height = config.physicalViewport.height,
+                    .samples = config.msaa,
+                    .format = config.hdrFormat
+            },
+            config, { .asSubpass = false, .customResolve = false },
+            pass.getExecutor(pass.begin(), refraction));
 
 
-        // Generate the mipmap chain
-        // Note: we can run some post-processing effects while the "color pass" descriptor set
-        // in bound because only the descriptor 0 (frame uniforms) matters, and it's
-        // present in both.
-        PostProcessManager::generateMipmapSSR(ppm, fg,
-                opaquePassOutput.linearColor,
-                ssrConfig.refraction,
-                true, ssrConfig);
+    // Generate the mipmap chain
+    // Note: we can run some post-processing effects while the "color pass" descriptor set
+    // in bound because only the descriptor 0 (frame uniforms) matters, and it's
+    // present in both.
+    PostProcessManager::generateMipmapSSR(ppm, fg,
+            opaquePassOutput.linearColor,
+            ssrConfig.refraction,
+            true, ssrConfig);
 
-        // Now we're doing the refraction pass proper.
-        // This uses the same framebuffer (color and depth) used by the opaque pass.
-        // For this reason, the `colorBufferDesc` parameter of colorPass() below is only used  for
-        // the width and height.
-        colorPassInput.linearColor = opaquePassOutput.linearColor;
-        colorPassInput.depth = opaquePassOutput.depth;
+    // Now we're doing the refraction pass proper.
+    // This uses the same framebuffer (color and depth) used by the opaque pass.
+    // For this reason, the `colorBufferDesc` parameter of colorPass() below is only used  for
+    // the width and height.
+    colorPassInput.linearColor = opaquePassOutput.linearColor;
+    colorPassInput.depth = opaquePassOutput.depth;
 
-        // Since we're reusing the existing target we don't want to clear any of its buffer.
-        // Important: if this target ended up being an imported target, then the clearFlags
-        // specified here wouldn't apply (the clearFlags of the imported target take precedence),
-        // and we'd end up clearing the opaque pass. This scenario never happens because it is
-        // prevented in Renderer.cpp's final blit.
-        config.clearFlags = TargetBufferFlags::NONE;
-        auto transparentPassOutput = colorPass(fg, "Color Pass (transparent)",
-                engine, view, colorPassInput, {
-                        .width = config.physicalViewport.width,
-                        .height = config.physicalViewport.height },
-                config, colorGradingConfig,
-                pass.getExecutor(refraction, pass.end()));
+    // Since we're reusing the existing target we don't want to clear any of its buffer.
+    // Important: if this target ended up being an imported target, then the clearFlags
+    // specified here wouldn't apply (the clearFlags of the imported target take precedence),
+    // and we'd end up clearing the opaque pass. This scenario never happens because it is
+    // prevented in Renderer.cpp's final blit.
+    config.clearFlags = TargetBufferFlags::NONE;
+    auto transparentPassOutput = colorPass(fg, "Color Pass (transparent)",
+            engine, view, colorPassInput, {
+                    .width = config.physicalViewport.width,
+                    .height = config.physicalViewport.height },
+            config, colorGradingConfig,
+            pass.getExecutor(refraction, pass.end()));
 
-        if (config.msaa > 1 && !colorGradingConfig.asSubpass) {
-            // We need to do a resolve here because later passes (such as color grading or DoF) will
-            // need to sample from 'output'. However, because we have MSAA, we know we're not
-            // sampleable. And this is because in the SSR case, we had to use a renderbuffer to
-            // conserve the multi-sample buffer.
-            transparentPassOutput.linearColor = ppm.resolve(fg, "Resolved Color Buffer",
-                    transparentPassOutput.linearColor, { .levels = 1 });
-        }
-        return transparentPassOutput;
+    if (config.msaa > 1 && !colorGradingConfig.asSubpass) {
+        // We need to do a resolve here because later passes (such as color grading or DoF) will
+        // need to sample from 'output'. However, because we have MSAA, we know we're not
+        // sampleable. And this is because in the SSR case, we had to use a renderbuffer to
+        // conserve the multi-sample buffer.
+        transparentPassOutput.linearColor = ppm.resolve(fg, "Resolved Color Buffer",
+                transparentPassOutput.linearColor, { .levels = 1 });
     }
-
-    return std::nullopt;
+    return transparentPassOutput;
 }
 
 UTILS_NOINLINE

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -26,17 +26,18 @@
 #include <filament/Viewport.h>
 
 #include <backend/DriverEnums.h>
-#include <backend/PixelBufferDescriptor.h>
+#include <backend/Handle.h>
 
 #include <math/vec2.h>
 #include <math/vec4.h>
 
 #include <stdint.h>
 
-#include <optional>
-#include <utility>
-
 namespace filament {
+
+namespace backend {
+class PixelBufferDescriptor;
+}
 
 class FRenderTarget;
 class FrameGraph;
@@ -99,18 +100,20 @@ public:
             PostProcessManager::ColorGradingConfig colorGradingConfig,
             RenderPass::Executor passExecutor) noexcept;
 
-    static std::optional<ColorPassOutput> refractionPass(
+    static ColorPassOutput refractionPass(
             FrameGraph& fg, FEngine& engine, FView const& view,
             ColorPassInput colorPassInput,
             ColorPassConfig config,
             PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,
             PostProcessManager::ColorGradingConfig colorGradingConfig,
-            RenderPass const& pass) noexcept;
+            RenderPass const& pass, RenderPass::Command const* firstRefractionCommand) noexcept;
 
     static void readPixels(backend::DriverApi& driver,
             backend::Handle<backend::HwRenderTarget> renderTargetHandle,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             backend::PixelBufferDescriptor&& buffer);
+
+    static RenderPass::Command const* getFirstRefractionCommand(RenderPass const& pass) noexcept;
 };
 
 } // namespace filament


### PR DESCRIPTION
The problem was that we need to know before rendering if we're doing so directly in the swapchain or an intermediate buffer. Unfortunately  this is determined by the framegraph (after culling and such). But at the point we need it the framefraph is not even constructed.

So we need to "guess" this from the parameters of the View. That logic missed the case where SSR (reflection or refraction) was used.

An extra level of complexity is that we need to generate the high level commands before we can determine if refraction will happen.

Fix #8910