### PR TITLE
vk: fix broken iblprefilter path

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -87,6 +87,8 @@ public:
 
     void gc();
 
+    void resetCachedState() noexcept { mLastBoundInfo = {}; }
+
 private:
     void updateSamplerImpl(VkDescriptorSet set, uint8_t binding,
             fvkmemory::resource_ptr<VulkanTexture> texture, VkSampler sampler) noexcept;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -2061,6 +2061,7 @@ void VulkanDriver::setDebugTag(HandleBase::HandleId handleId, utils::CString tag
 void VulkanDriver::endCommandRecording() {
     mCommands.flush();
     mPipelineCache.resetBoundPipeline();
+    mDescriptorSetCache.resetCachedState();
 }
 
 // explicit instantiation of the Dispatcher


### PR DESCRIPTION
The issue is that we need to reset the bound info in VulkanDescriptorSetCache when the current command buffer completes recording.