### PR TITLE
wgpu: support blit

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -258,6 +258,10 @@ if (FILAMENT_SUPPORTS_WEBGPU)
             include/backend/platforms/WebGPUPlatform.h
             src/webgpu/platform/WebGPUPlatform.cpp
             src/webgpu/SpdMipmapGenerator/SpdMipmapGenerator.cpp
+            src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
+            src/webgpu/utils/StringPlaceholderTemplateProcessor.h
+            src/webgpu/WebGPUBlitter.cpp
+            src/webgpu/WebGPUBlitter.h
             src/webgpu/WebGPUBufferBase.cpp
             src/webgpu/WebGPUBufferBase.h
             src/webgpu/WebGPUBufferObject.cpp
@@ -291,6 +295,7 @@ if (FILAMENT_SUPPORTS_WEBGPU)
             src/webgpu/WebGPUSwapChain.h
             src/webgpu/WebGPUTexture.cpp
             src/webgpu/WebGPUTexture.h
+            src/webgpu/WebGPUTextureHelpers.h
             src/webgpu/WebGPUVertexBuffer.cpp
             src/webgpu/WebGPUVertexBuffer.h
             src/webgpu/WebGPUVertexBufferInfo.cpp

--- a/filament/backend/src/webgpu/WebGPUBlitter.cpp
+++ b/filament/backend/src/webgpu/WebGPUBlitter.cpp
@@ -1,0 +1,671 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "WebGPUBlitter.h"
+
+#include "WebGPUConstants.h"
+#include "WebGPUStrings.h"
+#include "webgpu/utils/StringPlaceholderTemplateProcessor.h"
+
+#include <backend/DriverEnums.h>
+
+#include <webgpu/webgpu_cpp.h>
+
+#include <math/vec2.h>
+#include <utils/Hash.h>
+#include <utils/Panic.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace filament::backend {
+
+namespace {
+
+struct BlitFragmentShaderArgs final {
+    uint32_t depthPlane{ 0 };
+    uint32_t padding{ 0 }; // Add 4 bytes of padding to align the vec2 members
+    math::float2 scale{ 0.0f, 0.0f };
+    math::uint2 sourceOffset{ 0, 0 };
+    math::uint2 destinationOffset{ 0, 0 };
+};
+static_assert(sizeof(BlitFragmentShaderArgs) == 32,
+        "BlitFragmentShaderArgs must not have implicit padding.");
+
+// Note: would be nice to generate the constexpr string for the shader source from the constexpr
+// variables below, e.g. TEXTURE_BINDING_INDEX, to avoid them getting out of sync while still having
+// the compile/build time optimization
+constexpr uint32_t TEXTURE_BIND_GROUP_INDEX{ 0 };
+constexpr size_t MAX_TEXTURE_BIND_GROUP_ENTRY_SIZE{ 3 }; // texture and uniform and sampler
+constexpr uint32_t TEXTURE_BINDING_INDEX{ 0 };
+constexpr uint32_t UNIFORM_BINDING_INDEX{ 1 };
+constexpr uint32_t SAMPLER_BINDING_INDEX{ 2 };
+constexpr std::string_view VERTEX_SHADER_ENTRY_POINT{ "vertexShaderMain" };
+constexpr std::string_view FRAGMENT_SHADER_ENTRY_POINT{ "fragmentShaderMain" };
+// note that the placeholders below must start and end with this prefix and suffix and should not
+// otherwise be present in the template:
+constexpr std::string_view PLACEHOLDER_PREFIX{ "{{" };
+constexpr std::string_view PLACEHOLDER_SUFFIX{ "}}" };
+// texture_2d<f32> or texture_multisampled_2d<f32> or texture_3d<f32>
+constexpr std::string_view TEXTURE_TYPE_PLACEHOLDER{ "TEXTURE_TYPE" };
+// "" for no sampler, otherwise "@group(0) @binding(2) var sourceSampler: sampler;"
+constexpr std::string_view SAMPLER_DECLARATION_PLACEHOLDER{ "SAMPLER_DECLARATION" };
+constexpr std::string_view FRAGMENT_SHADER_SNIPPET_PLACEHOLDER{ "FRAGMENT_SHADER_SNIPPET" };
+constexpr std::string_view SHADER_SOURCE_TEMPLATE{ R"(
+    struct BlitFragmentShaderArgs {
+        depthPlane:        u32,
+        scale:             vec2<f32>,
+        sourceOffset:      vec2<u32>,
+        destinationOffset: vec2<u32>,
+    };
+
+    @group(0) @binding(0) var sourceTexture: {{TEXTURE_TYPE}};
+    @group(0) @binding(1) var<uniform> fragmentShaderArgs: BlitFragmentShaderArgs;
+    {{SAMPLER_DECLARATION}}
+
+    fn getUnnormalizedSourceTextureCoordinates(position: vec2<f32>) -> vec2<f32> {
+        // These coordinates match the Vulkan vkCmdBlitImage spec:
+        // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBlitImage.html
+        let uvOffset: vec2<f32> = position - vec2<f32>(f32(fragmentShaderArgs.destinationOffset.x),f32(fragmentShaderArgs.destinationOffset.y));
+        let uvScaled: vec2<f32> = uvOffset * fragmentShaderArgs.scale;
+        return uvScaled + vec2<f32>(f32(fragmentShaderArgs.sourceOffset.x), f32(fragmentShaderArgs.sourceOffset.y));
+    }
+
+    fn normalize2dSourceTextureCoordinates(
+            unnormalizedSourceTextureCoordinates: vec2<f32>,
+            sourceDimensions: vec2<u32>) -> vec2<f32> {
+        return unnormalizedSourceTextureCoordinates /
+            vec2<f32>(f32(sourceDimensions.x), f32(sourceDimensions.y));
+    }
+
+    fn getNormalized2dSourceTextureCoordinates(
+            position: vec2<f32>,
+            sourceTexture: texture_2d<f32>) -> vec2<f32> {
+        let sourceDimensions: vec2<u32> = textureDimensions(sourceTexture);
+        return normalize2dSourceTextureCoordinates(
+            getUnnormalizedSourceTextureCoordinates(position),
+            sourceDimensions
+        );
+    }
+
+    fn normalize3dSourceTextureCoordinates(
+            unnormalizedSourceTextureCoordinates: vec2<f32>,
+            sourceDimensions: vec3<u32>) -> vec3<f32> {
+        let uvNormalized: vec2<f32> = normalize2dSourceTextureCoordinates(
+            unnormalizedSourceTextureCoordinates,
+            sourceDimensions.xy
+        );
+        return vec3<f32>(
+            uvNormalized,
+            (f32(fragmentShaderArgs.depthPlane) + 0.5) / f32(sourceDimensions.z)
+        );
+    }
+
+    fn getNormalized3dSourceTextureCoordinates(
+            position: vec2<f32>,
+            sourceTexture: texture_3d<f32>) -> vec3<f32> {
+        let sourceDimensions: vec3<u32> = textureDimensions(sourceTexture);
+        return normalize3dSourceTextureCoordinates(
+            getUnnormalizedSourceTextureCoordinates(position),
+            sourceDimensions
+        );
+    }
+
+    @vertex
+    fn vertexShaderMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4<f32> {
+        let fullScreenTriangleVertices = array<vec2<f32>, 3>(
+            vec2<f32>(-1.0, -1.0),
+            vec2<f32>( 3.0, -1.0),
+            vec2<f32>(-1.0,  3.0)
+        );
+        return vec4<f32>(fullScreenTriangleVertices[vertexIndex].xy, 0.0, 1.0);
+    }
+
+    {{FRAGMENT_SHADER_SNIPPET}}
+)" };
+
+constexpr std::string_view FRAGMENT_SHADER_SNIPPET_MSAA_INPUT{ R"(
+    @fragment
+    fn fragmentShaderMain(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+        var color: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        let numberOfSamples: u32 = textureNumSamples(sourceTexture);
+        let coordinatesF: vec2<f32> = getUnnormalizedSourceTextureCoordinates(position.xy);
+        let coordinates: vec2<u32> = vec2<u32>(u32(coordinatesF.x), u32(coordinatesF.y));
+        for (var sampleIndex: u32 = 0; sampleIndex < numberOfSamples; sampleIndex++) {
+            color += textureLoad(sourceTexture, coordinates, sampleIndex);
+        }
+        color /= f32(numberOfSamples);
+        return color;
+    }
+)" };
+
+constexpr std::string_view FRAGMENT_SHADER_SNIPPET_3D_INPUT{ R"(
+    @fragment
+    fn fragmentShaderMain(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+        let coordinates: vec3<f32> = getNormalized3dSourceTextureCoordinates(position.xy, sourceTexture);
+        return textureSample(sourceTexture, sourceSampler, coordinates);
+    }
+)" };
+
+constexpr std::string_view FRAGMENT_SHADER_SNIPPET_2D_INPUT{ R"(
+    @fragment
+    fn fragmentShaderMain(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+        let coordinates: vec2<f32> = getNormalized2dSourceTextureCoordinates(position.xy, sourceTexture);
+        return textureSample(sourceTexture, sourceSampler, coordinates);
+    }
+)" };
+
+} // namespace
+
+WebGPUBlitter::WebGPUBlitter(wgpu::Device const& device)
+    : mDevice{ device } {}
+
+void WebGPUBlitter::blit(wgpu::Queue const& queue, wgpu::CommandEncoder const& commandEncoder,
+        BlitArgs const& args) {
+    // current assumptions/simplifications made in this implementation:
+    // 1. We can safely convert to and from f32 floats in the WGSL shader for all input/output
+    //    formats (where WebGPU is doing the conversions). Note that the Metal blitter
+    //    implementation does essentially the same. This may not be ideal for certain
+    //    signed or unsigned integer formats and may represent a possible optimization opportunity
+    //    in the future (or we may run into issues/bugs without and be forced to add the complexity
+    //    working with different formats as needed).
+    //    One idea for accomplishing this would be to define the shader as a template, do search
+    //    and replace of placeholders at the right places to get a shader with the desired formats,
+    //    and cache compiled shaders, where the key includes input/output formats. But, we would
+    //    like to defer that complexity until warranted (which is maybe never).
+    // 2. We do not need to support multisampled output textures (only multisampled input,
+    //    essentially doing a resolve in those instances). Again,
+    //    the Metal blitter implementation does not support this either.
+    //    One idea for accomplishing this, if needed (which is maybe never), would be to define
+    //    a version of each fragment shader with or without the need to generate multisampled color.
+    //    Alternatively, as in the varied input/output format problem (see 1), we could also
+    //    implement a shader template with placeholders, etc.
+    // 3. We do not need to support multisampled 3D textures. This is a safe assumption, as at this
+    //    time no major known graphics API supports this, including WebGPU. Furthermore, the Metal
+    //    blitter does not support this either.
+
+    // TODO REMOVE (keeping for troubleshooting/debug purposes for now)
+#if FWGPU_ENABLED(FWGPU_DEBUG_VALIDATION)
+    FWGPU_LOGD << "ABOUT to blit:";
+    FWGPU_LOGD << "  Source:";
+    FWGPU_LOGD << "    texture:" << webGPUPrintableToString(args.source.texture.GetFormat());
+    FWGPU_LOGD << "      depthOrArrayLayers: " << args.source.texture.GetDepthOrArrayLayers();
+    FWGPU_LOGD << "      " << webGPUPrintableToString(args.source.texture.GetDimension());
+    FWGPU_LOGD << "      format: " << webGPUTextureFormatToString(args.source.texture.GetFormat());
+    FWGPU_LOGD << "      height: " << args.source.texture.GetHeight();
+    FWGPU_LOGD << "      mipLevelCount: " << args.source.texture.GetMipLevelCount();
+    FWGPU_LOGD << "      sampleCount: " << args.source.texture.GetSampleCount();
+    FWGPU_LOGD << "      " << webGPUPrintableToString(args.source.texture.GetUsage());
+    FWGPU_LOGD << "      width: " << args.source.texture.GetWidth();
+    FWGPU_LOGD << "    origin: x: " << args.source.origin.x << " y: " << args.source.origin.y;
+    FWGPU_LOGD << "    extent: width: " << args.source.extent.width
+               << " height: " << args.source.extent.height;
+    FWGPU_LOGD << "    mipLevel: " << args.source.mipLevel;
+    FWGPU_LOGD << "    layerOrDepth: " << args.source.layerOrDepth;
+    FWGPU_LOGD << "  Destination:";
+    FWGPU_LOGD << "    texture:" << webGPUPrintableToString(args.destination.texture.GetFormat());
+    FWGPU_LOGD << "      depthOrArrayLayers: " << args.destination.texture.GetDepthOrArrayLayers();
+    FWGPU_LOGD << "      " << webGPUPrintableToString(args.destination.texture.GetDimension());
+    FWGPU_LOGD << "      format: "
+               << webGPUTextureFormatToString(args.destination.texture.GetFormat());
+    FWGPU_LOGD << "      height: " << args.destination.texture.GetHeight();
+    FWGPU_LOGD << "      mipLevelCount: " << args.destination.texture.GetMipLevelCount();
+    FWGPU_LOGD << "      sampleCount: " << args.destination.texture.GetSampleCount();
+    FWGPU_LOGD << "      " << webGPUPrintableToString(args.destination.texture.GetUsage());
+    FWGPU_LOGD << "      width: " << args.destination.texture.GetWidth();
+    FWGPU_LOGD << "    origin: x: " << args.destination.origin.x
+               << " y: " << args.destination.origin.y;
+    FWGPU_LOGD << "    extent: width: " << args.destination.extent.width
+               << " height: " << args.destination.extent.height;
+    FWGPU_LOGD << "    mipLevel: " << args.destination.mipLevel;
+    FWGPU_LOGD << "    layerOrDepth: " << args.destination.layerOrDepth;
+    FWGPU_LOGD << "  filter: " << (args.filter == SamplerMagFilter::NEAREST ? "NEAREST" : "LINEAR");
+#endif
+    FILAMENT_CHECK_PRECONDITION(args.source.texture.GetDimension() != wgpu::TextureDimension::e3D ||
+                                args.source.texture.GetSampleCount() == 1)
+            << "Multispampled 3D textures are not supported (the source 3D texture was configured "
+               "for multisampling) (this should not be possible?)";
+
+    FILAMENT_CHECK_PRECONDITION(args.destination.texture.GetSampleCount() == 1)
+            << "Blitting does not currently support writing to multisampled output textures.";
+
+    FILAMENT_CHECK_PRECONDITION(args.source.texture.GetUsage() & wgpu::TextureUsage::TextureBinding)
+            << "source texture usage doesn't have wgpu::TextureUsage::TextureBinding";
+
+    FILAMENT_CHECK_PRECONDITION(
+            args.destination.texture.GetUsage() & wgpu::TextureUsage::RenderAttachment)
+            << "destination texture usage doesn't have wgpu::TextureUsage::RenderAttachment";
+
+    // create input/output texture views...
+    const wgpu::TextureViewDimension sourceDimension{ args.source.texture.GetDimension() ==
+                                                                      wgpu::TextureDimension::e3D
+                                                              ? wgpu::TextureViewDimension::e3D
+                                                              : wgpu::TextureViewDimension::e2D };
+    const wgpu::TextureViewDescriptor sourceViewDescriptor{
+        .label = "blit_source",
+        .format = args.source.texture.GetFormat(),
+        .dimension = sourceDimension,
+        .baseMipLevel = args.source.mipLevel,
+        .mipLevelCount = 1,
+        .baseArrayLayer = args.source.texture.GetDimension() == wgpu::TextureDimension::e3D
+                                  ? 1
+                                  : args.source.layerOrDepth,
+        .arrayLayerCount = 1,
+        .aspect = wgpu::TextureAspect::All,
+        .usage = wgpu::TextureUsage::TextureBinding,
+    };
+    const wgpu::TextureView sourceView{ args.source.texture.CreateView(&sourceViewDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(sourceView)
+            << "Failed to create source texture view for baseArrayLayer "
+            << sourceViewDescriptor.baseArrayLayer << " and mip level "
+            << sourceViewDescriptor.baseMipLevel << " for render pass blit?";
+    const wgpu::TextureViewDescriptor destinationViewDescriptor{
+        .label = "blit_destination",
+        .format = args.destination.texture.GetFormat(),
+        .dimension = args.destination.texture.GetDimension() == wgpu::TextureDimension::e3D
+                             ? wgpu::TextureViewDimension::e3D
+                             : wgpu::TextureViewDimension::e2D,
+        .baseMipLevel = args.destination.mipLevel,
+        .mipLevelCount = 1,
+        .baseArrayLayer = args.destination.texture.GetDimension() == wgpu::TextureDimension::e3D
+                                  ? 1
+                                  : args.destination.layerOrDepth,
+        .arrayLayerCount = 1,
+        .aspect = wgpu::TextureAspect::All,
+        .usage = wgpu::TextureUsage::RenderAttachment,
+    };
+    const wgpu::TextureView destinationView{ args.destination.texture.CreateView(
+            &destinationViewDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(destinationView)
+            << "Failed to create destination texture view for baseArrayLayer "
+            << destinationViewDescriptor.baseArrayLayer << " and mip level "
+            << destinationViewDescriptor.baseMipLevel << " for render pass blit?";
+
+    // create uniform buffer (for shader args)...
+    const BlitFragmentShaderArgs blitFragmentShaderArgs{
+        .depthPlane = args.source.layerOrDepth,
+        .scale = { static_cast<float>(args.source.extent.width) / args.destination.extent.width,
+            static_cast<float>(args.source.extent.height) / args.destination.extent.height },
+        .sourceOffset = { args.source.origin.x, args.source.origin.y },
+        .destinationOffset = { args.destination.origin.x, args.destination.origin.y },
+    };
+    wgpu::BufferDescriptor uniformBufferDescriptor{
+        .label = "blit_args_uniform_buffer",
+        .usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst,
+        .size = sizeof(BlitFragmentShaderArgs),
+        // explicitly set for consistency, alt
+        .mappedAtCreation = false,
+    };
+    const wgpu::Buffer uniformBuffer{ mDevice.CreateBuffer(&uniformBufferDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(uniformBuffer)
+            << "Failed to create uniform buffer for texture swizzle?";
+    queue.WriteBuffer(uniformBuffer, /* buffer offset */ 0, &blitFragmentShaderArgs,
+            sizeof(BlitFragmentShaderArgs));
+    size_t textureBindGroupEntriesCount{ 2 }; // just the texture and uniform by default
+    // get/create/bind sample if needed...
+    wgpu::Sampler sampler{ nullptr };
+    if (args.source.texture.GetSampleCount() <= 1) {
+        textureBindGroupEntriesCount++; // add the sampler to the count
+        switch (args.filter) {
+            case SamplerMagFilter::NEAREST:
+                if (!mNearestSampler) {
+                    createSampler(args.filter);
+                }
+                sampler = mNearestSampler;
+                break;
+            case SamplerMagFilter::LINEAR:
+                if (!mLinearSampler) {
+                    createSampler(args.filter);
+                }
+                sampler = mLinearSampler;
+                break;
+        }
+    }
+    // create bind group...
+    const wgpu::BindGroupEntry textureBindGroupEntries[MAX_TEXTURE_BIND_GROUP_ENTRY_SIZE]{
+        {
+            .binding = TEXTURE_BINDING_INDEX,
+            .textureView = sourceView,
+        },
+        {
+            .binding = UNIFORM_BINDING_INDEX,
+            .buffer = uniformBuffer,
+            .offset = 0,              // explicitly defining for consistency
+            .size = wgpu::kWholeSize, // explicitly defining for consistency
+        },
+        {
+            .binding = SAMPLER_BINDING_INDEX,
+            .sampler = sampler, // note: might be nullptr if we don't need it
+        }
+    };
+    const wgpu::BindGroupDescriptor textureBindGroupDescriptor{
+        .label = "blit_texture_bind_group",
+        .layout = getOrCreateTextureBindGroupLayout(args.filter, sourceDimension,
+                args.source.texture.GetSampleCount() > 1),
+        .entryCount = textureBindGroupEntriesCount,
+        .entries = textureBindGroupEntries,
+    };
+    const wgpu::BindGroup textureBindGroup{ mDevice.CreateBindGroup(&textureBindGroupDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(textureBindGroup)
+            << "Failed to create texture bind group for render pass blit?";
+    // create color attachment (output)...
+    const wgpu::RenderPassColorAttachment colorAttachment{
+        .view = destinationView,
+        .depthSlice = args.destination.texture.GetDimension() == wgpu::TextureDimension::e3D
+                              ? args.destination.layerOrDepth
+                              : wgpu::kDepthSliceUndefined,
+        // we don't need this resolveTarget because we are doing a resolve in software (the shader),
+        // but we probably should (leveraging a msaa sidecar texture) to take advantage of
+        // hardware acceleration. Thus, this might be an opportunity for optimization
+        .resolveTarget = nullptr,
+        .loadOp = wgpu::LoadOp::Clear,
+        .storeOp = wgpu::StoreOp::Store,
+        .clearValue = { .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 },
+    };
+    const wgpu::RenderPassDescriptor renderPassDescriptor{
+        .label = "blit_render_pass",
+        .colorAttachmentCount = 1,
+        .colorAttachments = &colorAttachment,
+        .depthStencilAttachment = nullptr, // not applicable
+        .occlusionQuerySet = nullptr,      // not applicable
+        .timestampWrites = nullptr,        // not applicable
+    };
+    const wgpu::RenderPassEncoder renderPassEncoder{ commandEncoder.BeginRenderPass(
+            &renderPassDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(renderPassEncoder)
+            << "Failed to create render pass encoder for blit?";
+    renderPassEncoder.SetPipeline(getOrCreateRenderPipeline(args.filter, sourceDimension,
+            args.source.texture.GetSampleCount(), args.destination.texture.GetFormat()));
+    renderPassEncoder.SetBindGroup(TEXTURE_BIND_GROUP_INDEX, textureBindGroup);
+    renderPassEncoder.Draw(3); // draw the full-screen triangle
+                               // with hard-coded vertices in the shader
+    renderPassEncoder.End();
+}
+
+void WebGPUBlitter::createSampler(const SamplerMagFilter filter) {
+    wgpu::StringView label;
+    wgpu::FilterMode magFilter;
+    wgpu::FilterMode minFilter;
+    wgpu::MipmapFilterMode mipmapFilter;
+    switch (filter) {
+        case SamplerMagFilter::NEAREST:
+            label = "blit_sampler_nearest";
+            magFilter = wgpu::FilterMode::Nearest;
+            minFilter = wgpu::FilterMode::Nearest;
+            mipmapFilter = wgpu::MipmapFilterMode::Nearest;
+            break;
+        case SamplerMagFilter::LINEAR:
+            label = "blit_sampler_linear";
+            magFilter = wgpu::FilterMode::Linear;
+            minFilter = wgpu::FilterMode::Linear;
+            mipmapFilter = wgpu::MipmapFilterMode::Linear;
+            break;
+    }
+    const wgpu::SamplerDescriptor descriptor{
+        .label = label,
+        .addressModeU = wgpu::AddressMode::ClampToEdge,
+        .addressModeV = wgpu::AddressMode::ClampToEdge,
+        .addressModeW = wgpu::AddressMode::ClampToEdge,
+        .magFilter = magFilter,
+        // minFilter and mipmapFilter shouldn't really matter, as the source texture should
+        // have 1 mip level, but for consistency (also, Metal blitter implementation does this)...
+        .minFilter = minFilter,
+        .mipmapFilter = mipmapFilter,
+        .lodMinClamp = 0.0f,  // should not matter, just being consistently defined
+        .lodMaxClamp = 32.0f, // should not matter, just being consistently defined
+        .compare = wgpu::CompareFunction::Undefined, // should not matter, just being consistently
+                                                     // defined
+        .maxAnisotropy = 1, // should not matter, just being consistently defined
+    };
+    const wgpu::Sampler sampler{ mDevice.CreateSampler(&descriptor) };
+    FILAMENT_CHECK_POSTCONDITION(sampler) << "Failed to create blit sampler?";
+    switch (filter) {
+        case SamplerMagFilter::NEAREST:
+            mNearestSampler = sampler;
+            break;
+        case SamplerMagFilter::LINEAR:
+            mLinearSampler = sampler;
+            break;
+    }
+}
+
+wgpu::RenderPipeline const& WebGPUBlitter::getOrCreateRenderPipeline(
+        const SamplerMagFilter filterType, const wgpu::TextureViewDimension sourceDimension,
+        const uint32_t sourceSampleCount, const wgpu::TextureFormat destinationTextureFormat) {
+    const size_t key{ hashRenderPipelineKey(filterType, sourceDimension, sourceSampleCount) };
+    if (mRenderPipelines.find(key) == mRenderPipelines.end()) {
+        mRenderPipelines[key] = createRenderPipeline(filterType, sourceDimension, sourceSampleCount,
+                destinationTextureFormat);
+    }
+    return mRenderPipelines[key];
+}
+
+wgpu::RenderPipeline WebGPUBlitter::createRenderPipeline(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const uint32_t sourceSampleCount,
+        const wgpu::TextureFormat destinationTextureFormat) {
+    const wgpu::ColorTargetState colorTargetState{ .format = destinationTextureFormat };
+    wgpu::ShaderModule const& shaderModule{ getOrCreateShaderModule(sourceDimension,
+            sourceSampleCount > 1) };
+    const wgpu::FragmentState fragmentState{
+        .module = shaderModule,
+        .entryPoint = FRAGMENT_SHADER_ENTRY_POINT,
+        .constantCount = 0,   // should not matter, just being consistently defined
+        .constants = nullptr, // should not matter, just being consistently defined
+        .targetCount = 1,
+        .targets = &colorTargetState,
+    };
+    const wgpu::RenderPipelineDescriptor pipelineDescriptor{
+        .label = "render_pass_blit_pipeline",
+        .layout = getOrCreatePipelineLayout(filterType, sourceDimension, sourceSampleCount > 1),
+        .vertex = {
+            .module = shaderModule,
+            .entryPoint = VERTEX_SHADER_ENTRY_POINT,
+            .constantCount = 0, // should not matter, just being consistently defined
+            .constants = nullptr, // should not matter, just being consistently defined
+            .bufferCount = 0, // using hardcoded vertices in the shader for
+                              // performance and simplicity
+            .buffers = nullptr,
+        },
+        .primitive = {
+            .topology = wgpu::PrimitiveTopology::TriangleList,
+            .stripIndexFormat = wgpu::IndexFormat::Undefined, // should not matter
+                                                              // (not using a strip topology),
+                                                              // just being consistently defined
+            .frontFace = wgpu::FrontFace::Undefined, // should not matter (no cull mode),
+                                                     // just being consistently defined
+            .cullMode = wgpu::CullMode::None,
+            .unclippedDepth = false, // should not matter, just being consistently defined
+        },
+        .depthStencil = nullptr, // not applicable, but explicitly set here for
+                                 // consistent definition
+        .multisample = {
+            .count = sourceSampleCount,
+            .mask = 0xFFFFFFFF,
+            .alphaToCoverageEnabled = false,
+        },
+        .fragment = &fragmentState,
+    };
+    const wgpu::RenderPipeline pipeline{ mDevice.CreateRenderPipeline(&pipelineDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(pipeline) << "Failed to create pipeline for render pass blit?";
+    return pipeline;
+}
+
+size_t WebGPUBlitter::hashRenderPipelineKey(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const uint32_t sourceSampleCount) {
+    size_t seed{ std::hash<uint8_t>{}(static_cast<uint8_t>(filterType)) };
+    utils::hash::combine(seed, static_cast<uint32_t>(sourceDimension));
+    utils::hash::combine(seed, sourceSampleCount);
+    return seed;
+}
+
+wgpu::PipelineLayout const& WebGPUBlitter::getOrCreatePipelineLayout(
+        const SamplerMagFilter filterType, const wgpu::TextureViewDimension sourceDimension,
+        const bool multisampledSource) {
+    const size_t key{ hashPipelineLayoutKey(filterType, sourceDimension, multisampledSource) };
+    if (mPipelineLayouts.find(key) == mPipelineLayouts.end()) {
+        mPipelineLayouts[key] =
+                createPipelineLayout(filterType, sourceDimension, multisampledSource);
+    }
+    return mPipelineLayouts[key];
+}
+
+wgpu::PipelineLayout WebGPUBlitter::createPipelineLayout(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+    const wgpu::PipelineLayoutDescriptor pipelineLayoutDescriptor{
+        .label = "render_pass_blit_pipeline_layout",
+        .bindGroupLayoutCount = 1,
+        .bindGroupLayouts =
+                &getOrCreateTextureBindGroupLayout(filterType, sourceDimension, multisampledSource),
+    };
+    const wgpu::PipelineLayout pipelineLayout{ mDevice.CreatePipelineLayout(
+            &pipelineLayoutDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(pipelineLayout)
+            << "Failed to create pipeline layout for render pass blit?";
+    return pipelineLayout;
+}
+
+size_t WebGPUBlitter::hashPipelineLayoutKey(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+    size_t seed{ std::hash<uint8_t>{}(static_cast<uint8_t>(filterType)) };
+    utils::hash::combine(seed, static_cast<uint32_t>(sourceDimension));
+    utils::hash::combine(seed, multisampledSource);
+    return seed;
+}
+
+wgpu::BindGroupLayout const& WebGPUBlitter::getOrCreateTextureBindGroupLayout(
+        const SamplerMagFilter filterType, const wgpu::TextureViewDimension sourceDimension,
+        const bool multisampledSource) {
+    const size_t key{ hashTextureBindGroupLayoutKey(filterType, sourceDimension,
+            multisampledSource) };
+    if (mTextureBindGroupLayouts.find(key) == mTextureBindGroupLayouts.end()) {
+        mTextureBindGroupLayouts[key] =
+                createTextureBindGroupLayout(filterType, sourceDimension, multisampledSource);
+    }
+    return mTextureBindGroupLayouts[key];
+}
+
+wgpu::BindGroupLayout WebGPUBlitter::createTextureBindGroupLayout(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+    const wgpu::BindGroupLayoutEntry bindGroupLayoutEntries[MAX_TEXTURE_BIND_GROUP_ENTRY_SIZE] {
+        {
+            .binding = TEXTURE_BINDING_INDEX,
+            .visibility = wgpu::ShaderStage::Fragment,
+            .texture = {
+                .sampleType = wgpu::TextureSampleType::Float, // only F32 scalar sample
+                                                              // type supported for now
+                                                              // see assumptions listed
+                                                              // in blit function
+                .viewDimension = sourceDimension,
+                .multisampled = multisampledSource,
+            },
+        },
+        {
+            .binding = UNIFORM_BINDING_INDEX,
+            .visibility = wgpu::ShaderStage::Fragment,
+            .buffer = {
+                .type = wgpu::BufferBindingType::Uniform,
+                .hasDynamicOffset = false, // set explicitly for consistency
+                .minBindingSize = sizeof(BlitFragmentShaderArgs),
+            },
+        },
+        {
+            .binding = SAMPLER_BINDING_INDEX,
+            .visibility = wgpu::ShaderStage::Fragment,
+            .sampler = {
+                .type =filterType == SamplerMagFilter::LINEAR
+                                ? wgpu::SamplerBindingType::Filtering
+                                : wgpu::SamplerBindingType::NonFiltering,
+            },
+        },
+    };
+    const wgpu::BindGroupLayoutDescriptor textureBindGroupLayoutDescriptor{
+        .label = "render_pass_blit_texture_bind_group_layout",
+        // TODO, doesnt make any sense but gets rid of the error. Are the entries 0 based?
+        .entryCount = multisampledSource ? (MAX_TEXTURE_BIND_GROUP_ENTRY_SIZE - 1)
+                                         : (MAX_TEXTURE_BIND_GROUP_ENTRY_SIZE),
+        .entries = bindGroupLayoutEntries,
+    };
+    const wgpu::BindGroupLayout textureBindGroupLayout{ mDevice.CreateBindGroupLayout(
+            &textureBindGroupLayoutDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(textureBindGroupLayout)
+            << "Failed to create texture bind group layout for render pass blit?";
+    return textureBindGroupLayout;
+}
+
+size_t WebGPUBlitter::hashTextureBindGroupLayoutKey(const SamplerMagFilter filterType,
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+
+    size_t seed{ std::hash<uint8_t>{}(static_cast<uint8_t>(filterType)) };
+    utils::hash::combine(seed, static_cast<uint32_t>(sourceDimension));
+    utils::hash::combine(seed, multisampledSource);
+    return seed;
+}
+
+wgpu::ShaderModule const& WebGPUBlitter::getOrCreateShaderModule(
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+    const size_t key{ hashShaderModuleKey(sourceDimension, multisampledSource) };
+    if (mShaderModules.find(key) == mShaderModules.end()) {
+        mShaderModules[key] = createShaderModule(sourceDimension, multisampledSource);
+    }
+    return mShaderModules[key];
+}
+
+wgpu::ShaderModule WebGPUBlitter::createShaderModule(
+        const wgpu::TextureViewDimension sourceDimension, const bool multisampledSource) {
+    const std::string_view textureType{
+        multisampledSource
+                ? "texture_multisampled_2d<f32>"
+                : (sourceDimension == wgpu::TextureViewDimension::e3D ? "texture_3d<f32>"
+                                                                      : "texture_2d<f32>")
+    };
+    const std::string_view samplerDeclaration{
+        multisampledSource ? "" : "@group(0) @binding(2) var sourceSampler: sampler;"
+    };
+    const std::string_view fragmentShaderSnippet{
+        multisampledSource ? FRAGMENT_SHADER_SNIPPET_MSAA_INPUT
+                           : (sourceDimension == wgpu::TextureViewDimension::e3D
+                                             ? FRAGMENT_SHADER_SNIPPET_3D_INPUT
+                                             : FRAGMENT_SHADER_SNIPPET_2D_INPUT)
+    };
+    std::unordered_map<std::string_view, std::string_view> valueByPlaceholderName{
+        { TEXTURE_TYPE_PLACEHOLDER, textureType },
+        { SAMPLER_DECLARATION_PLACEHOLDER, samplerDeclaration },
+        { FRAGMENT_SHADER_SNIPPET_PLACEHOLDER, fragmentShaderSnippet }
+    };
+    const std::string shaderSource{ webgpuutils::processPlaceholderTemplate(SHADER_SOURCE_TEMPLATE,
+            PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX, valueByPlaceholderName) };
+    wgpu::ShaderModuleWGSLDescriptor wgslDescriptor{};
+    wgslDescriptor.code = shaderSource.data();
+    const wgpu::ShaderModuleDescriptor shaderModuleDescriptor{
+        .nextInChain = &wgslDescriptor,
+        .label = "render_pass_blit_shaders",
+    };
+    const wgpu::ShaderModule shaderModule{ mDevice.CreateShaderModule(&shaderModuleDescriptor) };
+    FILAMENT_CHECK_POSTCONDITION(shaderModule)
+            << "Failed to create shader module for render pass blit?";
+    return shaderModule;
+}
+
+size_t WebGPUBlitter::hashShaderModuleKey(const wgpu::TextureViewDimension sourceDimension,
+        const bool multisampledSource) {
+    size_t seed{ std::hash<uint32_t>{}(static_cast<uint32_t>(sourceDimension)) };
+    utils::hash::combine(seed, multisampledSource);
+    return seed;
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUBlitter.h
+++ b/filament/backend/src/webgpu/WebGPUBlitter.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_WEBGPUBLITTER_H
+#define TNT_FILAMENT_BACKEND_WEBGPUBLITTER_H
+
+#include <backend/DriverEnums.h>
+
+#include <tsl/robin_map.h>
+#include <webgpu/webgpu_cpp.h>
+
+#include <cstdint>
+
+namespace filament::backend {
+
+class WebGPUBlitter final {
+public:
+    struct BlitArgs final {
+        struct Attachment final {
+            wgpu::Texture const& texture;
+            wgpu::Origin2D origin{};
+            wgpu::Extent2D extent{};
+            uint32_t mipLevel{ 0 };
+            uint32_t layerOrDepth{ 0 };
+        };
+
+        Attachment source;
+        Attachment destination;
+        SamplerMagFilter filter;
+    };
+
+    explicit WebGPUBlitter(wgpu::Device const& device);
+
+    void blit(wgpu::Queue const&, wgpu::CommandEncoder const&, BlitArgs const&);
+
+private:
+    void createSampler(SamplerMagFilter);
+
+    [[nodiscard]] wgpu::RenderPipeline const& getOrCreateRenderPipeline(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount,
+            wgpu::TextureFormat destinationTextureFormat);
+
+    [[nodiscard]] wgpu::RenderPipeline createRenderPipeline(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount,
+            wgpu::TextureFormat destinationTextureFormat);
+
+    [[nodiscard]] static size_t hashRenderPipelineKey(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount);
+
+    [[nodiscard]] wgpu::PipelineLayout const& getOrCreatePipelineLayout(SamplerMagFilter,
+            wgpu::TextureViewDimension, bool multisampledSource);
+
+    [[nodiscard]] wgpu::PipelineLayout createPipelineLayout(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] static size_t hashPipelineLayoutKey(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] wgpu::BindGroupLayout const& getOrCreateTextureBindGroupLayout(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] wgpu::BindGroupLayout createTextureBindGroupLayout(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] static size_t hashTextureBindGroupLayoutKey(SamplerMagFilter,
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] wgpu::ShaderModule const& getOrCreateShaderModule(
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+
+    [[nodiscard]] wgpu::ShaderModule createShaderModule(wgpu::TextureViewDimension sourceDimension,
+            bool multisampledSource);
+
+    [[nodiscard]] static size_t hashShaderModuleKey(wgpu::TextureViewDimension sourceDimension,
+            bool multisampledSource);
+
+    wgpu::Device mDevice;
+    wgpu::Sampler mNearestSampler{ nullptr };
+    wgpu::Sampler mLinearSampler{ nullptr };
+    tsl::robin_map<size_t, wgpu::RenderPipeline> mRenderPipelines{};
+    tsl::robin_map<size_t, wgpu::PipelineLayout> mPipelineLayouts{};
+    tsl::robin_map<size_t, wgpu::BindGroupLayout> mTextureBindGroupLayouts{};
+    tsl::robin_map<size_t, wgpu::ShaderModule> mShaderModules{};
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_WEBGPUBLITTER_H

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_BACKEND_WEBGPUDRIVER_H
 
 #include "WebGPURenderTarget.h"
+#include "webgpu/WebGPUBlitter.h"
 #include "webgpu/WebGPUConstants.h"
 #include "webgpu/WebGPUMsaaTextureResolver.h"
 #include "webgpu/WebGPUPipelineCache.h"
@@ -46,7 +47,6 @@
 namespace filament::backend {
 
 class WebGPUSwapChain;
-
 /**
  * WebGPU backend (driver) implementation
  */
@@ -85,6 +85,7 @@ private:
     WebGPURenderPassMipmapGenerator mRenderPassMipmapGenerator;
     spd::MipmapGenerator mSpdComputePassMipmapGenerator;
     WebGPUMsaaTextureResolver mMsaaTextureResolver{};
+    WebGPUBlitter mBlitter;
 
     struct DescriptorSetBindingInfo{
         wgpu::BindGroup bindGroup;

--- a/filament/backend/src/webgpu/WebGPUTexture.cpp
+++ b/filament/backend/src/webgpu/WebGPUTexture.cpp
@@ -109,7 +109,7 @@ namespace {
         case wgpu::TextureFormat::BGRA8UnormSrgb:      return wgpu::TextureFormat::BGRA8Unorm;
         case wgpu::TextureFormat::BC1RGBAUnormSrgb:    return wgpu::TextureFormat::BC1RGBAUnorm;
         case wgpu::TextureFormat::BC2RGBAUnormSrgb:    return wgpu::TextureFormat::BC2RGBAUnorm;
-        case  wgpu::TextureFormat::BC3RGBAUnormSrgb:   return wgpu::TextureFormat::BC3RGBAUnorm;
+        case wgpu::TextureFormat::BC3RGBAUnormSrgb:    return wgpu::TextureFormat::BC3RGBAUnorm;
         case wgpu::TextureFormat::BC7RGBAUnormSrgb:    return wgpu::TextureFormat::BC7RGBAUnorm;
         case wgpu::TextureFormat::ETC2RGB8UnormSrgb:   return wgpu::TextureFormat::ETC2RGB8Unorm;
         case wgpu::TextureFormat::ETC2RGB8A1UnormSrgb: return wgpu::TextureFormat::ETC2RGB8A1Unorm;

--- a/filament/backend/src/webgpu/WebGPUTextureHelpers.h
+++ b/filament/backend/src/webgpu/WebGPUTextureHelpers.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_WEBGPUTEXTUREHELPERS_H
+#define TNT_FILAMENT_BACKEND_WEBGPUTEXTUREHELPERS_H
+
+#include <backend/DriverEnums.h>
+
+#include <webgpu/webgpu_cpp.h>
+
+#include <string_view>
+
+namespace filament::backend {
+
+[[nodiscard]] constexpr std::string_view toString(const PixelDataFormat format) {
+    switch (format) {
+        case PixelDataFormat::R:               return "R";
+        case PixelDataFormat::R_INTEGER:       return "R_INTEGER";
+        case PixelDataFormat::RG:              return "RG";
+        case PixelDataFormat::RG_INTEGER:      return "RG_INTEGER";
+        case PixelDataFormat::RGB:             return "RGB";
+        case PixelDataFormat::RGB_INTEGER:     return "RGB_INTEGER";
+        case PixelDataFormat::RGBA:            return "RGBA";
+        case PixelDataFormat::RGBA_INTEGER:    return "RGBA_INTEGER";
+        case PixelDataFormat::UNUSED:          return "UNUSED";
+        case PixelDataFormat::DEPTH_COMPONENT: return "DEPTH_COMPONENT";
+        case PixelDataFormat::DEPTH_STENCIL:   return "DEPTH_STENCIL";
+        case PixelDataFormat::ALPHA:           return "ALPHA";
+    };
+}
+
+[[nodiscard]] constexpr std::string_view toString(const PixelDataType type) {
+    switch (type) {
+        case PixelDataType::UBYTE:                 return "UBYTE";
+        case PixelDataType::BYTE:                  return "BYTE";
+        case PixelDataType::USHORT:                return "USHORT";
+        case PixelDataType::SHORT:                 return "SHORT";
+        case PixelDataType::UINT:                  return "UINT";
+        case PixelDataType::INT:                   return "INT";
+        case PixelDataType::HALF:                  return "HALF";
+        case PixelDataType::FLOAT:                 return "FLOAT";
+        case PixelDataType::COMPRESSED:            return "COMPRESSED";
+        case PixelDataType::UINT_10F_11F_11F_REV:  return "UINT_10F_11F_11F_REV";
+        case PixelDataType::USHORT_565:            return "USHORT_565";
+        case PixelDataType::UINT_2_10_10_10_REV:   return "UINT_2_10_10_10_REV";
+    };
+}
+
+[[nodiscard]] constexpr wgpu::TextureFormat toWebGPUFormat(const PixelDataFormat format,
+        const PixelDataType type) {
+    if (type == PixelDataType::UINT_2_10_10_10_REV)                                 return wgpu::TextureFormat::RGB10A2Unorm;
+    if (type == PixelDataType::UINT_10F_11F_11F_REV)                                return wgpu::TextureFormat::RG11B10Ufloat;
+    if (PixelDataFormat::R == format && PixelDataType::UBYTE == type)               return wgpu::TextureFormat::R8Unorm;
+    if (PixelDataFormat::R == format && PixelDataType::BYTE == type)                return wgpu::TextureFormat::R8Snorm;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::UBYTE == type)       return wgpu::TextureFormat::R8Uint;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::BYTE == type)        return wgpu::TextureFormat::R8Sint;
+    if (PixelDataFormat::RG == format && PixelDataType::UBYTE == type)              return wgpu::TextureFormat::RG8Unorm;
+    if (PixelDataFormat::RG == format && PixelDataType::BYTE == type)               return wgpu::TextureFormat::RG8Snorm;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::UBYTE == type)      return wgpu::TextureFormat::RG8Uint;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::BYTE == type)       return wgpu::TextureFormat::RG8Sint;
+    if (PixelDataFormat::RGBA == format && PixelDataType::UBYTE == type)            return wgpu::TextureFormat::RGBA8Unorm;
+    if (PixelDataFormat::RGBA == format && PixelDataType::BYTE == type)             return wgpu::TextureFormat::RGBA8Snorm;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::UBYTE == type)    return wgpu::TextureFormat::RGBA8Uint;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::BYTE == type)     return wgpu::TextureFormat::RGBA8Sint;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::USHORT == type)      return wgpu::TextureFormat::R16Uint;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::SHORT == type)       return wgpu::TextureFormat::R16Sint;
+    if (PixelDataFormat::R == format && PixelDataType::HALF == type)                return wgpu::TextureFormat::R16Float;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::USHORT == type)     return wgpu::TextureFormat::RG16Uint;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::SHORT == type)      return wgpu::TextureFormat::RG16Sint;
+    if (PixelDataFormat::RG == format && PixelDataType::HALF == type)               return wgpu::TextureFormat::RG16Float;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::USHORT == type)   return wgpu::TextureFormat::RGBA16Uint;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::SHORT == type)    return wgpu::TextureFormat::RGBA16Sint;
+    if (PixelDataFormat::RGBA == format && PixelDataType::HALF == type)             return wgpu::TextureFormat::RGBA16Float;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::UINT == type)        return wgpu::TextureFormat::R32Uint;
+    if (PixelDataFormat::R_INTEGER == format && PixelDataType::INT == type)         return wgpu::TextureFormat::R32Sint;
+    if (PixelDataFormat::R == format && PixelDataType::FLOAT == type)               return wgpu::TextureFormat::R32Float;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::UINT == type)       return wgpu::TextureFormat::RG32Uint;
+    if (PixelDataFormat::RG_INTEGER == format && PixelDataType::INT == type)        return wgpu::TextureFormat::RG32Sint;
+    if (PixelDataFormat::RG == format && PixelDataType::FLOAT == type)              return wgpu::TextureFormat::RG32Float;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::UINT == type)     return wgpu::TextureFormat::RGBA32Uint;
+    if (PixelDataFormat::RGBA_INTEGER == format && PixelDataType::INT == type)      return wgpu::TextureFormat::RGBA32Sint;
+    if (PixelDataFormat::RGBA == format && PixelDataType::FLOAT == type)            return wgpu::TextureFormat::RGBA32Float;
+    if (PixelDataFormat::DEPTH_COMPONENT == format && PixelDataType::FLOAT == type) return wgpu::TextureFormat::Depth32Float;
+    return wgpu::TextureFormat::Undefined;
+}
+
+[[nodiscard]] constexpr wgpu::TextureFormat toWebGPULinearFormat(const wgpu::TextureFormat format) {
+    switch (format) {
+        case wgpu::TextureFormat::RGBA8UnormSrgb:      return wgpu::TextureFormat::RGBA8Unorm;
+        case wgpu::TextureFormat::BGRA8UnormSrgb:      return wgpu::TextureFormat::BGRA8Unorm;
+        case wgpu::TextureFormat::BC1RGBAUnormSrgb:    return wgpu::TextureFormat::BC1RGBAUnorm;
+        case wgpu::TextureFormat::BC2RGBAUnormSrgb:    return wgpu::TextureFormat::BC2RGBAUnorm;
+        case wgpu::TextureFormat::BC3RGBAUnormSrgb:    return wgpu::TextureFormat::BC3RGBAUnorm;
+        case wgpu::TextureFormat::BC7RGBAUnormSrgb:    return wgpu::TextureFormat::BC7RGBAUnorm;
+        case wgpu::TextureFormat::ASTC4x4UnormSrgb:    return wgpu::TextureFormat::ASTC4x4Unorm;
+        case wgpu::TextureFormat::ASTC5x4UnormSrgb:    return wgpu::TextureFormat::ASTC5x4Unorm;
+        case wgpu::TextureFormat::ASTC5x5UnormSrgb:    return wgpu::TextureFormat::ASTC5x5Unorm;
+        case wgpu::TextureFormat::ASTC6x5UnormSrgb:    return wgpu::TextureFormat::ASTC6x5Unorm;
+        case wgpu::TextureFormat::ASTC6x6UnormSrgb:    return wgpu::TextureFormat::ASTC6x6Unorm;
+        case wgpu::TextureFormat::ASTC8x5UnormSrgb:    return wgpu::TextureFormat::ASTC8x5Unorm;
+        case wgpu::TextureFormat::ASTC8x6UnormSrgb:    return wgpu::TextureFormat::ASTC8x6Unorm;
+        case wgpu::TextureFormat::ASTC8x8UnormSrgb:    return wgpu::TextureFormat::ASTC8x8Unorm;
+        case wgpu::TextureFormat::ASTC10x5UnormSrgb:   return wgpu::TextureFormat::ASTC10x5Unorm;
+        case wgpu::TextureFormat::ASTC10x6UnormSrgb:   return wgpu::TextureFormat::ASTC10x6Unorm;
+        case wgpu::TextureFormat::ASTC10x8UnormSrgb:   return wgpu::TextureFormat::ASTC10x8Unorm;
+        case wgpu::TextureFormat::ASTC10x10UnormSrgb:  return wgpu::TextureFormat::ASTC10x10Unorm;
+        case wgpu::TextureFormat::ASTC12x10UnormSrgb:  return wgpu::TextureFormat::ASTC12x10Unorm;
+        case wgpu::TextureFormat::ASTC12x12UnormSrgb:  return wgpu::TextureFormat::ASTC12x12Unorm;
+        case wgpu::TextureFormat::ETC2RGB8UnormSrgb:   return wgpu::TextureFormat::ETC2RGB8Unorm;
+        case wgpu::TextureFormat::ETC2RGB8A1UnormSrgb: return wgpu::TextureFormat::ETC2RGB8A1Unorm;
+        case wgpu::TextureFormat::ETC2RGBA8UnormSrgb:  return wgpu::TextureFormat::ETC2RGBA8Unorm;
+        default:                                       return format;
+    }
+}
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_WEBGPUTEXTUREHELPERS_H

--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -61,7 +61,9 @@ constexpr std::array REQUIRED_FEATURES = {
     // Qualcomm 500 and 600 GPUs do not support this so it is not part of core webgpu spec. To
     // support such devices, we will either need Filament to not attempt this, or find another
     // workaround. https://github.com/gpuweb/gpuweb/issues/2648
-    wgpu::FeatureName::RG11B10UfloatRenderable
+    wgpu::FeatureName::RG11B10UfloatRenderable,
+    // necessary for blit conversions of formats like RGBA32Float...
+    wgpu::FeatureName::Float32Filterable,
 };
 
 constexpr std::array OPTIONAL_FEATURES = {

--- a/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
+++ b/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StringPlaceholderTemplateProcessor.h"
+
+#include <utils/Panic.h>
+#include <utils/debug.h>
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace filament::backend::webgpuutils {
+
+std::string processPlaceholderTemplate(std::string_view const& stringTemplate,
+        std::string_view const& placeholderPrefix, std::string_view const& placeholderSuffix,
+        std::unordered_map<std::string_view, std::string_view> const& valueByPlaceholderName) {
+    const char* const sourceData{ stringTemplate.data() };
+    std::stringstream out{};
+    size_t positionCursorInTemplateString{ 0 };
+    while (positionCursorInTemplateString < stringTemplate.size()) {
+        const size_t positionOfNextPlaceholder{ stringTemplate.find(placeholderPrefix,
+                positionCursorInTemplateString) };
+        if (positionOfNextPlaceholder == std::string::npos) {
+            // no more placeholders, so just stream the rest of the source string
+            out << std::string_view(sourceData + positionCursorInTemplateString,
+                    stringTemplate.size() - positionCursorInTemplateString);
+            break;
+        }
+        const size_t positionOfPlaceholder{ positionOfNextPlaceholder + placeholderPrefix.size() };
+        // stream up to the placeholder...
+        out << std::string_view(sourceData + positionCursorInTemplateString,
+                positionOfNextPlaceholder - positionCursorInTemplateString);
+        // stream the value in place of the placeholder...
+        const size_t positionAfterPlaceholder{ stringTemplate.find(placeholderSuffix,
+                positionOfPlaceholder) };
+        assert_invariant(positionAfterPlaceholder != std::string::npos &&
+                         "Malformed source with missing suffix to placeholder");
+        const std::string_view placeholderName{ std::string_view(sourceData + positionOfPlaceholder,
+                positionAfterPlaceholder - positionOfPlaceholder) };
+        if (const auto iter{ valueByPlaceholderName.find(placeholderName) };
+                iter == valueByPlaceholderName.end()) {
+            PANIC_POSTCONDITION("Found placeholder '%s' in template, but this is not present in "
+                                "valueByPlaceholderName",
+                    placeholderName.data());
+        } else {
+            const std::string_view value{ iter->second };
+            out << value;
+        }
+        // update the cursor for after the placeholder...
+        positionCursorInTemplateString = positionAfterPlaceholder + placeholderSuffix.size();
+    }
+    return out.str();
+}
+
+} // namespace filament::backend::webgpuutils

--- a/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.h
+++ b/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_UTIL_STRINGPLACEHOLDERTEMPLATEPROCESSOR_H
+#define TNT_FILAMENT_BACKEND_UTIL_STRINGPLACEHOLDERTEMPLATEPROCESSOR_H
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace filament::backend::webgpuutils {
+
+/**
+ * Given the string template, finds all placeholders (beginning with placeholderPrefix and ending
+ * placeholderSuffix, where the placeholder name is between the prefix and suffix, e.g.
+ * {{MY_PLACEHOLDER}} where the prefix is "{{", the suffix "}}", and the placeholder name
+ * "MY_PLACEHOLDER"), and replaces the placeholders with values as provided in a given map.
+ * @param stringTemplate The whole template to generate an output string
+ * @param placeholderPrefix Indicates the beginning of a placeholder. This string should not be
+ * present in the template for any other purpose. A typical choice might be "{{". If you
+ * choose "{{" any occurrence of "{{" should not exist in the template other than to indicate the
+ * beginning of a placeholder, otherwise you will have problems.
+ * @param placeholderSuffix Indicates the ending of a placeholder. This string should not be
+ * present in the template for any other purpose. A typical choice might be "}}". If you
+ * choose "}}" any occurrence of "}}" should not exist in the template other than to indicate the
+ * ending of a placeholder, otherwise you will have problems.
+ * @param valueByPlaceholderName A map of placeholder names present in the template (between
+ * placeholderPrefix and placeholderSuffix strings) to the string value to replace the whole
+ * placeholder (include prefix and suffix). If a placeholder name is found in the template but not
+ * in this map, the function will panic.
+ * @return the stringTemplate, where all placeholders are replaced based on the
+ * given valueByPlaceholderName map.
+ */
+[[nodiscard]] std::string processPlaceholderTemplate(std::string_view const& stringTemplate,
+        std::string_view const& placeholderPrefix, std::string_view const& placeholderSuffix,
+        std::unordered_map<std::string_view, std::string_view> const&
+                valueByPlaceholderName);
+
+} // namespace filament::backend::webgpuutils
+
+#endif // TNT_FILAMENT_BACKEND_UTIL_STRINGPLACEHOLDERTEMPLATEPROCESSOR_H


### PR DESCRIPTION
This fixes the -i IBL issue and the image viewer. However, more work is needed (subsequent PR) to add robustness for us in the  WebGPUDriver::blit function, such as handling depth formats.

But this is probably a good place to integrate with main before proceeding with next steps.

BUGS=[434650196, 432815114]