### PR TITLE
fix compile conflicts with system getopt.h on linux arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test*.json
 results
 /compile_commands.json
 /.cache
+local_build

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ test*.json
 results
 /compile_commands.json
 /.cache
-local_build

--- a/samples/frame_generator.cpp
+++ b/samples/frame_generator.cpp
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include <getopt/getopt.h>
-
 #include <utils/Path.h>
 
 #include <backend/PixelBufferDescriptor.h>
@@ -57,6 +55,8 @@
 #include <filamentapp/IBL.h>
 #include <filamentapp/FilamentApp.h>
 #include <filamentapp/MeshAssimp.h>
+
+#include <getopt/getopt.h>
 
 using namespace filament::math;
 using namespace filament;

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -34,9 +34,8 @@
 #include <utils/JobSystem.h>
 #include <utils/Path.h>
 
-#include <getopt/getopt.h>
-
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #define STB_PERLIN_IMPLEMENTATION
 #include <stb_perlin.h>

--- a/samples/hellomorphing.cpp
+++ b/samples/hellomorphing.cpp
@@ -31,10 +31,9 @@
 #include <utils/EntityManager.h>
 #include <utils/Path.h>
 
-#include <getopt/getopt.h>
-
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #include <cmath>
 #include <iostream>

--- a/samples/helloskinningbuffer.cpp
+++ b/samples/helloskinningbuffer.cpp
@@ -31,10 +31,9 @@
 #include <utils/EntityManager.h>
 #include <utils/Path.h>
 
-#include <getopt/getopt.h>
-
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #include <cmath>
 #include <iostream>

--- a/samples/helloskinningbuffer_morebones.cpp
+++ b/samples/helloskinningbuffer_morebones.cpp
@@ -31,10 +31,9 @@
 #include <utils/EntityManager.h>
 #include <utils/Path.h>
 
-#include <getopt/getopt.h>
-
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #include <cmath>
 #include <iostream>

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -21,8 +21,6 @@
 #include <map>
 #include <vector>
 
-#include <getopt/getopt.h>
-
 #include <utils/EntityManager.h>
 #include <utils/Path.h>
 
@@ -46,6 +44,7 @@
 #include <filamentapp/Cube.h>
 #include <filamentapp/IcoSphere.h>
 #include <filamentapp/Sphere.h>
+#include <getopt/getopt.h>
 
 #include "generated/resources/resources.h"
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -21,8 +21,6 @@
 #include <map>
 #include <vector>
 
-#include <getopt/getopt.h>
-
 #include <imgui.h>
 
 #include <filagui/ImGuiExtensions.h>
@@ -54,6 +52,7 @@
 #include <filamentapp/IBL.h>
 #include <filamentapp/FilamentApp.h>
 #include <filamentapp/MeshAssimp.h>
+#include <getopt/getopt.h>
 
 #include "material_sandbox.h"
 

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -21,8 +21,6 @@
 #include <map>
 #include <vector>
 
-#include <getopt/getopt.h>
-
 #include <utils/Path.h>
 
 #include <filament/Engine.h>
@@ -41,6 +39,7 @@
 
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #include <stb_image.h>
 

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -21,7 +21,6 @@
 #include <map>
 #include <vector>
 
-#include <getopt/getopt.h>
 
 #include <utils/Path.h>
 
@@ -41,6 +40,7 @@
 
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 #include <stb_image.h>
 
 #include <utils/EntityManager.h>

--- a/samples/skinningtest.cpp
+++ b/samples/skinningtest.cpp
@@ -32,10 +32,9 @@
 #include <utils/EntityManager.h>
 #include <utils/Path.h>
 
-#include <getopt/getopt.h>
-
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
+#include <getopt/getopt.h>
 
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION

~~~bash
[build] /usr/bin/clang++-19 -DFILAMENT_DISABLE_MATOPT=1 -DFILAMENT_DRIVER_SUPPORTS_VULKAN -DFILAMENT_SUPPORTS_OPENGL -DFILAMENT_SUPPORTS_X11 -DFILAMENT_SUPPORTS_XCB -DFILAMENT_SUPPORTS_XLIB -I/home/orangepi/filament/local_build/samples -I/home/orangepi/filament/libs/filamentapp/include -I/home/orangepi/filament/third_party/libassimp/tnt/../include -I/home/orangepi/filament/third_party/libz/tnt/.. -I/home/orangepi/filament/libs/camutils/include -I/home/orangepi/filament/libs/math/include -I/home/orangepi/filament/libs/filagui/include -I/home/orangepi/filament/third_party/imgui/tnt/.. -I/home/orangepi/filament/filament/include -I/home/orangepi/filament/filament/backend/include -I/home/orangepi/filament/libs/utils/include -I/home/orangepi/filament/third_party/robin-map/tnt/.. -I/home/orangepi/filament/libs/bluevk/include -I/home/orangepi/filament/third_party/vkmemalloc/tnt/../include -I/home/orangepi/filament/third_party/smol-v/tnt/../source -I/home/orangepi/filament/libs/filaflat/include -I/home/orangepi/filament/libs/filabridge/include -I/home/orangepi/filament/libs/matdbg/include -I/home/orangepi/filament/third_party/civetweb/tnt/../include -I/home/orangepi/filament/libs/filamat/include -I/home/orangepi/filament/local_build/shaders -I/home/orangepi/filament/local_build/include -I/home/orangepi/filament/third_party/glslang/glslang/tnt/../Include -I/home/orangepi/filament/third_party/glslang/glslang/tnt/../Public -I/home/orangepi/filament/third_party/glslang/glslang/tnt/../MachineIndependent -I/home/orangepi/filament/third_party/glslang/glslang/tnt/../.. -I/home/orangepi/filament/third_party/glslang/SPIRV/tnt/.. -I/home/orangepi/filament/third_party/glslang/SPIRV/tnt/../.. -I/home/orangepi/filament/third_party/spirv-tools/include -I/home/orangepi/filament/third_party/spirv-headers/include -I/home/orangepi/filament/third_party/spirv-cross/tnt/.. -I/home/orangepi/filament/libs/iblprefilter/include -I/home/orangepi/filament/libs/geometry/include -I/home/orangepi/filament/third_party/getopt/include -I/home/orangepi/filament/libs/image/include -I/home/orangepi/filament/libs/imageio/include -I/home/orangepi/filament/third_party/libpng/tnt/.. -I/home/orangepi/filament/third_party/tinyexr/tnt/.. -I/home/orangepi/filament/third_party/basisu/tnt/../encoder -I/home/orangepi/filament/third_party/basisu/tnt/../transcoder -I/home/orangepi/filament/third_party/basisu/tnt/../zstd -I/home/orangepi/filament/libs/ktxreader/include -I/home/orangepi/filament/third_party/libsdl2/tnt/../include -I/home/orangepi/filament/third_party/stb/tnt/.. -std=c++17 -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function -Wno-deprecated-declarations -stdlib=libc++ -fPIC -fcolor-diagnostics -fvisibility=hidden -DTNT_DEV -g -fstack-protector -Wno-extern-c-compat -MD -MT samples/CMakeFiles/heightfield.dir/heightfield.cpp.o -MF samples/CMakeFiles/heightfield.dir/heightfield.cpp.o.d -o samples/CMakeFiles/heightfield.dir/heightfield.cpp.o -c /home/orangepi/filament/samples/heightfield.cpp
[build] In file included from /home/orangepi/filament/samples/heightfield.cpp:39:
[build] In file included from /home/orangepi/filament/libs/filamentapp/include/filamentapp/FilamentApp.h:26:
[build] In file included from /home/orangepi/filament/third_party/libsdl2/tnt/../include/SDL.h:34:
[build] In file included from /home/orangepi/filament/third_party/libsdl2/tnt/../include/SDL_assert.h:59:
[build] In file included from /usr/include/signal.h:328:
[build] In file included from /usr/include/aarch64-linux-gnu/bits/sigstksz.h:24:
[build] In file included from /usr/include/unistd.h:903:
[build] In file included from /usr/include/aarch64-linux-gnu/bits/getopt_posix.h:27:
[build] /usr/include/aarch64-linux-gnu/bits/getopt_core.h:91:12: error: exception specification in declaration does not match previous declaration
[build] 91 | extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
[build] | ^
[build] /home/orangepi/filament/third_party/getopt/include/getopt/getopt.h:8:5: note: previous declaration is here
[build] 8 | int getopt(int, char * const [], const char *);
[build] | ^
[build] 1 error generated.
~~~

Above is the compiling error on vscode-cmake-tools. The solution is to reorder the header of `<getopt/getopt.h>` under the `<filament/FilamentApp.h>` for the reason of filamentApp.h contains sdl.h and internal contains signal.h. Conflicts occurs on the `thirdparty/getopt/getopt.h` and the system `getopt.h`.