### PR TITLE
Begin to refactor test_LoadImage to use SharedShaders

### DIFF
--- a/filament/backend/test/ImageExpectations.h
+++ b/filament/backend/test/ImageExpectations.h
@@ -19,6 +19,7 @@
 
 #include <filesystem>
 #include <vector>
+#include <optional>
 
 #include "gtest/gtest.h"
 
@@ -45,12 +46,72 @@ class ScreenshotParams {
 public:
     // TODO(b/422804941): Add a set of environments where this test should use a different golden.
     ScreenshotParams(int width, int height, std::string fileName, uint32_t expectedPixelHash,
-            bool isSrgb = false, int numAllowedDeviations = 0, int pixelMatchThreshold = 0);
+            bool isSrgb = false, int numAllowedDeviations = 0, int pixelMatchThreshold = 0,
+            std::optional<float> forceAlphaValue = std::nullopt);
+
+    class Builder {
+    public:
+        Builder& width(int width) {
+            mWidth = width;
+            return *this;
+        }
+
+        Builder& height(int height) {
+            mHeight = height;
+            return *this;
+        }
+
+        Builder& fileName(std::string fileName) {
+            mFileName = fileName;
+            return *this;
+        }
+
+        Builder& expectedPixelHash(uint32_t pixelHash) {
+            mExpectedPixelHash = pixelHash;
+            return *this;
+        }
+
+        Builder& isSrgb(bool isSrgb) {
+            mIsSrgb = isSrgb;
+            return *this;
+        }
+
+        Builder& numAllowedDeviations(int numAllowedDeviations) {
+            mNumAllowedDeviations = numAllowedDeviations;
+            return *this;
+        }
+
+        Builder& pixelMatchTheshold(int pixelMatchTheshold) {
+            mPixelMatchThreshold = pixelMatchTheshold;
+            return *this;
+        }
+
+        Builder& forceAlphaValue(float alphaValue) {
+            mForceAlphaValue = alphaValue;
+            return *this;
+        }
+
+        ScreenshotParams build() {
+            return ScreenshotParams(mWidth, mHeight, mFileName, mExpectedPixelHash, mIsSrgb,
+                    mNumAllowedDeviations, mPixelMatchThreshold, mForceAlphaValue);
+        }
+
+    private:
+        int mWidth;
+        int mHeight;
+        std::string mFileName;
+        uint32_t mExpectedPixelHash;
+        bool mIsSrgb;
+        int mNumAllowedDeviations;
+        int mPixelMatchThreshold;
+        std::optional<float> mForceAlphaValue;
+    };
 
     int width() const;
     int height() const;
     bool isSrgb() const;
     uint32_t expectedHash() const;
+    std::optional<float> forceAlphaValue() const;
 
     static std::filesystem::path actualDirectoryPath();
     std::string actualFileName() const;
@@ -70,6 +131,7 @@ private:
     std::string mFileName;
     int mAllowedPixelDeviations;
     int mPixelMatchThreshold;
+    std::optional<float> mForceAlphaValue;
 };
 
 /**

--- a/filament/backend/test/SharedShaders.cpp
+++ b/filament/backend/test/SharedShaders.cpp
@@ -158,9 +158,19 @@ layout(binding = 0, set = 0) uniform Params {
 } params;
 )";
         }
-        case ShaderUniformType::Sampler: {
+        case ShaderUniformType::Sampler2D: {
             return R"(
 layout(location = 0, set = 0) uniform sampler2D test_tex;
+)";
+        }
+        case ShaderUniformType::ISampler2D: {
+            return R"(
+layout(location = 0, set = 0) uniform isampler2D test_tex;
+)";
+        }
+        case ShaderUniformType::USampler2D: {
+            return R"(
+layout(location = 0, set = 0) uniform usampler2D test_tex;
 )";
         }
         default:
@@ -179,12 +189,28 @@ std::vector<UniformConfig> GetUniformConfig(ShaderUniformType type) {
         case ShaderUniformType::SimpleWithPadding: {
             return {{ "Params" }};
         }
-        case ShaderUniformType::Sampler: {
+        case ShaderUniformType::Sampler2D: {
             filament::SamplerInterfaceBlock::SamplerInfo samplerInfo{
                     "backend_test", "test_tex", 0,
                     SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH, false };
             return {{
                             "test_tex", DescriptorType::SAMPLER_2D_FLOAT, samplerInfo
+                    }};
+        }
+        case ShaderUniformType::ISampler2D: {
+            filament::SamplerInterfaceBlock::SamplerInfo samplerInfo{
+                    "backend_test", "test_tex", 0,
+                    SamplerType::SAMPLER_2D, SamplerFormat::INT, Precision::HIGH, false };
+            return {{
+                            "test_tex", DescriptorType::SAMPLER_2D_INT, samplerInfo
+                    }};
+        }
+        case ShaderUniformType::USampler2D: {
+            filament::SamplerInterfaceBlock::SamplerInfo samplerInfo{
+                    "backend_test", "test_tex", 0,
+                    SamplerType::SAMPLER_2D, SamplerFormat::UINT, Precision::HIGH, false };
+            return {{
+                            "test_tex", DescriptorType::SAMPLER_2D_INT, samplerInfo
                     }};
         }
         default:

--- a/filament/backend/test/SharedShadersConstants.h
+++ b/filament/backend/test/SharedShadersConstants.h
@@ -23,7 +23,9 @@ enum class ShaderUniformType : uint8_t {
     None,
     Simple,
     SimpleWithPadding,
-    Sampler,
+    Sampler2D,
+    ISampler2D,
+    USampler2D,
 };
 
 struct SimpleMaterialParams {

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -69,12 +69,12 @@ TEST_F(BackendTest, TextureViewLod) {
         Shader whiteShader = SharedShaders::makeShader(api, cleanup, ShaderRequest {
             .mVertexType = VertexShaderType::Textured,
             .mFragmentType = FragmentShaderType::White,
-            .mUniformType = ShaderUniformType::Sampler
+            .mUniformType = ShaderUniformType::Sampler2D
         });
 
         // Create a program that samples a texture.
         std::string vertexShader = SharedShaders::getVertexShaderText(
-                VertexShaderType::Textured, ShaderUniformType::Sampler);
+                VertexShaderType::Textured, ShaderUniformType::Sampler2D);
         filament::SamplerInterfaceBlock::SamplerInfo samplerInfo {
             "backend_test", "sib_tex", 0,
             SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH, false };

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -40,7 +40,7 @@ Shader createShader(DriverApi& api, Cleanup& cleanup, Backend backend) {
     return SharedShaders::makeShader(api, cleanup, ShaderRequest{
             .mVertexType = VertexShaderType::Textured,
             .mFragmentType = FragmentShaderType::Textured,
-            .mUniformType = ShaderUniformType::Sampler
+            .mUniformType = ShaderUniformType::Sampler2D
     });
 }
 


### PR DESCRIPTION
This updates _LoadImageTest.UpdateImage2D_ to use `SharedShaders`.

- Update `SharedShaders` to support different sampler types
- Add a `Builder` to `ScreenshotParams`
- Allow forcing an alpha value when comparing screenshots