### PR TITLE
vk: clean-up VulkanContext usage

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -86,8 +86,8 @@ bool VulkanGroupMarkers::empty() const noexcept {
 }
 #endif // FVK_DEBUG_GROUP_MARKERS
 
-VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext* context, VkDevice device, VkQueue queue,
-        VkCommandPool pool, bool isProtected)
+VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, VkDevice device,
+        VkQueue queue, VkCommandPool pool, bool isProtected)
     : mContext(context),
       mMarkerCount(0),
       isProtected(isProtected),
@@ -120,14 +120,14 @@ void VulkanCommandBuffer::reset() noexcept {
 }
 
 void VulkanCommandBuffer::pushMarker(char const* marker) noexcept {
-    if (mContext->isDebugUtilsSupported()) {
+    if (mContext.isDebugUtilsSupported()) {
         VkDebugUtilsLabelEXT labelInfo = {
                 .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
                 .pLabelName = marker,
                 .color = {0, 1, 0, 1},
         };
         vkCmdBeginDebugUtilsLabelEXT(mBuffer, &labelInfo);
-    } else if (mContext->isDebugMarkersSupported()) {
+    } else if (mContext.isDebugMarkersSupported()) {
         VkDebugMarkerMarkerInfoEXT markerInfo = {
                 .sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT,
                 .pMarkerName = marker,
@@ -140,23 +140,23 @@ void VulkanCommandBuffer::pushMarker(char const* marker) noexcept {
 
 void VulkanCommandBuffer::popMarker() noexcept{
     assert_invariant(mMarkerCount > 0);
-    if (mContext->isDebugUtilsSupported()) {
+    if (mContext.isDebugUtilsSupported()) {
         vkCmdEndDebugUtilsLabelEXT(mBuffer);
-    } else if (mContext->isDebugMarkersSupported()) {
+    } else if (mContext.isDebugMarkersSupported()) {
         vkCmdDebugMarkerEndEXT(mBuffer);
     }
     mMarkerCount--;
 }
 
 void VulkanCommandBuffer::insertEvent(char const* marker) noexcept {
-    if (mContext->isDebugUtilsSupported()) {
+    if (mContext.isDebugUtilsSupported()) {
         VkDebugUtilsLabelEXT labelInfo = {
                 .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
                 .pLabelName = marker,
                 .color = {1, 1, 0, 1},
         };
         vkCmdInsertDebugUtilsLabelEXT(mBuffer, &labelInfo);
-    } else if (mContext->isDebugMarkersSupported()) {
+    } else if (mContext.isDebugMarkersSupported()) {
         VkDebugMarkerMarkerInfoEXT markerInfo = {
                 .sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT,
                 .pMarkerName = marker,
@@ -232,7 +232,7 @@ VkSemaphore VulkanCommandBuffer::submit() {
     return mSubmission;
 }
 
-CommandBufferPool::CommandBufferPool(VulkanContext* context, VkDevice device, VkQueue queue,
+CommandBufferPool::CommandBufferPool(VulkanContext const& context, VkDevice device, VkQueue queue,
         uint8_t queueFamilyIndex, bool isProtected)
     : mDevice(device),
       mRecording(INVALID) {
@@ -384,7 +384,7 @@ void CommandBufferPool::insertEvent(char const* marker) {
 #endif // FVK_DEBUG_GROUP_MARKERS
 
 VulkanCommands::VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
-        VkQueue protectedQueue, uint32_t protectedQueueFamilyIndex, VulkanContext* context)
+        VkQueue protectedQueue, uint32_t protectedQueueFamilyIndex, VulkanContext const& context)
     : mDevice(device),
       mProtectedQueue(protectedQueue),
       mProtectedQueueFamilyIndex(protectedQueueFamilyIndex),

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -23,6 +23,7 @@
 
 #include "VulkanAsyncHandles.h"
 #include "VulkanConstants.h"
+#include "VulkanContext.h"
 #include "vulkan/memory/ResourcePointer.h"
 #include "vulkan/utils/StaticVector.h"
 
@@ -40,8 +41,6 @@
 namespace filament::backend {
 
 using namespace fvkmemory;
-
-struct VulkanContext;
 
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
 class VulkanGroupMarkers {
@@ -64,7 +63,7 @@ private:
 // DriverApi fence object and should not be destroyed until both the DriverApi object is freed and
 // we're done waiting on the most recent submission of the given command buffer.
 struct VulkanCommandBuffer {
-    VulkanCommandBuffer(VulkanContext* mContext,
+    VulkanCommandBuffer(VulkanContext const& mContext,
             VkDevice device, VkQueue queue, VkCommandPool pool, bool isProtected);
 
     VulkanCommandBuffer(VulkanCommandBuffer const&) = delete;
@@ -110,7 +109,7 @@ struct VulkanCommandBuffer {
     }
 
 private:
-    VulkanContext* mContext;
+    VulkanContext const& mContext;
     uint8_t mMarkerCount;
     bool const isProtected;
     VkDevice mDevice;
@@ -127,7 +126,7 @@ struct CommandBufferPool {
     using ActiveBuffers = utils::bitset64;
     static constexpr int8_t INVALID = -1;
 
-    CommandBufferPool(VulkanContext* context, VkDevice device, VkQueue queue,
+    CommandBufferPool(VulkanContext const& context, VkDevice device, VkQueue queue,
             uint8_t queueFamilyIndex, bool isProtected);
     ~CommandBufferPool();
 
@@ -195,7 +194,8 @@ private:
 class VulkanCommands {
 public:
     VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
-            VkQueue protectedQueue, uint32_t protectedQueueFamilyIndex, VulkanContext* context);
+            VkQueue protectedQueue, uint32_t protectedQueueFamilyIndex,
+            VulkanContext const& context);
 
     void terminate();
 
@@ -246,7 +246,7 @@ private:
     VkQueue const mProtectedQueue;
     // For defered initialization if/when we need protected content
     uint32_t const mProtectedQueueFamilyIndex;
-    VulkanContext* mContext;
+    VulkanContext const& mContext;
 
     std::unique_ptr<CommandBufferPool> mPool;
     std::unique_ptr<CommandBufferPool> mProtectedPool;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -56,7 +56,7 @@ constexpr uint8_t MAX_RENDERTARGET_ATTACHMENT_TEXTURES =
 
 class VulkanDriver final : public DriverBase {
 public:
-    static Driver* create(VulkanPlatform* platform, VulkanContext const& context,
+    static Driver* create(VulkanPlatform* platform, VulkanContext& context,
             Platform::DriverConfig const& driverConfig);
 
 #if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
@@ -69,7 +69,7 @@ public:
     private:
         static DebugUtils* get();
 
-        DebugUtils(VkInstance instance, VkDevice device, VulkanContext const* context);
+        DebugUtils(VkInstance instance, VkDevice device, VulkanContext const& context);
         ~DebugUtils();
 
         VkInstance const mInstance;
@@ -92,7 +92,7 @@ private:
     void debugCommandBegin(CommandStream* cmds, bool synchronous,
             const char* methodName) noexcept override;
 
-    VulkanDriver(VulkanPlatform* platform, VulkanContext const& context,
+    VulkanDriver(VulkanPlatform* platform, VulkanContext& context,
             Platform::DriverConfig const& driverConfig);
 
     ~VulkanDriver() noexcept override;
@@ -134,7 +134,7 @@ private:
     VmaAllocator mAllocator = VK_NULL_HANDLE;
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
 
-    VulkanContext mContext = {};
+    VulkanContext& mContext;
 
     VulkanCommands mCommands;
     VulkanPipelineLayoutCache mPipelineLayoutCache;


### PR DESCRIPTION
 - Make sure that we don't allocate a VulkanContext on the function stack since this was passed erroroneously to other components and stored as a pointer
 - Use const& to refer to VulkanContext across components for consistency.
 - Remove unused VkPhysicalDeviceProtectedMemoryProperties struct.