### PR TITLE
 vk: VulkanBuffer cannot skip staging buffer after a read

### DIFF
--- a/filament/backend/src/vulkan/VulkanBufferProxy.h
+++ b/filament/backend/src/vulkan/VulkanBufferProxy.h
@@ -25,6 +25,9 @@
 
 namespace filament::backend {
 
+struct VulkanDescriptorSet;
+struct VulkanCommandBuffer;
+
 // This class acts as a dynamic wrapper for a `VulkanBuffer`. It allows you to modify the
 // `VulkanBuffer` it references at runtime, wihtout affecting any external objects.
 class VulkanBufferProxy {
@@ -38,17 +41,19 @@ public:
 
     VkBuffer getVkBuffer() const noexcept;
 
-    VulkanBufferUsage getUsage() const noexcept;
+    void referencedBy(VulkanCommandBuffer& commands);
 
 private:
+    VulkanBufferUsage getUsage() const noexcept;
+
     bool const mStagingBufferBypassEnabled;
     VmaAllocator mAllocator;
     VulkanStagePool& mStagePool;
     VulkanBufferCache& mBufferCache;
 
     fvkmemory::resource_ptr<VulkanBuffer> mBuffer;
-    uint32_t mUpdatedOffset = 0;
-    uint32_t mUpdatedBytes = 0;
+
+    uint32_t mLastReadAge;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -86,6 +86,8 @@ bool VulkanGroupMarkers::empty() const noexcept {
 }
 #endif // FVK_DEBUG_GROUP_MARKERS
 
+uint32_t VulkanCommandBuffer::sAgeCounter = 0;
+
 VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, VkDevice device,
         VkQueue queue, VkCommandPool pool, bool isProtected)
     : mContext(context),
@@ -94,7 +96,8 @@ VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, VkDevice 
       mDevice(device),
       mQueue(queue),
       mBuffer(createCommandBuffer(device, pool)),
-      mFenceStatus(std::make_shared<VulkanCmdFence>(VK_INCOMPLETE)) {
+      mFenceStatus(std::make_shared<VulkanCmdFence>(VK_INCOMPLETE)),
+      mAge(++sAgeCounter) {
     VkSemaphoreCreateInfo sci{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
     vkCreateSemaphore(mDevice, &sci, VKALLOC, &mSubmission);
 
@@ -111,6 +114,7 @@ void VulkanCommandBuffer::reset() noexcept {
     mMarkerCount = 0;
     mResources.clear();
     mWaitSemaphores.clear();
+    mAge = ++sAgeCounter;
 
     // Internally we use the VK_INCOMPLETE status to mean "not yet submitted". When this fence
     // gets, gets submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -108,7 +108,13 @@ struct VulkanCommandBuffer {
         return mBuffer;
     }
 
+    uint32_t age() const {
+        return mAge;
+    }
+
 private:
+    static uint32_t sAgeCounter;
+
     VulkanContext const& mContext;
     uint8_t mMarkerCount;
     bool const isProtected;
@@ -120,6 +126,7 @@ private:
     VkFence mFence;
     std::shared_ptr<VulkanCmdFence> mFenceStatus;
     std::vector<fvkmemory::resource_ptr<Resource>> mResources;
+    uint32_t mAge;
 };
 
 struct CommandBufferPool {

--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
@@ -290,7 +290,9 @@ void VulkanDescriptorSetCache::commit(VulkanCommandBuffer* commands,
     if (mLastBoundInfo.pipelineLayout == pipelineLayout) {
         auto& lastBoundSets = mLastBoundInfo.boundSets;
         curMask.forEachSetBit([&](size_t index) {
-            if (updateSets[index] == lastBoundSets[index] && !useExternalSamplers[index]) {
+            auto& set = updateSets[index];
+            if (set == lastBoundSets[index] && !useExternalSamplers[index] &&
+                    set->uniqueDynamicUboCount == 0) {
                 curMask.unset(index);
             }
         });
@@ -302,25 +304,24 @@ void VulkanDescriptorSetCache::commit(VulkanCommandBuffer* commands,
         VkCommandBuffer const cmdbuffer = commands->buffer();
         VkDescriptorSet vkset = useExternalSamplers[index] ? set->getExternalSamplerVkSet() :
             set->getVkSet();
+        commands->acquire(set);
         vkCmdBindDescriptorSets(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, index,
                 1, &vkset, set->uniqueDynamicUboCount, set->getOffsets()->data());
-        commands->acquire(set);
+        set->referencedBy(*commands);
     });
-
-    mStashedSets = {};
-
     mLastBoundInfo = {
         pipelineLayout,
         setMask,
         updateSets,
     };
+    mStashedSets = {};
 }
 
 void VulkanDescriptorSetCache::updateBuffer(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
         uint8_t binding, fvkmemory::resource_ptr<VulkanBufferObject> bufferObject,
         VkDeviceSize offset, VkDeviceSize size) noexcept {
     VkDescriptorBufferInfo const info = {
-        .buffer = bufferObject->buffer.getVkBuffer(),
+        .buffer = bufferObject->getVkBuffer(),
         .offset = offset,
         .range = size,
     };

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1239,7 +1239,7 @@ void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor
     VulkanCommandBuffer& commands = mCommands.get();
     auto ib = resource_ptr<VulkanIndexBuffer>::cast(&mResourceManager, ibh);
     commands.acquire(ib);
-    ib->buffer.loadFromCpu(commands, p.buffer, byteOffset, p.size);
+    ib->loadFromCpu(commands, p.buffer, byteOffset, p.size);
 
     scheduleDestroy(std::move(p));
 }
@@ -1255,7 +1255,7 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
 
     auto bo = resource_ptr<VulkanBufferObject>::cast(&mResourceManager, boh);
     commands.acquire(bo);
-    bo->buffer.loadFromCpu(commands, bd.buffer, byteOffset, bd.size);
+    bo->loadFromCpu(commands, bd.buffer, byteOffset, bd.size);
 
     scheduleDestroy(std::move(bd));
 }
@@ -1266,7 +1266,7 @@ void VulkanDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> boh,
     auto bo = resource_ptr<VulkanBufferObject>::cast(&mResourceManager, boh);
     commands.acquire(bo);
     // TODO: implement unsynchronized version
-    bo->buffer.loadFromCpu(commands, bd.buffer, byteOffset, bd.size);
+    bo->loadFromCpu(commands, bd.buffer, byteOffset, bd.size);
     scheduleDestroy(std::move(bd));
 }
 
@@ -1915,7 +1915,7 @@ void VulkanDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     // avoid rebinding these if they are already bound, but since we do not (yet) support subranges
     // it would be rare for a client to make consecutive draw calls with the same render primitive.
     vkCmdBindVertexBuffers(cmdbuffer, 0, bufferCount, buffers, offsets);
-    vkCmdBindIndexBuffer(cmdbuffer, prim->indexBuffer->buffer.getVkBuffer(), 0,
+    vkCmdBindIndexBuffer(cmdbuffer, prim->indexBuffer->getVkBuffer(), 0,
             prim->indexBuffer->indexType);
 }
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -39,6 +39,20 @@ namespace filament::backend {
 
 namespace {
 
+inline VulkanBufferUsage getBufferObjectUsage(BufferObjectBinding bindingType) noexcept {
+    switch (bindingType) {
+        case BufferObjectBinding::VERTEX:
+            return VulkanBufferUsage::VERTEX;
+        case BufferObjectBinding::UNIFORM:
+            return VulkanBufferUsage::UNIFORM;
+        case BufferObjectBinding::SHADER_STORAGE:
+            return VulkanBufferUsage::SHADER_STORAGE;
+            // when adding more buffer-types here, make sure to update VulkanBuffer::loadFromCpu()
+            // if necessary.
+    }
+    return VulkanBufferUsage::UNKNOWN;
+}
+
 void flipVertically(VkViewport* rect, uint32_t framebufferHeight) {
     rect->y = framebufferHeight - rect->y - rect->height;
 }
@@ -166,14 +180,6 @@ VulkanAttachment createSwapchainAttachment(const fvkmemory::resource_ptr<VulkanT
 
 } // anonymous namespace
 
-void VulkanDescriptorSet::acquire(fvkmemory::resource_ptr<VulkanTexture> texture) {
-    mResources.push_back(texture);
-}
-
-void VulkanDescriptorSet::acquire(fvkmemory::resource_ptr<VulkanBufferObject> obj) {
-    mResources.push_back(obj);
-}
-
 VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(DescriptorSetLayout&& layout,
         VkDescriptorSetLayout vkLayout)
     : bitmask(fromBackendLayout(layout)),
@@ -183,6 +189,17 @@ VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(DescriptorSetLayout&& layou
 VulkanDescriptorSetLayout::Bitmask VulkanDescriptorSetLayout::Bitmask::fromLayoutDescription(
         DescriptorSetLayout const& layout) {
     return fromBackendLayout(layout);
+}
+
+// This method will store an age associated with this command buffer into the VulkanBuffer, which
+// will allow us to determine whether a barrier is necessary or not.
+void VulkanDescriptorSet::referencedBy(VulkanCommandBuffer& commands) {
+    mUboMask.forEachSetBit([this, &commands](size_t index) {
+        auto& res = mResources[index];
+        fvkmemory::resource_ptr<VulkanBufferObject> bo =
+                fvkmemory::resource_ptr<VulkanBufferObject>::cast((VulkanBufferObject*) res.get());
+        bo->referencedBy(commands);
+    });
 }
 
 PushConstantDescription::PushConstantDescription(backend::Program const& program) {
@@ -588,7 +605,7 @@ void VulkanVertexBuffer::setBuffer(fvkmemory::resource_ptr<VulkanBufferObject> b
     int8_t const* const attribToBuffer = vbi->getAttributeToBuffer();
     for (uint8_t attribIndex = 0; attribIndex < count; attribIndex++) {
         if (attribToBuffer[attribIndex] == static_cast<int8_t>(index)) {
-            vkbuffers[attribIndex] = bufferObject->buffer.getVkBuffer();
+            vkbuffers[attribIndex] = bufferObject->getVkBuffer();
         }
     }
     mResources.push_back(bufferObject);
@@ -598,9 +615,8 @@ VulkanBufferObject::VulkanBufferObject(VulkanContext const& context, VmaAllocato
         VulkanStagePool& stagePool, VulkanBufferCache& bufferCache, uint32_t byteCount,
         BufferObjectBinding bindingType)
     : HwBufferObject(byteCount),
-      buffer(context, allocator, stagePool, bufferCache, getBufferObjectUsage(bindingType),
-              byteCount),
-      bindingType(bindingType) {}
+      bindingType(bindingType),
+      mBuffer(context, allocator, stagePool, bufferCache, getBufferObjectUsage(bindingType), byteCount) {}
 
 VulkanRenderPrimitive::VulkanRenderPrimitive(PrimitiveType pt,
         fvkmemory::resource_ptr<VulkanVertexBuffer> vb,

--- a/filament/backend/src/vulkan/memory/Resource.h
+++ b/filament/backend/src/vulkan/memory/Resource.h
@@ -72,7 +72,10 @@ struct Resource {
           restype(ResourceType::UNDEFINED_TYPE),
           mHandleConsideredDestroyed(false) {}
 
-    uint32_t getCount() const { return mCount; }
+    template<typename D>
+    bool isType() const {
+        return getTypeEnum<D>() == restype;
+    }
 
 private:
     inline void inc() noexcept {


### PR DESCRIPTION
The previous introduction of VulkanBufferProxy uses the refcount of the backing VulkanBuffer as an indication whether there's a write in progress or not. But we also want to make sure there is no read in progress (i.e. not referenced in a descriptor set). This commit fixes the bookkeeping while trying to clean up the relevant structs.