### PR TITLE
add a --workarounds option to matc 

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -27,7 +27,6 @@
 #include <backend/DriverEnums.h>
 #include <backend/TargetBufferInfo.h>
 
-#include <mutex>
 #include <utils/BitmaskEnum.h>
 #include <utils/bitset.h>
 #include <utils/compiler.h>
@@ -36,6 +35,8 @@
 #include <math/vec3.h>
 
 #include <atomic>
+#include <limits>
+#include <mutex>
 #include <memory>
 #include <string>
 #include <utility>
@@ -117,6 +118,11 @@ public:
         PERFORMANCE
     };
 
+    enum class Workarounds : uint64_t {
+        NONE = 0,
+        ALL = 0xFFFFFFFFFFFFFFFF
+    };
+
     /**
      * Initialize MaterialBuilder.
      *
@@ -140,6 +146,7 @@ protected:
     Platform mPlatform = Platform::DESKTOP;
     TargetApi mTargetApi = (TargetApi) 0;
     Optimization mOptimization = Optimization::PERFORMANCE;
+    Workarounds mWorkarounds = Workarounds::ALL;
     bool mPrintShaders = false;
     bool mSaveRawVariants = false;
     bool mGenerateDebugInfo = false;
@@ -606,6 +613,13 @@ public:
      */
     MaterialBuilder& optimization(Optimization optimization) noexcept;
 
+    /**
+     * Specifies workarounds to enable during code generation. By default, all workaround are
+     * enabled. These workarounds typically disable important optimizations and in some cases
+     * whole features.
+     */
+    MaterialBuilder& workarounds(Workarounds workarounds) noexcept;
+
     // TODO: this is present here for matc's "--print" flag, but ideally does not belong inside MaterialBuilder.
     //! If true, will output the generated GLSL shader code to stdout.
     MaterialBuilder& printShaders(bool printShaders) noexcept;
@@ -992,7 +1006,15 @@ private:
 
 } // namespace filamat
 
-template<> struct utils::EnableBitMaskOperators<filamat::MaterialBuilder::TargetApi>
-        : public std::true_type {};
+template<>
+struct utils::EnableBitMaskOperators<filamat::MaterialBuilder::TargetApi>
+        : public std::true_type {
+};
+
+template<>
+struct utils::EnableBitMaskOperators<filamat::MaterialBuilder::Workarounds>
+        : public std::true_type {
+};
+
 
 #endif

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -58,7 +58,10 @@ public:
         GENERATE_DEBUG_INFO = 1 << 1,
     };
 
-    GLSLPostProcessor(MaterialBuilder::Optimization optimization, uint32_t flags);
+    GLSLPostProcessor(
+            MaterialBuilder::Optimization optimization,
+            MaterialBuilder::Workarounds workarounds,
+            uint32_t flags);
 
     ~GLSLPostProcessor();
 
@@ -67,6 +70,7 @@ public:
         filament::UserVariantFilterMask variantFilter;
         MaterialBuilder::TargetApi targetApi;
         MaterialBuilder::TargetLanguage targetLanguage;
+        MaterialBuilder::Workarounds workarounds;
         filament::backend::ShaderStage shaderType;
         filament::backend::ShaderModel shaderModel;
         filament::backend::FeatureLevel featureLevel;
@@ -133,6 +137,7 @@ private:
     void fixupClipDistance(SpirvBlob& spirv, GLSLPostProcessor::Config const& config) const;
 
     const MaterialBuilder::Optimization mOptimization;
+    const MaterialBuilder::Workarounds mWorkarounds;
     const bool mPrintShaders;
     const bool mGenerateDebugInfo;
 };

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -585,7 +585,6 @@ MaterialBuilder& MaterialBuilder::stereoscopicType(StereoscopicType const stereo
     mStereoscopicType = stereoscopicType;
     return *this;
 }
-
 MaterialBuilder& MaterialBuilder::stereoscopicEyeCount(uint8_t const eyeCount) noexcept {
     mStereoscopicEyeCount = eyeCount;
     return *this;
@@ -608,6 +607,11 @@ MaterialBuilder& MaterialBuilder::targetApi(TargetApi const targetApi) noexcept 
 
 MaterialBuilder& MaterialBuilder::optimization(Optimization const optimization) noexcept {
     mOptimization = optimization;
+    return *this;
+}
+
+MaterialBuilder& MaterialBuilder::workarounds(Workarounds const workarounds) noexcept {
+    mWorkarounds = workarounds;
     return *this;
 }
 
@@ -929,7 +933,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
     uint32_t flags = 0;
     flags |= mPrintShaders ? GLSLPostProcessor::PRINT_SHADERS : 0;
     flags |= mGenerateDebugInfo ? GLSLPostProcessor::GENERATE_DEBUG_INFO : 0;
-    GLSLPostProcessor postProcessor(mOptimization, flags);
+    GLSLPostProcessor postProcessor(mOptimization, mWorkarounds, flags);
 
     // Start: must be protected by lock
     Mutex entriesLock;
@@ -1059,6 +1063,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .variantFilter = mVariantFilter,
                         .targetApi = targetApi,
                         .targetLanguage = targetLanguage,
+                        .workarounds = mWorkarounds,
                         .shaderType = v.stage,
                         .shaderModel = shaderModel,
                         .featureLevel = featureLevel,

--- a/libs/filament-matp/include/filament-matp/Config.h
+++ b/libs/filament-matp/include/filament-matp/Config.h
@@ -17,16 +17,20 @@
 #ifndef TNT_CONFIG_H
 #define TNT_CONFIG_H
 
-#include <filament/MaterialEnums.h>
-#include <backend/DriverEnums.h>
-
 #include <filamat/MaterialBuilder.h>
 
+#include <filament/MaterialEnums.h>
+
+#include <backend/DriverEnums.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <ostream>
-
-#include <utils/compiler.h>
+#include <string>
 
 namespace matp {
 
@@ -40,6 +44,7 @@ public:
     using Platform = filamat::MaterialBuilder::Platform;
     using TargetApi = filamat::MaterialBuilder::TargetApi;
     using Optimization = filamat::MaterialBuilder::Optimization;
+    using Workarounds = filamat::MaterialBuilder::Workarounds;
 
     // For defines, template, and material parameters, we use an ordered map with a transparent comparator.
     // Even though the key is stored using std::string, this allows you to make lookups using
@@ -97,10 +102,6 @@ public:
         return mOptimizationLevel;
     }
 
-    void setOptimizationLevel(Optimization level) noexcept {
-        mOptimizationLevel = level;
-    }
-
     Metadata getReflectionTarget() const noexcept {
         return mReflectionTarget;
     }
@@ -149,6 +150,10 @@ public:
         return mFeatureLevel;
     }
 
+    Workarounds getWorkarounds() const noexcept {
+        return mWorkarounds;
+    }
+
 protected:
     bool mDebug = false;
     bool mIsValid = true;
@@ -166,6 +171,7 @@ protected:
     StringReplacementMap mTemplateMap;
     StringReplacementMap mMaterialParameters;
     filament::UserVariantFilterMask mVariantFilter = 0;
+    Workarounds mWorkarounds = Workarounds::ALL;
     bool mIncludeEssl1 = true;
 };
 

--- a/libs/filament-matp/src/MaterialParser.cpp
+++ b/libs/filament-matp/src/MaterialParser.cpp
@@ -501,6 +501,7 @@ bool MaterialParser::parse(filamat::MaterialBuilder& builder,
             .platform(config.getPlatform())
             .targetApi(config.getTargetApi())
             .optimization(config.getOptimizationLevel())
+            .workarounds(config.getWorkarounds())
             .printShaders(config.printShaders())
             .saveRawVariants(config.saveRawVariants())
             .generateDebugInfo(config.isDebug())

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -16,22 +16,32 @@
 
 #include "CommandlineConfig.h"
 
-#include <private/filament/Variant.h>
+#include <filament-matp/Config.h>
 
-#include <getopt/getopt.h>
+#include <filament/MaterialEnums.h>
+
+#include <backend/DriverEnums.h>
 
 #include <utils/Path.h>
 
-#include <istream>
+#include <getopt/getopt.h>
+
+#include <cstddef>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
 #include <sstream>
 #include <string>
 
 using namespace utils;
+using namespace filament;
 
 namespace matc {
 
 static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:P:OSEr:vV:gtwF1R";
-static const struct option OPTIONS[] = {
+static const option OPTIONS[] = {
         { "help",                    no_argument, nullptr, 'h' },
         { "license",                 no_argument, nullptr, 'L' },
         { "output",            required_argument, nullptr, 'o' },
@@ -78,7 +88,7 @@ static bool isPIIOption(const char* longOptionName) {
 }
 
 static void usage(char* name) {
-    std::string exec_name(utils::Path(name).getName());
+    std::string const exec_name(Path(name).getName());
     std::string usage(
             "MATC is a command-line tool to compile material definition.\n"
             "\n"
@@ -161,37 +171,37 @@ static void usage(char* name) {
 }
 
 static void license() {
-    static const char *license[] = {
+    static char const * const license[] = {
         #include "licenses/licenses.inc"
         nullptr
     };
 
-    const char **p = &license[0];
+    const char * const *p = &license[0];
     while (*p)
         std::cout << *p++ << std::endl;
 }
 
-static filament::UserVariantFilterMask parseVariantFilter(const std::string& arg) {
+static UserVariantFilterMask parseVariantFilter(const std::string& arg) {
     std::stringstream ss(arg);
     std::string item;
-    filament::UserVariantFilterMask variantFilter = 0;
+    UserVariantFilterMask variantFilter = 0;
     while (std::getline(ss, item, ',')) {
         if (item == "directionalLighting") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::DIRECTIONAL_LIGHTING;
+            variantFilter |= uint32_t(UserVariantFilterBit::DIRECTIONAL_LIGHTING);
         } else if (item == "dynamicLighting") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::DYNAMIC_LIGHTING;
+            variantFilter |= uint32_t(UserVariantFilterBit::DYNAMIC_LIGHTING);
         } else if (item == "shadowReceiver") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::SHADOW_RECEIVER;
+            variantFilter |= uint32_t(UserVariantFilterBit::SHADOW_RECEIVER);
         } else if (item == "skinning") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::SKINNING;
+            variantFilter |= uint32_t(UserVariantFilterBit::SKINNING);
         } else if (item == "vsm") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::VSM;
+            variantFilter |= uint32_t(UserVariantFilterBit::VSM);
         } else if (item == "fog") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::FOG;
+            variantFilter |= uint32_t(UserVariantFilterBit::FOG);
         } else if (item == "ssr") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::SSR;
+            variantFilter |= uint32_t(UserVariantFilterBit::SSR);
         } else if (item == "stereo") {
-            variantFilter |= (uint32_t) filament::UserVariantFilterBit::STE;
+            variantFilter |= uint32_t(UserVariantFilterBit::STE);
         }
     }
     return variantFilter;
@@ -201,7 +211,7 @@ CommandlineConfig::CommandlineConfig(int argc, char** argv) : Config(), mArgc(ar
     mIsValid = parse();
 }
 
-static void parseDefine(std::string defineString, matp::Config::StringReplacementMap& defines) {
+static void parseDefine(std::string const& defineString, matp::Config::StringReplacementMap& defines) {
     const char* const defineArg = defineString.c_str();
     const size_t length = defineString.length();
 
@@ -217,13 +227,13 @@ static void parseDefine(std::string defineString, matp::Config::StringReplacemen
             // Edge-cases, missing define name or value.
             return;
         }
-        std::string def(defineArg, p - defineArg);
+        std::string const def(defineArg, p - defineArg);
         defines.emplace(def, p + 1);
         return;
     }
 
     // No explicit assignment, use a default value of 1.
-    std::string def(defineArg, p - defineArg);
+    std::string const def(defineArg, p - defineArg);
     defines.emplace(def, "1");
 }
 
@@ -232,17 +242,15 @@ bool CommandlineConfig::parse() {
     int option_index = 0;
 
     while ((opt = getopt_long(mArgc, mArgv, OPTSTR, OPTIONS, &option_index)) >= 0) {
-        std::string arg(optarg ? optarg : "");
+        std::string const arg(optarg ? optarg : "");
         switch (opt) {
             default:
             case 'h':
                 usage(mArgv[0]);
                 exit(0);
-                break;
             case 'L':
                 license();
                 exit(0);
-                break;
             case 'o':
                 mOutput = new FilesystemOutput(arg.c_str());
                 break;
@@ -291,13 +299,13 @@ bool CommandlineConfig::parse() {
                 }
                 break;
             case 'l': {
-                auto featureLevel = filament::backend::FeatureLevel(std::atoi(arg.c_str()));
-                mFeatureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
+                auto featureLevel = backend::FeatureLevel(std::atoi(arg.c_str()));
+                mFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_3;
                 switch (featureLevel) {
-                    case filament::backend::FeatureLevel::FEATURE_LEVEL_0:
-                    case filament::backend::FeatureLevel::FEATURE_LEVEL_1:
-                    case filament::backend::FeatureLevel::FEATURE_LEVEL_2:
-                    case filament::backend::FeatureLevel::FEATURE_LEVEL_3:
+                    case backend::FeatureLevel::FEATURE_LEVEL_0:
+                    case backend::FeatureLevel::FEATURE_LEVEL_1:
+                    case backend::FeatureLevel::FEATURE_LEVEL_2:
+                    case backend::FeatureLevel::FEATURE_LEVEL_3:
                         mFeatureLevel = featureLevel;
                         break;
                 }
@@ -318,9 +326,8 @@ bool CommandlineConfig::parse() {
             case 'v':
                 // Similar to --help, the --version command does an early exit in order to avoid
                 // subsequent error spew such as "Missing input filename" etc.
-                std::cout << filament::MATERIAL_VERSION << std::endl;
+                std::cout << MATERIAL_VERSION << std::endl;
                 exit(0);
-                break;
             case 'V':
                 mVariantFilter = parseVariantFilter(arg);
                 break;

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -27,10 +27,10 @@
 #include <getopt/getopt.h>
 
 #include <cstddef>
-#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -111,7 +111,7 @@ static void usage(char* name) {
             "       Specify path to output file\n\n"
             "   --platform, -p\n"
             "       Shader family to generate: desktop, mobile or all (default)\n\n"
-            "   --optimize-size, -S\n"
+            "   --optimize-size, -S, -Os\n"
             "       Optimize generated shader code for size instead of just performance\n\n"
             "   --api, -a\n"
             "       Specify the target API: opengl (default), vulkan, metal, or all\n"
@@ -146,7 +146,7 @@ static void usage(char* name) {
             "   --version, -v\n"
             "       Print the material version number\n\n"
             "Internal use and debugging only:\n"
-            "   --optimize-none, -g\n"
+            "   --optimize-none, -g, -O0\n"
             "       Disable all shader optimizations, for debugging\n\n"
             "   --preprocessor-only, -E\n"
             "       Optimize shaders by running only the preprocessor\n\n"
@@ -208,6 +208,17 @@ static UserVariantFilterMask parseVariantFilter(const std::string& arg) {
 }
 
 CommandlineConfig::CommandlineConfig(int argc, char** argv) : Config(), mArgc(argc), mArgv(argv) {
+    // Add aliases for some optimization flags. We do this by pre-processing the arguments,
+    // since getopt has trouble with short options that are longer than one character (e.g. -Os).
+    for (int i = 1; i < mArgc; i++) {
+        if (mArgv[i]) {
+            if (strcmp(mArgv[i], "-Os") == 0) {
+                mArgv[i] = (char*)"-S";
+            } else if (strcmp(mArgv[i], "-O0") == 0) {
+                mArgv[i] = (char*)"-g";
+            }
+        }
+    }
     mIsValid = parse();
 }
 


### PR DESCRIPTION
Currently the only values possible are `none` and `all`. `all` is the default. This option will be used to control code generation workarounds individually. Currently `all` disables the *MergeReturn* and *Simplification* passes, which have caused issues in the past on some older Android devices.
