### PR TITLE
fix the 3-parameters fresnel calculation

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,5 +10,6 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - engine: add a `linearFog` material parameter. [⚠️ **New Material Version**]
 - opengl: When `Material::compile()` is called on a platform which doesn't support parallel compilation, shaders are automatically compiled over a number of frames
-- Added `useDefaultDepthVariant` material parameter to force Filament to use its default variant for
+- engine: Added `useDefaultDepthVariant` material parameter to force Filament to use its default variant for
   depth-only passes. [**Requires recompiling materials**]
+- material: fix specularFactor in `LOW_QUALITY` mode. [**Requires recompiling materials**] to take effect.

--- a/shaders/src/surface_brdf.fs
+++ b/shaders/src/surface_brdf.fs
@@ -187,11 +187,7 @@ vec3 fresnel(const vec3 f0, float LoH) {
 
 vec3 fresnel(const vec3 f0, const float f90, float LoH) {
 #if BRDF_SPECULAR_F == SPECULAR_F_SCHLICK
-#if FILAMENT_QUALITY == FILAMENT_QUALITY_LOW
-    return F_Schlick(f0, LoH); // f90 = 1.0
-#else
     return F_Schlick(f0, f90, LoH);
-#endif
 #endif
 }
 


### PR DESCRIPTION
it would automatically degrade to the 2-parameters version in  LOW_QUALITY mode, but some other code relied on the proper calculation, in particular when specularFactor was used.


FIXES=[436866605]