### PR TITLE
Better set default shader stages for samplers

### DIFF
--- a/filament/src/materials/blitDepth.mat
+++ b/filament/src/materials/blitDepth.mat
@@ -19,7 +19,7 @@ material {
             target : depth,
             type : float
         }
-    ],    
+    ],
     variables : [
         vertex
     ],

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -11,7 +11,8 @@ material {
         },
         {
            type : samplerCubemap,
-           name : skybox
+           name : skybox,
+           stages : [ "fragment" ]
         },
         {
            type : float4,

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -41,6 +41,7 @@
 #include <utility>
 #include <vector>
 #include <variant>
+#include <optional>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -327,7 +328,7 @@ public:
             ParameterPrecision precision = ParameterPrecision::DEFAULT,
             bool filterable = true, /* defaulting to filterable because format is default to float */
             bool multisample = false, const char* transformName = "",
-            ShaderStageFlags stages = ShaderStageFlags::ALL_SHADER_STAGE_FLAGS);
+            std::optional<ShaderStageFlags> stages = {});
 
     MaterialBuilder& buffer(filament::BufferInterfaceBlock bib);
 
@@ -660,7 +661,7 @@ public:
 
         // Sampler
         Parameter(const char* paramName, SamplerType t, SamplerFormat f, ParameterPrecision p,
-                bool filterable, bool ms, const char* tn, ShaderStageFlags s)
+                bool filterable, bool ms, const char* tn, std::optional<ShaderStageFlags> s)
             : name(paramName),
               size(1),
               precision(p),
@@ -704,7 +705,7 @@ public:
         bool filterable;
         bool multisample;
         utils::CString transformName;
-        ShaderStageFlags stages;
+        std::optional<ShaderStageFlags> stages;
         enum {
             INVALID,
             UNIFORM,

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -247,6 +247,105 @@ const char* toString(backend::ConstantType type) noexcept {
     return "--";
 }
 
+inline
+const char* toString(backend::DescriptorType type) noexcept {
+    switch (type) {
+        case backend::DescriptorType::SAMPLER_2D_FLOAT:
+            return "sampler2d float";
+        case backend::DescriptorType::SAMPLER_2D_INT:
+            return "sampler2d int";
+        case backend::DescriptorType::SAMPLER_2D_UINT:
+            return "sampler2d uint";
+        case backend::DescriptorType::SAMPLER_2D_DEPTH:
+            return "sampler2d depth";
+        case backend::DescriptorType::SAMPLER_2D_ARRAY_FLOAT:
+            return "sampler2d array float";
+        case backend::DescriptorType::SAMPLER_2D_ARRAY_INT:
+            return "sampler2d array int";
+        case backend::DescriptorType::SAMPLER_2D_ARRAY_UINT:
+            return "sampler2d array uint";
+        case backend::DescriptorType::SAMPLER_2D_ARRAY_DEPTH:
+            return "sampler2d array depth";
+        case backend::DescriptorType::SAMPLER_CUBE_FLOAT:
+            return "samplercube float";
+        case backend::DescriptorType::SAMPLER_CUBE_INT:
+            return "samplercube int";
+        case backend::DescriptorType::SAMPLER_CUBE_UINT:
+            return "samplercube uint";
+        case backend::DescriptorType::SAMPLER_CUBE_DEPTH:
+            return "samplercube depth";
+        case backend::DescriptorType::SAMPLER_CUBE_ARRAY_FLOAT:
+            return "samplercube array float";
+        case backend::DescriptorType::SAMPLER_CUBE_ARRAY_INT:
+            return "samplercube array int";
+        case backend::DescriptorType::SAMPLER_CUBE_ARRAY_UINT:
+            return "samplercube array uint";
+        case backend::DescriptorType::SAMPLER_CUBE_ARRAY_DEPTH:
+            return "samplercube array depth";
+        case backend::DescriptorType::SAMPLER_3D_FLOAT:
+            return "sampler3d float";
+        case backend::DescriptorType::SAMPLER_3D_INT:
+            return "sampler3d int";
+        case backend::DescriptorType::SAMPLER_3D_UINT:
+            return "sampler3d uint";
+        case backend::DescriptorType::SAMPLER_2D_MS_FLOAT:
+            return "sampler2d ms float";
+        case backend::DescriptorType::SAMPLER_2D_MS_INT:
+            return "sampler2d ms int";
+        case backend::DescriptorType::SAMPLER_2D_MS_UINT:
+            return "sampler2d ms uint";
+        case backend::DescriptorType::SAMPLER_2D_MS_ARRAY_FLOAT:
+            return "sampler2d ms array float";
+        case backend::DescriptorType::SAMPLER_2D_MS_ARRAY_INT:
+            return "sampler2d ms array int";
+        case backend::DescriptorType::SAMPLER_2D_MS_ARRAY_UINT:
+            return "sampler2d ms array uint";
+        case backend::DescriptorType::SAMPLER_EXTERNAL:
+            return "sampler external";
+        case backend::DescriptorType::UNIFORM_BUFFER:
+            return "uniform buffer";
+        case backend::DescriptorType::SHADER_STORAGE_BUFFER:
+            return "shader storage buffer";
+        case backend::DescriptorType::INPUT_ATTACHMENT:
+            return "input attachment";
+    }
+    return "--";
+}
+
+inline
+const char* toString(backend::ShaderStageFlags flags) noexcept {
+    switch (uint8_t(flags)) {
+        case uint8_t(backend::ShaderStageFlags::VERTEX):
+            return "vertex";
+        case uint8_t(backend::ShaderStageFlags::FRAGMENT):
+            return "fragment";
+        case uint8_t(backend::ShaderStageFlags::VERTEX | backend::ShaderStageFlags::FRAGMENT):
+            return "vertex | fragment";
+        case uint8_t(backend::ShaderStageFlags::COMPUTE):
+            return "compute";
+        case uint8_t(backend::ShaderStageFlags::VERTEX | backend::ShaderStageFlags::COMPUTE):
+            return "vertex | compute";
+        case uint8_t(backend::ShaderStageFlags::FRAGMENT | backend::ShaderStageFlags::COMPUTE):
+            return "fragment | compute";
+        case uint8_t(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS):
+            return "vertex | fragment | compute";
+    }
+    return "--";
+}
+
+inline
+const char* toString(backend::DescriptorFlags flags) noexcept {
+    switch (uint8_t(flags)) {
+        case uint8_t(backend::DescriptorFlags::DYNAMIC_OFFSET):
+            return "dynamic offset";
+        case uint8_t(backend::DescriptorFlags::UNFILTERABLE):
+            return "unfilterable";
+        case uint8_t(backend::DescriptorFlags::DYNAMIC_OFFSET | backend::DescriptorFlags::UNFILTERABLE):
+            return "dynamic offset | unfilterable";
+    }
+    return "--";
+}
+
 // Returns a human-readable variant description.
 // For example: DYN|DIR
 std::string formatVariantString(Variant variant, MaterialDomain domain) noexcept;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -205,8 +205,9 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
 
     const JsonishValue* stagesValue = jsonObject.getValue("stages");
     using filament::backend::ShaderStageFlags;
-    auto stages = ShaderStageFlags::NONE;
+    std::optional<ShaderStageFlags> stages;
     if (stagesValue) {
+        ShaderStageFlags parsedStages = ShaderStageFlags::NONE;
         if (stagesValue->getType() != JsonishValue::ARRAY) {
             std::cerr << "parameters: stages must be an ARRAY." << std::endl;
             return false;
@@ -217,7 +218,7 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
                 using Qualifier = filament::BufferInterfaceBlock::Qualifier;
                 auto stageString = value->toJsonString()->getString();
                 if (Enums::isValid<ShaderStageType>(stageString)) {
-                    stages |= Enums::toEnum<ShaderStageType>(stageString);
+                    parsedStages |= Enums::toEnum<ShaderStageType>(stageString);
                 } else {
                     std::cerr << "stages: the stage '" << stageString
                               << "' for parameter with name '" << nameString
@@ -229,12 +230,13 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
             std::cerr << "parameters: stages must be an array of STRINGs." << std::endl;
             return false;
         }
+        stages = parsedStages;
     }
 
     size_t const arraySize = extractArraySize(typeString);
 
     if (Enums::isValid<UniformType>(typeString)) {
-        if (stages != ShaderStageFlags::NONE) {
+        if (stages.has_value()) {
             std::cerr << "parameters: the uniform parameter with name '" << nameString << "'"
                       << " has shader stages specified. Shader stages are only supported for"
                       << " samplers." << std::endl;
@@ -288,11 +290,6 @@ static bool processParameter(MaterialBuilder& builder, const JsonishObject& json
 
         auto multisample = multiSampleValue ? multiSampleValue->toJsonBool()->getBool() : false;
 
-        if (stages == ShaderStageFlags::NONE) {
-            // TODO: Infer the default shader stages based on which blocks are present in the
-            // material.
-            stages = ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT;
-        }
         if (transformNameValue) {
             if (type != MaterialBuilder::SamplerType::SAMPLER_EXTERNAL) {
                 std::cerr << "parameters: the parameter with name '" << nameString << "'"


### PR DESCRIPTION
Now by default, we set the shader stages for samplers to **fragment only** unless:
- It's a post-process material
- There's a custom vertex shader

This helps avoid unnecessary dependencies between render passes.