### PR TITLE
Use default descriptor set for shared material variants

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -1091,7 +1091,7 @@ void RenderPass::Executor::execute(FEngine const& engine, DriverApi& driver,
                     }
 
                     // Each MaterialInstance has its own descriptor set. This binds it.
-                    mi->use(driver);
+                    mi->use(driver, info.materialVariant);
                 }
 
                 assert_invariant(ma);

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -150,6 +150,23 @@ public:
         return mCachedPrograms[variant.key];
     }
 
+    // MaterialInstance::use() binds descriptor sets before drawing. For shared variants,
+    // however, the material instance will call useShared() to bind the default material's sets
+    // instead.
+    // Returns true if this is a shared variant.
+    bool useShared(backend::DriverApi& driver, Variant variant) const noexcept {
+        if (!isSharedVariant(variant)) {
+            return false;
+        }
+        FMaterial const* const pDefaultMaterial = mEngine.getDefaultMaterial();
+        if (UTILS_UNLIKELY(!pDefaultMaterial)) {
+            return false;
+        }
+        FMaterialInstance const* const pDefaultInstance = pDefaultMaterial->getDefaultInstance();
+        pDefaultInstance->use(driver, variant);
+        return true;
+    }
+
     [[nodiscard]]
     backend::Handle<backend::HwProgram> getProgramWithMATDBG(Variant variant) const noexcept;
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -380,7 +380,7 @@ const char* FMaterialInstance::getName() const noexcept {
 
 // ------------------------------------------------------------------------------------------------
 
-void FMaterialInstance::use(FEngine::DriverApi& driver) const {
+void FMaterialInstance::use(FEngine::DriverApi& driver, Variant variant) const {
 
     if (UTILS_UNLIKELY(mMissingSamplerDescriptors.any())) {
         std::call_once(mMissingSamplersFlag, [this] {
@@ -399,6 +399,12 @@ void FMaterialInstance::use(FEngine::DriverApi& driver) const {
             });
         });
         mMissingSamplerDescriptors.clear();
+    }
+
+    // Checks if this variant is shared. If so, FMaterial takes responsibility for binding the
+    // descriptor sets.
+    if (mMaterial->useShared(driver, variant)) {
+        return;
     }
 
     mDescriptorSet.bind(driver, DescriptorSetBindingPoints::PER_MATERIAL);

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -29,6 +29,8 @@
 
 #include <filament/MaterialInstance.h>
 
+#include <private/filament/Variant.h>
+
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
 
@@ -71,7 +73,7 @@ public:
 
     void commit(FEngine::DriverApi& driver) const;
 
-    void use(FEngine::DriverApi& driver) const;
+    void use(FEngine::DriverApi& driver, Variant variant = {}) const;
 
     FMaterial const* getMaterial() const noexcept { return mMaterial; }
 


### PR DESCRIPTION
This avoids binding unnecessary textures to the pipeline when a shared variant (such as the default depth variant) is used.