### PR TITLE
fix -d (matdbg) build option

### DIFF
--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -74,6 +74,10 @@ if (FILAMENT_ENABLE_FGVIEWER)
 endif()
 
 if (FILAMENT_ENABLE_MATDBG)
+    add_library(filamat STATIC IMPORTED)
+    set_target_properties(filamat PROPERTIES IMPORTED_LOCATION
+            ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilamat.a)
+
     add_library(matdbg STATIC IMPORTED)
     set_target_properties(matdbg PROPERTIES IMPORTED_LOCATION
             ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libmatdbg.a)

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -148,7 +148,7 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/filamat DESTINATION include)
 
 # Need to install libtint for filamat on Android.
 # See libs/filamat/CMakeLists.txt and android/filamat-android/CMakeLists.txt.
-if (ANDROID)
+if (ANDROID AND FILAMENT_SUPPORTS_WEBGPU)
    target_link_libraries(${TARGET} libtint_combined)
 endif()
 


### PR DESCRIPTION
There was two problems:
- tint was needed regardless of webgpu support
- libfilamat wasn't built on the android side (I don't know how it ever worked)