### PR TITLE
Add per-byte image comparison to backend tests

### DIFF
--- a/filament/backend/test/ImageExpectations.cpp
+++ b/filament/backend/test/ImageExpectations.cpp
@@ -36,12 +36,14 @@
 namespace test {
 
 ScreenshotParams::ScreenshotParams(int width, int height, std::string fileName,
-        uint32_t expectedHash, bool isSrgb)
+        uint32_t expectedHash, bool isSrgb, int numAllowedDeviations, int pixelMatchThreshold)
     : mWidth(width),
       mHeight(height),
       mIsSrgb(isSrgb),
       mExpectedPixelHash(expectedHash),
-      mFileName(std::move(fileName)) {}
+      mFileName(std::move(fileName)),
+      mAllowedPixelDeviations(numAllowedDeviations),
+      mPixelMatchThreshold(pixelMatchThreshold) {}
 
 int ScreenshotParams::width() const {
     return mWidth;
@@ -89,6 +91,14 @@ const std::string ScreenshotParams::filePrefix() const {
     return mFileName;
 }
 
+int ScreenshotParams::allowedPixelDeviations() const {
+    return mAllowedPixelDeviations;
+}
+
+int ScreenshotParams::pixelMatchThreshold() const {
+    return mPixelMatchThreshold;
+}
+
 ImageExpectation::ImageExpectation(const char* fileName, int lineNumber,
         filament::backend::DriverApi& api, ScreenshotParams params,
         filament::backend::RenderTargetHandle renderTarget)
@@ -116,21 +126,27 @@ void ImageExpectation::compareImage() const {
     EXPECT_THAT(bytesFilled, testing::IsTrue())
                         << "Render target wasn't copied to the buffer for " << mFileName;
     if (bytesFilled) {
-        // Rather than directly compare the two images compare their hashes because comparing very
-        // large arrays generates way too much debug output to be useful.
-        uint32_t actualHash = mResult.hash();
 #ifndef FILAMENT_IOS
         LoadedPng loadedImage(mParams.expectedFilePath());
-        uint32_t loadedImageHash = loadedImage.hash();
-        auto compareToImageMatcher = testing::Eq(loadedImageHash);
-        if (!testing::Matches(compareToImageMatcher)(actualHash)) {
+        // Bytewise compare.
+        EXPECT_EQ(loadedImage.bytes().size(), mResult.bytes().size());
+        int pixelDeviations = 0;
+        for (int i = 0; i < mResult.bytes().size(); ++i) {
+            if (std::abs( mResult.bytes()[i] - loadedImage.bytes()[i] ) >
+                mParams.pixelMatchThreshold()) {
+                pixelDeviations++;
+            }
+        }
+        if (pixelDeviations > mParams.allowedPixelDeviations()) {
             BackendTest::markImageAsFailure(mParams.filePrefix());
         }
-        EXPECT_THAT(actualHash, compareToImageMatcher) << mParams.expectedFileName();
-#endif
-        // For builds that can't load PNGs (currently iOS only) use the expected hash.
-        EXPECT_THAT(actualHash, testing::Eq(mParams.expectedHash())) << mParams.expectedFileName();
+        EXPECT_LE(pixelDeviations, mParams.allowedPixelDeviations());
         // TODO: Add better debug output, such as generating a diff image.
+#else
+        // For builds that can't load PNGs (currently iOS only) use the expected hash.
+        uint32_t actualHash = mResult.hash();
+        EXPECT_THAT(actualHash, testing::Eq(mParams.expectedHash())) << mParams.expectedFileName();
+#endif
     }
 }
 

--- a/filament/backend/test/ImageExpectations.h
+++ b/filament/backend/test/ImageExpectations.h
@@ -45,7 +45,7 @@ class ScreenshotParams {
 public:
     // TODO(b/422804941): Add a set of environments where this test should use a different golden.
     ScreenshotParams(int width, int height, std::string fileName, uint32_t expectedPixelHash,
-            bool isSrgb = false);
+            bool isSrgb = false, int numAllowedDeviations = 0, int pixelMatchThreshold = 0);
 
     int width() const;
     int height() const;
@@ -59,6 +59,8 @@ public:
     std::string expectedFileName() const;
     std::filesystem::path expectedFilePath() const;
     const std::string filePrefix() const;
+    int allowedPixelDeviations() const;
+    int pixelMatchThreshold() const;
 
 private:
     int mWidth;
@@ -66,6 +68,8 @@ private:
     bool mIsSrgb;
     uint32_t mExpectedPixelHash;
     std::string mFileName;
+    int mAllowedPixelDeviations;
+    int mPixelMatchThreshold;
 };
 
 /**
@@ -83,7 +87,7 @@ public:
     ~RenderTargetDump();
 
     /**
-     * Should only bue used if BytesFilled returns true.
+     * Should only be used if BytesFilled returns true.
      * @return The hash of the stored bytes.
      */
     uint32_t hash() const;


### PR DESCRIPTION
Instead of importing opencv as I had intended with https://github.com/google/filament/pull/8937 this open codes a very simple, almost trivial image comparison that can nevertheless be expanded to provide image diffs and adjustable image comparison thresholds for golden images.

I had not previously appreciated that this could be quite this simple since the captures generated in these tests are so uniform.

This code is mostly inactive as there are no examples of off-by-one-pixel images in the current test corpus. As such image artifacts are encountered, the allowance of number of non-matching bytes (for errant bad pixels) or the threshold for counting a byte as matching (for color selection variation) can be specified to the constructor of a ScreenshotParams struct for a particular test.

BUGS=[398199436]