### PR TITLE
Add feature to emit image diff for failing image comparison tests

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -594,6 +594,7 @@ if (APPLE OR LINUX)
         spirv-cross-glsl)
     # Create input/output directories for test result images.
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/images/actual_images)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/images/diff_images)
     file(COPY test/expected_images DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/images)
 endif()
 

--- a/filament/backend/test/ImageExpectations.h
+++ b/filament/backend/test/ImageExpectations.h
@@ -58,6 +58,9 @@ public:
     static std::filesystem::path expectedDirectoryPath();
     std::string expectedFileName() const;
     std::filesystem::path expectedFilePath() const;
+    static std::filesystem::path diffDirectoryPath();
+    std::string diffFileName() const;
+    std::filesystem::path diffFilePath() const;
     const std::string filePrefix() const;
     int allowedPixelDeviations() const;
     int pixelMatchThreshold() const;

--- a/filament/backend/test/README.md
+++ b/filament/backend/test/README.md
@@ -19,6 +19,8 @@ code. When cmake is run it will copy this directory to the build output creating
 The unit tests will then write their resulting images into `images/actual_images` in order to make
 the tests easier to debug.
 
+If an image comparison test fails, it writes a diff image to `images/diff_images` where each pixel of the diff is white (255,255,255) if the comparison for the corresponding pixel succeeds and black (0,0,0) of the comparison for the corresponding pixel fails.
+
 ### Python utility for updating golden images and comparing results
 
 Inside the unit test source code directory there is a python script called


### PR DESCRIPTION
This is intended to make many kinds of visual artifacts easier to see than by comparing the expected and actual images.

I went in circles for a bit trying to make it more "diff-like" by signaling what color channels were impacted and to what extent, but I was never happy with the outcome and it risks defeating the purpose of making discrepancies highly visible.