### PR TITLE
renderdiff: upload artifact even when comparison fails

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -130,13 +130,30 @@ jobs:
         run: |
           bash build/common/get-mesa.sh
           pip install tifffile numpy
-      - name: Run Test
+      - name: Render
         run: |
-          echo "${{ steps.get_commit_msg.outputs.msg }}" | bash test/renderdiff/test.sh
+          TEST_DIR=test/renderdiff
+          source ${TEST_DIR}/src/preamble.sh
+          start_
+          GOLDEN_BRANCH=$(echo "${{ steps.get_commit_msg.outputs.msg }}" | python3 ${TEST_DIR}/src/commit_msg.py)
+          bash ${TEST_DIR}/generate.sh && \
+              python3 ${TEST_DIR}/src/golden_manager.py \
+                  --branch=${GOLDEN_BRANCH} \
+                  --output=${GOLDEN_OUTPUT_DIR}
+          # Note that we need to upload the output even if comparison fails
       - uses: actions/upload-artifact@v4
         with:
           name: presubmit-renderdiff-result
           path: ./out/renderdiff
+      - name: Compare output
+        run: |
+          TEST_DIR=test/renderdiff
+          source ${TEST_DIR}/src/preamble.sh
+          python3 ${TEST_DIR}/src/compare.py \
+              --src=${GOLDEN_OUTPUT_DIR} \
+              --dest=${RENDER_OUTPUT_DIR} \
+              --out=${DIFF_OUTPUT_DIR}
+          end_
 
   validate-wgsl-webgpu:
     name: validate-wgsl-webgpu

--- a/test/renderdiff/local_test.sh
+++ b/test/renderdiff/local_test.sh
@@ -19,9 +19,8 @@ source `dirname $0`/src/preamble.sh
 start_
 
 if [[ "$GITHUB_WORKFLOW" ]]; then
-    # The commit message would have been piped as stdin to this script
-    COMMIT_MSG=$(cat)
-    GOLDEN_BRANCH=$(echo "${COMMIT_MSG}" | python3 test/renderdiff/src/commit_msg.py)
+    echo "This is meant to run locally (not part of the CI)"
+    exit 1
 else
     GOLDEN_BRANCH=$(git log -1 | python3 test/renderdiff/src/commit_msg.py)
 fi


### PR DESCRIPTION
Previously, if a comparison fails then the artifacts are not uploaded.  This is defeats the puprpose of having artifacts. We fix that by moving the test logic into presubmit.yml.

local_test.sh is the way to repro a run from local machine.