### PR TITLE
unbind descriptor-sets after renderpasses

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -36,6 +36,7 @@
 
 #include "details/Engine.h"
 
+#include "ds/DescriptorSet.h"
 #include "ds/SsrPassDescriptorSet.h"
 #include "ds/TypedUniformBuffer.h"
 
@@ -555,6 +556,11 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
                 driver.beginRenderPass(out.target, out.params);
                 pass.getExecutor().execute(mEngine, driver);
                 driver.endRenderPass();
+
+                // unbind all descriptor sets to avoid false dependencies with the next pass
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_VIEW);
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_RENDERABLE);
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
             });
 
     auto const depth = structurePass->depth;
@@ -660,6 +666,11 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::transparentPicking(FrameGrap
                         driver.beginRenderPass(target, params);
                         pass.getExecutor().execute(mEngine, driver);
                         driver.endRenderPass();
+
+                        // unbind all descriptor sets to avoid false dependencies with the next pass
+                        DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_VIEW);
+                        DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_RENDERABLE);
+                        DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
                 });
 
     return pickingRenderPass->picking;
@@ -766,6 +777,11 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssr(FrameGraph& fg,
                 driver.beginRenderPass(out.target, out.params);
                 pass.getExecutor().execute(mEngine, driver);
                 driver.endRenderPass();
+
+                // unbind all descriptor sets to avoid false dependencies with the next pass
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_VIEW);
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_RENDERABLE);
+                DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
             });
 
     return ssrPass->reflections;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -23,7 +23,7 @@
 #include <filament/LightManager.h>
 #include <filament/Options.h>
 
-#include <iterator>
+
 #include <private/filament/EngineEnums.h>
 
 #include "components/RenderableManager.h"
@@ -32,6 +32,8 @@
 #include "details/DebugRegistry.h"
 #include "details/Texture.h"
 #include "details/View.h"
+
+#include "ds/DescriptorSet.h"
 
 #include "fg/FrameGraph.h"
 #include "fg/FrameGraphId.h"
@@ -57,6 +59,7 @@
 #include <array>
 #include <cmath>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <new>
 #include <memory>
@@ -560,14 +563,19 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                         // if we know there are no visible shadows, we can skip rendering, but
                         // we need the render-pass to clear/initialize the shadow-map
                         // Note: this is always true for directional/cascade shadows.
-                        if (curr->shadowMap->hasVisibleShadows()) {
-                            curr->shadowMap->bind(driver);
-                            curr->executor.overrideScissor(curr->shadowMap->getScissor());
+                        if (ShadowMap const* const shadowMap = curr->shadowMap; shadowMap->hasVisibleShadows()) {
+                            shadowMap->bind(driver);
+                            curr->executor.overrideScissor(shadowMap->getScissor());
                             curr->executor.execute(engine, driver);
                         }
                     }
 
                     driver.endRenderPass();
+
+                    // unbind all descriptor sets to avoid false dependencies with the next pass
+                    DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_VIEW);
+                    DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_RENDERABLE);
+                    DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
                 });
 
         first = last;

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -999,10 +999,6 @@ void FView::commitUniformsAndSamplers(DriverApi& driver) const noexcept {
     getColorPassDescriptorSet().commit(driver);
 }
 
-void FView::unbindSamplers(FEngine& engine) noexcept {
-    getColorPassDescriptorSet().unbindSamplers(engine);
-}
-
 void FView::commitFroxels(DriverApi& driverApi) const noexcept {
     if (mHasDynamicLighting) {
         mFroxelizer.commit(driverApi);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -182,7 +182,6 @@ public:
 
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;
     void commitUniformsAndSamplers(backend::DriverApi& driver) const noexcept;
-    void unbindSamplers(FEngine& engine) noexcept;
 
     utils::JobSystem::Job* getFroxelizerSync() const noexcept { return mFroxelizerSync; }
     void setFroxelizerSync(utils::JobSystem::Job* sync) noexcept { mFroxelizerSync = sync; }

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -475,23 +475,6 @@ void ColorPassDescriptorSet::commit(DriverApi& driver) noexcept {
     }
 }
 
-void ColorPassDescriptorSet::unbindSamplers(FEngine& engine) noexcept {
-    // this needs to reset the sampler that are only set in RendererUtils::colorPass(), because
-    // this descriptor-set is also used for ssr/picking/structure and these could be stale
-    // it would be better to use a separate descriptor-set for those two cases so that we don't
-    // have to do this
-    setBuffer(+PerViewBindingPoints::SHADOWS,
-            engine.getDummyUniformBuffer(), 0, sizeof(ShadowUib));
-    setSampler(+PerViewBindingPoints::STRUCTURE,
-            engine.getZeroTexture(), {});
-    setSampler(+PerViewBindingPoints::SHADOW_MAP,
-            engine.getOneTextureArrayDepth(), {});
-    setSampler(+PerViewBindingPoints::SSAO,
-            engine.getZeroTextureArray(), {});
-    setSampler(+PerViewBindingPoints::SSR,
-            engine.getZeroTextureArray(), {});
-}
-
 void ColorPassDescriptorSet::setSampler(descriptor_binding_t const binding,
         TextureHandle th, SamplerParams const params) noexcept {
     for (size_t i = 0; i < DESCRIPTOR_LAYOUT_COUNT; i++) {

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -148,8 +148,6 @@ public:
     // update local data into GPU UBO
     void commit(backend::DriverApi& driver) noexcept;
 
-    void unbindSamplers(FEngine& engine) noexcept;
-
     // bind this UBO
     void bind(backend::DriverApi& driver, uint8_t const index) const noexcept {
         mDescriptorSet[index].bind(driver, DescriptorSetBindingPoints::PER_VIEW);

--- a/filament/src/ds/DescriptorSet.cpp
+++ b/filament/src/ds/DescriptorSet.cpp
@@ -139,6 +139,11 @@ void DescriptorSet::bind(FEngine::DriverApi& driver, DescriptorSetBindingPoints 
     driver.bindDescriptorSet(mDescriptorSetHandle, +set, std::move(dynamicOffsets));
 }
 
+void DescriptorSet::unbind(backend::DriverApi& driver,
+        DescriptorSetBindingPoints set) noexcept {
+    driver.bindDescriptorSet({}, +set, {});
+}
+
 void DescriptorSet::setBuffer(DescriptorSetLayout const& layout,
         backend::descriptor_binding_t const binding,
         backend::Handle<backend::HwBufferObject> boh, uint32_t const offset, uint32_t const size) {

--- a/filament/src/ds/DescriptorSet.h
+++ b/filament/src/ds/DescriptorSet.h
@@ -62,6 +62,9 @@ public:
     void bind(backend::DriverApi& driver, DescriptorSetBindingPoints set,
             backend::DescriptorSetOffsetArray dynamicOffsets) const noexcept;
 
+    // unbind the descriptor set
+    static void unbind(backend::DriverApi& driver, DescriptorSetBindingPoints set) noexcept;
+
     // sets a ubo/ssbo descriptor
     void setBuffer(DescriptorSetLayout const& layout,
             backend::descriptor_binding_t binding,


### PR DESCRIPTION
this prevents a false dependency with the next pass and keeps us honest about what resources we're using.