### PR TITLE
undeprecate a few methods because there is no cost keeping them

### DIFF
--- a/filament/include/filament/Box.h
+++ b/filament/include/filament/Box.h
@@ -120,8 +120,11 @@ public:
     }
 
     /**
-     * @deprecated Use transform() instead
-     * @see transform()
+     * Transform a Box by a linear transform and a translation.
+     *
+     * @param m a linear transform matrix
+     * @param box the box to transform
+     * @return the bounding box of the transformed box
      */
     friend Box rigidTransform(Box const& box, const math::mat4f& m) noexcept {
         return transform(m.upperLeft(), m[3].xyz, box);
@@ -235,8 +238,10 @@ struct UTILS_PUBLIC Aabb {
     }
 
     /**
-     * @deprecated Use transform() instead
-     * @see transform()
+     * Applies an affine transformation to the AABB.
+     *
+     * @param m the affine transformation to apply
+     * @return the bounding box of the transformed box
      */
     Aabb transform(const math::mat4f& m) const noexcept {
         return transform(m.upperLeft(), m[3].xyz, *this);

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -339,13 +339,24 @@ public:
     static math::float4 getColorEstimate(const math::float3 sh[UTILS_NONNULL 9],
             math::float3 direction) noexcept;
 
-
-    /** @deprecated use static versions instead */
-    UTILS_DEPRECATED
+    /**
+     * Helper to estimate the direction of the dominant light in the environment represented by
+     * spherical harmonics.
+     * Spherical harmonics must be set in the Builder or the result is undefined.
+     * @see getDirectionEstimate(const math::float3)
+     * @see Builder::irradiance(uint8_t, math::float3 const*)
+     * @see Builder::radiance(uint8_t, math::float3 const*)
+     */
     math::float3 getDirectionEstimate() const noexcept;
 
-    /** @deprecated use static versions instead */
-    UTILS_DEPRECATED
+    /**
+     * Helper to estimate the color and relative intensity of the environment represented by
+     * spherical harmonics in a given direction.
+     * Spherical harmonics must be set in the Builder or the result is undefined.
+     * @see getColorEstimate(const math::float3, math::float3)
+     * @see Builder::irradiance(uint8_t, math::float3 const*)
+     * @see Builder::radiance(uint8_t, math::float3 const*)
+     */
     math::float4 getColorEstimate(math::float3 direction) const noexcept;
 
 protected:


### PR DESCRIPTION
Box::transform is just an inline
IndirectLight::get{Color|Direction}Estimate() can be document to handle the UB cases.