### PR TITLE
move the management of the InstanceBuffer's UBO into InstanceBuffer

### DIFF
--- a/filament/include/filament/InstanceBuffer.h
+++ b/filament/include/filament/InstanceBuffer.h
@@ -101,7 +101,7 @@ public:
         /**
          * Creates the InstanceBuffer object and returns a pointer to it.
          */
-        InstanceBuffer* UTILS_NONNULL build(Engine& engine);
+        InstanceBuffer* UTILS_NONNULL build(Engine& engine) const;
 
     private:
         friend class FInstanceBuffer;

--- a/filament/include/filament/InstanceBuffer.h
+++ b/filament/include/filament/InstanceBuffer.h
@@ -45,7 +45,7 @@ public:
     public:
 
         /**
-         * @param instanceCount the number of instances this InstanceBuffer will support, must be
+         * @param instanceCount The number of instances this InstanceBuffer will support, must be
          *                      >= 1 and <= \c Engine::getMaxAutomaticInstances()
          * @see Engine::getMaxAutomaticInstances
          */

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -671,7 +671,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
         cmd.key |= makeField(soaVisibility[i].priority, PRIORITY_MASK, PRIORITY_SHIFT);
         cmd.key |= makeField(soaVisibility[i].channel, CHANNEL_MASK, CHANNEL_SHIFT);
         cmd.info.index = i;
-        cmd.info.hasHybridInstancing = bool(soaInstanceInfo[i].handle);
+        cmd.info.hasHybridInstancing = bool(soaInstanceInfo[i].buffer);
         cmd.info.instanceCount = soaInstanceInfo[i].count;
         cmd.info.hasMorphing = bool(morphing.handle);
         cmd.info.hasSkinning = bool(skinning.handle);

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -585,17 +585,6 @@ void FRenderableManager::create(
         InstancesInfo& instances = manager[ci].instances;
         instances.count = builder->mInstanceCount;
         instances.buffer = builder->mInstanceBuffer;
-        if (instances.buffer) {
-            // Allocate our instance buffer for this Renderable. We always allocate a size to match
-            // PerRenderableUib, regardless of the number of instances. This is because the buffer
-            // will get bound to the PER_RENDERABLE UBO, and we can't bind a buffer smaller than the
-            // full size of the UBO.
-            instances.handle = driver.createBufferObject(sizeof(PerRenderableUib),
-                    BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
-            if (auto name = instances.buffer->getName(); !name.empty()) {
-                driver.setDebugTag(instances.handle.getId(), std::move(name));
-            }
-        }
 
         const uint32_t boneCount = builder->mSkinningBoneCount;
         const uint32_t targetCount = builder->mMorphTargetCount;
@@ -773,11 +762,6 @@ void FRenderableManager::destroyComponent(Instance const ci) noexcept {
     MorphWeights const& morphWeights = manager[ci].morphWeights;
     if (morphWeights.handle) {
         driver.destroyBufferObject(morphWeights.handle);
-    }
-
-    InstancesInfo const& instances = manager[ci].instances;
-    if (instances.handle) {
-        driver.destroyBufferObject(instances.handle);
     }
 }
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -165,7 +165,7 @@ public:
 
 
     inline Box const& getAABB(Instance instance) const noexcept;
-    inline Box const& getAxisAlignedBoundingBox(Instance const instance) const noexcept { return getAABB(instance); }
+    Box const& getAxisAlignedBoundingBox(Instance const instance) const noexcept { return getAABB(instance); }
     inline Visibility getVisibility(Instance instance) const noexcept;
     inline uint8_t getLayerMask(Instance instance) const noexcept;
     inline uint8_t getPriority(Instance instance) const noexcept;
@@ -189,18 +189,15 @@ public:
     inline MorphingBindingInfo getMorphingBufferInfo(Instance instance) const noexcept;
 
     struct InstancesInfo {
-        union {
-            FInstanceBuffer* buffer;
-            uint64_t padding;          // ensures the pointer is 64 bits on all archs
-        };
-        backend::Handle<backend::HwBufferObject> handle;
-        uint16_t count;
-        char padding0[2];
+        FInstanceBuffer* buffer = nullptr;
+        alignas(8) // ensures the pointer is 64 bits on all archs
+        uint16_t count = 0;
+        char padding0[6] = {};
     };
     static_assert(sizeof(InstancesInfo) == 16);
     inline InstancesInfo getInstancesInfo(Instance instance) const noexcept;
 
-    inline size_t getLevelCount(Instance) const noexcept { return 1u; }
+    size_t getLevelCount(Instance) const noexcept { return 1u; }
     size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;
     void setMaterialInstanceAt(Instance instance, uint8_t level,
             size_t primitiveIndex, FMaterialInstance const* materialInstance);

--- a/filament/src/details/InstanceBuffer.h
+++ b/filament/src/details/InstanceBuffer.h
@@ -28,8 +28,11 @@
 #include <utils/CString.h>
 #include <utils/FixedCapacityVector.h>
 
+#include <cstddef>
+
 namespace filament {
 
+class RenderableManager;
 class FEngine;
 
 struct PerRenderableData;
@@ -44,7 +47,7 @@ public:
 
     void setLocalTransforms(math::mat4f const* localTransforms, size_t count, size_t offset);
 
-    void prepare(FEngine& engine, math::mat4f rootTransform, const PerRenderableData& ubo,
+    void prepare(FEngine& engine, math::mat4f const& rootTransform, const PerRenderableData& ubo,
             backend::Handle<backend::HwBufferObject> handle);
 
     utils::CString const& getName() const noexcept { return mName; }

--- a/filament/src/details/InstanceBuffer.h
+++ b/filament/src/details/InstanceBuffer.h
@@ -40,17 +40,19 @@ struct PerRenderableData;
 class FInstanceBuffer : public InstanceBuffer {
 public:
     FInstanceBuffer(FEngine& engine, const Builder& builder);
+    ~FInstanceBuffer() noexcept;
 
     void terminate(FEngine& engine);
 
-    inline size_t getInstanceCount() const noexcept { return mInstanceCount; }
+    size_t getInstanceCount() const noexcept { return mInstanceCount; }
 
     void setLocalTransforms(math::mat4f const* localTransforms, size_t count, size_t offset);
 
-    void prepare(FEngine& engine, math::mat4f const& rootTransform, const PerRenderableData& ubo,
-            backend::Handle<backend::HwBufferObject> handle);
+    void prepare(FEngine& engine, math::mat4f const& rootTransform, const PerRenderableData& ubo);
 
     utils::CString const& getName() const noexcept { return mName; }
+
+    backend::BufferObjectHandle getHandle() const noexcept { return mHandle; }
 
 private:
     friend class RenderableManager;
@@ -58,6 +60,7 @@ private:
     utils::FixedCapacityVector<math::mat4f> mLocalTransforms;
     utils::CString mName;
     size_t mInstanceCount;
+    backend::BufferObjectHandle mHandle;
 };
 
 FILAMENT_DOWNCAST(InstanceBuffer)

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -435,7 +435,7 @@ void FScene::updateUBOs(
         auto& instancesInfo = instancesData[i];
         if (UTILS_UNLIKELY(instancesInfo.buffer)) {
             instancesInfo.buffer->prepare(
-                    mEngine, worldTransformData[i], uboData[i], instancesInfo.handle);
+                    mEngine, worldTransformData[i], uboData[i]);
         }
     }
 

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -16,27 +16,50 @@
 
 #include "details/Scene.h"
 
+#include "Allocators.h"
+#include "BufferPoolAllocator.h"
+
+#include "backend/Handle.h"
 #include "components/LightManager.h"
 #include "components/RenderableManager.h"
-
-#include <private/filament/UibStructs.h>
+#include "components/TransformManager.h"
 
 #include "details/Engine.h"
-#include "details/IndirectLight.h"
 #include "details/InstanceBuffer.h"
 #include "details/Skybox.h"
 
-#include "BufferPoolAllocator.h"
-
+#include <private/filament/UibStructs.h>
 #include <private/utils/Tracing.h>
 
+#include <filament/Box.h>
+#include <filament/TransformManager.h>
+#include <filament/RenderableManager.h>
+#include <filament/LightManager.h>
+
+#include <math/mat3.h>
+#include <math/mat4.h>
+#include <math/vec2.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
+
+#include <utils/Allocator.h>
 #include <utils/compiler.h>
+#include <utils/debug.h>
 #include <utils/EntityManager.h>
+#include <utils/FixedCapacityVector.h>
+#include <utils/Invocable.h>
+#include <utils/JobSystem.h>
 #include <utils/Range.h>
 
-#include <math/quat.h>
-
 #include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <new>
+
+#include <cstddef>
 
 using namespace filament::backend;
 using namespace filament::math;
@@ -65,7 +88,7 @@ void FScene::prepare(JobSystem& js,
     FILAMENT_TRACING_CONTEXT(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     // This will reset the allocator upon exiting
-    ArenaScope<RootArenaScope::Arena> localArenaScope(rootArenaScope.getArena());
+    ArenaScope localArenaScope(rootArenaScope.getArena());
 
     FEngine& engine = mEngine;
     EntityManager const& em = engine.getEntityManager();
@@ -139,7 +162,7 @@ void FScene::prepare(JobSystem& js,
 
     // The light data list will always contain at least one entry for the
     // dominating directional light, even if there are no entities.
-    // we need the capacity to be multiple of 16 for SIMD loops
+    // We need the capacity to be multiple of 16 for SIMD loops
     size_t lightDataCapacity = std::max<size_t>(DIRECTIONAL_LIGHTS_COUNT, entities.size());
     lightDataCapacity = (lightDataCapacity + 0xFu) & ~0xFu;
 
@@ -314,7 +337,7 @@ void FScene::prepare(JobSystem& js,
 
     // Purely for the benefit of MSAN, we can avoid uninitialized reads by zeroing out the
     // unused scene elements between the end of the array and the rounded-up count.
-    if (UTILS_HAS_SANITIZE_MEMORY) {
+    if constexpr (UTILS_HAS_SANITIZE_MEMORY) {
         for (size_t i = sceneData.size(), e = sceneData.capacity(); i < e; i++) {
             sceneData.data<LAYERS>()[i] = 0;
             sceneData.data<VISIBLE_MASK>()[i] = 0;
@@ -396,7 +419,7 @@ void FScene::updateUBOs(
         if (count >= MAX_STREAM_ALLOCATION_COUNT) {
             // use the heap allocator
             auto& bufferPoolAllocator = mSharedState->mBufferPoolAllocator;
-            return (PerRenderableData*)bufferPoolAllocator.get(count * sizeof(PerRenderableData));
+            return static_cast<PerRenderableData*>(bufferPoolAllocator.get(count * sizeof(PerRenderableData)));
         } else {
             // allocate space into the command stream directly
             return driver.allocatePod<PerRenderableData>(count);
@@ -423,7 +446,7 @@ void FScene::updateUBOs(
 
     // We capture state shared between Scene and the update buffer callback, because the Scene could
     // be destroyed before the callback executes.
-    std::weak_ptr<SharedState>* const weakShared = new std::weak_ptr<SharedState>(mSharedState);
+    std::weak_ptr<SharedState>* const weakShared = new(std::nothrow) std::weak_ptr(mSharedState);
 
     // update the UBO
     driver.resetBufferObject(renderableUbh);

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -786,7 +786,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
             // FIXME: when only one is active the UBO handle of the other is null
             //        (probably a problem on vulkan)
-            if (UTILS_UNLIKELY(skinning.handle || morphing.handle || instance.handle)) {
+            if (UTILS_UNLIKELY(skinning.handle || morphing.handle || instance.buffer)) {
                 auto const ci = sceneData.elementAt<FScene::RENDERABLE_INSTANCE>(i);
                 FRenderableManager& rcm = engine.getRenderableManager();
                 auto& descriptorSet = rcm.getDescriptorSet(ci);
@@ -800,7 +800,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
                 descriptorSet.setBuffer(layout,
                         +PerRenderableBindingPoints::OBJECT_UNIFORMS,
-                        instance.handle ? instance.handle : mRenderableUbh,
+                        instance.buffer ? instance.buffer->getHandle() : mRenderableUbh,
                         0, sizeof(PerRenderableUib));
 
                 descriptorSet.setBuffer(layout,


### PR DESCRIPTION
For some reason the UBO was managed by RenderableManager, but it's a
lot cleaner and easier to have this done by InstanceBuffer itself.