### PR TITLE
vk: fix leak in VulkanDescriptorSetCache

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
@@ -258,6 +258,8 @@ VulkanDescriptorSetCache::~VulkanDescriptorSetCache() = default;
 
 void VulkanDescriptorSetCache::terminate() noexcept{
     mDescriptorPool.reset();
+    mStashedSets = {};
+    mLastBoundInfo = {};
 }
 
 // bind() is not really binding the set but just stashing until we have all the info


### PR DESCRIPTION
PR #8946 fixed the caching logic in commit(), but in turn, created a leak on terminate(). We proplery clean-up on terminate().