### PR TITLE
ppm: add fixed material instance references

### DIFF
--- a/filament/src/MaterialInstanceManager.cpp
+++ b/filament/src/MaterialInstanceManager.cpp
@@ -21,26 +21,27 @@
 #include "details/Material.h"
 #include "details/MaterialInstance.h"
 
+#include <utils/debug.h>
+
 namespace filament {
 
 using Record = MaterialInstanceManager::Record;
 
-FMaterialInstance* Record::getInstance() {
-    if (mAvailable.any()) {
-        int picked = -1;
-        mAvailable.forEachSetBit([&picked](size_t index) {
-            if (picked >= 0) {
-                return;
-            }
-            picked = index;
-        });
-        mAvailable.unset(picked);
-        return mInstances[picked];
+std::pair<FMaterialInstance*, int32_t> Record::getInstance() {
+    if (mAvailable < mInstances.size()) {
+        auto index = mAvailable++;
+        return { mInstances[index], index };
     }
+    assert_invariant(mAvailable == mInstances.size());
     auto& name = mMaterial->getName();
     FMaterialInstance* inst = mMaterial->createInstance(name.c_str_safe());
     mInstances.push_back(inst);
-    return inst;
+    return { inst, mAvailable++ };
+}
+
+FMaterialInstance* Record::getInstance(int32_t fixedInstanceindex) {
+    assert_invariant(fixedInstanceindex >= 0 &&  fixedInstanceindex < (int32_t) mInstances.size());
+    return mInstances[fixedInstanceindex];
 }
 
 // Defined in cpp to avoid inlining
@@ -72,18 +73,31 @@ void MaterialInstanceManager::terminate(FEngine& engine) {
     });
 }
 
-FMaterialInstance* MaterialInstanceManager::getMaterialInstance(
-        FMaterial const* ma) {
+Record& MaterialInstanceManager::getRecord(FMaterial const* ma) {
     auto itr = std::find_if(mMaterials.begin(), mMaterials.end(), [ma](auto& record) {
         return ma == record.mMaterial;
     });
-
-    if (itr != mMaterials.end()) {
-        return itr->getInstance();
+    if (itr == mMaterials.end()) {
+        mMaterials.emplace_back(ma);
+        itr = std::prev(mMaterials.end());
     }
-
-    mMaterials.emplace_back(ma);
-    return mMaterials.back().getInstance();
+    return *itr;
 }
+
+FMaterialInstance* MaterialInstanceManager::getMaterialInstance(FMaterial const* ma) {
+    auto [inst, index] = getRecord(ma).getInstance();
+    return inst;
+}
+
+FMaterialInstance* MaterialInstanceManager::getMaterialInstance(FMaterial const* ma,
+        int32_t const fixedIndex) {
+    return getRecord(ma).getInstance(fixedIndex);
+}
+
+std::pair<FMaterialInstance*, int32_t> MaterialInstanceManager::getFixedMaterialInstance(
+        FMaterial const* ma) {
+    return getRecord(ma).getInstance();
+}
+
 
 } // namespace filament

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -445,6 +445,12 @@ private:
 
     MaterialInstanceManager mMaterialInstanceManager;
 
+    struct {
+        int32_t colorGradingTranslucent = MaterialInstanceManager::INVALID_FIXED_INDEX;
+        int32_t colorGradingOpaque = MaterialInstanceManager::INVALID_FIXED_INDEX;
+        int32_t customResolve = MaterialInstanceManager::INVALID_FIXED_INDEX;
+    } mFixedMaterialInstanceIndex;
+
     backend::Handle<backend::HwTexture> mStarburstTexture;
 
     std::uniform_real_distribution<float> mUniformDistribution{0.0f, 1.0f};


### PR DESCRIPTION
In the introduction of MaterialInstanceManager, the assumption is that everytime PostprocessManager wants an instance, we can just provide a "new" one since all of the instance's content - UBOS, textures - will not be shared between passes.  But this is not the right assumption. For `colorGradingPrepareSubpass` and `customResolvePrepareSubpass`, they are filling in an instance for later passes to use.

To address this, we add a way to identify a fixed instance in MaterialInstanceManager. This will allow us to refer to specific instances of a material across passes (for the duration of a frame).

This address the following crashes:
 - Enabling custom resolve for MSAA for the metal backend
 - Resizing the gltf_viewer window

Also move the dof instance into the loop to prevent UBO reuse.

Remove instance dependencies in Gaussian Blur Pass (separable).