### PR TITLE
Fix dynamic resolution with TRANSLUCENT views

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1390,7 +1390,7 @@ public class View {
      *
      * \note
      * Dynamic resolution is only supported on platforms where the time to render
-     * a frame can be measured accurately. On platform where this is not supported,
+     * a frame can be measured accurately. On platforms where this is not supported,
      * Dynamic Resolution can't be enabled unless minScale == maxScale.
      *
      * @see Renderer::FrameRateOptions
@@ -1423,9 +1423,12 @@ public class View {
          * MEDIUM: Qualcomm Snapdragon Game Super Resolution (SGSR) 1.0
          * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations
          * ULTRA:  AMD FidelityFX FSR1
-         *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene. Avoid FXAA and dithering.
+         *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene.
+         *      Avoid FXAA and dithering.
          *
          * The default upscaling quality is set to LOW.
+         *
+         * caveat: currently, 'quality' is always set to LOW if the View is TRANSLUCENT.
          */
         @NonNull
         public QualityLevel quality = QualityLevel.LOW;

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -70,7 +70,7 @@ enum class BlendMode : uint8_t {
  *
  * \note
  * Dynamic resolution is only supported on platforms where the time to render
- * a frame can be measured accurately. On platform where this is not supported,
+ * a frame can be measured accurately. On platforms where this is not supported,
  * Dynamic Resolution can't be enabled unless minScale == maxScale.
  *
  * @see Renderer::FrameRateOptions
@@ -89,9 +89,12 @@ struct DynamicResolutionOptions {
      * MEDIUM: Qualcomm Snapdragon Game Super Resolution (SGSR) 1.0
      * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations
      * ULTRA:  AMD FidelityFX FSR1
-     *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene. Avoid FXAA and dithering.
+     *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene.
+     *      Avoid FXAA and dithering.
      *
      * The default upscaling quality is set to LOW.
+     *
+     * caveat: currently, 'quality' is always set to LOW if the View is TRANSLUCENT.
      */
     QualityLevel quality = QualityLevel::LOW;
 };

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -246,7 +246,7 @@ public:
             FrameGraphId<FrameGraphTexture> input, Viewport const& vp,
             FrameGraphTexture::Descriptor const& outDesc, backend::SamplerMagFilter filter) noexcept;
 
-    FrameGraphId<FrameGraphTexture> upscaleBilinear(FrameGraph& fg,
+    FrameGraphId<FrameGraphTexture> upscaleBilinear(FrameGraph& fg, bool translucent,
             DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
             Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
             backend::SamplerMagFilter filter) noexcept;
@@ -259,12 +259,18 @@ public:
             DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
             filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc) noexcept;
 
+    enum class RcasMode {
+        OPAQUE,
+        ALPHA_PASSTHROUGH,
+        BLENDED
+    };
+
     FrameGraphId<FrameGraphTexture> rcas(
             FrameGraph& fg,
             float sharpness,
             FrameGraphId<FrameGraphTexture> input,
             FrameGraphTexture::Descriptor const& outDesc,
-            bool translucent);
+            RcasMode mode);
 
     // color blitter using shaders
     FrameGraphId<FrameGraphTexture> blit(FrameGraph& fg, bool translucent,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1360,6 +1360,8 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
         }
 
         if (scaled) {
+            // upscale() below always performs the final blending if needed (View in `TRANSLUCENT`
+            // mode). So we can set `mightNeedFinalBlit` to `false` to avoid an extra copy.
             mightNeedFinalBlit = false;
             auto viewport = DEBUG_DYNAMIC_SCALING ? xvp : vp;
             bool const sourceHasLuminance = !needsAlphaChannel &&
@@ -1367,6 +1369,8 @@ void FRenderer::renderJob(RootArenaScope& rootArenaScope, FView& view) {
             input = ppm.upscale(fg, needsAlphaChannel, sourceHasLuminance, dsrOptions, input, xvp, {
                 .width = viewport.width, .height = viewport.height,
                 .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::LINEAR);
+            // scaling has been applied, and offset removed
+            xvp = viewport;
             xvp.left = xvp.bottom = 0;
             svp = xvp;
         }

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1146,7 +1146,7 @@ export enum View$BlendMode {
  *
  * \note
  * Dynamic resolution is only supported on platforms where the time to render
- * a frame can be measured accurately. On platform where this is not supported,
+ * a frame can be measured accurately. On platforms where this is not supported,
  * Dynamic Resolution can't be enabled unless minScale == maxScale.
  *
  * @see Renderer::FrameRateOptions
@@ -1179,9 +1179,12 @@ export interface View$DynamicResolutionOptions {
      * MEDIUM: Qualcomm Snapdragon Game Super Resolution (SGSR) 1.0
      * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations
      * ULTRA:  AMD FidelityFX FSR1
-     *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene. Avoid FXAA and dithering.
+     *      FSR1 and SGSR require a well anti-aliased (MSAA or TAA), noise free scene.
+     *      Avoid FXAA and dithering.
      *
      * The default upscaling quality is set to LOW.
+     *
+     * caveat: currently, 'quality' is always set to LOW if the View is TRANSLUCENT.
      */
     quality?: View$QualityLevel;
 }


### PR DESCRIPTION
A few bugs in that area were introduced by #8391. Upscaling is  supposed to perform the final blending if needed, but it didn't. Transparency/blending is only supported by the bilinear upscaler, which is automatically selected in that case.

The upscaling pass itself may include a final `RCAS` pass for sharpening, in that case, blending must be performed then. So we added the logic for that.


Fixes #9061