### PR TITLE
use RG32UI for picking instead of RG32F

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -569,7 +569,7 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
                     // FIXME: the DescriptorSetLayout must specify SAMPLER_FLOAT
                     data.picking = builder.createTexture("Picking Buffer", {
                             .width = width, .height = height,
-                            .format = isES2 ? TextureFormat::RGBA8 : TextureFormat::RG32F });
+                            .format = isES2 ? TextureFormat::RGBA8 : TextureFormat::RG32UI });
 
                     data.picking = builder.write(data.picking,
                             FrameGraphTexture::Usage::COLOR_ATTACHMENT);

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -1399,8 +1399,8 @@ void FView::executePickingQueries(DriverApi& driver,
             });
         } else {
             driver.readPixels(handle, x, y, 1, 1, {
-                    &pQuery->result.renderable, 4u * 4u, // 4*float
-                    PixelDataFormat::RG, PixelDataType::FLOAT,
+                    &pQuery->result.renderable, 4u * 4u, // 4*uint
+                    PixelDataFormat::RGBA_INTEGER, PixelDataType::UINT,
                     pQuery->handler, [](void*, size_t, void* user) {
                         FPickingQuery* const pQuery = static_cast<FPickingQuery*>(user);
                         // pQuery->result.renderable already contains the right value!

--- a/shaders/src/surface_depth_main.fs
+++ b/shaders/src/surface_depth_main.fs
@@ -7,7 +7,7 @@ highp vec4 outPicking;
 #       if MATERIAL_FEATURE_LEVEL == 0
 layout(location = 0) out highp vec4 outPicking;
 #       else
-layout(location = 0) out highp vec2 outPicking;
+layout(location = 0) out highp uvec2 outPicking;
 #       endif
 #   endif
 #else
@@ -63,8 +63,8 @@ void main() {
     outPicking.g = mod(float(object_uniforms_objectId)        , 256.0) / 255.0;
     outPicking.r = vertex_position.z / vertex_position.w;
 #else
-    outPicking.x = intBitsToFloat(object_uniforms_objectId);
-    outPicking.y = vertex_position.z / vertex_position.w;
+    outPicking.x = uint(object_uniforms_objectId);
+    outPicking.y = floatBitsToUint(vertex_position.z / vertex_position.w);
 #endif
 #if __VERSION__ == 100
     gl_FragData[0] = outPicking;


### PR DESCRIPTION
The reason for this is that according to the GLES 3.0 spec, RG32UI is  guaranteed to be supported for writing, unlike RG32F.

We also use RGBA_INTEGER / UINT for readPixels() which is also a guaranteed format.

Attempt to Fix #8762