### PR TITLE
bilateral blur & shadow map materials require unfilterable samplers

### DIFF
--- a/filament/src/materials/shadowmap.mat
+++ b/filament/src/materials/shadowmap.mat
@@ -4,7 +4,8 @@ material {
         {
            type : sampler2dArray,
            name : shadowmap,
-           precision : high
+           precision : high,
+           filterable : false
         },
         {
            type : float,

--- a/filament/src/materials/ssao/bilateralBlur.mat
+++ b/filament/src/materials/ssao/bilateralBlur.mat
@@ -4,7 +4,8 @@ material {
         {
             type : sampler2dArray,
             name : ssao,
-            precision: medium
+            precision: medium,
+            filterable: false
         },
         {
             type : float2,

--- a/filament/src/materials/ssao/bilateralBlurBentNormals.mat
+++ b/filament/src/materials/ssao/bilateralBlurBentNormals.mat
@@ -4,7 +4,8 @@ material {
         {
             type : sampler2dArray,
             name : ssao,
-            precision: medium
+            precision: medium,
+            filterable: false
         },
         {
             type : float2,


### PR DESCRIPTION
This fixes the Display Shader Texture with the WebGPU implementation.

BUGS = [435237421]