### PR TITLE
mat: Store matc parameters in material packages

### DIFF
--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -58,6 +58,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
 
     MaterialName = charTo64bitNum("MAT_NAME"),
     MaterialVersion = charTo64bitNum("MAT_VERS"),
+    MaterialCompilationParameters = charTo64bitNum("MAT_CPRM"),
     MaterialCacheId = charTo64bitNum("MAT_UUID"),
     MaterialFeatureLevel = charTo64bitNum("MAT_FEAT"),
     MaterialShading = charTo64bitNum("MAT_SHAD"),

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -295,6 +295,9 @@ public:
     //! Set the file name of this material file. Used in error reporting.
     MaterialBuilder& fileName(const char* name) noexcept;
 
+    //! Set the commandline parameters of matc. Used for debugging purpose.
+    MaterialBuilder& compilationParameters(const char* params) noexcept;
+
     //! Set the shading model.
     MaterialBuilder& shading(Shading shading) noexcept;
 
@@ -876,6 +879,7 @@ private:
 
     utils::CString mMaterialName;
     utils::CString mFileName;
+    utils::CString mCompilationParameters;
 
     class ShaderCode {
     public:

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -232,6 +232,11 @@ MaterialBuilder& MaterialBuilder::fileName(const char* name) noexcept {
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::compilationParameters(const char* params) noexcept {
+    mCompilationParameters = CString(params);
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::material(const char* code, size_t const line) noexcept {
     mMaterialFragmentCode.setUnresolved(CString(code));
     mMaterialFragmentCode.setLineOffset(line);
@@ -1594,6 +1599,8 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
     container.emplace<uint32_t>(MaterialVersion, MATERIAL_VERSION);
     container.emplace<uint8_t>(MaterialFeatureLevel, (uint8_t)info.featureLevel);
     container.emplace<const char*>(MaterialName, mMaterialName.c_str_safe());
+    container.emplace<const char*>(MaterialCompilationParameters,
+            mCompilationParameters.c_str_safe());
     container.emplace<uint32_t>(MaterialShaderModels, mShaderModels.getValue());
     container.emplace<uint8_t>(ChunkType::MaterialDomain, static_cast<uint8_t>(mMaterialDomain));
 

--- a/libs/filament-matp/include/filament-matp/Config.h
+++ b/libs/filament-matp/include/filament-matp/Config.h
@@ -75,6 +75,8 @@ public:
 
     virtual std::string toString() const noexcept = 0;
 
+    virtual std::string toPIISafeString() const noexcept = 0;
+
     bool isDebug() const noexcept {
         return mDebug;
     }

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -107,6 +107,12 @@ static bool printMaterial(ostream& text, const ChunkContainer& container) {
         text << name.c_str() << endl;
     }
 
+    CString compilationParameters;
+    if (read(container, MaterialCompilationParameters, &compilationParameters)) {
+        text << "    " << setw(alignment) << left << "Compilation Parameters: ";
+        text << compilationParameters.c_str() << endl;
+    }
+
     text << endl;
 
     text << "Shading:" << endl;

--- a/tools/matc/src/matc/CommandlineConfig.h
+++ b/tools/matc/src/matc/CommandlineConfig.h
@@ -122,6 +122,8 @@ public:
         return parameters;
     }
 
+    std::string toPIISafeString() const noexcept override;
+
 private:
     bool parse();
 

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -76,6 +76,8 @@ bool MaterialCompiler::run(const matp::Config& config) {
         return true;
     }
 
+    builder.compilationParameters(config.toPIISafeString().c_str());
+
     JobSystem js;
     js.adopt();
 


### PR DESCRIPTION
This commit enhances the material compilation process by embedding the `matc` command-line parameters directly into the compiled material file. This feature is valuable for debugging, as it allows developers to inspect the exact compilation settings used for a given material.

A key consideration is the potential for personally identifiable information (PII) in the command-line arguments (e.g., file paths). To address this, a `toPIISafeString` method has been implemented to filter out PII-sensitive options before they are stored in the material.

With this change, the matc command below
    /path/to/matc -a opengl --api vulkan -p desktop -g -o /path/to/my.filamat /path/to/my.mat

is stored to the package as below. (veryfied by running `matinfo my.filamat`)
    Compilation Parameters:         -a opengl --api vulkan -p desktop -g