### PR TITLE
dynamic resolution can be always be enable if minScale==maxScale

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1390,8 +1390,8 @@ public class View {
      *
      * \note
      * Dynamic resolution is only supported on platforms where the time to render
-     * a frame can be measured accurately. Dynamic resolution is currently only
-     * supported on Android.
+     * a frame can be measured accurately. On platform where this is not supported,
+     * Dynamic Resolution can't be enabled unless minScale == maxScale.
      *
      * @see Renderer::FrameRateOptions
      *

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -70,8 +70,8 @@ enum class BlendMode : uint8_t {
  *
  * \note
  * Dynamic resolution is only supported on platforms where the time to render
- * a frame can be measured accurately. Dynamic resolution is currently only
- * supported on Android.
+ * a frame can be measured accurately. On platform where this is not supported,
+ * Dynamic Resolution can't be enabled unless minScale == maxScale.
  *
  * @see Renderer::FrameRateOptions
  *

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -209,8 +209,9 @@ void FView::setDynamicResolutionOptions(DynamicResolutionOptions const& options)
     DynamicResolutionOptions& dynamicResolution = mDynamicResolution;
     dynamicResolution = options;
 
-    // only enable if dynamic resolution is supported
-    dynamicResolution.enabled = dynamicResolution.enabled && mIsDynamicResolutionSupported;
+    // only enable if dynamic resolution is supported or if it's not actually dynamic
+    dynamicResolution.enabled = dynamicResolution.enabled &&
+            (mIsDynamicResolutionSupported || dynamicResolution.minScale == dynamicResolution.maxScale);
     if (dynamicResolution.enabled) {
         // if enabled, sanitize the parameters
 
@@ -249,6 +250,8 @@ float2 FView::updateScale(FEngine& engine,
 
     DynamicResolutionOptions const& options = mDynamicResolution;
     if (options.enabled) {
+        // if timerQueries are not supported, info.valid will always be false; but in that case
+        // we're guaranteed that minScale == maxScale.
         if (!UTILS_UNLIKELY(info.valid)) {
             // always clamp to the min/max scale range
             mScale = clamp(1.0f, options.minScale, options.maxScale);

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1146,8 +1146,8 @@ export enum View$BlendMode {
  *
  * \note
  * Dynamic resolution is only supported on platforms where the time to render
- * a frame can be measured accurately. Dynamic resolution is currently only
- * supported on Android.
+ * a frame can be measured accurately. On platform where this is not supported,
+ * Dynamic Resolution can't be enabled unless minScale == maxScale.
  *
  * @see Renderer::FrameRateOptions
  *


### PR DESCRIPTION
normally dynamic resolution is turned off when timerQueries are no available, but we should still allow it if minScale==maxScale.

FIXES=[428767320]