### PR TITLE
webgpu: support depth in blit + copy when we can.

### DIFF
--- a/filament/backend/src/webgpu/WebGPUBlitter.h
+++ b/filament/backend/src/webgpu/WebGPUBlitter.h
@@ -31,6 +31,7 @@ public:
     struct BlitArgs final {
         struct Attachment final {
             wgpu::Texture const& texture;
+            wgpu::TextureAspect aspect{ wgpu::TextureAspect::Undefined };
             wgpu::Origin2D origin{};
             wgpu::Extent2D extent{};
             uint32_t mipLevel{ 0 };
@@ -47,45 +48,52 @@ public:
     void blit(wgpu::Queue const&, wgpu::CommandEncoder const&, BlitArgs const&);
 
 private:
+    /**
+     * ONLY should be called if canDoDirectCopy(...) is true (see it in WebGPUBlitter.cpp)
+     */
+    void copy(wgpu::CommandEncoder const&, BlitArgs const&);
+
     void createSampler(SamplerMagFilter);
 
     [[nodiscard]] wgpu::RenderPipeline const& getOrCreateRenderPipeline(SamplerMagFilter,
             wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount,
-            wgpu::TextureFormat destinationTextureFormat);
+            bool depthSource, wgpu::TextureFormat destinationTextureFormat);
 
     [[nodiscard]] wgpu::RenderPipeline createRenderPipeline(SamplerMagFilter,
             wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount,
-            wgpu::TextureFormat destinationTextureFormat);
+            bool depthSource, wgpu::TextureFormat destinationTextureFormat);
 
     [[nodiscard]] static size_t hashRenderPipelineKey(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount);
+            wgpu::TextureViewDimension sourceDimension, uint32_t sourceSampleCount,
+            bool depthSource, wgpu::TextureFormat destinationTextureFormat);
 
     [[nodiscard]] wgpu::PipelineLayout const& getOrCreatePipelineLayout(SamplerMagFilter,
-            wgpu::TextureViewDimension, bool multisampledSource);
+            wgpu::TextureViewDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] wgpu::PipelineLayout createPipelineLayout(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] static size_t hashPipelineLayoutKey(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] wgpu::BindGroupLayout const& getOrCreateTextureBindGroupLayout(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] wgpu::BindGroupLayout createTextureBindGroupLayout(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] static size_t hashTextureBindGroupLayoutKey(SamplerMagFilter,
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource);
 
     [[nodiscard]] wgpu::ShaderModule const& getOrCreateShaderModule(
-            wgpu::TextureViewDimension sourceDimension, bool multisampledSource);
+            wgpu::TextureViewDimension sourceDimension, bool multisampledSource, bool depthSource,
+            bool depthDestination);
 
     [[nodiscard]] wgpu::ShaderModule createShaderModule(wgpu::TextureViewDimension sourceDimension,
-            bool multisampledSource);
+            bool multisampledSource, bool depthSource, bool depthDestination);
 
     [[nodiscard]] static size_t hashShaderModuleKey(wgpu::TextureViewDimension sourceDimension,
-            bool multisampledSource);
+            bool multisampledSource, bool depthSource, bool depthDestination);
 
     wgpu::Device mDevice;
     wgpu::Sampler mNearestSampler{ nullptr };

--- a/filament/backend/src/webgpu/WebGPUConstants.h
+++ b/filament/backend/src/webgpu/WebGPUConstants.h
@@ -36,6 +36,14 @@ constexpr size_t FILAMENT_WEBGPU_BUFFER_SIZE_MODULUS = 4;
 // appear in order of calls).
 #define FWGPU_DEBUG_FORCE_LOG_TO_I 0x00000004
 
+// Set this to enable logging related to the WebGPU backend's update3DImage function, which would
+// otherwise spam the logs.
+#define FWGPU_DEBUG_UPDATE_IMAGE 0x00000008
+
+// Set this to enable logging related to the WebGPU backend's WebGPUBlitter functionality,
+// which would otherwise spam the logs.
+#define FWGPU_DEBUG_BLIT 0x00000010
+
 // Useful default combinations
 #define FWGPU_DEBUG_EVERYTHING     0xFFFFFFFF
 

--- a/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.cpp
+++ b/filament/backend/src/webgpu/WebGPUMsaaTextureResolver.cpp
@@ -16,7 +16,7 @@
 
 #include "WebGPUMsaaTextureResolver.h"
 
-#include "WebGPUTexture.h"
+#include "WebGPUTextureHelpers.h"
 
 #include <utils/Panic.h>
 

--- a/filament/backend/src/webgpu/WebGPUPipelineCache.cpp
+++ b/filament/backend/src/webgpu/WebGPUPipelineCache.cpp
@@ -17,7 +17,7 @@
 #include "WebGPUPipelineCache.h"
 
 #include "WebGPUConstants.h"
-#include "WebGPUTexture.h"
+#include "WebGPUTextureHelpers.h"
 #include "WebGPUVertexBufferInfo.h"
 
 #include <backend/DriverEnums.h>

--- a/filament/backend/src/webgpu/WebGPUStrings.h
+++ b/filament/backend/src/webgpu/WebGPUStrings.h
@@ -36,7 +36,9 @@
 
 namespace filament::backend {
 
-#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM) \
+        || FWGPU_ENABLED(FWGPU_DEBUG_UPDATE_IMAGE) \
+        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)
 template<typename WebGPUPrintable>
 [[nodiscard]] inline std::string webGPUPrintableToString(const WebGPUPrintable printable) {
     std::stringstream out;
@@ -238,6 +240,36 @@ template<typename WebGPUPrintable>
         case wgpu::TextureFormat::External:                    return "External";
     }
 }
+
+[[nodiscard]] constexpr std::string_view webGPUTextureDimensionToString(
+        const wgpu::TextureDimension dimension) {
+    switch (dimension) {
+        case wgpu::TextureDimension::Undefined: return "Undefined";
+        case wgpu::TextureDimension::e1D:       return "e1D";
+        case wgpu::TextureDimension::e2D:       return "e2D";
+        case wgpu::TextureDimension::e3D:       return "e3D";
+    }
+}
+
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM) \
+        || FWGPU_ENABLED(FWGPU_DEBUG_UPDATE_IMAGE) \
+        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)
+[[nodiscard]] std::string webGPUTextureToString(wgpu::Texture const& texture) {
+    if (texture == nullptr) {
+        return "nullptr (no wgpu::Texture)";
+    }
+    std::stringstream out;
+    out << "wgpu::Texture("
+        << " format:" << webGPUTextureFormatToString(texture.GetFormat())
+        << " dimension:" << webGPUTextureDimensionToString(texture.GetDimension())
+        << " " << webGPUPrintableToString(texture.GetUsage())
+        << " mipLevelCount:" << texture.GetMipLevelCount()
+        << " sampleCount:" << texture.GetSampleCount() << " width:" << texture.GetWidth()
+        << " height:" << texture.GetHeight()
+        << " depthOrArrayLayers:" << texture.GetDepthOrArrayLayers() << ")";
+    return out.str();
+}
+#endif
 
 [[nodiscard]] constexpr std::string_view filamentShaderStageToString(const ShaderStage stage) {
     switch (stage) {

--- a/filament/backend/src/webgpu/WebGPUTexture.cpp
+++ b/filament/backend/src/webgpu/WebGPUTexture.cpp
@@ -19,6 +19,7 @@
 #include "WebGPUConstants.h"
 #include "WebGPURenderPassMipmapGenerator.h"
 #include "WebGPUStrings.h"
+#include "WebGPUTextureHelpers.h"
 
 #include "DriverBase.h"
 #include "private/backend/BackendUtils.h"
@@ -61,37 +62,6 @@ namespace {
         case SamplerType::SAMPLER_EXTERNAL:      return "an_external_user_texture_view";
         case SamplerType::SAMPLER_3D:            return "a_3D_user_texture_view";
         case SamplerType::SAMPLER_CUBEMAP_ARRAY: return "a_cube_map_array_user_texture_view";
-    }
-}
-
-/**
- * @param format texture format to potentially be used for storage binding
- * @return true if the format is compatible with wgpu::TextureUsage::StorageBinding
- */
-[[nodiscard]] constexpr bool isFormatStorageCompatible(const wgpu::TextureFormat format) {
-    switch (format) {
-        // List of formats that support storage binding
-        case wgpu::TextureFormat::R32Float:
-        case wgpu::TextureFormat::R32Sint:
-        case wgpu::TextureFormat::R32Uint:
-        case wgpu::TextureFormat::RG32Float:
-        case wgpu::TextureFormat::RG32Sint:
-        case wgpu::TextureFormat::RG32Uint:
-        case wgpu::TextureFormat::RGBA16Float:
-        case wgpu::TextureFormat::RGBA16Sint:
-        case wgpu::TextureFormat::RGBA16Uint:
-        case wgpu::TextureFormat::RGBA32Float:
-        case wgpu::TextureFormat::RGBA32Sint:
-        case wgpu::TextureFormat::RGBA32Uint:
-        case wgpu::TextureFormat::RGBA8Unorm:
-        case wgpu::TextureFormat::RGBA8Snorm:
-        case wgpu::TextureFormat::RGBA8Uint:
-        case wgpu::TextureFormat::RGBA8Sint:
-            return true;
-        default:
-            // All other formats, including packed floats (RG11B10Ufloat),
-            // depth/stencil, and sRGB formats do not support storage.
-            return false;
     }
 }
 
@@ -249,30 +219,6 @@ namespace {
     return wgpu::TextureAspect::All;
 }
 
-[[nodiscard]] constexpr wgpu::TextureViewDimension toWebGPUTextureViewDimension(
-        const SamplerType samplerType) {
-    switch (samplerType) {
-        case SamplerType::SAMPLER_2D:            return wgpu::TextureViewDimension::e2D;
-        case SamplerType::SAMPLER_2D_ARRAY:      return wgpu::TextureViewDimension::e2DArray;
-        case SamplerType::SAMPLER_CUBEMAP:       return wgpu::TextureViewDimension::Cube;
-        case SamplerType::SAMPLER_EXTERNAL:      return wgpu::TextureViewDimension::e2D;
-        case SamplerType::SAMPLER_3D:            return wgpu::TextureViewDimension::e3D;
-        case SamplerType::SAMPLER_CUBEMAP_ARRAY: return wgpu::TextureViewDimension::CubeArray;
-    }
-}
-
-[[nodiscard]] constexpr wgpu::TextureDimension toWebGPUTextureDimension(
-        const SamplerType samplerType) {
-    switch (samplerType) {
-        case SamplerType::SAMPLER_2D:            return wgpu::TextureDimension::e2D;
-        case SamplerType::SAMPLER_2D_ARRAY:      return wgpu::TextureDimension::e2D;
-        case SamplerType::SAMPLER_CUBEMAP:       return wgpu::TextureDimension::e2D;
-        case SamplerType::SAMPLER_EXTERNAL:      return wgpu::TextureDimension::e2D;
-        case SamplerType::SAMPLER_3D:            return wgpu::TextureDimension::e3D;
-        case SamplerType::SAMPLER_CUBEMAP_ARRAY: return wgpu::TextureDimension::e2D;
-    }
-}
-
 [[nodiscard]] WebGPUTexture::MipmapGenerationStrategy determineMipmapGenerationStrategy(
         const wgpu::TextureFormat format, const SamplerType samplerType, const uint8_t sampleCount,
         const uint8_t mipmapLevels) {
@@ -324,82 +270,12 @@ namespace {
 
 } // namespace
 
-size_t WebGPUTexture::getWGPUTextureFormatPixelSize(const wgpu::TextureFormat format) {
-    switch (format) {
-        // 1 byte
-        case wgpu::TextureFormat::R8Unorm:
-        case wgpu::TextureFormat::R8Snorm:
-        case wgpu::TextureFormat::R8Uint:
-        case wgpu::TextureFormat::R8Sint:
-        case wgpu::TextureFormat::Stencil8:
-            return 1;
-
-        // 2 bytes
-        case wgpu::TextureFormat::R16Uint:
-        case wgpu::TextureFormat::R16Sint:
-        case wgpu::TextureFormat::R16Float:
-        case wgpu::TextureFormat::RG8Unorm:
-        case wgpu::TextureFormat::RG8Snorm:
-        case wgpu::TextureFormat::RG8Uint:
-        case wgpu::TextureFormat::RG8Sint:
-        case wgpu::TextureFormat::Depth16Unorm:
-            return 2;
-
-        // 4 bytes
-        // -- 32-bit single-channel formats
-        case wgpu::TextureFormat::R32Float:
-        case wgpu::TextureFormat::R32Uint:
-        case wgpu::TextureFormat::R32Sint:
-        // -- 16-bit two-channel formats
-        case wgpu::TextureFormat::RG16Uint:
-        case wgpu::TextureFormat::RG16Sint:
-        case wgpu::TextureFormat::RG16Float:
-        // -- 8-bit four-channel formats
-        case wgpu::TextureFormat::RGBA8Unorm:
-        case wgpu::TextureFormat::RGBA8UnormSrgb:
-        case wgpu::TextureFormat::RGBA8Snorm:
-        case wgpu::TextureFormat::RGBA8Uint:
-        case wgpu::TextureFormat::RGBA8Sint:
-        case wgpu::TextureFormat::BGRA8Unorm:
-        case wgpu::TextureFormat::BGRA8UnormSrgb:
-        // -- Packed 32-bit formats
-        case wgpu::TextureFormat::RGB10A2Unorm:
-        case wgpu::TextureFormat::RGB10A2Uint:
-        case wgpu::TextureFormat::RG11B10Ufloat:
-        case wgpu::TextureFormat::RGB9E5Ufloat:
-        // -- Depth/Stencil formats
-        case wgpu::TextureFormat::Depth32Float:
-        case wgpu::TextureFormat::Depth24Plus:
-        case wgpu::TextureFormat::Depth24PlusStencil8:
-            return 4;
-
-        // 8 bytes
-        case wgpu::TextureFormat::RG32Float:
-        case wgpu::TextureFormat::RG32Uint:
-        case wgpu::TextureFormat::RG32Sint:
-        case wgpu::TextureFormat::RGBA16Uint:
-        case wgpu::TextureFormat::RGBA16Sint:
-        case wgpu::TextureFormat::RGBA16Float:
-            return 8;
-
-        // 16 bytes
-        case wgpu::TextureFormat::RGBA32Float:
-        case wgpu::TextureFormat::RGBA32Uint:
-        case wgpu::TextureFormat::RGBA32Sint:
-            return 16;
-
-        // Non-copyable or compressed formats
-        case wgpu::TextureFormat::Depth32FloatStencil8: // Not copyable from texture to buffer
-        default:
-            return 0;
-    }
-}
 WebGPUTexture::WebGPUTexture(const SamplerType samplerType, const uint8_t levels,
         const TextureFormat format, const uint8_t samples, const uint32_t width,
         const uint32_t height, const uint32_t depth, const TextureUsage usage,
         wgpu::Device const& device) noexcept
     : HwTexture{ samplerType, levels, samples, width, height, depth, format, usage },
-      mViewFormat{ fToWGPUTextureFormat(format) },
+      mViewFormat{ toWGPUTextureFormat(format) },
       mMipmapGenerationStrategy{ determineMipmapGenerationStrategy(mViewFormat, samplerType,
               samples, levels) },
       mWebGPUFormat{ mMipmapGenerationStrategy == MipmapGenerationStrategy::SPD_COMPUTE_PASS
@@ -565,176 +441,6 @@ wgpu::TextureView WebGPUTexture::makeMsaaSidecarTextureViewIfTextureSidecarExist
     return textureView;
 }
 
-wgpu::TextureFormat WebGPUTexture::fToWGPUTextureFormat(TextureFormat const& fFormat) {
-    switch (fFormat) {
-        case TextureFormat::R8:                      return wgpu::TextureFormat::R8Unorm;
-        case TextureFormat::R8_SNORM:                return wgpu::TextureFormat::R8Snorm;
-        case TextureFormat::R8UI:                    return wgpu::TextureFormat::R8Uint;
-        case TextureFormat::R8I:                     return wgpu::TextureFormat::R8Sint;
-        case TextureFormat::STENCIL8:                return wgpu::TextureFormat::Stencil8;
-        case TextureFormat::R16F:                    return wgpu::TextureFormat::R16Float;
-        case TextureFormat::R16UI:                   return wgpu::TextureFormat::R16Uint;
-        case TextureFormat::R16I:                    return wgpu::TextureFormat::R16Sint;
-        case TextureFormat::RG8:                     return wgpu::TextureFormat::RG8Unorm;
-        case TextureFormat::RG8_SNORM:               return wgpu::TextureFormat::RG8Snorm;
-        case TextureFormat::RG8UI:                   return wgpu::TextureFormat::RG8Uint;
-        case TextureFormat::RG8I:                    return wgpu::TextureFormat::RG8Sint;
-        case TextureFormat::R32F:                    return wgpu::TextureFormat::R32Float;
-        case TextureFormat::R32UI:                   return wgpu::TextureFormat::R32Uint;
-        case TextureFormat::R32I:                    return wgpu::TextureFormat::R32Sint;
-        case TextureFormat::RG16F:                   return wgpu::TextureFormat::RG16Float;
-        case TextureFormat::RG16UI:                  return wgpu::TextureFormat::RG16Uint;
-        case TextureFormat::RG16I:                   return wgpu::TextureFormat::RG16Sint;
-        case TextureFormat::RGBA8:                   return wgpu::TextureFormat::RGBA8Unorm;
-        case TextureFormat::SRGB8_A8:                return wgpu::TextureFormat::RGBA8UnormSrgb;
-        case TextureFormat::RGBA8_SNORM:             return wgpu::TextureFormat::RGBA8Snorm;
-        case TextureFormat::RGBA8UI:                 return wgpu::TextureFormat::RGBA8Uint;
-        case TextureFormat::RGBA8I:                  return wgpu::TextureFormat::RGBA8Sint;
-        case TextureFormat::DEPTH16:                 return wgpu::TextureFormat::Depth16Unorm;
-        case TextureFormat::DEPTH24:                 return wgpu::TextureFormat::Depth24Plus;
-        case TextureFormat::DEPTH32F:                return wgpu::TextureFormat::Depth32Float;
-        case TextureFormat::DEPTH24_STENCIL8:        return wgpu::TextureFormat::Depth24PlusStencil8;
-        case TextureFormat::DEPTH32F_STENCIL8:       return wgpu::TextureFormat::Depth32FloatStencil8;
-        case TextureFormat::RG32F:                   return wgpu::TextureFormat::RG32Float;
-        case TextureFormat::RG32UI:                  return wgpu::TextureFormat::RG32Uint;
-        case TextureFormat::RG32I:                   return wgpu::TextureFormat::RG32Sint;
-        case TextureFormat::RGBA16F:                 return wgpu::TextureFormat::RGBA16Float;
-        case TextureFormat::RGBA16UI:                return wgpu::TextureFormat::RGBA16Uint;
-        case TextureFormat::RGBA16I:                 return wgpu::TextureFormat::RGBA16Sint;
-        case TextureFormat::RGBA32F:                 return wgpu::TextureFormat::RGBA32Float;
-        case TextureFormat::RGBA32UI:                return wgpu::TextureFormat::RGBA32Uint;
-        case TextureFormat::RGBA32I:                 return wgpu::TextureFormat::RGBA32Sint;
-        case TextureFormat::EAC_R11:                 return wgpu::TextureFormat::EACR11Unorm;
-        case TextureFormat::EAC_R11_SIGNED:          return wgpu::TextureFormat::EACR11Snorm;
-        case TextureFormat::EAC_RG11:                return wgpu::TextureFormat::EACRG11Unorm;
-        case TextureFormat::EAC_RG11_SIGNED:         return wgpu::TextureFormat::EACRG11Snorm;
-        case TextureFormat::ETC2_RGB8:               return wgpu::TextureFormat::ETC2RGB8Unorm;
-        case TextureFormat::ETC2_SRGB8:              return wgpu::TextureFormat::ETC2RGB8UnormSrgb;
-        case TextureFormat::ETC2_RGB8_A1:            return wgpu::TextureFormat::ETC2RGB8A1Unorm;
-        case TextureFormat::ETC2_SRGB8_A1:           return wgpu::TextureFormat::ETC2RGB8A1UnormSrgb;
-        case TextureFormat::ETC2_EAC_RGBA8:          return wgpu::TextureFormat::ETC2RGBA8Unorm;
-        case TextureFormat::ETC2_EAC_SRGBA8:         return wgpu::TextureFormat::ETC2RGBA8UnormSrgb;
-        case TextureFormat::RGBA_ASTC_4x4:           return wgpu::TextureFormat::ASTC4x4Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_4x4:   return wgpu::TextureFormat::ASTC4x4UnormSrgb;
-        case TextureFormat::RGBA_ASTC_5x4:           return wgpu::TextureFormat::ASTC5x4Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_5x4:   return wgpu::TextureFormat::ASTC5x4UnormSrgb;
-        case TextureFormat::RGBA_ASTC_5x5:           return wgpu::TextureFormat::ASTC5x5Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_5x5:   return wgpu::TextureFormat::ASTC5x5UnormSrgb;
-        case TextureFormat::RGBA_ASTC_6x5:           return wgpu::TextureFormat::ASTC6x5Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_6x5:   return wgpu::TextureFormat::ASTC6x5UnormSrgb;
-        case TextureFormat::RGBA_ASTC_6x6:           return wgpu::TextureFormat::ASTC6x6Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_6x6:   return wgpu::TextureFormat::ASTC6x6UnormSrgb;
-        case TextureFormat::RGBA_ASTC_8x5:           return wgpu::TextureFormat::ASTC8x5Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_8x5:   return wgpu::TextureFormat::ASTC8x5UnormSrgb;
-        case TextureFormat::RGBA_ASTC_8x6:           return wgpu::TextureFormat::ASTC8x6Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_8x6:   return wgpu::TextureFormat::ASTC8x6UnormSrgb;
-        case TextureFormat::RGBA_ASTC_8x8:           return wgpu::TextureFormat::ASTC8x8Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_8x8:   return wgpu::TextureFormat::ASTC8x8UnormSrgb;
-        case TextureFormat::RGBA_ASTC_10x5:          return wgpu::TextureFormat::ASTC10x5Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_10x5:  return wgpu::TextureFormat::ASTC10x5UnormSrgb;
-        case TextureFormat::RGBA_ASTC_10x6:          return wgpu::TextureFormat::ASTC10x6Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_10x6:  return wgpu::TextureFormat::ASTC10x6UnormSrgb;
-        case TextureFormat::RGBA_ASTC_10x8:          return wgpu::TextureFormat::ASTC10x8Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_10x8:  return wgpu::TextureFormat::ASTC10x8UnormSrgb;
-        case TextureFormat::RGBA_ASTC_10x10:         return wgpu::TextureFormat::ASTC10x10Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_10x10: return wgpu::TextureFormat::ASTC10x10UnormSrgb;
-        case TextureFormat::RGBA_ASTC_12x10:         return wgpu::TextureFormat::ASTC12x10Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_12x10: return wgpu::TextureFormat::ASTC12x10UnormSrgb;
-        case TextureFormat::RGBA_ASTC_12x12:         return wgpu::TextureFormat::ASTC12x12Unorm;
-        case TextureFormat::SRGB8_ALPHA8_ASTC_12x12: return wgpu::TextureFormat::ASTC12x12UnormSrgb;
-        case TextureFormat::RED_RGTC1:               return wgpu::TextureFormat::BC4RUnorm;
-        case TextureFormat::SIGNED_RED_RGTC1:        return wgpu::TextureFormat::BC4RSnorm;
-        case TextureFormat::RED_GREEN_RGTC2:         return wgpu::TextureFormat::BC5RGUnorm;
-        case TextureFormat::SIGNED_RED_GREEN_RGTC2:  return wgpu::TextureFormat::BC5RGSnorm;
-        case TextureFormat::RGB_BPTC_UNSIGNED_FLOAT: return wgpu::TextureFormat::BC6HRGBUfloat;
-        case TextureFormat::RGB_BPTC_SIGNED_FLOAT:   return wgpu::TextureFormat::BC6HRGBFloat;
-        case TextureFormat::RGBA_BPTC_UNORM:         return wgpu::TextureFormat::BC7RGBAUnorm;
-        case TextureFormat::SRGB_ALPHA_BPTC_UNORM:   return wgpu::TextureFormat::BC7RGBAUnormSrgb;
-        case TextureFormat::RGB565:
-            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
-            // and discard the alpha and lower precision.
-            FWGPU_LOGW << "Requested Filament texture format RGB565 but getting "
-                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
-            return wgpu::TextureFormat::Undefined;
-        case TextureFormat::RGB9_E5: return wgpu::TextureFormat::RGB9E5Ufloat;
-        case TextureFormat::RGB5_A1:
-            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
-            // and handle the packing/unpacking in shaders.
-            FWGPU_LOGW << "Requested Filament texture format RGB5_A1 but getting "
-                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
-            return wgpu::TextureFormat::Undefined;
-        case TextureFormat::RGBA4:
-            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
-            // and handle the packing/unpacking in shaders.
-            FWGPU_LOGW << "Requested Filament texture format RGBA4 but getting "
-                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
-            return wgpu::TextureFormat::Undefined;
-        case TextureFormat::RGB8:
-            FWGPU_LOGW << "Requested Filament texture format RGB8 but getting "
-                          "wgpu::TextureFormat::RGBA8Unorm (no direct sRGB equivalent in wgpu "
-                          "without alpha)";
-            return wgpu::TextureFormat::RGBA8Unorm;
-        case TextureFormat::SRGB8:
-            FWGPU_LOGW << "Requested Filament texture format SRGB8 but getting "
-                          "wgpu::TextureFormat::RGBA8UnormSrgb (no direct sRGB equivalent in wgpu "
-                          "without alpha)";
-            return wgpu::TextureFormat::RGBA8UnormSrgb;
-        case TextureFormat::RGB8_SNORM:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB8_SNORM but getting "
-                       "wgpu::TextureFormat::RGBA8Snorm (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA8Snorm;
-        case TextureFormat::RGB8UI:
-            FWGPU_LOGW << "Requested Filament texture format RGB8UI but getting "
-                          "wgpu::TextureFormat::RGBA8Uint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA8Uint;
-        case TextureFormat::RGB8I:
-            FWGPU_LOGW << "Requested Filament texture format RGB8I but getting "
-                          "wgpu::TextureFormat::RGBA8Sint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA8Sint;
-        case TextureFormat::R11F_G11F_B10F:          return wgpu::TextureFormat::RG11B10Ufloat;
-        case TextureFormat::UNUSED:                  return wgpu::TextureFormat::Undefined;
-        case TextureFormat::RGB10_A2:                return wgpu::TextureFormat::RGB10A2Unorm;
-        case TextureFormat::RGB16F:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB16F but getting "
-                       "wgpu::TextureFormat::RGBA16Float (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA16Float;
-        case TextureFormat::RGB16UI:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB16UI but getting "
-                       "wgpu::TextureFormat::RGBA16Uint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA16Uint;
-        case TextureFormat::RGB16I:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB16I but getting "
-                       "wgpu::TextureFormat::RGBA16Sint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA16Sint;
-        case TextureFormat::RGB32F:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB32F but getting "
-                       "wgpu::TextureFormat::RGBA32Float (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA32Float;
-        case TextureFormat::RGB32UI:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB32UI but getting "
-                       "wgpu::TextureFormat::RGBA32Uint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA32Uint;
-        case TextureFormat::RGB32I:
-            FWGPU_LOGW
-                    << "Requested Filament texture format RGB32I but getting "
-                       "wgpu::TextureFormat::RGBA32Sint (no direct mapping in wgpu without alpha)";
-            return wgpu::TextureFormat::RGBA32Sint;
-        case TextureFormat::DXT1_RGB:                return wgpu::TextureFormat::BC1RGBAUnorm;
-        case TextureFormat::DXT1_RGBA:               return wgpu::TextureFormat::BC1RGBAUnorm;
-        case TextureFormat::DXT3_RGBA:               return wgpu::TextureFormat::BC2RGBAUnorm;
-        case TextureFormat::DXT5_RGBA:               return wgpu::TextureFormat::BC3RGBAUnorm;
-        case TextureFormat::DXT1_SRGB:               return wgpu::TextureFormat::BC1RGBAUnormSrgb;
-        case TextureFormat::DXT1_SRGBA:              return wgpu::TextureFormat::BC1RGBAUnormSrgb;
-        case TextureFormat::DXT3_SRGBA:              return wgpu::TextureFormat::BC2RGBAUnormSrgb;
-        case TextureFormat::DXT5_SRGBA:              return wgpu::TextureFormat::BC3RGBAUnormSrgb;
-    }
-}
 wgpu::TextureView WebGPUTexture::makeTextureView(const uint8_t& baseLevel,
         const uint8_t& levelCount, const uint32_t& baseArrayLayer, const uint32_t& arrayLayerCount,
         const wgpu::TextureViewDimension dimension) const noexcept {

--- a/filament/backend/src/webgpu/WebGPUTexture.h
+++ b/filament/backend/src/webgpu/WebGPUTexture.h
@@ -26,20 +26,6 @@
 
 namespace filament::backend {
 
-[[nodiscard]] constexpr bool hasStencil(const wgpu::TextureFormat textureFormat) {
-    return textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
-           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8 ||
-           textureFormat == wgpu::TextureFormat::Stencil8;
-}
-
-[[nodiscard]] constexpr bool hasDepth(const wgpu::TextureFormat textureFormat) {
-    return textureFormat == wgpu::TextureFormat::Depth16Unorm ||
-           textureFormat == wgpu::TextureFormat::Depth32Float ||
-           textureFormat == wgpu::TextureFormat::Depth24Plus ||
-           textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
-           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8;
-}
-
 class WebGPUTexture : public HwTexture {
 public:
     enum class MipmapGenerationStrategy : uint8_t {
@@ -104,10 +90,8 @@ public:
     /**
      * @return nullptr if a MSAA sidecar texture is not appliable, otherwise a view to one
      */
-    [[nodiscard]] wgpu::TextureView makeMsaaSidecarTextureView(wgpu::Texture const&, uint8_t mipLevel, uint32_t arrayLayer) const;
-
-    [[nodiscard]] static wgpu::TextureFormat fToWGPUTextureFormat(
-            filament::backend::TextureFormat const& fFormat);
+    [[nodiscard]] wgpu::TextureView makeMsaaSidecarTextureView(wgpu::Texture const&,
+            uint8_t mipLevel, uint32_t arrayLayer) const;
 
     /**
      * @param format a required texture format (can be a view to a different underlying texture
@@ -117,8 +101,6 @@ public:
      */
     [[nodiscard]] static bool supportsMultipleMipLevelsViaStorageBinding(
             wgpu::TextureFormat format);
-
-    [[nodiscard]] static size_t getWGPUTextureFormatPixelSize(const wgpu::TextureFormat format);
 
 private:
     // the texture view's format, which may differ from the underlying texture's format itself,

--- a/filament/backend/src/webgpu/WebGPUTextureHelpers.h
+++ b/filament/backend/src/webgpu/WebGPUTextureHelpers.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_BACKEND_WEBGPUTEXTUREHELPERS_H
 #define TNT_FILAMENT_BACKEND_WEBGPUTEXTUREHELPERS_H
 
+#include "webgpu/WebGPUConstants.h"
+
 #include <backend/DriverEnums.h>
 
 #include <webgpu/webgpu_cpp.h>
@@ -24,6 +26,20 @@
 #include <string_view>
 
 namespace filament::backend {
+
+[[nodiscard]] constexpr bool hasStencil(const wgpu::TextureFormat textureFormat) {
+    return textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
+           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8 ||
+           textureFormat == wgpu::TextureFormat::Stencil8;
+}
+
+[[nodiscard]] constexpr bool hasDepth(const wgpu::TextureFormat textureFormat) {
+    return textureFormat == wgpu::TextureFormat::Depth16Unorm ||
+           textureFormat == wgpu::TextureFormat::Depth32Float ||
+           textureFormat == wgpu::TextureFormat::Depth24Plus ||
+           textureFormat == wgpu::TextureFormat::Depth24PlusStencil8 ||
+           textureFormat == wgpu::TextureFormat::Depth32FloatStencil8;
+}
 
 [[nodiscard]] constexpr std::string_view toString(const PixelDataFormat format) {
     switch (format) {
@@ -97,7 +113,206 @@ namespace filament::backend {
     return wgpu::TextureFormat::Undefined;
 }
 
-[[nodiscard]] constexpr wgpu::TextureFormat toWebGPULinearFormat(const wgpu::TextureFormat format) {
+[[nodiscard]] constexpr wgpu::TextureFormat toWGPUTextureFormat(const TextureFormat fFormat) {
+    switch (fFormat) {
+        case TextureFormat::R8:                      return wgpu::TextureFormat::R8Unorm;
+        case TextureFormat::R8_SNORM:                return wgpu::TextureFormat::R8Snorm;
+        case TextureFormat::R8UI:                    return wgpu::TextureFormat::R8Uint;
+        case TextureFormat::R8I:                     return wgpu::TextureFormat::R8Sint;
+        case TextureFormat::STENCIL8:                return wgpu::TextureFormat::Stencil8;
+        case TextureFormat::R16F:                    return wgpu::TextureFormat::R16Float;
+        case TextureFormat::R16UI:                   return wgpu::TextureFormat::R16Uint;
+        case TextureFormat::R16I:                    return wgpu::TextureFormat::R16Sint;
+        case TextureFormat::RG8:                     return wgpu::TextureFormat::RG8Unorm;
+        case TextureFormat::RG8_SNORM:               return wgpu::TextureFormat::RG8Snorm;
+        case TextureFormat::RG8UI:                   return wgpu::TextureFormat::RG8Uint;
+        case TextureFormat::RG8I:                    return wgpu::TextureFormat::RG8Sint;
+        case TextureFormat::R32F:                    return wgpu::TextureFormat::R32Float;
+        case TextureFormat::R32UI:                   return wgpu::TextureFormat::R32Uint;
+        case TextureFormat::R32I:                    return wgpu::TextureFormat::R32Sint;
+        case TextureFormat::RG16F:                   return wgpu::TextureFormat::RG16Float;
+        case TextureFormat::RG16UI:                  return wgpu::TextureFormat::RG16Uint;
+        case TextureFormat::RG16I:                   return wgpu::TextureFormat::RG16Sint;
+        case TextureFormat::RGBA8:                   return wgpu::TextureFormat::RGBA8Unorm;
+        case TextureFormat::SRGB8_A8:                return wgpu::TextureFormat::RGBA8UnormSrgb;
+        case TextureFormat::RGBA8_SNORM:             return wgpu::TextureFormat::RGBA8Snorm;
+        case TextureFormat::RGBA8UI:                 return wgpu::TextureFormat::RGBA8Uint;
+        case TextureFormat::RGBA8I:                  return wgpu::TextureFormat::RGBA8Sint;
+        case TextureFormat::DEPTH16:                 return wgpu::TextureFormat::Depth16Unorm;
+        case TextureFormat::DEPTH24:                 return wgpu::TextureFormat::Depth24Plus;
+        case TextureFormat::DEPTH32F:                return wgpu::TextureFormat::Depth32Float;
+        case TextureFormat::DEPTH24_STENCIL8:        return wgpu::TextureFormat::Depth24PlusStencil8;
+        case TextureFormat::DEPTH32F_STENCIL8:       return wgpu::TextureFormat::Depth32FloatStencil8;
+        case TextureFormat::RG32F:                   return wgpu::TextureFormat::RG32Float;
+        case TextureFormat::RG32UI:                  return wgpu::TextureFormat::RG32Uint;
+        case TextureFormat::RG32I:                   return wgpu::TextureFormat::RG32Sint;
+        case TextureFormat::RGBA16F:                 return wgpu::TextureFormat::RGBA16Float;
+        case TextureFormat::RGBA16UI:                return wgpu::TextureFormat::RGBA16Uint;
+        case TextureFormat::RGBA16I:                 return wgpu::TextureFormat::RGBA16Sint;
+        case TextureFormat::RGBA32F:                 return wgpu::TextureFormat::RGBA32Float;
+        case TextureFormat::RGBA32UI:                return wgpu::TextureFormat::RGBA32Uint;
+        case TextureFormat::RGBA32I:                 return wgpu::TextureFormat::RGBA32Sint;
+        case TextureFormat::EAC_R11:                 return wgpu::TextureFormat::EACR11Unorm;
+        case TextureFormat::EAC_R11_SIGNED:          return wgpu::TextureFormat::EACR11Snorm;
+        case TextureFormat::EAC_RG11:                return wgpu::TextureFormat::EACRG11Unorm;
+        case TextureFormat::EAC_RG11_SIGNED:         return wgpu::TextureFormat::EACRG11Snorm;
+        case TextureFormat::ETC2_RGB8:               return wgpu::TextureFormat::ETC2RGB8Unorm;
+        case TextureFormat::ETC2_SRGB8:              return wgpu::TextureFormat::ETC2RGB8UnormSrgb;
+        case TextureFormat::ETC2_RGB8_A1:            return wgpu::TextureFormat::ETC2RGB8A1Unorm;
+        case TextureFormat::ETC2_SRGB8_A1:           return wgpu::TextureFormat::ETC2RGB8A1UnormSrgb;
+        case TextureFormat::ETC2_EAC_RGBA8:          return wgpu::TextureFormat::ETC2RGBA8Unorm;
+        case TextureFormat::ETC2_EAC_SRGBA8:         return wgpu::TextureFormat::ETC2RGBA8UnormSrgb;
+        case TextureFormat::RGBA_ASTC_4x4:           return wgpu::TextureFormat::ASTC4x4Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_4x4:   return wgpu::TextureFormat::ASTC4x4UnormSrgb;
+        case TextureFormat::RGBA_ASTC_5x4:           return wgpu::TextureFormat::ASTC5x4Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x4:   return wgpu::TextureFormat::ASTC5x4UnormSrgb;
+        case TextureFormat::RGBA_ASTC_5x5:           return wgpu::TextureFormat::ASTC5x5Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x5:   return wgpu::TextureFormat::ASTC5x5UnormSrgb;
+        case TextureFormat::RGBA_ASTC_6x5:           return wgpu::TextureFormat::ASTC6x5Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x5:   return wgpu::TextureFormat::ASTC6x5UnormSrgb;
+        case TextureFormat::RGBA_ASTC_6x6:           return wgpu::TextureFormat::ASTC6x6Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x6:   return wgpu::TextureFormat::ASTC6x6UnormSrgb;
+        case TextureFormat::RGBA_ASTC_8x5:           return wgpu::TextureFormat::ASTC8x5Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x5:   return wgpu::TextureFormat::ASTC8x5UnormSrgb;
+        case TextureFormat::RGBA_ASTC_8x6:           return wgpu::TextureFormat::ASTC8x6Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x6:   return wgpu::TextureFormat::ASTC8x6UnormSrgb;
+        case TextureFormat::RGBA_ASTC_8x8:           return wgpu::TextureFormat::ASTC8x8Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x8:   return wgpu::TextureFormat::ASTC8x8UnormSrgb;
+        case TextureFormat::RGBA_ASTC_10x5:          return wgpu::TextureFormat::ASTC10x5Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x5:  return wgpu::TextureFormat::ASTC10x5UnormSrgb;
+        case TextureFormat::RGBA_ASTC_10x6:          return wgpu::TextureFormat::ASTC10x6Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x6:  return wgpu::TextureFormat::ASTC10x6UnormSrgb;
+        case TextureFormat::RGBA_ASTC_10x8:          return wgpu::TextureFormat::ASTC10x8Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x8:  return wgpu::TextureFormat::ASTC10x8UnormSrgb;
+        case TextureFormat::RGBA_ASTC_10x10:         return wgpu::TextureFormat::ASTC10x10Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x10: return wgpu::TextureFormat::ASTC10x10UnormSrgb;
+        case TextureFormat::RGBA_ASTC_12x10:         return wgpu::TextureFormat::ASTC12x10Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x10: return wgpu::TextureFormat::ASTC12x10UnormSrgb;
+        case TextureFormat::RGBA_ASTC_12x12:         return wgpu::TextureFormat::ASTC12x12Unorm;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x12: return wgpu::TextureFormat::ASTC12x12UnormSrgb;
+        case TextureFormat::RED_RGTC1:               return wgpu::TextureFormat::BC4RUnorm;
+        case TextureFormat::SIGNED_RED_RGTC1:        return wgpu::TextureFormat::BC4RSnorm;
+        case TextureFormat::RED_GREEN_RGTC2:         return wgpu::TextureFormat::BC5RGUnorm;
+        case TextureFormat::SIGNED_RED_GREEN_RGTC2:  return wgpu::TextureFormat::BC5RGSnorm;
+        case TextureFormat::RGB_BPTC_UNSIGNED_FLOAT: return wgpu::TextureFormat::BC6HRGBUfloat;
+        case TextureFormat::RGB_BPTC_SIGNED_FLOAT:   return wgpu::TextureFormat::BC6HRGBFloat;
+        case TextureFormat::RGBA_BPTC_UNORM:         return wgpu::TextureFormat::BC7RGBAUnorm;
+        case TextureFormat::SRGB_ALPHA_BPTC_UNORM:   return wgpu::TextureFormat::BC7RGBAUnormSrgb;
+        case TextureFormat::RGB565:
+            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
+            // and discard the alpha and lower precision.
+            FWGPU_LOGW << "Requested Filament texture format RGB565 but getting "
+                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
+            return wgpu::TextureFormat::Undefined;
+        case TextureFormat::RGB9_E5: return wgpu::TextureFormat::RGB9E5Ufloat;
+        case TextureFormat::RGB5_A1:
+            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
+            // and handle the packing/unpacking in shaders.
+            FWGPU_LOGW << "Requested Filament texture format RGB5_A1 but getting "
+                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
+            return wgpu::TextureFormat::Undefined;
+        case TextureFormat::RGBA4:
+            // No direct mapping in wgpu. Could potentially map to RGBA8Unorm
+            // and handle the packing/unpacking in shaders.
+            FWGPU_LOGW << "Requested Filament texture format RGBA4 but getting "
+                          "wgpu::TextureFormat::Undefined (no direct mapping in wgpu)";
+            return wgpu::TextureFormat::Undefined;
+        case TextureFormat::RGB8:
+            FWGPU_LOGW << "Requested Filament texture format RGB8 but getting "
+                          "wgpu::TextureFormat::RGBA8Unorm (no direct sRGB equivalent in wgpu "
+                          "without alpha)";
+            return wgpu::TextureFormat::RGBA8Unorm;
+        case TextureFormat::SRGB8:
+            FWGPU_LOGW << "Requested Filament texture format SRGB8 but getting "
+                          "wgpu::TextureFormat::RGBA8UnormSrgb (no direct sRGB equivalent in wgpu "
+                          "without alpha)";
+            return wgpu::TextureFormat::RGBA8UnormSrgb;
+        case TextureFormat::RGB8_SNORM:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB8_SNORM but getting "
+                       "wgpu::TextureFormat::RGBA8Snorm (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA8Snorm;
+        case TextureFormat::RGB8UI:
+            FWGPU_LOGW << "Requested Filament texture format RGB8UI but getting "
+                          "wgpu::TextureFormat::RGBA8Uint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA8Uint;
+        case TextureFormat::RGB8I:
+            FWGPU_LOGW << "Requested Filament texture format RGB8I but getting "
+                          "wgpu::TextureFormat::RGBA8Sint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA8Sint;
+        case TextureFormat::R11F_G11F_B10F:          return wgpu::TextureFormat::RG11B10Ufloat;
+        case TextureFormat::UNUSED:                  return wgpu::TextureFormat::Undefined;
+        case TextureFormat::RGB10_A2:                return wgpu::TextureFormat::RGB10A2Unorm;
+        case TextureFormat::RGB16F:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB16F but getting "
+                       "wgpu::TextureFormat::RGBA16Float (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA16Float;
+        case TextureFormat::RGB16UI:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB16UI but getting "
+                       "wgpu::TextureFormat::RGBA16Uint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA16Uint;
+        case TextureFormat::RGB16I:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB16I but getting "
+                       "wgpu::TextureFormat::RGBA16Sint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA16Sint;
+        case TextureFormat::RGB32F:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB32F but getting "
+                       "wgpu::TextureFormat::RGBA32Float (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA32Float;
+        case TextureFormat::RGB32UI:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB32UI but getting "
+                       "wgpu::TextureFormat::RGBA32Uint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA32Uint;
+        case TextureFormat::RGB32I:
+            FWGPU_LOGW
+                    << "Requested Filament texture format RGB32I but getting "
+                       "wgpu::TextureFormat::RGBA32Sint (no direct mapping in wgpu without alpha)";
+            return wgpu::TextureFormat::RGBA32Sint;
+        case TextureFormat::DXT1_RGB:                return wgpu::TextureFormat::BC1RGBAUnorm;
+        case TextureFormat::DXT1_RGBA:               return wgpu::TextureFormat::BC1RGBAUnorm;
+        case TextureFormat::DXT3_RGBA:               return wgpu::TextureFormat::BC2RGBAUnorm;
+        case TextureFormat::DXT5_RGBA:               return wgpu::TextureFormat::BC3RGBAUnorm;
+        case TextureFormat::DXT1_SRGB:               return wgpu::TextureFormat::BC1RGBAUnormSrgb;
+        case TextureFormat::DXT1_SRGBA:              return wgpu::TextureFormat::BC1RGBAUnormSrgb;
+        case TextureFormat::DXT3_SRGBA:              return wgpu::TextureFormat::BC2RGBAUnormSrgb;
+        case TextureFormat::DXT5_SRGBA:              return wgpu::TextureFormat::BC3RGBAUnormSrgb;
+    }
+}
+
+[[nodiscard]] constexpr wgpu::TextureViewDimension toWebGPUTextureViewDimension(
+        const SamplerType samplerType) {
+    switch (samplerType) {
+        case SamplerType::SAMPLER_2D:            return wgpu::TextureViewDimension::e2D;
+        case SamplerType::SAMPLER_2D_ARRAY:      return wgpu::TextureViewDimension::e2DArray;
+        case SamplerType::SAMPLER_CUBEMAP:       return wgpu::TextureViewDimension::Cube;
+        case SamplerType::SAMPLER_EXTERNAL:      return wgpu::TextureViewDimension::e2D;
+        case SamplerType::SAMPLER_3D:            return wgpu::TextureViewDimension::e3D;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY: return wgpu::TextureViewDimension::CubeArray;
+    }
+}
+
+[[nodiscard]] constexpr wgpu::TextureDimension toWebGPUTextureDimension(
+        const SamplerType samplerType) {
+    switch (samplerType) {
+        case SamplerType::SAMPLER_2D:            return wgpu::TextureDimension::e2D;
+        case SamplerType::SAMPLER_2D_ARRAY:      return wgpu::TextureDimension::e2D;
+        case SamplerType::SAMPLER_CUBEMAP:       return wgpu::TextureDimension::e2D;
+        case SamplerType::SAMPLER_EXTERNAL:      return wgpu::TextureDimension::e2D;
+        case SamplerType::SAMPLER_3D:            return wgpu::TextureDimension::e3D;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY: return wgpu::TextureDimension::e2D;
+    }
+}
+
+/**
+ * @return the linear version of the format (removing the Srgb part) or the original format if it
+ * is already linear
+ */
+[[nodiscard]] constexpr wgpu::TextureFormat toLinearFormat(const wgpu::TextureFormat format) {
     switch (format) {
         case wgpu::TextureFormat::RGBA8UnormSrgb:      return wgpu::TextureFormat::RGBA8Unorm;
         case wgpu::TextureFormat::BGRA8UnormSrgb:      return wgpu::TextureFormat::BGRA8Unorm;
@@ -123,6 +338,199 @@ namespace filament::backend {
         case wgpu::TextureFormat::ETC2RGB8A1UnormSrgb: return wgpu::TextureFormat::ETC2RGB8A1Unorm;
         case wgpu::TextureFormat::ETC2RGBA8UnormSrgb:  return wgpu::TextureFormat::ETC2RGBA8Unorm;
         default:                                       return format;
+    }
+}
+
+/**
+ * @return true if https://www.w3.org/TR/webgpu/#copy-compatible which states:
+ *  Two GPUTextureFormats format1 and format2 are copy-compatible if:
+ *  - format1 equals format2, or
+ *  - format1 and format2 differ only in whether they are srgb formats (have the -srgb suffix).
+ */
+[[nodiscard]] constexpr bool areCopyCompatible(const wgpu::TextureFormat sourceFormat,
+        const wgpu::TextureFormat destinationFormat) {
+    return sourceFormat == destinationFormat ||
+           (toLinearFormat(sourceFormat) == toLinearFormat(destinationFormat));
+}
+
+[[nodiscard]] constexpr wgpu::Extent2D getBlockSize(const wgpu::TextureFormat format) {
+    // see https://www.w3.org/TR/webgpu/#texture-formats
+    //  and https://www.w3.org/TR/webgpu/#texture-format-caps
+    switch (format) {
+        // BC compressed formats
+        case wgpu::TextureFormat::BC1RGBAUnorm:
+        case wgpu::TextureFormat::BC1RGBAUnormSrgb:
+        case wgpu::TextureFormat::BC2RGBAUnorm:
+        case wgpu::TextureFormat::BC2RGBAUnormSrgb:
+        case wgpu::TextureFormat::BC3RGBAUnorm:
+        case wgpu::TextureFormat::BC3RGBAUnormSrgb:
+        case wgpu::TextureFormat::BC4RUnorm:
+        case wgpu::TextureFormat::BC4RSnorm:
+        case wgpu::TextureFormat::BC5RGUnorm:
+        case wgpu::TextureFormat::BC5RGSnorm:
+        case wgpu::TextureFormat::BC6HRGBUfloat:
+        case wgpu::TextureFormat::BC6HRGBFloat:
+        case wgpu::TextureFormat::BC7RGBAUnorm:
+        case wgpu::TextureFormat::BC7RGBAUnormSrgb:
+        // ETC2 compressed formats
+        case wgpu::TextureFormat::ETC2RGB8Unorm:
+        case wgpu::TextureFormat::ETC2RGB8UnormSrgb:
+        case wgpu::TextureFormat::ETC2RGB8A1Unorm:
+        case wgpu::TextureFormat::ETC2RGB8A1UnormSrgb:
+        case wgpu::TextureFormat::ETC2RGBA8Unorm:
+        case wgpu::TextureFormat::ETC2RGBA8UnormSrgb:
+        case wgpu::TextureFormat::EACR11Unorm:
+        case wgpu::TextureFormat::EACR11Snorm:
+        case wgpu::TextureFormat::EACRG11Unorm:
+        case wgpu::TextureFormat::EACRG11Snorm:
+        // ASTC compressed formats
+        case wgpu::TextureFormat::ASTC4x4Unorm:
+        case wgpu::TextureFormat::ASTC4x4UnormSrgb:
+            return { .width = 4, .height = 4 };
+        case wgpu::TextureFormat::ASTC5x4Unorm:
+        case wgpu::TextureFormat::ASTC5x4UnormSrgb:
+            return { .width = 5, .height = 4 };
+        case wgpu::TextureFormat::ASTC5x5Unorm:
+        case wgpu::TextureFormat::ASTC5x5UnormSrgb:
+            return { .width = 5, .height = 5 };
+        case wgpu::TextureFormat::ASTC6x5Unorm:
+        case wgpu::TextureFormat::ASTC6x5UnormSrgb:
+            return { .width = 6, .height = 5 };
+        case wgpu::TextureFormat::ASTC6x6Unorm:
+        case wgpu::TextureFormat::ASTC6x6UnormSrgb:
+            return { .width = 6, .height = 6 };
+        case wgpu::TextureFormat::ASTC8x5Unorm:
+        case wgpu::TextureFormat::ASTC8x5UnormSrgb:
+            return { .width = 8, .height = 5 };
+        case wgpu::TextureFormat::ASTC8x6Unorm:
+        case wgpu::TextureFormat::ASTC8x6UnormSrgb:
+            return { .width = 8, .height = 6 };
+        case wgpu::TextureFormat::ASTC8x8Unorm:
+        case wgpu::TextureFormat::ASTC8x8UnormSrgb:
+            return { .width = 8, .height = 8 };
+        case wgpu::TextureFormat::ASTC10x5Unorm:
+        case wgpu::TextureFormat::ASTC10x5UnormSrgb:
+            return { .width = 10, .height = 5 };
+        case wgpu::TextureFormat::ASTC10x6Unorm:
+        case wgpu::TextureFormat::ASTC10x6UnormSrgb:
+            return { .width = 10, .height = 6 };
+        case wgpu::TextureFormat::ASTC10x8Unorm:
+        case wgpu::TextureFormat::ASTC10x8UnormSrgb:
+            return { .width = 10, .height = 8 };
+        case wgpu::TextureFormat::ASTC10x10Unorm:
+        case wgpu::TextureFormat::ASTC10x10UnormSrgb:
+            return { .width = 10, .height = 10 };
+        case wgpu::TextureFormat::ASTC12x10Unorm:
+        case wgpu::TextureFormat::ASTC12x10UnormSrgb:
+            return { .width = 12, .height = 10 };
+        case wgpu::TextureFormat::ASTC12x12Unorm:
+        case wgpu::TextureFormat::ASTC12x12UnormSrgb:
+            return { .width = 12, .height = 12 };
+        default:
+            // All other formats are uncompressed and have a 1x1 block size.
+            return { .width = 1, .height = 1 };
+    }
+}
+
+[[nodiscard]] constexpr size_t getWGPUTextureFormatPixelSize(const wgpu::TextureFormat format) {
+    switch (format) {
+        // 1 byte
+        case wgpu::TextureFormat::R8Unorm:
+        case wgpu::TextureFormat::R8Snorm:
+        case wgpu::TextureFormat::R8Uint:
+        case wgpu::TextureFormat::R8Sint:
+        case wgpu::TextureFormat::Stencil8:
+            return 1;
+
+        // 2 bytes
+        case wgpu::TextureFormat::R16Uint:
+        case wgpu::TextureFormat::R16Sint:
+        case wgpu::TextureFormat::R16Float:
+        case wgpu::TextureFormat::RG8Unorm:
+        case wgpu::TextureFormat::RG8Snorm:
+        case wgpu::TextureFormat::RG8Uint:
+        case wgpu::TextureFormat::RG8Sint:
+        case wgpu::TextureFormat::Depth16Unorm:
+            return 2;
+
+        // 4 bytes
+        // -- 32-bit single-channel formats
+        case wgpu::TextureFormat::R32Float:
+        case wgpu::TextureFormat::R32Uint:
+        case wgpu::TextureFormat::R32Sint:
+        // -- 16-bit two-channel formats
+        case wgpu::TextureFormat::RG16Uint:
+        case wgpu::TextureFormat::RG16Sint:
+        case wgpu::TextureFormat::RG16Float:
+        // -- 8-bit four-channel formats
+        case wgpu::TextureFormat::RGBA8Unorm:
+        case wgpu::TextureFormat::RGBA8UnormSrgb:
+        case wgpu::TextureFormat::RGBA8Snorm:
+        case wgpu::TextureFormat::RGBA8Uint:
+        case wgpu::TextureFormat::RGBA8Sint:
+        case wgpu::TextureFormat::BGRA8Unorm:
+        case wgpu::TextureFormat::BGRA8UnormSrgb:
+        // -- Packed 32-bit formats
+        case wgpu::TextureFormat::RGB10A2Unorm:
+        case wgpu::TextureFormat::RGB10A2Uint:
+        case wgpu::TextureFormat::RG11B10Ufloat:
+        case wgpu::TextureFormat::RGB9E5Ufloat:
+        // -- Depth/Stencil formats
+        case wgpu::TextureFormat::Depth32Float:
+        case wgpu::TextureFormat::Depth24Plus:
+        case wgpu::TextureFormat::Depth24PlusStencil8:
+            return 4;
+
+        // 8 bytes
+        case wgpu::TextureFormat::RG32Float:
+        case wgpu::TextureFormat::RG32Uint:
+        case wgpu::TextureFormat::RG32Sint:
+        case wgpu::TextureFormat::RGBA16Uint:
+        case wgpu::TextureFormat::RGBA16Sint:
+        case wgpu::TextureFormat::RGBA16Float:
+            return 8;
+
+        // 16 bytes
+        case wgpu::TextureFormat::RGBA32Float:
+        case wgpu::TextureFormat::RGBA32Uint:
+        case wgpu::TextureFormat::RGBA32Sint:
+            return 16;
+
+        // Non-copyable or compressed formats
+        case wgpu::TextureFormat::Depth32FloatStencil8: // Not copyable from texture to buffer
+        default:
+            return 0;
+    }
+}
+
+/**
+ * @param format texture format to potentially be used for storage binding
+ * @return true if the format is compatible with wgpu::TextureUsage::StorageBinding
+ */
+[[nodiscard]] constexpr bool isFormatStorageCompatible(const wgpu::TextureFormat format) {
+    switch (format) {
+        // List of formats that support storage binding
+        case wgpu::TextureFormat::R32Float:
+        case wgpu::TextureFormat::R32Sint:
+        case wgpu::TextureFormat::R32Uint:
+        case wgpu::TextureFormat::RG32Float:
+        case wgpu::TextureFormat::RG32Sint:
+        case wgpu::TextureFormat::RG32Uint:
+        case wgpu::TextureFormat::RGBA16Float:
+        case wgpu::TextureFormat::RGBA16Sint:
+        case wgpu::TextureFormat::RGBA16Uint:
+        case wgpu::TextureFormat::RGBA32Float:
+        case wgpu::TextureFormat::RGBA32Sint:
+        case wgpu::TextureFormat::RGBA32Uint:
+        case wgpu::TextureFormat::RGBA8Unorm:
+        case wgpu::TextureFormat::RGBA8Snorm:
+        case wgpu::TextureFormat::RGBA8Uint:
+        case wgpu::TextureFormat::RGBA8Sint:
+            return true;
+        default:
+            // All other formats, including packed floats (RG11B10Ufloat),
+            // depth/stencil, and sRGB formats do not support storage.
+            return false;
     }
 }
 

--- a/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
+++ b/filament/backend/src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
@@ -54,9 +54,10 @@ std::string processPlaceholderTemplate(std::string_view const& stringTemplate,
                 positionAfterPlaceholder - positionOfPlaceholder) };
         if (const auto iter{ valueByPlaceholderName.find(placeholderName) };
                 iter == valueByPlaceholderName.end()) {
+            // wrapping placeholderName in a std::string to null terminate the C string....
             PANIC_POSTCONDITION("Found placeholder '%s' in template, but this is not present in "
                                 "valueByPlaceholderName",
-                    placeholderName.data());
+                    std::string{ placeholderName }.data());
         } else {
             const std::string_view value{ iter->second };
             out << value;


### PR DESCRIPTION
(in draft because of the handle allocator issue blocking manually testing. but that is happening on main as well, so I don't that is related to this change)