### PR TITLE
use a separate UBO for the postfx user passes

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -134,12 +134,14 @@ set(SRCS
         src/details/Texture.cpp
         src/details/VertexBuffer.cpp
         src/details/View.cpp
+        src/ds/PerViewDescriptorSetUtils.cpp
         src/ds/ColorPassDescriptorSet.cpp
         src/ds/DescriptorSet.cpp
         src/ds/DescriptorSetLayout.cpp
         src/ds/PostProcessDescriptorSet.cpp
         src/ds/ShadowMapDescriptorSet.cpp
         src/ds/SsrPassDescriptorSet.cpp
+        src/ds/StructureDescriptorSet.cpp
         src/fg/Blackboard.cpp
         src/fg/DependencyGraph.cpp
         src/fg/FrameGraph.cpp

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -23,6 +23,7 @@
 
 #include "ds/PostProcessDescriptorSet.h"
 #include "ds/SsrPassDescriptorSet.h"
+#include "ds/StructureDescriptorSet.h"
 #include "ds/TypedUniformBuffer.h"
 
 #include "materials/StaticMaterialInfo.h"
@@ -103,6 +104,10 @@ public:
     StructurePassOutput structure(FrameGraph& fg,
             RenderPassBuilder const& passBuilder, uint8_t structureRenderFlags,
             uint32_t width, uint32_t height, StructurePassConfig const& config) noexcept;
+
+    FrameGraphId<FrameGraphTexture> transparentPicking(FrameGraph& fg,
+            RenderPassBuilder const& passBuilder, uint8_t structureRenderFlags,
+            uint32_t width, uint32_t height, float scale) noexcept;
 
     // reflections pass
     FrameGraphId<FrameGraphTexture> ssr(FrameGraph& fg,
@@ -393,6 +398,8 @@ public:
             ColorGradingConfig const& colorGradingConfig, VignetteOptions const& vignetteOptions,
             uint32_t width, uint32_t height) noexcept;
 
+    StructureDescriptorSet& getStructureDescriptorSet() const noexcept { return mStructureDescriptorSet; }
+
 private:
     backend::RenderPrimitiveHandle mFullScreenQuadRph;
     backend::VertexBufferInfoHandle mFullScreenQuadVbih;
@@ -402,6 +409,7 @@ private:
 
     mutable SsrPassDescriptorSet mSsrPassDescriptorSet;
     mutable PostProcessDescriptorSet mPostProcessDescriptorSet;
+    mutable StructureDescriptorSet mStructureDescriptorSet;
 
     struct BilateralPassConfig {
         uint8_t kernelSize = 11;

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -391,7 +391,7 @@ public:
     FMaterialInstance* configureColorGradingMaterial(
             PostProcessMaterial& material, FColorGrading const* colorGrading,
             ColorGradingConfig const& colorGradingConfig, VignetteOptions const& vignetteOptions,
-            uint32_t const width, uint32_t const height) noexcept;
+            uint32_t width, uint32_t height) noexcept;
 
 private:
     backend::RenderPrimitiveHandle mFullScreenQuadRph;

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -521,9 +521,9 @@ public:
     }
 
     // Specifies camera information (e.g. used for sorting commands)
-    RenderPassBuilder& camera(const CameraInfo& camera) noexcept {
-        mCameraPosition = camera.getPosition();
-        mCameraForwardVector = camera.getForwardVector();
+    RenderPassBuilder& camera(math::float3 position, math::float3 forward) noexcept {
+        mCameraPosition = position;
+        mCameraForwardVector = forward;
         return *this;
     }
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1366,8 +1366,8 @@ float4 ShadowMap::getClampToEdgeCoords(ShadowMapInfo const& shadowMapInfo) const
 // ------------------------------------------------------------------------------------------------
 
 void ShadowMap::prepareCamera(Transaction const& transaction,
-        DriverApi& driver, const CameraInfo& cameraInfo) noexcept {
-    ShadowMapDescriptorSet::prepareCamera(transaction, driver, cameraInfo);
+        FEngine const& engine, const CameraInfo& cameraInfo) noexcept {
+    ShadowMapDescriptorSet::prepareCamera(transaction, engine, cameraInfo);
     ShadowMapDescriptorSet::prepareLodBias(transaction, 0.0f);
 }
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1381,6 +1381,11 @@ void ShadowMap::prepareTime(Transaction const& transaction,
     ShadowMapDescriptorSet::prepareTime(transaction, engine, userTime);
 }
 
+void ShadowMap::prepareMaterialGlobals(Transaction const& transaction,
+        std::array<float4, 4> const& materialGlobals) noexcept {
+    ShadowMapDescriptorSet::prepareMaterialGlobals(transaction, materialGlobals);
+}
+
 void ShadowMap::prepareShadowMapping(Transaction const& transaction,
         bool const highPrecision) noexcept {
     ShadowMapDescriptorSet::prepareShadowMapping(transaction, highPrecision);

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -33,9 +33,6 @@
 #include <utils/compiler.h>
 
 #include <math/mathfwd.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
-#include <math/mat4.h>
 
 #include <array>
 
@@ -199,6 +196,8 @@ public:
             backend::Viewport const& viewport) noexcept;
     static void prepareTime(Transaction const& transaction,
             FEngine const& engine, math::float4 const& userTime) noexcept;
+    static void prepareMaterialGlobals(Transaction const& transaction,
+            std::array<math::float4, 4> const& materialGlobals) noexcept;
     static void prepareShadowMapping(Transaction const& transaction,
             bool highPrecision) noexcept;
     static ShadowMapDescriptorSet::Transaction open(backend::DriverApi& driver) noexcept;
@@ -326,12 +325,12 @@ private:
     static float texelSizeWorldSpace(const math::mat4f& W, const math::mat4f& MbMtF,
             uint16_t shadowDimension) noexcept;
 
-    static constexpr const Segment sBoxSegments[12] = {
+    static constexpr Segment sBoxSegments[12] = {
             { 0, 1 }, { 1, 3 }, { 3, 2 }, { 2, 0 },
             { 4, 5 }, { 5, 7 }, { 7, 6 }, { 6, 4 },
             { 0, 4 }, { 1, 5 }, { 3, 7 }, { 2, 6 },
     };
-    static constexpr const Quad sBoxQuads[6] = {
+    static constexpr Quad sBoxQuads[6] = {
             { 2, 0, 1, 3 },  // far
             { 6, 4, 5, 7 },  // near
             { 2, 0, 4, 6 },  // left

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -194,7 +194,7 @@ public:
     using Transaction = ShadowMapDescriptorSet::Transaction;
 
     static void prepareCamera(Transaction const& transaction,
-            backend::DriverApi& driver, const CameraInfo& cameraInfo) noexcept;
+            FEngine const& engine, const CameraInfo& cameraInfo) noexcept;
     static void prepareViewport(Transaction const& transaction,
             backend::Viewport const& viewport) noexcept;
     static void prepareTime(Transaction const& transaction,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -385,7 +385,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     const CameraInfo cameraInfo{ shadowMap.getCamera(), mainCameraInfo };
 
                     auto transaction = ShadowMap::open(driver);
-                    ShadowMap::prepareCamera(transaction, driver, cameraInfo);
+                    ShadowMap::prepareCamera(transaction, engine, cameraInfo);
                     ShadowMap::prepareViewport(transaction, shadowMap.getViewport());
                     ShadowMap::prepareTime(transaction, engine, userTime);
                     ShadowMap::prepareShadowMapping(transaction,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -388,6 +388,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     ShadowMap::prepareCamera(transaction, engine, cameraInfo);
                     ShadowMap::prepareViewport(transaction, shadowMap.getViewport());
                     ShadowMap::prepareTime(transaction, engine, userTime);
+                    ShadowMap::prepareMaterialGlobals(transaction, view.getMaterialGlobals());
                     ShadowMap::prepareShadowMapping(transaction,
                             vsmShadowOptions.highPrecision);
                     shadowMap.commit(transaction, engine, driver);

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -413,7 +413,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
 
                     RenderPass const pass = passBuilder
                             .renderFlags(RenderPass::HAS_DEPTH_CLAMP, renderPassFlags)
-                            .camera(cameraInfo)
+                            .camera(cameraInfo.getPosition(), cameraInfo.getForwardVector())
                             .visibilityMask(entry.visibilityMask)
                             .geometry(scene->getRenderableData(), entry.range)
                             .commandTypeFlags(RenderPass::CommandTypeFlags::SHADOW)

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -980,7 +980,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     FView::updatePrimitivesLod(scene.getRenderableData(),
             engine, cameraInfo, view.getVisibleRenderables());
 
-    passBuilder.camera(cameraInfo);
+    passBuilder.camera(cameraInfo.getPosition(), cameraInfo.getForwardVector());
     passBuilder.geometry(scene.getRenderableData(), view.getVisibleRenderables());
 
     // --------------------------------------------------------------------------------------------

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -28,8 +28,18 @@
 #include "details/Fence.h"
 #include "details/Scene.h"
 #include "details/SwapChain.h"
-#include "details/Texture.h"
 #include "details/View.h"
+
+#include "ds/StructureDescriptorSet.h"
+
+#include "fg/FrameGraph.h"
+#include "fg/FrameGraphId.h"
+#include "fg/FrameGraphResources.h"
+#include "fg/FrameGraphTexture.h"
+
+#include <private/filament/Variant.h>
+
+#include <private/utils/Tracing.h>
 
 #include <filament/Camera.h>
 #include <filament/Fence.h>
@@ -41,23 +51,17 @@
 #include <backend/Handle.h>
 #include <backend/PixelBufferDescriptor.h>
 
-#include "fg/FrameGraph.h"
-#include "fg/FrameGraphId.h"
-#include "fg/FrameGraphResources.h"
-#include "fg/FrameGraphTexture.h"
-
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/mat4.h>
 
-#include <private/utils/Tracing.h>
-
+#include <utils/architecture.h>
+#include <utils/Allocator.h>
 #include <utils/JobSystem.h>
 #include <utils/Logger.h>
 #include <utils/Panic.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
-#include <utils/ostream.h>
 
 #include <chrono>
 #include <limits>
@@ -198,6 +202,7 @@ TextureFormat FRenderer::getHdrFormat(const FView& view, bool const translucent)
             return mHdrQualityHigh;
         }
     }
+    return mHdrQualityMedium;
 }
 
 TextureFormat FRenderer::getLdrFormat(bool const translucent) const noexcept {
@@ -230,7 +235,7 @@ void FRenderer::initializeClearFlags() noexcept {
     mClearFlags = getClearFlags();
 }
 
-void FRenderer::setPresentationTime(int64_t const monotonic_clock_ns) {
+void FRenderer::setPresentationTime(int64_t const monotonic_clock_ns) const {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     driver.setPresentationTime(monotonic_clock_ns);
 }
@@ -301,7 +306,7 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     using namespace std::chrono;
     const steady_clock::time_point now{ steady_clock::now() };
     const steady_clock::time_point userVsync{ steady_clock::duration(vsyncSteadyClockTimeNano) };
-    const time_point<steady_clock> appVsync(vsyncSteadyClockTimeNano ? userVsync : now);
+    const time_point appVsync(vsyncSteadyClockTimeNano ? userVsync : now);
 
     mFrameId++;
     mViewRenderedCount = 0;
@@ -341,7 +346,7 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     * to ignore the return value and render the frame anyway -- which is perfectly fine.
     * The remaining work will be done when the first render() call is made.
     */
-    auto beginFrameInternal = [this, appVsync, swapChain]() {
+    auto beginFrameInternal = [this, appVsync, swapChain] {
         FEngine& engine = mEngine;
         FEngine::DriverApi& driver = engine.getDriverApi();
 
@@ -398,7 +403,7 @@ void FRenderer::endFrame() {
     FEngine& engine = mEngine;
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    if (UTILS_HAS_THREADING) {
+    if constexpr (UTILS_HAS_THREADING) {
         // on debug builds this helps to catch cases where we're writing to
         // the buffer form another thread, which is currently not allowed.
         driver.debugThreading();
@@ -441,7 +446,9 @@ void FRenderer::endFrame() {
     js.waitAndRelease(job);
 }
 
-void FRenderer::readPixels(uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
+void FRenderer::readPixels(
+        uint32_t const xoffset, uint32_t const yoffset,
+        uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
 
     const bool withinFrame = mSwapChain != nullptr;
@@ -453,8 +460,9 @@ void FRenderer::readPixels(uint32_t const xoffset, uint32_t const yoffset, uint3
             xoffset, yoffset, width, height, std::move(buffer));
 }
 
-void FRenderer::readPixels(FRenderTarget* renderTarget,
-        uint32_t const xoffset, uint32_t const yoffset, uint32_t const width, uint32_t const height,
+void FRenderer::readPixels(FRenderTarget const* renderTarget,
+        uint32_t const xoffset, uint32_t const yoffset,
+        uint32_t const width, uint32_t const height,
         PixelBufferDescriptor&& buffer) {
 
     // TODO: change the following to an assert when client call sites have addressed the issue.
@@ -795,6 +803,24 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
     view.prepareUpscaler(scale, taaOptions, dsrOptions);
 
+    // Set the PER_VIEW UBO for the passes that use the user materials, but are not the color pass
+    // (e.g. structure, ssao). The PER_VIEW UBO may be different because these passes don't run
+    // at the same resolution. We set only the values that are relevant to both user-materials
+    // and the concerned passes. The PER_VIEW UBO contains data that is needed by the user
+    // materials public APIs.
+    StructureDescriptorSet& descriptorSet = ppm.getStructureDescriptorSet();
+    descriptorSet.prepareCamera(engine, cameraInfo);
+    descriptorSet.prepareTime(engine, getShaderUserTime());
+    descriptorSet.prepareViewport(svp, {
+            int32_t(float(xvp.left) * aoOptions.resolution),
+            int32_t(float(xvp.bottom) * aoOptions.resolution),
+            uint32_t(float(xvp.width) * aoOptions.resolution),
+            uint32_t(float(xvp.height) * aoOptions.resolution) });
+    //descriptorSet.prepareLodBias(); // FIXME: we need to do that too
+    descriptorSet.prepareMaterialGlobals(view.getMaterialGlobals());
+    descriptorSet.commit(driver);
+
+
     /*
      * Allocate command buffer
      */
@@ -938,46 +964,6 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     passBuilder.camera(cameraInfo);
     passBuilder.geometry(scene.getRenderableData(), view.getVisibleRenderables());
 
-    // view set-ups that need to happen before rendering
-    fg.addTrivialSideEffectPass("Prepare View Uniforms",
-            [=, &view, &engine](DriverApi& driver) {
-                view.prepareCamera(engine, cameraInfo);
-
-                // The code here is a little fragile. In theory, we need to call prepareViewport()
-                // for each render pass, because the viewport parameters depend on the resolution.
-                // However, in practice, we only have two resolutions: the color pass resolution,
-                // and the structure pass which is governed by aoOptions.resolution (this could
-                // change in the future).
-                // So here we set the parameters for the structure pass and SSAO passes which
-                // are always done first. The SSR pass will also use these parameters which
-                // is wrong if it doesn't run at the same resolution as SSAO.
-                // prepareViewport() is called again during the color pass, which resets the
-                // values correctly for the Color pass, however, this will be again wrong
-                // for passes that come after the Color pass, such as DoF.
-                //
-                // The solution is to call prepareViewport() for each pass, really (so we should
-                // move it to its own UBO).
-                //
-                // The reason why this bug is acceptable is that the viewport parameters are
-                // currently only used for generating noise, so it's not too bad.
-
-                // note: aoOptions.resolution is either 1.0 or 0.5, and the result is then
-                // guaranteed to be an integer (because xvp is a multiple of 16).
-                view.prepareViewport(svp,
-                        filament::Viewport{
-                             int32_t(float(xvp.left  ) * aoOptions.resolution),
-                             int32_t(float(xvp.bottom) * aoOptions.resolution),
-                            uint32_t(float(xvp.width ) * aoOptions.resolution),
-                            uint32_t(float(xvp.height) * aoOptions.resolution)});
-
-                // this needs to reset the sampler that are only set in RendererUtils::colorPass(), because
-                // this descriptor-set is also used for ssr/picking/structure and these could be stale
-                // it would be better to use a separate desriptor-set for those two cases so that we don't
-                // have to do this
-                view.unbindSamplers(engine);
-                view.commitUniformsAndSamplers(driver);
-            });
-
     // --------------------------------------------------------------------------------------------
     // structure pass -- automatically culled if not used
     // Currently it consists of a simple depth pass.
@@ -998,68 +984,20 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
     if (view.hasPicking()) {
         if (view.isTransparentPickingEnabled()) {
-            struct PickingRenderPassData {
-                FrameGraphId<FrameGraphTexture> depth;
-                FrameGraphId<FrameGraphTexture> picking;
-            };
-            auto& pickingRenderPass = fg.addPass<PickingRenderPassData>("Picking Render Pass",
-                [&](FrameGraph::Builder& builder, auto& data) {
-                    bool const isFL0 = mEngine.getDriverApi().getFeatureLevel() == 
-                        FeatureLevel::FEATURE_LEVEL_0;
-
-                    // TODO: Specify the precision for picking pass
-                    uint32_t const width = std::max(32u,
-                        (uint32_t)std::ceil(float(svp.width) * aoOptions.resolution));
-                    uint32_t const height = std::max(32u,
-                        (uint32_t)std::ceil(float(svp.height) * aoOptions.resolution));
-                    data.depth = builder.createTexture("Depth Buffer", {
-                            .width = width, .height = height,
-                            .format = isFL0 ? TextureFormat::DEPTH24 : TextureFormat::DEPTH32F });
-
-                    data.depth = builder.write(data.depth,
-                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
-
-                    data.picking = builder.createTexture("Picking Buffer", {
-                            .width = width, .height = height,
-                            .format = isFL0 ? TextureFormat::RGBA8 : TextureFormat::RG32F });
-
-                    data.picking = builder.write(data.picking,
-                        FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-
-                    builder.declareRenderPass("Picking Render Target", {
-                            .attachments = {.color = { data.picking }, .depth = data.depth },
-                            .clearFlags = TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH
-                        });
-                },
-                [=, passBuilder = passBuilder](FrameGraphResources const& resources,
-                    auto const& data, DriverApi& driver) mutable {
-                        Variant pickingVariant(Variant::DEPTH_VARIANT);
-                        pickingVariant.setPicking(true);
-
-                        auto out = resources.getRenderPassInfo();
-                        passBuilder.renderFlags(renderFlags);
-                        passBuilder.variant(pickingVariant);
-                        passBuilder.commandTypeFlags(RenderPass::CommandTypeFlags::DEPTH);
-
-                        RenderPass const pass{ passBuilder.build(mEngine, driver) };
-                        driver.beginRenderPass(out.target, out.params);
-                        pass.getExecutor().execute(mEngine, driver);
-                        driver.endRenderPass();
-                });
-            picking = pickingRenderPass->picking;
+            picking = ppm.transparentPicking(fg,
+                    passBuilder, renderFlags, svp.width, svp.height, aoOptions.resolution);
         }
 
         struct PickingResolvePassData {
             FrameGraphId<FrameGraphTexture> picking;
         };
-        fg.addPass<PickingResolvePassData>(
-                "Picking Resolve Pass",
+        fg.addPass<PickingResolvePassData>("Picking Resolve Pass",
                 [&](FrameGraph::Builder& builder, auto& data) {
                     // Note that BLIT_SRC is needed because this texture will be read later (via
                     // readPixels()).
-                    data.picking =
-                            builder.read(picking, FrameGraphTexture::Usage::COLOR_ATTACHMENT |
-                                                          FrameGraphTexture::Usage::BLIT_SRC);
+                    data.picking = builder.read(picking,
+                            FrameGraphTexture::Usage::COLOR_ATTACHMENT |
+                            FrameGraphTexture::Usage::BLIT_SRC);
                     builder.declareRenderPass("Picking Resolve Target", {
                             .attachments = { .color = { data.picking }}
                     });
@@ -1067,23 +1005,21 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
                 },
                 [=, &view](FrameGraphResources const& resources,
                         auto const&, DriverApi& driver) mutable {
-                    auto out = resources.getRenderPassInfo();
-                    view.executePickingQueries(driver, out.target, scale * aoOptions.resolution);
+                    auto [target, params] = resources.getRenderPassInfo();
+                    view.executePickingQueries(driver, target, scale * aoOptions.resolution);
                 });
     }
 
     // Store this frame's camera projection in the frame history.
+    // TODO: We do this after we're configured the structure and ssao passes;
+    //       but I'm not 100% sure this should be done before or after.
     if (UTILS_UNLIKELY(taaOptions.enabled)) {
         // Apply the TAA jitter to everything after the structure pass, starting with the color pass.
         ppm.TaaJitterCamera(svp, taaOptions, view.getFrameHistory(),
                 &FrameHistoryEntry::taa, &cameraInfo);
 
-        fg.addTrivialSideEffectPass("Jitter Camera",
-                [&engine, &cameraInfo, &descriptorSet = view.getColorPassDescriptorSet()]
-                (DriverApi& driver) {
-                    descriptorSet.prepareCamera(engine, cameraInfo);
-                    descriptorSet.commit(driver);
-                });
+        // this just re-set the color pass UBO content
+        view.prepareCamera(engine, cameraInfo);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -1143,7 +1079,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
         passBuilder.customCommand(3,
                 RenderPass::Pass::BLENDED,
                 RenderPass::CustomCommand::EPILOG,
-                0, [&ppm, &driver, colorGradingConfigForColor]() {
+                0, [&ppm, &driver, colorGradingConfigForColor] {
                     ppm.colorGradingSubpass(driver, colorGradingConfigForColor);
                 });
     } else if (colorGradingConfig.customResolve) {
@@ -1151,7 +1087,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
         passBuilder.customCommand(3,
                 RenderPass::Pass::BLENDED,
                 RenderPass::CustomCommand::EPILOG,
-                0, [&ppm, &driver]() {
+                0, [&ppm, &driver] {
                     ppm.customResolveSubpass(driver);
                 });
     }
@@ -1222,8 +1158,7 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
 
                 // We use a framegraph pass to wait for froxelization to finish (so it can be done
                 // in parallel with .compile()
-                auto sync = view.getFroxelizerSync();
-                if (sync) {
+                if (auto sync = view.getFroxelizerSync()) {
                     js.waitAndRelease(sync);
                     view.commitFroxels(driver);
                 }

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1129,7 +1129,9 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
     // (i.e. it won't be culled, unless everything is culled), so no need to complexify things.
     passBuilder.variant(variant);
 
-    // This is optional, if not set, the per-view descriptor-set must be set before calling execute()
+    // We need to specify the ColorPassDescriptorSet (which is in fact a collection of descriptor
+    // sets) because the layout can change based on the material used, and that's only known
+    // at execution time.
     passBuilder.colorPassDescriptorSet(&view.getColorPassDescriptorSet());
 
     // color-grading as subpass is done either by the color pass or the TAA pass if any

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -87,7 +87,7 @@ public:
     void renderStandaloneView(FView const* view);
 
 
-    void setPresentationTime(int64_t monotonic_clock_ns);
+    void setPresentationTime(int64_t monotonic_clock_ns) const;
 
     void setVsyncTime(uint64_t steadyClockTimeNano) noexcept;
 
@@ -108,7 +108,7 @@ public:
             backend::PixelBufferDescriptor&& buffer);
 
     // read pixel from a rendertarget. must be called between beginFrame/enfFrame.
-    void readPixels(FRenderTarget* renderTarget,
+    void readPixels(FRenderTarget const* renderTarget,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             backend::PixelBufferDescriptor&& buffer);
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -189,6 +189,10 @@ private:
     void renderInternal(FView const* view);
     void renderJob(RootArenaScope& rootArenaScope, FView& view);
 
+    std::pair<float, math::float2> prepareUpscaler(math::float2 scale,
+            TemporalAntiAliasingOptions const& taaOptions,
+            DynamicResolutionOptions const& dsrOptions);
+
     // keep a reference to our engine
     FEngine& mEngine;
     FrameSkipper mFrameSkipper;

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -906,27 +906,13 @@ UTILS_NOINLINE
     });
 }
 
-void FView::prepareUpscaler(float2 const scale,
-        TemporalAntiAliasingOptions const& taaOptions,
-        DynamicResolutionOptions const& dsrOptions) const noexcept {
-    FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
-    float bias = 0.0f;
-    float2 derivativesScale{ 1.0f };
-    if (dsrOptions.enabled && dsrOptions.quality >= QualityLevel::HIGH) {
-        bias = std::log2(std::min(scale.x, scale.y));
-    }
-    if (taaOptions.enabled) {
-        bias += taaOptions.lodBias;
-        if (taaOptions.upscaling) {
-            derivativesScale = 0.5f;
-        }
-    }
-    getColorPassDescriptorSet().prepareLodBias(bias, derivativesScale);
-}
-
 void FView::prepareCamera(FEngine& engine, const CameraInfo& cameraInfo) const noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
     getColorPassDescriptorSet().prepareCamera(engine, cameraInfo);
+}
+
+void FView::prepareLodBias(float const bias, float2 const derivativesScale) const noexcept {
+    getColorPassDescriptorSet().prepareLodBias(bias, derivativesScale);
 }
 
 void FView::prepareViewport(

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -854,6 +854,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
     auto const fogTransform = tcm.getWorldTransformAccurate(tcm.getInstance(mFogEntity));
 
     auto& colorPassDescriptorSet = getColorPassDescriptorSet();
+    colorPassDescriptorSet.prepareCamera(engine, cameraInfo);
     colorPassDescriptorSet.prepareTime(engine, userTime);
     colorPassDescriptorSet.prepareFog(engine, cameraInfo, fogTransform, mFogOptions,
             scene->getIndirectLight());

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -16,11 +16,15 @@
 
 #include "details/View.h"
 
+#include "Allocators.h"
 #include "Culler.h"
+#include "DebugRegistry.h"
 #include "FrameHistory.h"
+#include "FrameInfo.h"
 #include "Froxelizer.h"
 #include "RenderPrimitive.h"
 #include "ResourceAllocator.h"
+#include "ShadowMap.h"
 #include "ShadowMapManager.h"
 
 #include "details/Engine.h"
@@ -30,9 +34,15 @@
 #include "details/Scene.h"
 #include "details/Skybox.h"
 
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <fg/FrameGraphTexture.h>
+#include <fg/FrameGraphId.h>
+
 #include <filament/Exposure.h>
+#include <filament/Frustum.h>
 #include <filament/DebugRegistry.h>
-#include <filament/TextureSampler.h>
 #include <filament/View.h>
 
 #include <private/filament/UibStructs.h>
@@ -40,18 +50,29 @@
 
 #include <private/utils/Tracing.h>
 
+#include <utils/architecture.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
-#include <utils/Profiler.h>
+#include <utils/Panic.h>
 #include <utils/Slice.h>
 #include <utils/Zip2Iterator.h>
 
+#include <math/mat3.h>
+#include <math/mat4.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
 #include <math/scalar.h>
-#include <math/fast.h>
+
+#include <assert.h>
 
 #include <array>
+#include <algorithm>
+#include <cmath>
+#include <chrono>
+#include <functional>
 #include <memory>
-#include <tuple>
+#include <ratio>
+#include <utility>
 
 using namespace utils;
 
@@ -114,7 +135,7 @@ FView::FView(FEngine& engine)
 #ifndef NDEBUG
     // This can fail if another view has already registered this data source
     mDebugState->owner = debugRegistry.registerDataSource("d.view.frame_info",
-            [weak = std::weak_ptr<DebugState>(mDebugState)]() -> DebugRegistry::DataSource {
+            [weak = std::weak_ptr(mDebugState)]() -> DebugRegistry::DataSource {
                 // the View could have been destroyed by the time we do this
                 auto const state = weak.lock();
                 if (!state) {
@@ -200,8 +221,8 @@ void FView::terminate(FEngine& engine) {
 
 void FView::setViewport(filament::Viewport const& viewport) noexcept {
     // catch the cases were user had an underflow and didn't catch it.
-    assert((int32_t)viewport.width > 0);
-    assert((int32_t)viewport.height > 0);
+    assert(int32_t(viewport.width) > 0);
+    assert(int32_t(viewport.height) > 0);
     mViewport = viewport;
 }
 
@@ -274,7 +295,7 @@ float2 FView::updateScale(FEngine& engine,
         const float dt = 1.0f; // we don't really need dt here, setting it to 1, means our parameters are in "frames"
         const float target = (1000.0f * float(frameRateOptions.interval)) / displayInfo.refreshRate;
         const float targetWithHeadroom = target * (1.0f - frameRateOptions.headRoomRatio);
-        float const measured = duration<float, std::milli>{ info.denoisedFrameTime }.count();
+        float const measured = duration{ info.denoisedFrameTime }.count();
         float const out = mPidController.update(measured / targetWithHeadroom, 1.0f, dt);
 
         // maps pid command to a scale (absolute or relative, see below)
@@ -433,7 +454,7 @@ void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableD
 
     if (builder.hasShadowMaps()) {
         ShadowMapManager::createIfNeeded(engine, mShadowMapManager);
-        auto shadowTechnique = mShadowMapManager->update(builder, engine, *this,
+        auto const shadowTechnique = mShadowMapManager->update(builder, engine, *this,
                 cameraInfo, renderableData, lightData);
 
         mHasShadowing = any(shadowTechnique);
@@ -493,7 +514,7 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
     getColorPassDescriptorSet().prepareDirectionalLight(engine, exposure, sceneSpaceDirection, directionalLight);
 }
 
-CameraInfo FView::computeCameraInfo(FEngine& engine) const noexcept {
+CameraInfo FView::computeCameraInfo(FEngine const& engine) const noexcept {
     FScene const* const scene = getScene();
 
     /*
@@ -546,15 +567,14 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
             // In the common case when we don't have a viewing camera, cameraInfo.view is
             // already the culling view matrix
             return Frustum{ mat4f{ highPrecisionMultiply(cameraInfo.cullingProjection, cameraInfo.view) }};
-        } else {
-            // Otherwise, we need to recalculate it from the culling camera.
-            // Note: it is correct to always do the math from mCullingCamera, but it hides the
-            // intent of the code, which is that we should only depend on CameraInfo here.
-            // This is an extremely uncommon case.
-            const mat4 projection = mCullingCamera->getCullingProjectionMatrix();
-            const mat4 view = inverse(cameraInfo.worldTransform * mCullingCamera->getModelMatrix());
-            return Frustum{ mat4f{ projection * view }};
         }
+        // Otherwise, we need to recalculate it from the culling camera.
+        // Note: it is correct to always do the math from mCullingCamera, but it hides the
+        // intent of the code, which is that we should only depend on CameraInfo here.
+        // This is an extremely uncommon case.
+        const mat4 projection = mCullingCamera->getCullingProjectionMatrix();
+        const mat4 view = inverse(cameraInfo.worldTransform * mCullingCamera->getModelMatrix());
+        return Frustum{ mat4f{ projection * view }};
     };
 
     const Frustum cullingFrustum = getFrustum();
@@ -599,9 +619,9 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
     setFroxelizerSync(froxelizeLightsJob);
 
     Range merged;
-    FScene::RenderableSoa& renderableData = scene->getRenderableData();
 
     { // all the operations in this scope must happen sequentially
+        FScene::RenderableSoa& renderableData = scene->getRenderableData();
 
         Slice<Culler::result_type> cullingMask = renderableData.slice<FScene::VISIBLE_MASK>();
         std::uninitialized_fill(cullingMask.begin(), cullingMask.end(), 0);
@@ -646,7 +666,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
             }
             // We need to pass viewMatrix by value here because it extends the scope of this
             // function.
-            std::function<void(JobSystem&, JobSystem::Job*)> froxelizerWork =
+            std::function froxelizerWork =
                     [&froxelizer = mFroxelizer, &engine, viewMatrix = cameraInfo.view, &lightData]
                             (JobSystem&, JobSystem::Job*) {
                         froxelizer.froxelizeLights(engine, viewMatrix, lightData);
@@ -1107,7 +1127,7 @@ void FView::prepareVisibleLights(FLightManager const& lcm,
         computeLightCameraDistances(distances, viewMatrix, spheres, visibleLightCount);
 
         // skip directional light
-        Zip2Iterator<FScene::LightSoa::iterator, float*> b = { lightData.begin(), distances };
+        Zip2Iterator b = { lightData.begin(), distances };
         std::sort(b + FScene::DIRECTIONAL_LIGHTS_COUNT, b + visibleLightCount,
                 [](auto const& lhs, auto const& rhs) { return lhs.second < rhs.second; });
     }
@@ -1277,8 +1297,8 @@ void FView::setAmbientOcclusionOptions(AmbientOcclusionOptions options) noexcept
     options.ssct.lightDirection = normalize(options.ssct.lightDirection);
     options.ssct.depthBias = std::max(0.0f, options.ssct.depthBias);
     options.ssct.depthSlopeBias = std::max(0.0f, options.ssct.depthSlopeBias);
-    options.ssct.sampleCount = clamp((unsigned)options.ssct.sampleCount, 1u, 255u);
-    options.ssct.rayCount = clamp((unsigned)options.ssct.rayCount, 1u, 255u);
+    options.ssct.sampleCount = clamp(unsigned(options.ssct.sampleCount), 1u, 255u);
+    options.ssct.rayCount = clamp(unsigned(options.ssct.rayCount), 1u, 255u);
     mAmbientOcclusionOptions = options;
 }
 void FView::setVsmShadowOptions(VsmShadowOptions options) noexcept {
@@ -1306,7 +1326,6 @@ void FView::setFogOptions(FogOptions options) noexcept {
     options.maximumOpacity = clamp(options.maximumOpacity, 0.0f, 1.0f);
     options.density = std::max(0.0f, options.density);
     options.heightFalloff = std::max(0.0f, options.heightFalloff);
-    options.inScatteringSize = options.inScatteringSize;
     options.inScatteringStart = std::max(0.0f, options.inScatteringStart);
     mFogOptions = options;
 }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -102,6 +102,7 @@ class FScene;
 
 class FView : public View {
 public:
+    using MaterialGlobals = std::array<math::float4, 4>;
     using Range = utils::Range<uint32_t>;
 
     explicit FView(FEngine& engine);
@@ -483,6 +484,8 @@ public:
         return mFrameGraphViewerViewHandle;
     }
 
+    MaterialGlobals getMaterialGlobals() const { return mMaterialGlobals; }
+
 private:
     struct FPickingQuery : public PickingQuery {
     private:
@@ -609,12 +612,12 @@ private:
 
     std::unique_ptr<ShadowMapManager> mShadowMapManager;
 
-    std::array<math::float4, 4> mMaterialGlobals = {{
-                                                            { 0, 0, 0, 1 },
-                                                            { 0, 0, 0, 1 },
-                                                            { 0, 0, 0, 1 },
-                                                            { 0, 0, 0, 1 },
-                                                    }};
+    MaterialGlobals mMaterialGlobals = {{
+            { 0, 0, 0, 1 },
+            { 0, 0, 0, 1 },
+            { 0, 0, 0, 1 },
+            { 0, 0, 0, 1 },
+    }};
 
     fgviewer::ViewHandle mFrameGraphViewerViewHandle;
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -110,7 +110,7 @@ public:
 
     void terminate(FEngine& engine);
 
-    CameraInfo computeCameraInfo(FEngine& engine) const noexcept;
+    CameraInfo computeCameraInfo(FEngine const& engine) const noexcept;
 
     // note: viewport/cameraInfo are passed by value to make it clear that prepare cannot
     // keep references on them that would outlive the scope of prepare() (e.g. with JobSystem).
@@ -618,7 +618,7 @@ private:
             { 0, 0, 0, 1 },
     }};
 
-    fgviewer::ViewHandle mFrameGraphViewerViewHandle;
+    fgviewer::ViewHandle mFrameGraphViewerViewHandle{};
 
 #ifndef NDEBUG
     struct DebugState {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -160,10 +160,9 @@ public:
         return mName.c_str_safe();
     }
 
-    void prepareUpscaler(math::float2 scale,
-            TemporalAntiAliasingOptions const& taaOptions,
-            DynamicResolutionOptions const& dsrOptions) const noexcept;
     void prepareCamera(FEngine& engine, const CameraInfo& cameraInfo) const noexcept;
+
+    void prepareLodBias(float bias, math::float2 derivativesScale) const noexcept;
 
     void prepareViewport(
             const Viewport& physicalViewport,

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -16,7 +16,9 @@
 
 #include "ColorPassDescriptorSet.h"
 
+
 #include "Froxelizer.h"
+#include "PerViewDescriptorSetUtils.h"
 #include "HwDescriptorSetLayoutFactory.h"
 #include "ShadowMapManager.h"
 #include "TypedUniformBuffer.h"
@@ -144,44 +146,11 @@ void ColorPassDescriptorSet::terminate(HwDescriptorSetLayoutFactory& factory, Dr
 }
 
 void ColorPassDescriptorSet::prepareCamera(FEngine& engine, const CameraInfo& camera) noexcept {
-    mat4f const& viewFromWorld = camera.view;
-    mat4f const& worldFromView = camera.model;
-    mat4f const& clipFromView  = camera.projection;
-
-    const mat4f viewFromClip{ inverse((mat4)camera.projection) };
-    const mat4f worldFromClip{ highPrecisionMultiply(worldFromView, viewFromClip) };
-
-    auto& s = mUniforms.edit();
-    s.viewFromWorldMatrix = viewFromWorld;    // view
-    s.worldFromViewMatrix = worldFromView;    // model
-    s.clipFromViewMatrix  = clipFromView;     // projection
-    s.viewFromClipMatrix  = viewFromClip;     // 1/projection
-    s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
-    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldTransform));
-    s.clipTransform = camera.clipTransform;
-    s.cameraFar = camera.zf;
-    s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);
-    s.nearOverFarMinusNear = camera.zn / (camera.zf - camera.zn);
-
-    mat4f const& headFromWorld = camera.view;
-    Engine::Config const& config = engine.getConfig();
-    for (int i = 0; i < config.stereoscopicEyeCount; i++) {
-        mat4f const& eyeFromHead = camera.eyeFromView[i];   // identity for monoscopic rendering
-        mat4f const& clipFromEye = camera.eyeProjection[i];
-        // clipFromEye * eyeFromHead * headFromWorld
-        s.clipFromWorldMatrix[i] = highPrecisionMultiply(
-                clipFromEye, highPrecisionMultiply(eyeFromHead, headFromWorld));
-    }
-
-    // with a clip-space of [-w, w] ==> z' = -z
-    // with a clip-space of [0,  w] ==> z' = (w - z)/2
-    s.clipControl = engine.getDriverApi().getClipSpaceParams();
+    PerViewDescriptorSetUtils::prepareCamera(mUniforms.edit(), engine, camera);
 }
 
 void ColorPassDescriptorSet::prepareLodBias(float const bias, float2 const derivativesScale) noexcept {
-    auto& s = mUniforms.edit();
-    s.lodBias = bias;
-    s.derivativesScale = derivativesScale;
+    PerViewDescriptorSetUtils::prepareLodBias(mUniforms.edit(), bias, derivativesScale);
 }
 
 void ColorPassDescriptorSet::prepareExposure(float const ev100) noexcept {
@@ -194,22 +163,11 @@ void ColorPassDescriptorSet::prepareExposure(float const ev100) noexcept {
 void ColorPassDescriptorSet::prepareViewport(
         const filament::Viewport& physicalViewport,
         const filament::Viewport& logicalViewport) noexcept {
-    float4 const physical{ physicalViewport.left, physicalViewport.bottom,
-                           physicalViewport.width, physicalViewport.height };
-    float4 const logical{ logicalViewport.left, logicalViewport.bottom,
-                          logicalViewport.width, logicalViewport.height };
-    auto& s = mUniforms.edit();
-    s.resolution = { physical.zw, 1.0f / physical.zw };
-    s.logicalViewportScale = physical.zw / logical.zw;
-    s.logicalViewportOffset = -logical.xy / logical.zw;
+    PerViewDescriptorSetUtils::prepareViewport(mUniforms.edit(), physicalViewport, logicalViewport);
 }
 
 void ColorPassDescriptorSet::prepareTime(FEngine& engine, float4 const& userTime) noexcept {
-    auto& s = mUniforms.edit();
-    const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
-    const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
-    s.time = fraction;
-    s.userTime = userTime;
+    PerViewDescriptorSetUtils::prepareTime(mUniforms.edit(), engine, userTime);
 }
 
 void ColorPassDescriptorSet::prepareTemporalNoise(FEngine& engine,
@@ -324,10 +282,7 @@ void ColorPassDescriptorSet::prepareBlending(bool const needsAlphaChannel) noexc
 
 void ColorPassDescriptorSet::prepareMaterialGlobals(
         std::array<float4, 4> const& materialGlobals) noexcept {
-    mUniforms.edit().custom[0] = materialGlobals[0];
-    mUniforms.edit().custom[1] = materialGlobals[1];
-    mUniforms.edit().custom[2] = materialGlobals[2];
-    mUniforms.edit().custom[3] = materialGlobals[3];
+    PerViewDescriptorSetUtils::prepareMaterialGlobals(mUniforms.edit(), materialGlobals);
 }
 
 void ColorPassDescriptorSet::prepareSSR(Handle<HwTexture> ssr,

--- a/filament/src/ds/DescriptorSet.cpp
+++ b/filament/src/ds/DescriptorSet.cpp
@@ -73,8 +73,7 @@ DescriptorSet& DescriptorSet::operator=(DescriptorSet&& rhs) noexcept {
 
 void DescriptorSet::terminate(FEngine::DriverApi& driver) noexcept {
     if (mDescriptorSetHandle) {
-        driver.destroyDescriptorSet(mDescriptorSetHandle);
-        mDescriptorSetHandle.clear();
+        driver.destroyDescriptorSet(std::move(mDescriptorSetHandle));
     }
 }
 

--- a/filament/src/ds/PerViewDescriptorSetUtils.cpp
+++ b/filament/src/ds/PerViewDescriptorSetUtils.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PerViewDescriptorSetUtils.h"
+
+#include "details/Camera.h"
+#include "details/Engine.h"
+
+#include <private/filament/UibStructs.h>
+
+#include <filament/Engine.h>
+#include <filament/Viewport.h>
+
+#include <backend/DriverEnums.h>
+
+#include <math/mat4.h>
+#include <math/vec4.h>
+
+#include <array>
+
+#include <stdint.h>
+
+namespace filament {
+
+using namespace backend;
+using namespace math;
+
+void PerViewDescriptorSetUtils::prepareCamera(PerViewUib& s,
+        FEngine const& engine, const CameraInfo& camera) noexcept {
+    mat4f const& viewFromWorld = camera.view;
+    mat4f const& worldFromView = camera.model;
+    mat4f const& clipFromView  = camera.projection;
+
+    const mat4f viewFromClip{ inverse((mat4)camera.projection) };
+    const mat4f worldFromClip{ highPrecisionMultiply(worldFromView, viewFromClip) };
+
+    s.viewFromWorldMatrix = viewFromWorld;    // view
+    s.worldFromViewMatrix = worldFromView;    // model
+    s.clipFromViewMatrix  = clipFromView;     // projection
+    s.viewFromClipMatrix  = viewFromClip;     // 1/projection
+    s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldTransform));
+    s.clipTransform = camera.clipTransform;
+    s.cameraFar = camera.zf;
+    s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);
+    s.nearOverFarMinusNear = camera.zn / (camera.zf - camera.zn);
+
+    mat4f const& headFromWorld = camera.view;
+    Engine::Config const& config = engine.getConfig();
+    for (int i = 0; i < config.stereoscopicEyeCount; i++) {
+        mat4f const& eyeFromHead = camera.eyeFromView[i];   // identity for monoscopic rendering
+        mat4f const& clipFromEye = camera.eyeProjection[i];
+        // clipFromEye * eyeFromHead * headFromWorld
+        s.clipFromWorldMatrix[i] = highPrecisionMultiply(
+                clipFromEye, highPrecisionMultiply(eyeFromHead, headFromWorld));
+    }
+
+    // with a clip-space of [-w, w] ==> z' = -z
+    // with a clip-space of [0,  w] ==> z' = (w - z)/2
+    s.clipControl = const_cast<FEngine&>(engine).getDriverApi().getClipSpaceParams();
+}
+
+void PerViewDescriptorSetUtils::prepareLodBias(PerViewUib& s, float bias,
+        float2 derivativesScale) noexcept {
+    s.lodBias = bias;
+    s.derivativesScale = derivativesScale;
+}
+
+void PerViewDescriptorSetUtils::prepareViewport(PerViewUib& s,
+        backend::Viewport const& physicalViewport,
+        backend::Viewport const& logicalViewport) noexcept {
+    float4 const physical{ physicalViewport.left, physicalViewport.bottom,
+                           physicalViewport.width, physicalViewport.height };
+    float4 const logical{ logicalViewport.left, logicalViewport.bottom,
+                          logicalViewport.width, logicalViewport.height };
+    s.resolution = { physical.zw, 1.0f / physical.zw };
+    s.logicalViewportScale = physical.zw / logical.zw;
+    s.logicalViewportOffset = -logical.xy / logical.zw;
+}
+
+void PerViewDescriptorSetUtils::prepareTime(PerViewUib& s,
+        FEngine const& engine, float4 const& userTime) noexcept {
+    const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
+    const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
+    s.time = fraction;
+    s.userTime = userTime;
+}
+
+void PerViewDescriptorSetUtils::prepareMaterialGlobals(PerViewUib& s,
+        std::array<float4, 4> const& materialGlobals) noexcept {
+    s.custom[0] = materialGlobals[0];
+    s.custom[1] = materialGlobals[1];
+    s.custom[2] = materialGlobals[2];
+    s.custom[3] = materialGlobals[3];
+}
+
+} // namespace filament

--- a/filament/src/ds/PerViewDescriptorSetUtils.h
+++ b/filament/src/ds/PerViewDescriptorSetUtils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <private/filament/UibStructs.h>
+
+#include <math/vec2.h>
+#include <math/vec4.h>
+
+#include <array>
+
+namespace filament {
+namespace backend {
+struct Viewport;
+} // namespace backend
+
+class FEngine;
+struct CameraInfo;
+
+class PerViewDescriptorSetUtils {
+public:
+    static void prepareCamera(PerViewUib& uniforms,
+            FEngine const& engine, const CameraInfo& camera) noexcept;
+
+    static void prepareLodBias(PerViewUib& uniforms,
+            float bias, math::float2 derivativesScale) noexcept;
+
+    static void prepareViewport(PerViewUib& uniforms,
+            backend::Viewport const& physicalViewport,
+            backend::Viewport const& logicalViewport) noexcept;
+
+    static void prepareTime(PerViewUib& uniforms,
+            FEngine const& engine, math::float4 const& userTime) noexcept;
+
+    static void prepareMaterialGlobals(PerViewUib& uniforms,
+            std::array<math::float4, 4> const& materialGlobals) noexcept;
+};
+
+} //namespace filament

--- a/filament/src/ds/ShadowMapDescriptorSet.cpp
+++ b/filament/src/ds/ShadowMapDescriptorSet.cpp
@@ -22,16 +22,15 @@
 #include "details/Engine.h"
 
 #include <private/filament/EngineEnums.h>
-#include <private/filament/DescriptorSets.h>
 #include <private/filament/UibStructs.h>
 
 #include <backend/DriverEnums.h>
 
 #include <utils/debug.h>
 
-#include <math/mat4.h>
+#include <math/vec4.h>
 
-#include <stdint.h>
+#include <array>
 
 namespace filament {
 
@@ -83,6 +82,11 @@ void ShadowMapDescriptorSet::prepareViewport(Transaction const& transaction,
 void ShadowMapDescriptorSet::prepareTime(Transaction const& transaction,
         FEngine const& engine, float4 const& userTime) noexcept {
     PerViewDescriptorSetUtils::prepareTime(edit(transaction), engine, userTime);
+}
+
+void ShadowMapDescriptorSet::prepareMaterialGlobals(Transaction const& transaction,
+        std::array<float4, 4> const& materialGlobals) noexcept {
+    PerViewDescriptorSetUtils::prepareMaterialGlobals(edit(transaction), materialGlobals);
 }
 
 void ShadowMapDescriptorSet::prepareShadowMapping(Transaction const& transaction,

--- a/filament/src/ds/ShadowMapDescriptorSet.h
+++ b/filament/src/ds/ShadowMapDescriptorSet.h
@@ -29,6 +29,8 @@
 
 #include <math/vec4.h>
 
+#include <array>
+
 namespace filament {
 
 struct CameraInfo;
@@ -69,7 +71,8 @@ public:
     static void prepareTime(Transaction const& transaction,
             FEngine const& engine, math::float4 const& userTime) noexcept;
 
-    // FIXME: I think this misses prepareMaterialGlobals()
+    static void prepareMaterialGlobals(Transaction const& transaction,
+            std::array<math::float4, 4> const& materialGlobals) noexcept;
 
     static void prepareShadowMapping(Transaction const& transaction,
             bool highPrecision) noexcept;

--- a/filament/src/ds/ShadowMapDescriptorSet.h
+++ b/filament/src/ds/ShadowMapDescriptorSet.h
@@ -55,8 +55,10 @@ public:
 
     void terminate(backend::DriverApi& driver);
 
+    // All UBO values that can affect user code must be set here
+
     static void prepareCamera(Transaction const& transaction,
-            backend::DriverApi& driver, const CameraInfo& camera) noexcept;
+            FEngine const& engine, const CameraInfo& camera) noexcept;
 
     static void prepareLodBias(Transaction const& transaction,
             float bias) noexcept;
@@ -66,6 +68,8 @@ public:
 
     static void prepareTime(Transaction const& transaction,
             FEngine const& engine, math::float4 const& userTime) noexcept;
+
+    // FIXME: I think this misses prepareMaterialGlobals()
 
     static void prepareShadowMapping(Transaction const& transaction,
             bool highPrecision) noexcept;

--- a/filament/src/ds/StructureDescriptorSet.cpp
+++ b/filament/src/ds/StructureDescriptorSet.cpp
@@ -27,6 +27,7 @@
 #include <utils/compiler.h>
 #include <utils/debug.h>
 
+#include <math/vec2.h>
 #include <math/vec4.h>
 
 #include <array>
@@ -63,13 +64,10 @@ void StructureDescriptorSet::terminate(DriverApi& driver) {
 }
 
 void StructureDescriptorSet::commit(DriverApi& driver) noexcept {
+    assert_invariant(mDescriptorSetLayout);
     driver.updateBufferObject(mUniforms.getUboHandle(),
             mUniforms.toBufferDescriptor(driver), 0);
-
-    assert_invariant(mDescriptorSetLayout);
-    if (mDescriptorSetLayout) {
-        mDescriptorSet.commit(*mDescriptorSetLayout, driver);
-    }
+    mDescriptorSet.commit(*mDescriptorSetLayout, driver);
 }
 
 void StructureDescriptorSet::bind(DriverApi& driver) const noexcept {
@@ -87,7 +85,7 @@ void StructureDescriptorSet::prepareCamera(FEngine const& engine,
     PerViewDescriptorSetUtils::prepareCamera(mUniforms.edit(), engine, camera);
 }
 
-void StructureDescriptorSet::prepareLodBias(float bias, float2 derivativesScale) noexcept {
+void StructureDescriptorSet::prepareLodBias(float bias, float2 const derivativesScale) noexcept {
     PerViewDescriptorSetUtils::prepareLodBias(mUniforms.edit(), bias, derivativesScale);
 }
 

--- a/filament/src/ds/StructureDescriptorSet.cpp
+++ b/filament/src/ds/StructureDescriptorSet.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StructureDescriptorSet.h"
+
+#include "PerViewDescriptorSetUtils.h"
+
+#include "details/Camera.h"
+#include "details/Engine.h"
+
+#include <private/filament/EngineEnums.h>
+#include <private/filament/UibStructs.h>
+
+#include <math/vec4.h>
+
+#include <array>
+
+namespace filament {
+
+using namespace backend;
+using namespace math;
+
+StructureDescriptorSet::StructureDescriptorSet(FEngine& engine) noexcept
+        : mDescriptorSetLayout(engine.getPerViewDescriptorSetLayoutDepthVariant()),
+          mUniforms(engine.getDriverApi()) {
+    // create the descriptor-set from the layout
+    mDescriptorSet = DescriptorSet{
+        "StructureDescriptorSet", mDescriptorSetLayout };
+
+    // initialize the descriptor-set
+    mDescriptorSet.setBuffer(mDescriptorSetLayout, +PerViewBindingPoints::FRAME_UNIFORMS,
+            mUniforms.getUboHandle(), 0, sizeof(PerViewUib));
+}
+
+void StructureDescriptorSet::terminate(DriverApi& driver) {
+    mDescriptorSet.terminate(driver);
+    mUniforms.terminate(driver);
+}
+
+void StructureDescriptorSet::commit(DriverApi& driver) noexcept {
+    driver.updateBufferObject(mUniforms.getUboHandle(),
+            mUniforms.toBufferDescriptor(driver), 0);
+    mDescriptorSet.commit(mDescriptorSetLayout, driver);
+}
+
+void StructureDescriptorSet::bind(DriverApi& driver) const noexcept {
+    mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
+}
+
+void StructureDescriptorSet::prepareViewport(
+        backend::Viewport const& physicalViewport,
+        backend::Viewport const& logicalViewport) noexcept {
+    PerViewDescriptorSetUtils::prepareViewport(mUniforms.edit(), physicalViewport, logicalViewport);
+}
+
+void StructureDescriptorSet::prepareCamera(FEngine const& engine,
+        CameraInfo const& camera) noexcept {
+    PerViewDescriptorSetUtils::prepareCamera(mUniforms.edit(), engine, camera);
+}
+
+void StructureDescriptorSet::prepareLodBias(float bias, float2 derivativesScale) noexcept {
+    PerViewDescriptorSetUtils::prepareLodBias(mUniforms.edit(), bias, derivativesScale);
+}
+
+void StructureDescriptorSet::prepareTime(FEngine const& engine, float4 const& userTime) noexcept {
+    PerViewDescriptorSetUtils::prepareTime(mUniforms.edit(), engine, userTime);
+}
+
+void StructureDescriptorSet::prepareMaterialGlobals(
+        std::array<float4, 4> const& materialGlobals) noexcept {
+    PerViewDescriptorSetUtils::prepareMaterialGlobals(mUniforms.edit(), materialGlobals);
+}
+
+} // namespace filament

--- a/filament/src/ds/StructureDescriptorSet.h
+++ b/filament/src/ds/StructureDescriptorSet.h
@@ -38,7 +38,10 @@ struct CameraInfo;
 
 class StructureDescriptorSet {
 public:
-    explicit StructureDescriptorSet(FEngine& engine) noexcept;
+    StructureDescriptorSet() noexcept;
+    ~StructureDescriptorSet() noexcept;
+
+    void init(FEngine& engine) noexcept;
 
     void terminate(backend::DriverApi& driver);
 
@@ -61,7 +64,7 @@ public:
     void prepareMaterialGlobals(std::array<math::float4, 4> const& materialGlobals) noexcept;
 
 private:
-    DescriptorSetLayout const& mDescriptorSetLayout;
+    DescriptorSetLayout const* mDescriptorSetLayout = nullptr;
     DescriptorSet mDescriptorSet;
     TypedUniformBuffer<PerViewUib> mUniforms;
 };

--- a/filament/src/ds/StructureDescriptorSet.h
+++ b/filament/src/ds/StructureDescriptorSet.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "DescriptorSet.h"
+
+#include "TypedUniformBuffer.h"
+
+#include <private/filament/UibStructs.h>
+
+#include <math/vec2.h>
+#include <math/vec4.h>
+
+#include <array>
+
+namespace filament {
+namespace backend {
+struct Viewport;
+} // namespace backend
+
+class FEngine;
+class DescriptorSetLayout;
+struct CameraInfo;
+
+class StructureDescriptorSet {
+public:
+    explicit StructureDescriptorSet(FEngine& engine) noexcept;
+
+    void terminate(backend::DriverApi& driver);
+
+    void commit(backend::DriverApi& driver) noexcept;
+
+    void bind(backend::DriverApi& driver) const noexcept;
+
+
+    // All UBO values that can affect user code must be set here
+
+    void prepareCamera(FEngine const& engine, const CameraInfo& camera) noexcept;
+
+    void prepareLodBias(float bias, math::float2 derivativesScale) noexcept;
+
+    void prepareViewport(const backend::Viewport& physicalViewport,
+            const backend::Viewport& logicalViewport) noexcept;
+
+    void prepareTime(FEngine const& engine, math::float4 const& userTime) noexcept;
+
+    void prepareMaterialGlobals(std::array<math::float4, 4> const& materialGlobals) noexcept;
+
+private:
+    DescriptorSetLayout const& mDescriptorSetLayout;
+    DescriptorSet mDescriptorSet;
+    TypedUniformBuffer<PerViewUib> mUniforms;
+};
+
+} // namespace filament

--- a/filament/src/ds/TypedUniformBuffer.h
+++ b/filament/src/ds/TypedUniformBuffer.h
@@ -21,7 +21,11 @@
 
 #include <backend/BufferDescriptor.h>
 #include <backend/DriverApiForward.h>
+#include <backend/DriverEnums.h>
 #include <backend/Handle.h>
+#include <utils/debug.h>
+
+#include <utility>
 
 #include <stddef.h>
 
@@ -31,7 +35,14 @@ template<typename T, size_t N = 1>
 class TypedUniformBuffer {
 public:
 
+    TypedUniformBuffer() noexcept = default;
+
     explicit TypedUniformBuffer(backend::DriverApi& driver) noexcept {
+        init(driver);
+    }
+
+    void init(backend::DriverApi& driver) noexcept {
+        assert_invariant(!mUboHandle);
         mUboHandle = driver.createBufferObject(
                 mTypedBuffer.getSize(),
                 backend::BufferObjectBinding::UNIFORM,
@@ -39,7 +50,12 @@ public:
     }
 
     void terminate(backend::DriverApi& driver) noexcept {
-        driver.destroyBufferObject(mUboHandle);
+        assert_invariant(mUboHandle);
+        driver.destroyBufferObject(std::move(mUboHandle));
+    }
+
+    ~TypedUniformBuffer() noexcept {
+        assert_invariant(!mUboHandle);
     }
 
     TypedBuffer<T,N>& getTypedBuffer() noexcept {


### PR DESCRIPTION
The per-view UBO is used in several different contexts, for instance:
- during the color pass
- during the shadow pass
- during the structure pass
- during app postfx passes

For shadows and other passes, its content is actually different because
the camera is very different. In that case, we use a different buffer.

However, the code that was used to set the values into the UBO was
duplicated and did slightly different things. In addition some
UBO values were (and are still) probably missing (e.g. the per-material
data).

To improve this situation we new use a utility class that does the
UBO set up of those "shared" values.

It turns out that the structure, ssr and ssao passes also need a 
slightly different content (because they run at half res) and currently
are sharing the color pass UBO, which causes mid-frame updates.

We introduce a new StructureDescriptorSet which is managing a new UBO,
it too is now implemented in terms of the new utility class. 
StructureDescriptorSet Is not used yet.