### PR TITLE
matp: Fix crash when reflecting parameters

### DIFF
--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -70,6 +70,12 @@ bool MaterialCompiler::run(const matp::Config& config) {
         return false;
     }
 
+    // If we're reflecting parameters, the MaterialParser will have handled it inside of parse().
+    // We should return here to avoid actually building a material.
+    if (config.getReflectionTarget() != matp::Config::Metadata::NONE) {
+        return true;
+    }
+
     JobSystem js;
     js.adopt();
 


### PR DESCRIPTION
When calling matc with `--reflect`, it's allowed to not pass an output file. To avoid crashing, we need to not actually compile and output a material.