### PR TITLE
webgpu: add visibility for debugging bind groups via logging (compile-time flag option)

### DIFF
--- a/filament/backend/src/webgpu/WebGPUConstants.h
+++ b/filament/backend/src/webgpu/WebGPUConstants.h
@@ -44,6 +44,10 @@ constexpr size_t FILAMENT_WEBGPU_BUFFER_SIZE_MODULUS = 4;
 // which would otherwise spam the logs.
 #define FWGPU_DEBUG_BLIT 0x00000010
 
+// Set this to enable logging relating to bind groups (bind group layouts, bind groups themselves,
+// textures, samplers, and buffers,...), which would otherwise spam the logs.
+#define FWGPU_DEBUG_BIND_GROUPS 0x00000020
+
 // Useful default combinations
 #define FWGPU_DEBUG_EVERYTHING     0xFFFFFFFF
 

--- a/filament/backend/src/webgpu/WebGPUDescriptorSet.h
+++ b/filament/backend/src/webgpu/WebGPUDescriptorSet.h
@@ -19,6 +19,8 @@
 
 #include "WebGPUDescriptorSetLayout.h"
 
+#include "WebGPUConstants.h"
+
 #include "DriverBase.h"
 #include <backend/DriverEnums.h>
 
@@ -48,6 +50,10 @@ public:
 
     // May be nullptr. Use lockAndReturn to create the bind group when appropriate
     [[nodiscard]] wgpu::BindGroup const& getBindGroup() const { return mBindGroup; }
+
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+    [[nodiscard]] wgpu::BindGroupLayout const& getLayout() const { return mLayout; }
+#endif
 
 private:
     wgpu::BindGroupLayout mLayout = nullptr;

--- a/filament/backend/src/webgpu/WebGPUDescriptorSetLayout.cpp
+++ b/filament/backend/src/webgpu/WebGPUDescriptorSetLayout.cpp
@@ -16,6 +16,11 @@
 
 #include "WebGPUDescriptorSetLayout.h"
 
+#include "WebGPUConstants.h"
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+#include "WebGPUStrings.h"
+#endif
+
 #include <backend/DriverEnums.h>
 
 #include <utils/BitmaskEnum.h>
@@ -184,6 +189,19 @@ WebGPUDescriptorSetLayout::WebGPUDescriptorSetLayout(DescriptorSetLayout const& 
     mLayout = device.CreateBindGroupLayout(&layoutDescriptor);
     FILAMENT_CHECK_POSTCONDITION(mLayout)
             << "Failed to create bind group layout with label " << label;
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+    FWGPU_LOGD << "WebGPUDescriptorSetLayout:";
+    FWGPU_LOGD << "  label: " << label;
+    FWGPU_LOGD << "  wgpu::BindGroupLayout handle: " << mLayout.Get();
+    FWGPU_LOGD << "  Filament bindings (" << layout.bindings.size() << "):";
+    for (DescriptorSetLayoutBinding const& layoutBinding: layout.bindings) {
+        FWGPU_LOGD << "    binding:" << +layoutBinding.binding
+                   << " type:" << filamentDescriptorTypeToString(layoutBinding.type)
+                   << " stageFlags:" << filamentStageFlagsToString(layoutBinding.stageFlags)
+                   << " flags:" << filamentDescriptorFlagsToString(layoutBinding.flags)
+                   << " count:" << layoutBinding.count;
+    }
+#endif
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -16,6 +16,7 @@
 #include "webgpu/WebGPUDriver.h"
 
 #include "WebGPUBufferObject.h"
+#include "WebGPUConstants.h"
 #include "WebGPUDescriptorSet.h"
 #include "WebGPUDescriptorSetLayout.h"
 #include "WebGPUFence.h"
@@ -1699,6 +1700,23 @@ void WebGPUDriver::updateDescriptorSetTexture(Handle<HwDescriptorSet> descriptor
             .binding = static_cast<uint32_t>(binding * 2 + 1),
             .sampler = sampler };
         bindGroup->addEntry(sEntry.binding, std::move(sEntry));
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+        FWGPU_LOGD << "updateDescriptorSetTexture:";
+        FWGPU_LOGD << "  wgpu::BindGroupLayout handle: " << bindGroup->getLayout().Get();
+        FWGPU_LOGD << "  texture: binding:" << tEntry.binding
+                   << " wgpu handle:" << texture->getTexture().Get()
+                   << " " << webGPUTextureToString(texture->getTexture())
+                   << " " << webGPUPrintableToString(texture->getAspect());
+        FWGPU_LOGD << "  sampler: binding:" << sEntry.binding
+                   << " filterMag:" << filamentSamplerMagFilterToString(params.filterMag)
+                   << " filterMin:" << filamentSamplerMinFilterToString(params.filterMin)
+                   << " wrapS:" << filamentSamplerWrapModeToString(params.wrapS)
+                   << " wrapT:" << filamentSamplerWrapModeToString(params.wrapT)
+                   << " wrapR:" << filamentSamplerWrapModeToString(params.wrapR)
+                   << " anisotropyLog2:" << +params.anisotropyLog2
+                   << " compareMode:" << filamentSamplerCompareModeToString(params.compareMode)
+                   << " compareFunc:" << filamentSamplerCompareFuncToString(params.compareFunc);
+#endif
     }
 }
 

--- a/filament/backend/src/webgpu/WebGPUStrings.h
+++ b/filament/backend/src/webgpu/WebGPUStrings.h
@@ -38,7 +38,8 @@ namespace filament::backend {
 
 #if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM) \
         || FWGPU_ENABLED(FWGPU_DEBUG_UPDATE_IMAGE) \
-        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)
+        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)\
+        || FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
 template<typename WebGPUPrintable>
 [[nodiscard]] inline std::string webGPUPrintableToString(const WebGPUPrintable printable) {
     std::stringstream out;
@@ -253,7 +254,8 @@ template<typename WebGPUPrintable>
 
 #if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM) \
         || FWGPU_ENABLED(FWGPU_DEBUG_UPDATE_IMAGE) \
-        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)
+        || FWGPU_ENABLED(FWGPU_DEBUG_BLIT)         \
+        || FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
 [[nodiscard]] std::string webGPUTextureToString(wgpu::Texture const& texture) {
     if (texture == nullptr) {
         return "nullptr (no wgpu::Texture)";
@@ -278,6 +280,206 @@ template<typename WebGPUPrintable>
         case ShaderStage::COMPUTE:  return "compute";
     }
 }
+
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+[[nodiscard]] constexpr std::string_view filamentDescriptorTypeToString(const DescriptorType type) {
+    switch (type) {
+     case DescriptorType::SAMPLER_2D_FLOAT:          return "SAMPLER_2D_FLOAT";
+     case DescriptorType::SAMPLER_2D_INT:            return "SAMPLER_2D_INT";
+     case DescriptorType::SAMPLER_2D_UINT:           return "SAMPLER_2D_UINT";
+     case DescriptorType::SAMPLER_2D_DEPTH:          return "SAMPLER_2D_DEPTH";
+     case DescriptorType::SAMPLER_2D_ARRAY_FLOAT:    return "SAMPLER_2D_ARRAY_FLOAT";
+     case DescriptorType::SAMPLER_2D_ARRAY_INT:      return "SAMPLER_2D_ARRAY_INT";
+     case DescriptorType::SAMPLER_2D_ARRAY_UINT:     return "SAMPLER_2D_ARRAY_UINT";
+     case DescriptorType::SAMPLER_2D_ARRAY_DEPTH:    return "SAMPLER_2D_ARRAY_DEPTH";
+     case DescriptorType::SAMPLER_CUBE_FLOAT:        return "SAMPLER_CUBE_FLOAT";
+     case DescriptorType::SAMPLER_CUBE_INT:          return "SAMPLER_CUBE_INT";
+     case DescriptorType::SAMPLER_CUBE_UINT:         return "SAMPLER_CUBE_UINT";
+     case DescriptorType::SAMPLER_CUBE_DEPTH:        return "SAMPLER_CUBE_DEPTH";
+     case DescriptorType::SAMPLER_CUBE_ARRAY_FLOAT:  return "SAMPLER_CUBE_ARRAY_FLOAT";
+     case DescriptorType::SAMPLER_CUBE_ARRAY_INT:    return "SAMPLER_CUBE_ARRAY_INT";
+     case DescriptorType::SAMPLER_CUBE_ARRAY_UINT:   return "SAMPLER_CUBE_ARRAY_UINT";
+     case DescriptorType::SAMPLER_CUBE_ARRAY_DEPTH:  return "SAMPLER_CUBE_ARRAY_DEPTH";
+     case DescriptorType::SAMPLER_3D_FLOAT:          return "SAMPLER_3D_FLOAT";
+     case DescriptorType::SAMPLER_3D_INT:            return "SAMPLER_3D_INT";
+     case DescriptorType::SAMPLER_3D_UINT:           return "SAMPLER_3D_UINT";
+     case DescriptorType::SAMPLER_2D_MS_FLOAT:       return "SAMPLER_2D_MS_FLOAT";
+     case DescriptorType::SAMPLER_2D_MS_INT:         return "SAMPLER_2D_MS_INT";
+     case DescriptorType::SAMPLER_2D_MS_UINT:        return "SAMPLER_2D_MS_UINT";
+     case DescriptorType::SAMPLER_2D_MS_ARRAY_FLOAT: return "SAMPLER_2D_MS_ARRAY_FLOAT";
+     case DescriptorType::SAMPLER_2D_MS_ARRAY_INT:   return "SAMPLER_2D_MS_ARRAY_INT";
+     case DescriptorType::SAMPLER_2D_MS_ARRAY_UINT:  return "SAMPLER_2D_MS_ARRAY_UINT";
+     case DescriptorType::SAMPLER_EXTERNAL:          return "SAMPLER_EXTERNAL";
+     case DescriptorType::UNIFORM_BUFFER:            return "UNIFORM_BUFFER";
+     case DescriptorType::SHADER_STORAGE_BUFFER:     return "SHADER_STORAGE_BUFFER";
+     case DescriptorType::INPUT_ATTACHMENT:          return "INPUT_ATTACHMENT";
+    }
+}
+
+[[nodiscard]] constexpr std::string_view filamentStageFlagsToString(const ShaderStageFlags flags) {
+    if (flags == ShaderStageFlags::FRAGMENT) {
+        return "FRAGMENT";
+    }
+    if (flags == (ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT)) {
+        return "VERTEX | FRAGMENT";
+    }
+    if (flags == ShaderStageFlags::VERTEX) {
+        return "VERTEX";
+    }
+    if (flags == ShaderStageFlags::COMPUTE) {
+        return "COMPUTE";
+    }
+    if (flags == ShaderStageFlags::ALL_SHADER_STAGE_FLAGS) {
+        return "VERTEX | FRAGMENT | COMPUTE";
+    }
+    if (flags == (ShaderStageFlags::FRAGMENT | ShaderStageFlags::COMPUTE)) {
+        return "FRAGMENT | COMPUTE";
+    }
+    if (flags == (ShaderStageFlags::VERTEX | ShaderStageFlags::COMPUTE)) {
+        return "VERTEX | COMPUTE";
+    }
+    if (flags == ShaderStageFlags::NONE) {
+        return "NONE";
+    }
+    return "UNKNOWN/UNHANDLED"; // should not be possible
+}
+
+[[nodiscard]] constexpr std::string_view filamentDescriptorFlagsToString(const DescriptorFlags flags) {
+    if (flags == DescriptorFlags::NONE) {
+        return "NONE";
+    }
+    if (flags == DescriptorFlags::DYNAMIC_OFFSET) {
+        return "DYNAMIC_OFFSET";
+    }
+    if (flags == DescriptorFlags::UNFILTERABLE) {
+        return "UNFILTERABLE";
+    }
+    if (flags == (DescriptorFlags::DYNAMIC_OFFSET | DescriptorFlags::UNFILTERABLE)) {
+        return "DYNAMIC_OFFSET | UNFILTERABLE";
+    }
+    return "UNKNOWN/UNHANDLED"; // should not be possible
+}
+
+[[nodiscard]] constexpr std::string_view filamentSamplerMagFilterToString(
+        const SamplerMagFilter filter) {
+    switch (filter) {
+        case SamplerMagFilter::NEAREST: return "NEAREST";
+        case SamplerMagFilter::LINEAR:  return "LINEAR";
+    }
+}
+
+[[nodiscard]] constexpr std::string_view filamentSamplerMinFilterToString(
+        const SamplerMinFilter filter) {
+    switch (filter) {
+        case SamplerMinFilter::NEAREST:                return "NEAREST";
+        case SamplerMinFilter::LINEAR:                 return "LINEAR";
+        case SamplerMinFilter::NEAREST_MIPMAP_NEAREST: return "NEAREST_MIPMAP_NEAREST";
+        case SamplerMinFilter::LINEAR_MIPMAP_NEAREST:  return "LINEAR_MIPMAP_NEAREST";
+        case SamplerMinFilter::NEAREST_MIPMAP_LINEAR:  return "NEAREST_MIPMAP_LINEAR";
+        case SamplerMinFilter::LINEAR_MIPMAP_LINEAR:   return "LINEAR_MIPMAP_LINEAR";
+    }
+}
+
+[[nodiscard]] constexpr std::string_view filamentSamplerWrapModeToString(
+        const SamplerWrapMode mode) {
+    switch (mode) {
+        case SamplerWrapMode::CLAMP_TO_EDGE:   return "CLAMP_TO_EDGE";
+        case SamplerWrapMode::REPEAT:          return "REPEAT";
+        case SamplerWrapMode::MIRRORED_REPEAT: return "MIRRORED_REPEAT";
+    }
+}
+
+[[nodiscard]] constexpr std::string_view filamentSamplerCompareModeToString(
+        const SamplerCompareMode mode) {
+    switch (mode) {
+        case SamplerCompareMode::NONE:               return "NONE";
+        case SamplerCompareMode::COMPARE_TO_TEXTURE: return "COMPARE_TO_TEXTURE";
+    }
+}
+
+[[nodiscard]] constexpr std::string_view filamentSamplerCompareFuncToString(
+        const SamplerCompareFunc func) {
+    switch (func) {
+        case SamplerCompareFunc::LE: return "LE";
+        case SamplerCompareFunc::GE: return "GE";
+        case SamplerCompareFunc::L:  return "L";
+        case SamplerCompareFunc::G:  return "G";
+        case SamplerCompareFunc::E:  return "E";
+        case SamplerCompareFunc::NE: return "NE";
+        case SamplerCompareFunc::A:  return "A";
+        case SamplerCompareFunc::N:  return "N";
+    }
+}
+
+[[nodiscard]] std::string filamentTextureUsageFlagsToString(const TextureUsage flags) {
+    if (flags == TextureUsage::NONE) {
+        return "NONE";
+    }
+    bool first{ true };
+    std::stringstream out;
+    if (any(flags & TextureUsage::COLOR_ATTACHMENT)) {
+        first = false;
+        out << "COLOR_ATTACHMENT";
+    }
+    if (any(flags & TextureUsage::DEPTH_ATTACHMENT)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "DEPTH_ATTACHMENT";
+    }
+    if (any(flags & TextureUsage::STENCIL_ATTACHMENT)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "STENCIL_ATTACHMENT";
+    }
+    if (any(flags & TextureUsage::UPLOADABLE)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "UPLOADABLE";
+    }
+    if (any(flags & TextureUsage::SAMPLEABLE)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "SAMPLEABLE";
+    }
+    if (any(flags & TextureUsage::SUBPASS_INPUT)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "SUBPASS_INPUT";
+    }
+    if (any(flags & TextureUsage::BLIT_SRC)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "BLIT_SRC";
+    }
+    if (any(flags & TextureUsage::BLIT_DST)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "BLIT_DST";
+    }
+    if (any(flags & TextureUsage::PROTECTED)) {
+        if (!first) {
+            out << " | ";
+        }
+        first = false;
+        out << "PROTECTED";
+    }
+    return out.str();
+}
+#endif // FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
 
 }// namespace filament::backend
 

--- a/filament/backend/src/webgpu/WebGPUTexture.cpp
+++ b/filament/backend/src/webgpu/WebGPUTexture.cpp
@@ -329,6 +329,12 @@ WebGPUTexture::WebGPUTexture(const SamplerType samplerType, const uint8_t levels
                    << viewFormatStream.str() << " and texture format " << textureFormatStream.str();
     }
 #endif
+#if FWGPU_ENABLED(FWGPU_DEBUG_BIND_GROUPS)
+    FWGPU_LOGD << "WebGPUTexture: wgpu handle " << mTexture.Get()
+               << " samplerType:" << to_string(samplerType)
+               << " usage flags:" << filamentTextureUsageFlagsToString(usage)
+               << " " << webGPUTextureToString(mTexture);
+#endif
 }
 
 WebGPUTexture::WebGPUTexture(WebGPUTexture const* src, const uint8_t baseLevel,


### PR DESCRIPTION
This becomes a fire hose of log spamming when switched on, but useful in correlating bind group items together for troubleshooting. If one switches it on, I recommend running it from the command line and piping stdout and stderr to a file, do the actions in the sample quickly, and analyze the log file afterward. This is because, the IDE's log output gets truncated and you lose information useful for correlation. And, due to frequency of logs, this truncation happens quickly.

BUGS = [435237421]