### PR TITLE
Fix two compilation errors

### DIFF
--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -446,7 +446,8 @@ void FScene::updateUBOs(
 
     // We capture state shared between Scene and the update buffer callback, because the Scene could
     // be destroyed before the callback executes.
-    std::weak_ptr<SharedState>* const weakShared = new(std::nothrow) std::weak_ptr(mSharedState);
+    std::weak_ptr<SharedState>* const weakShared =
+            new (std::nothrow) std::weak_ptr<SharedState>(mSharedState);
 
     // update the UBO
     driver.resetBufferObject(renderableUbh);

--- a/libs/utils/include/utils/bitset.h
+++ b/libs/utils/include/utils/bitset.h
@@ -26,6 +26,7 @@
 
 #include <algorithm> // for std::fill
 #include <iterator>
+#include <limits>
 #include <type_traits>
 
 #if defined(__ARM_NEON)


### PR DESCRIPTION
- Include <limits> in bitset.h
- The type could not be inferred for Scene.cpp's `SharedState` line.  The failure came from clang version 1:14.0-55~exp2