### PR TITLE
remove fake dependencies on the PER_VIEW UBO

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -114,9 +114,7 @@ public:
     FrameGraphId<FrameGraphTexture> ssr(FrameGraph& fg,
             RenderPassBuilder const& passBuilder,
             FrameHistory const& frameHistory,
-            CameraInfo const& cameraInfo,
             FrameGraphId<FrameGraphTexture> structure,
-            ScreenSpaceReflectionsOptions const& options,
             FrameGraphTexture::Descriptor const& desc) noexcept;
 
     // SSAO
@@ -395,6 +393,7 @@ public:
     void resetForRender();
 
 private:
+    static void unbindAllDescriptorSets(backend::DriverApi& driver) noexcept;
 
     // Helper to get a MaterialInstance from a FMaterial
     // This currently just call FMaterial::getDefaultInstance().

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -208,37 +208,23 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
                 view.prepareSSAO(data.ssao ?
                         resources.getTexture(data.ssao) : engine.getOneTextureArray());
 
-                view.prepareShadowMapping(engine, view.getVsmShadowOptions().highPrecision);
-
-                // set shadow sampler
-                view.prepareShadow(data.shadows ?
-                        resources.getTexture(data.shadows) :
-                            (view.getShadowType() != ShadowType::PCF ?
-                                engine.getOneTextureArray() : engine.getOneTextureArrayDepth()));
+                // set screen-space reflections and screen-space refractions
+                view.prepareSSR(data.ssr ?
+                        resources.getTexture(data.ssr) : engine.getOneTextureArray());
 
                 // set structure sampler
                 view.prepareStructure(data.structure ?
                         resources.getTexture(data.structure) : engine.getOneTexture());
 
-                // set screen-space reflections and screen-space refractions
-                TextureHandle const ssr = data.ssr ?
-                        resources.getTexture(data.ssr) : engine.getOneTextureArray();
+                // set shadow sampler
+                view.prepareShadowMapping(engine,
+                        data.shadows
+                            ? resources.getTexture(data.shadows)
+                            : (view.getShadowType() != ShadowType::PCF
+                                   ? engine.getOneTextureArray()
+                                   : engine.getOneTextureArrayDepth()));
 
-                view.prepareSSR(ssr, config.screenSpaceReflectionHistoryNotReady,
-                        config.ssrLodOffset, view.getScreenSpaceReflectionsOptions());
-
-                // Note: here we can't use data.color's descriptor for the viewport because
-                // the actual viewport might be offset when the target is the swapchain.
-                // However, the width/height should be the same.
-                assert_invariant(
-                        out.params.viewport.width == resources.getDescriptor(data.color).width);
-                assert_invariant(
-                        out.params.viewport.height == resources.getDescriptor(data.color).height);
-
-                view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport),
-                        config.logicalViewport);
-
-                view.commitUniformsAndSamplers(driver);
+                view.commitDescriptorSet(driver);
 
                 // TODO: this should be a parameter of FrameGraphRenderPass::Descriptor
                 out.params.clearStencil = config.clearStencil;

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -65,16 +65,12 @@ public:
         math::float4 clearColor = {};
         // Clear stencil
         uint8_t clearStencil = 0u;
-        // Lod offset for the SSR passes
-        float ssrLodOffset;
         // Contact shadow enabled?
         bool hasContactShadows;
         // Screen space reflections enabled
         bool hasScreenSpaceReflectionsOrRefractions;
         // Use a depth format with a stencil component.
         bool enabledStencilBuffer;
-        // whether the screenspace reflections history buffer is initialized
-        bool screenSpaceReflectionHistoryNotReady;
     };
 
     struct ColorPassInput {

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -436,6 +436,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
 
                 // Finally update our UBO in one batch
                 if (mShadowUb.isDirty()) {
+                    mShadowUb.clean();
                     driver.updateBufferObject(mShadowUbh,
                             mShadowUb.toBufferDescriptor(driver), 0);
                 }

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -222,6 +222,7 @@ void FMaterialInstance::commit(FEngine& engine) const {
 void FMaterialInstance::commit(DriverApi& driver) const {
     // update uniforms if needed
     if (mUniforms.isDirty() || mHasStreamUniformAssociations) {
+        mUniforms.clean();
         driver.updateBufferObject(mUbHandle, mUniforms.toBufferDescriptor(driver), 0);
     }
     if (!mTextureParameters.empty()) {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -173,15 +173,19 @@ public:
     void prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexcept;
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
-    void prepareSSR(backend::Handle<backend::HwTexture> ssr, bool disableSSR,
-            float refractionLodOffset,
-            ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
+    void prepareSSAO(AmbientOcclusionOptions const& options) const noexcept;
+
+    void prepareSSR(backend::Handle<backend::HwTexture> ssr) const noexcept;
+    void prepareSSR(FEngine& engine, CameraInfo const& cameraInfo,
+            float refractionLodOffset, ScreenSpaceReflectionsOptions const& options) const noexcept;
+
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
-    void prepareShadow(backend::Handle<backend::HwTexture> structure) const noexcept;
-    void prepareShadowMapping(FEngine const& engine, bool highPrecision) const noexcept;
+    void prepareShadowMapping(FEngine const& engine, backend::Handle<backend::HwTexture> structure) const noexcept;
+    void prepareShadowMapping() const noexcept;
 
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;
-    void commitUniformsAndSamplers(backend::DriverApi& driver) const noexcept;
+    void commitUniforms(backend::DriverApi& driver) const noexcept;
+    void commitDescriptorSet(backend::DriverApi& driver) const noexcept;
 
     utils::JobSystem::Job* getFroxelizerSync() const noexcept { return mFroxelizerSync; }
     void setFroxelizerSync(utils::JobSystem::Job* sync) noexcept { mFroxelizerSync = sync; }

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -23,6 +23,7 @@
 
 #include "TypedUniformBuffer.h"
 
+#include <private/filament/EngineEnums.h>
 #include <private/filament/UibStructs.h>
 
 #include <backend/DriverEnums.h>
@@ -66,11 +67,6 @@ class ColorPassDescriptorSet {
     using LightManagerInstance = utils::EntityInstance<LightManager>;
     using TextureHandle = backend::Handle<backend::HwTexture>;
 
-    static constexpr uint32_t SHADOW_SAMPLING_RUNTIME_PCF   = 0u;
-    static constexpr uint32_t SHADOW_SAMPLING_RUNTIME_EVSM  = 1u;
-    static constexpr uint32_t SHADOW_SAMPLING_RUNTIME_DPCF  = 2u;
-    static constexpr uint32_t SHADOW_SAMPLING_RUNTIME_PCSS  = 3u;
-
 public:
 
     static uint8_t getIndex(bool lit, bool ssr, bool fog)  noexcept;
@@ -112,12 +108,9 @@ public:
     void prepareMaterialGlobals(std::array<math::float4, 4> const& materialGlobals) noexcept;
 
     // screen-space reflection and/or refraction (SSR)
-    void prepareSSR(TextureHandle ssr,
-            bool disableSSR,
-            float refractionLodOffset,
-            ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
+    void prepareScreenSpaceRefraction(TextureHandle ssr) noexcept;
 
-    void prepareShadowMapping(backend::BufferObjectHandle shadowUniforms, bool highPrecision) noexcept;
+    void prepareShadowMapping(backend::BufferObjectHandle shadowUniforms) noexcept;
 
     void prepareDirectionalLight(FEngine& engine, float exposure,
             math::float3 const& sceneSpaceDirection, LightManagerInstance instance) noexcept;
@@ -128,22 +121,15 @@ public:
     void prepareDynamicLights(Froxelizer& froxelizer) noexcept;
 
     void prepareShadowVSM(TextureHandle texture,
-            ShadowMappingUniforms const& shadowMappingUniforms,
             VsmShadowOptions const& options) noexcept;
 
-    void prepareShadowPCF(TextureHandle texture,
-            ShadowMappingUniforms const& shadowMappingUniforms) noexcept;
+    void prepareShadowPCF(TextureHandle texture) noexcept;
 
-    void prepareShadowDPCF(TextureHandle texture,
-            ShadowMappingUniforms const& shadowMappingUniforms,
-            SoftShadowOptions const& options) noexcept;
+    void prepareShadowDPCF(TextureHandle texture) noexcept;
 
-    void prepareShadowPCSS(TextureHandle texture,
-            ShadowMappingUniforms const& shadowMappingUniforms,
-            SoftShadowOptions const& options) noexcept;
+    void prepareShadowPCSS(TextureHandle texture) noexcept;
 
-    void prepareShadowPCFDebug(TextureHandle texture,
-            ShadowMappingUniforms const& shadowMappingUniforms) noexcept;
+    void prepareShadowPCFDebug(TextureHandle texture) noexcept;
 
     // update local data into GPU UBO
     void commit(backend::DriverApi& driver) noexcept;
@@ -163,9 +149,6 @@ private:
 
     void setBuffer(backend::descriptor_binding_t binding,
             backend::BufferObjectHandle boh, uint32_t offset, uint32_t size) noexcept;
-
-    static void prepareShadowSampling(PerViewUib& uniforms,
-            ShadowMappingUniforms const& shadowMappingUniforms) noexcept;
 
     TypedUniformBuffer<PerViewUib>& mUniforms;
     std::array<DescriptorSetLayout, DESCRIPTOR_LAYOUT_COUNT> mDescriptorSetLayout;

--- a/filament/src/ds/SsrPassDescriptorSet.h
+++ b/filament/src/ds/SsrPassDescriptorSet.h
@@ -19,16 +19,12 @@
 
 #include "DescriptorSet.h"
 
-#include "DescriptorSetLayout.h"
-
 #include "TypedUniformBuffer.h"
 
 #include <private/filament/UibStructs.h>
 
 #include <backend/DriverApiForward.h>
 #include <backend/Handle.h>
-
-#include <math/mat4.h>
 
 namespace filament {
 
@@ -51,11 +47,7 @@ public:
 
     void prepareStructure(FEngine const& engine, TextureHandle structure) noexcept;
 
-    void prepareHistorySSR(FEngine const& engine, TextureHandle ssr,
-            math::mat4f const& historyProjection,
-            math::mat4f const& uvFromViewMatrix,
-            ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
-
+    void prepareHistorySSR(FEngine const& engine, TextureHandle ssr) noexcept;
 
     // update local data into GPU UBO
     void commit(FEngine& engine) noexcept;
@@ -64,7 +56,6 @@ public:
     void bind(backend::DriverApi& driver) noexcept;
 
 private:
-    TypedUniformBuffer<PerViewUib>* mUniforms = nullptr;
     DescriptorSet mDescriptorSet;
     backend::BufferObjectHandle mShadowUbh;
 };

--- a/filament/src/ds/StructureDescriptorSet.cpp
+++ b/filament/src/ds/StructureDescriptorSet.cpp
@@ -63,14 +63,14 @@ void StructureDescriptorSet::terminate(DriverApi& driver) {
     mUniforms.terminate(driver);
 }
 
-void StructureDescriptorSet::commit(DriverApi& driver) noexcept {
-    assert_invariant(mDescriptorSetLayout);
-    driver.updateBufferObject(mUniforms.getUboHandle(),
-            mUniforms.toBufferDescriptor(driver), 0);
-    mDescriptorSet.commit(*mDescriptorSetLayout, driver);
-}
-
 void StructureDescriptorSet::bind(DriverApi& driver) const noexcept {
+    assert_invariant(mDescriptorSetLayout);
+    if (mUniforms.isDirty()) {
+        mUniforms.clean();
+        driver.updateBufferObject(mUniforms.getUboHandle(),
+                mUniforms.toBufferDescriptor(driver), 0);
+        mDescriptorSet.commit(*mDescriptorSetLayout, driver);
+    }
     mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
 }
 

--- a/filament/src/ds/StructureDescriptorSet.h
+++ b/filament/src/ds/StructureDescriptorSet.h
@@ -45,8 +45,7 @@ public:
 
     void terminate(backend::DriverApi& driver);
 
-    void commit(backend::DriverApi& driver) noexcept;
-
+    // this commits the UBO if needed and binds the descriptor set
     void bind(backend::DriverApi& driver) const noexcept;
 
 
@@ -65,7 +64,7 @@ public:
 
 private:
     DescriptorSetLayout const* mDescriptorSetLayout = nullptr;
-    DescriptorSet mDescriptorSet;
+    mutable DescriptorSet mDescriptorSet;
     TypedUniformBuffer<PerViewUib> mUniforms;
 };
 


### PR DESCRIPTION
The PER_VIEW UBO was updated by different render passes at different times, which created synchronizations on the GPU, between unrelated passes and prevented the vertex shader to run on parallel with another pass for instance.

In the PR, we fix this by moving ALL the UBO set-up outside of  render passes. It's now done early, just before creating the framegraph.

The PER_VIEW UBO is shared between several passes, themselves using different descriptor sets; so we need to make sure all the data necessary for these passes is computed and set in the UBO (e.g. SSR passes).

The passes themselves (like the color pass) still set the textures and UBOs in their descriptor sets, but then no longer updated the content of the UBO itself.

In this PR we also remove some "fake" dependencies between passes due to descriptor sets straddling between passes. This is done by unbinding all descriptor sets at the end of each pass. The PER_MATERIAL descriptor set is a bit special because it should be unbound between full screen quads draws.

Additionally, there some places in the code attempting to update UBOs only when the content was dirty were missing a "clean" call, to reset the dirty bit to the unset state.

The main change here is to move the code that set the UBO content out of the ColorPassDescriptorSet (and a few other) into View and instead of updating the content in the color pass (and a few other), do that at the beginning of Renderer::render().