### PR TITLE
Fix dangling material reference after destruction

### DIFF
--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -88,7 +88,8 @@ public:
 
     // sets the material name and variant for diagnostic purposes only
     Program& diagnostics(utils::CString const& name,
-            utils::Invocable<utils::io::ostream&(utils::io::ostream& out)>&& logger);
+            utils::Invocable<utils::io::ostream&(utils::CString const& name,
+                    utils::io::ostream& out)>&& logger);
 
     // Sets one of the program's shader (e.g. vertex, fragment)
     // string-based shaders are null terminated, consequently the size parameter must include the
@@ -173,7 +174,8 @@ private:
     utils::CString mName;
     uint64_t mCacheId{};
     CompilerPriorityQueue mPriorityQueue = CompilerPriorityQueue::HIGH;
-    utils::Invocable<utils::io::ostream&(utils::io::ostream& out)> mLogger;
+    utils::Invocable<utils::io::ostream&(utils::CString const& name, utils::io::ostream& out)>
+            mLogger;
     SpecializationConstantsInfo mSpecializationConstants;
     std::array<utils::FixedCapacityVector<PushConstant>, SHADER_TYPE_COUNT> mPushConstants;
     DescriptorSetInfo mDescriptorBindings;

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -45,7 +45,7 @@ Program& Program::priorityQueue(CompilerPriorityQueue priorityQueue) noexcept {
 }
 
 Program& Program::diagnostics(CString const& name,
-        Invocable<io::ostream&(io::ostream&)>&& logger) {
+        Invocable<io::ostream&(utils::CString const& name, io::ostream&)>&& logger) {
     mName = name;
     mLogger = std::move(logger);
     return *this;
@@ -103,7 +103,7 @@ Program& Program::multiview(bool multiview) noexcept {
 
 io::ostream& operator<<(io::ostream& out, const Program& builder) {
     out << "Program{";
-    builder.mLogger(out);
+    builder.mLogger(builder.mName, out);
     out << "}";
     return out;
 }

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -619,10 +619,10 @@ Program FMaterial::getProgramWithVariants(
             .shader(ShaderStage::FRAGMENT, fsBuilder.data(), fsBuilder.size())
             .shaderLanguage(mMaterialParser->getShaderLanguage())
             .diagnostics(mName,
-                    [this, variant, vertexVariant, fragmentVariant](
+                    [variant, vertexVariant, fragmentVariant](utils::CString const& name,
                             io::ostream& out) -> io::ostream& {
-                        return out << mName.c_str_safe() << ", variant=(" << io::hex
-                                   << +variant.key << io::dec << "), vertexVariant=(" << io::hex
+                        return out << name.c_str_safe() << ", variant=(" << io::hex << +variant.key
+                                   << io::dec << "), vertexVariant=(" << io::hex
                                    << +vertexVariant.key << io::dec << "), fragmentVariant=("
                                    << io::hex << +fragmentVariant.key << io::dec << ")";
                     });


### PR DESCRIPTION
The invocable sent to Program::diagnostic contains a reference to Material, which could be destroyed by the time the invocable is called. We make sure that invocable does not have a reference.