### PR TITLE
remove the explicit command queue flushes

### DIFF
--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -254,11 +254,6 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
                 driver.beginRenderPass(out.target, out.params);
                 passExecutor.execute(engine, driver);
                 driver.endRenderPass();
-
-                // color pass is typically heavy, and we don't have much CPU work left after
-                // this point, so flushing now allows us to start the GPU earlier and reduce
-                // latency, without creating bubbles.
-                driver.flush();
             }
     );
 

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -63,6 +63,8 @@
 #include <utils/compiler.h>
 #include <utils/debug.h>
 
+#include <algorithm>
+#include <cmath>
 #include <chrono>
 #include <limits>
 #include <memory>
@@ -173,7 +175,7 @@ void FRenderer::terminate(FEngine& engine) {
     // Before we can destroy this Renderer's resources, we must make sure
     // that all pending commands have been executed (as they could reference data in this
     // instance, e.g. Fences, Callbacks, etc...)
-    if (UTILS_HAS_THREADING) {
+    if constexpr (UTILS_HAS_THREADING) {
         Fence::waitAndDestroy(engine.createFence());
     } else {
         // In single threaded mode, allow recently-created objects (e.g. no-op fences in Skipper)
@@ -326,7 +328,6 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     const time_point appVsync(vsyncSteadyClockTimeNano ? userVsync : now);
 
     mFrameId++;
-    mViewRenderedCount = 0;
 
     FILAMENT_TRACING_FRAME_ID(FILAMENT_TRACING_CATEGORY_FILAMENT, mFrameId);
 
@@ -508,9 +509,9 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
     // destination.
     driver.makeCurrent(dstSwapChain->getHwHandle(), mSwapChain->getHwHandle());
 
-    RenderPassParams params = {};
     // Clear color to black if the CLEAR flag is set.
     if (flags & CLEAR) {
+        RenderPassParams params = {};
         params.clearColor = {0.f, 0.f, 0.f, 1.f};
         params.flags.clear = TargetBufferFlags::COLOR;
         params.flags.discardStart = TargetBufferFlags::ALL;
@@ -583,7 +584,7 @@ void FRenderer::render(FView const* view) {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     if (UTILS_UNLIKELY(mBeginFrameInternal)) {
-        // this should not happen, the user should not call render() if we returned false from
+        // This is unlikely to happen, the user should not call render() if we returned false from
         // beginFrame(). But because this is allowed, we handle it gracefully.
         mBeginFrameInternal();
         mBeginFrameInternal = {};
@@ -593,13 +594,7 @@ void FRenderer::render(FView const* view) {
     assert_invariant(mSwapChain);
 
     if (UTILS_LIKELY(view && view->getScene() && view->hasCamera())) {
-        if (mViewRenderedCount) {
-            // This is a good place to kick the GPU, since we've rendered a View before,
-            // and we're about to render another one.
-            mEngine.getDriverApi().flush();
-        }
         renderInternal(view);
-        mViewRenderedCount++;
     }
 }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -189,7 +189,7 @@ private:
     void renderInternal(FView const* view);
     void renderJob(RootArenaScope& rootArenaScope, FView& view);
 
-    std::pair<float, math::float2> prepareUpscaler(math::float2 scale,
+    static std::pair<float, math::float2> prepareUpscaler(math::float2 scale,
             TemporalAntiAliasingOptions const& taaOptions,
             DynamicResolutionOptions const& dsrOptions);
 
@@ -200,7 +200,6 @@ private:
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;
-    uint32_t mViewRenderedCount = 0;
     FrameInfoManager mFrameInfoManager;
     backend::TextureFormat mHdrTranslucent;
     backend::TextureFormat mHdrQualityMedium;


### PR DESCRIPTION
Filament used to issue command queue flushes (E.g. glFlush()) after large passes like the color pass in order to kick the gpu into action sooner and reduce latency.  This however comes at a high cost on the gpu timeline as command queue flushes are expensive on vulkan and  metal. Moreover GL drivers are allowed to ignore glFlush().

So we just remove all these calls.