### PR TITLE
Tests: Fixes for backend tests when using Vulkan

### DIFF
--- a/filament/backend/test/Lifetimes.cpp
+++ b/filament/backend/test/Lifetimes.cpp
@@ -25,6 +25,7 @@ RenderFrame::RenderFrame(filament::backend::DriverApi& api): mApi(api) {
 
 RenderFrame::~RenderFrame() {
     mApi.endFrame(0);
+    mApi.finish();
 }
 
 Cleanup::Cleanup(filament::backend::DriverApi& driverApi) : mDriverApi(driverApi) {}

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -486,7 +486,6 @@ TEST_F(BlitTest, BlitRegion) {
 }
 
 TEST_F(BlitTest, BlitRegionToSwapChain) {
-    FAIL_IF(Backend::VULKAN, "Crashes due to not finding color attachment, see b/417481493");
     auto& api = getDriverApi();
     mCleanup.addPostCall([&]() { executeCommands(); });
 
@@ -498,10 +497,9 @@ TEST_F(BlitTest, BlitRegionToSwapChain) {
     constexpr int kNumLevels = 3;
 
     // Create a SwapChain and make it current.
+    Handle<HwRenderTarget> dstRenderTarget = mCleanup.add(api.createDefaultRenderTarget());
     auto swapChain = mCleanup.add(createSwapChain());
     api.makeCurrent(swapChain, swapChain);
-
-    Handle<HwRenderTarget> dstRenderTarget = mCleanup.add(api.createDefaultRenderTarget());
 
     // Create a source texture.
     Handle<HwTexture> srcTexture = mCleanup.add(api.createTexture(

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -34,9 +34,8 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     // Create a SwapChain.
     // In order for the frameScheduledCallback to be called, this must be a real SwapChain (not
     // headless) so we obtain a drawable.
-    auto swapChain = cleanup.add(createSwapChain());
-
     Handle<HwRenderTarget> renderTarget = cleanup.add(api.createDefaultRenderTarget());
+    auto swapChain = cleanup.add(createSwapChain());
 
     int callbackCountA = 0;
     api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -53,6 +53,8 @@ TEST_F(BackendTest, MRT) {
     // The test is executed within this block scope to force destructors to run before
     // executeCommands().
     {
+        auto defaultRenderTarget = cleanup.add(api.createDefaultRenderTarget(0));
+
         // Create a platform-specific SwapChain and make it current.
         auto swapChain = cleanup.add(createSwapChain());
         api.makeCurrent(swapChain, swapChain);
@@ -65,8 +67,6 @@ TEST_F(BackendTest, MRT) {
         });
 
         TrianglePrimitive triangle(api);
-
-        auto defaultRenderTarget = cleanup.add(api.createDefaultRenderTarget(0));
 
         // Create two Textures.
         auto usage = TextureUsage::COLOR_ATTACHMENT | TextureUsage::SAMPLEABLE;
@@ -110,7 +110,6 @@ TEST_F(BackendTest, MRT) {
 
         api.startCapture(0);
 
-        api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0, 0);
 
         // Draw a triangle.

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -62,6 +62,10 @@ TEST_F(BackendTest, TextureViewLod) {
     // The test is executed within this block scope to force destructors to run before
     // executeCommands().
     {
+        // Create a platform-specific SwapChain and make it current.
+        auto defaultRenderTarget = cleanup.add(api.createDefaultRenderTarget(0));
+        assert_invariant(defaultRenderTarget);
+
         // Create a SwapChain and make it current.
         auto swapChain = cleanup.add(createSwapChain());
         api.makeCurrent(swapChain, swapChain);
@@ -152,9 +156,6 @@ TEST_F(BackendTest, TextureViewLod) {
             api.draw2(0, 3, 1);
             api.endRenderPass();
         }
-
-        backend::Handle<HwRenderTarget> defaultRenderTarget =
-                cleanup.add(api.createDefaultRenderTarget(0));
 
         PipelineState state = getColorWritePipelineState();
         texturedShader.addProgramToPipelineState(state);

--- a/filament/backend/test/test_MissingRequiredAttributes.cpp
+++ b/filament/backend/test/test_MissingRequiredAttributes.cpp
@@ -65,6 +65,8 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
         DriverApi& api = getDriverApi();
         Cleanup cleanup(api);
         // Create a platform-specific SwapChain and make it current.
+        auto defaultRenderTarget = cleanup.add(api.createDefaultRenderTarget(0));
+
         auto swapChain = cleanup.add(createSwapChain());
         api.makeCurrent(swapChain, swapChain);
 
@@ -74,8 +76,6 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
                 .fragmentShader = SharedShaders::getFragmentShaderText(FragmentShaderType::White,
                         ShaderUniformType::None),
         });
-
-        auto defaultRenderTarget = cleanup.add(api.createDefaultRenderTarget(0));
 
         TrianglePrimitive triangle(api);
 

--- a/filament/backend/test/test_PushConstants.cpp
+++ b/filament/backend/test/test_PushConstants.cpp
@@ -117,6 +117,8 @@ TEST_F(BackendTest, PushConstants) {
     // executeCommands().
     {
         // Create a SwapChain and make it current.
+        Handle<HwRenderTarget> renderTarget = cleanup.add(api.createDefaultRenderTarget());
+
         auto swapChain = cleanup.add(createSwapChain());
         api.makeCurrent(swapChain, swapChain);
 
@@ -125,8 +127,6 @@ TEST_F(BackendTest, PushConstants) {
         Program p =
                 shaderGen.getProgramWithPushConstants(api, { gVertConstants, gFragConstants, {} });
         ProgramHandle program = cleanup.add(api.createProgram(std::move(p)));
-
-        Handle<HwRenderTarget> renderTarget = cleanup.add(api.createDefaultRenderTarget());
 
         TrianglePrimitive triangle(api);
 
@@ -139,7 +139,6 @@ TEST_F(BackendTest, PushConstants) {
         ps.rasterState.colorWrite = true;
         ps.rasterState.depthWrite = false;
 
-        api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0, 0);
 
         api.beginRenderPass(renderTarget, params);
@@ -178,12 +177,13 @@ TEST_F(BackendTest, PushConstants) {
 
         api.endRenderPass();
 
-        EXPECT_IMAGE(renderTarget, getExpectations(),
-                ScreenshotParams(params.viewport.width, params.viewport.height, "pushConstants",
-                        3575588741));
-
         api.commit(swapChain);
         api.endFrame(0);
+        api.finish();
+
+        EXPECT_IMAGE(renderTarget, getExpectations(),
+        ScreenshotParams(params.viewport.width, params.viewport.height, "pushConstants",
+                3575588741));
     }
 
     api.stopCapture(0);

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -82,10 +82,10 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         // Create source color and depth textures.
         Handle<HwTexture> srcTexture = cleanup.add(api.createTexture(SamplerType::SAMPLER_2D,
                 kNumLevels, kSrcTexFormat, 1, kSrcTexWidth, kSrcTexHeight, 1,
-                TextureUsage::SAMPLEABLE | TextureUsage::COLOR_ATTACHMENT));
+                TextureUsage::SAMPLEABLE | TextureUsage::COLOR_ATTACHMENT | TextureUsage::BLIT_SRC));
         Handle<HwTexture> depthTexture = cleanup.add(api.createTexture(SamplerType::SAMPLER_2D, 1,
                 TextureFormat::DEPTH16, 1, 512, 512, 1,
-                TextureUsage::DEPTH_ATTACHMENT));
+                TextureUsage::DEPTH_ATTACHMENT  | TextureUsage::BLIT_SRC));
 
         // Render into the bottom-left quarter of the texture.
         Viewport srcRect = {
@@ -132,11 +132,12 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         api.draw2(0, 3, 1);
         api.endRenderPass();
 
-        EXPECT_IMAGE(fullRenderTarget, getExpectations(),
-                ScreenshotParams(kSrcTexWidth >> 1, kSrcTexHeight >> 1, "scissor", 15842520));
-
         api.commit(swapChain);
         api.endFrame(0);
+        api.finish();
+
+        EXPECT_IMAGE(fullRenderTarget, getExpectations(),
+                ScreenshotParams(kSrcTexWidth >> 1, kSrcTexHeight >> 1, "scissor", 15842520));
 
         api.stopCapture(0);
     }
@@ -165,7 +166,7 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         // Create a source color textures.
         Handle<HwTexture> srcTexture = cleanup.add(api.createTexture(SamplerType::SAMPLER_2D, 1,
                 TextureFormat::RGBA8, 1, 512, 512, 1,
-                TextureUsage::SAMPLEABLE | TextureUsage::COLOR_ATTACHMENT));
+                TextureUsage::SAMPLEABLE | TextureUsage::COLOR_ATTACHMENT | TextureUsage::BLIT_SRC));
 
         // Render into the bottom-left quarter of the texture, checking 3 special cases.
         // 1. negative viewport left/bottom
@@ -224,11 +225,12 @@ TEST_F(BackendTest, ScissorViewportEdgeCases) {
         api.draw2(0, 3, 1);
         api.endRenderPass();
 
-        EXPECT_IMAGE(renderTarget, getExpectations(),
-                ScreenshotParams(512, 512, "ScissorViewportEdgeCases", 2199186852));
-
         api.commit(swapChain);
         api.endFrame(0);
+        api.finish();
+
+        EXPECT_IMAGE(renderTarget, getExpectations(),
+                ScreenshotParams(512, 512, "ScissorViewportEdgeCases", 2199186852));
 
         api.stopCapture(0);
     }

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -37,6 +37,7 @@ class BasicStencilBufferTest : public BackendTest {
 public:
 
     Handle <HwSwapChain> mSwapChain;
+    Handle <HwRenderTarget> mDefaultRenderTarget;
     ProgramHandle mProgram;
     Cleanup mCleanup;
 
@@ -46,6 +47,8 @@ public:
         auto& api = getDriverApi();
 
         // Create a platform-specific SwapChain and make it current.
+        mDefaultRenderTarget = mCleanup.add(api.createDefaultRenderTarget(0));
+
         mSwapChain = mCleanup.add(createSwapChain());
         api.makeCurrent(mSwapChain, mSwapChain);
 


### PR DESCRIPTION
- Make sure the defaultRenderTarget is created before calling makeCurrent.
- Add some missing TextureUsage flags to textures
- Add a finish to the RenderFrame destructor, so it guarantess that the GPU work is completed,
prevents some synchronization issues.