### PR TITLE
webgpu: skip PushConstants backend test for webgpu

### DIFF
--- a/filament/backend/test/test_PushConstants.cpp
+++ b/filament/backend/test/test_PushConstants.cpp
@@ -105,6 +105,7 @@ void initPushConstants() {
 
 TEST_F(BackendTest, PushConstants) {
     SKIP_IF(Backend::OPENGL, "Push constants not supported on OpenGL");
+    SKIP_IF(Backend::WEBGPU, "Push constants not supported on WebGPU");
 
     initPushConstants();
 


### PR DESCRIPTION
We can revert this once dawn supports push constants