### PR TITLE
webgpu: fix buffer misalignment

### DIFF
--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -178,7 +178,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float fogNearOverFarMinusNear;
     std140::mat33 fogFromWorldMatrix;
     math::float2 fogLinearParams; // { 1/(end-start), -start/(end-start) }
-    math::float2 fogReserved[1];
+    math::float2 fogReserved0;
 
     // --------------------------------------------------------------------------------------------
     // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -190,7 +190,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "fogNearOverFarMinusNear", 0, Type::FLOAT, Precision::HIGH },
             { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogLinearParams",         0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogReserved",             1, Type::FLOAT2, Precision::HIGH },
+            { "fogReserved0",            0, Type::FLOAT2, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
             // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]


### PR DESCRIPTION
When running the WebGPU Backend we were getting the error
```
WebGPU device error: VALIDATION [Buffer "buffer_object"] bound with size 2048 at group 0, binding 0 is too small. The pipeline ([RenderPipeline "BakedColor"]) requires a buffer binding which is at least 2064 bytes. This binding is a uniform buffer binding. It is padded to a multiple of 16 bytes, and as a result may be larger than the associated data in the shader source.
 - While encoding [RenderPassEncoder (unlabeled)].DrawIndexed(3, 1, 0, 0, 0).
 - While finishing [CommandEncoder "frame_comman
```
Reason being that the WGSL was treating fogReserved as a 16 byte aligned item. Therefore having the extra 16 bytes.

Alternatively this change can be an array of math::float4 fogReserved[1] and the reserved at the end can be updated to 38. Needed for the STD 140 Alignment