### PR TITLE
fixbug:"debug error, reason: The material 'Material_MR' has not been …

### DIFF
--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -58,7 +58,7 @@ private:
     std::vector<Material*> mMaterials;
     Engine* const mEngine;
     const bool mOptimizeShaders;
-    filament::UserVariantFilterMask mVariantFilter;
+    filament::UserVariantFilterMask mVariantFilter{};
 };
 
 JitShaderProvider::JitShaderProvider(Engine* engine, bool optimizeShaders,


### PR DESCRIPTION
…compiled to include the required GLSL or SPIR-V chunks for the vertex shader (variant=5, filtered=5)",Because the member variable mVariantFilter is not initialized, random values will appear on Windows 10 or others platform, which eventually causes some variants to be filtered out by this mVariantFilter.