### PR TITLE
[WIP] Create exportable Syncs (fences)

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -40,6 +40,7 @@ set(PUBLIC_HDRS
         include/filament/Skybox.h
         include/filament/Stream.h
         include/filament/SwapChain.h
+        include/filament/Sync.h
         include/filament/Texture.h
         include/filament/TextureSampler.h
         include/filament/ToneMapper.h
@@ -103,6 +104,7 @@ set(SRCS
         src/Skybox.cpp
         src/Stream.cpp
         src/SwapChain.cpp
+        src/Sync.cpp
         src/Texture.cpp
         src/ToneMapper.cpp
         src/TransformManager.cpp
@@ -132,6 +134,7 @@ set(SRCS
         src/details/Skybox.cpp
         src/details/Stream.cpp
         src/details/SwapChain.cpp
+        src/details/Sync.cpp
         src/details/Texture.cpp
         src/details/VertexBuffer.cpp
         src/details/View.cpp

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -599,6 +599,20 @@ enum class FenceStatus : int8_t {
     TIMEOUT_EXPIRED = 1,        //!< wait()'s timeout expired. The Fence condition is not satisfied.
 };
 
+/**
+ * Error codes for DriverApi::getFenceFD()
+ * @see Fence, DriverApi::getFenceFD()
+ */
+enum class FenceConversionResult : int8_t {
+    HANDLE_NOT_AVAILABLE =
+            -3, //!< The underlying handle hasn't been allocated yet. Likely was requested too soon.
+    NOT_SUPPORTED =
+            -2,  //!< The current platform doesn't support converting fences to external handles.
+    ERROR = -1,  //!< An error occurred while converting the fence to an external handle.
+    SUCCESS = 0, //!< Successfully converted to external handle.
+    PREVIOUSLY_SIGNALED = 1, //!< The fence has already been signaled, can't convert.
+};
+
 static constexpr uint64_t FENCE_WAIT_FOR_EVER = uint64_t(-1);
 
 /**

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -260,6 +260,18 @@ public:
     virtual Fence* UTILS_NULLABLE createFence() noexcept;
 
     /**
+     * Called by the driver to convert a fence to an external handle, if
+     * supported. Requires the fence to have been created with the appropriate
+     * flags, indicating that it can be exported. Will fail otherwise.
+     *
+     * @param fence The fence to convert to an external handle.
+     * @param fd A pointer that will be supplied with the external handle.
+     * @return A status code indicating if the conversion was successful.
+     */
+    virtual FenceConversionResult getFenceFD(Fence* UTILS_NONNULL fence,
+            int32_t* UTILS_NONNULL fd) noexcept;
+
+    /**
      * Destroys a Fence object. The default implementation does nothing.
      *
      * @param fence Fence to destroy.

--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -92,6 +92,8 @@ protected:
 
     Stream* createStream(void* nativeStream) noexcept override;
     void destroyStream(Stream* stream) noexcept override;
+    Fence* createFence() noexcept override;
+    FenceConversionResult getFenceFD(Fence* fence, int32_t* fd) noexcept override;
     void attach(Stream* stream, intptr_t tname) noexcept override;
     void detach(Stream* stream) noexcept override;
     void updateTexImage(Stream* stream, int64_t* timestamp) noexcept override;

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -407,12 +407,16 @@ public:
         return {};
     }
 
+    virtual FenceConversionResult getFenceFD(VkFence fence, int32_t* fd) const noexcept;
+
 protected:
     virtual ExtensionSet getSwapchainInstanceExtensions() const;
 
     using SurfaceBundle = std::tuple<VkSurfaceKHR, VkExtent2D>;
     virtual SurfaceBundle createVkSurfaceKHR(void* nativeWindow, VkInstance instance,
             uint64_t flags) const noexcept;
+
+    virtual VkExternalFenceHandleTypeFlagBits getFenceExportFlags() const noexcept;
 
 private:
     // Platform dependent helper methods

--- a/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatformAndroid.h
@@ -44,12 +44,16 @@ public:
 
     virtual ImageData createVkImageFromExternal(ExternalImageHandleRef image) const override;
 
+    virtual FenceConversionResult getFenceFD(VkFence fence, int32_t* fd) const noexcept override;
+
 protected:
     virtual ExtensionSet getSwapchainInstanceExtensions() const override;
 
     using SurfaceBundle = VulkanPlatform::SurfaceBundle;
     virtual SurfaceBundle createVkSurfaceKHR(void* nativeWindow, VkInstance instance,
             uint64_t flags) const noexcept override;
+
+    virtual VkExternalFenceHandleTypeFlagBits getFenceExportFlags() const noexcept override;
 
 private:
     struct ExternalImageVulkanAndroid : public Platform::ExternalImage {

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -344,6 +344,8 @@ DECL_DRIVER_API_SYNCHRONOUS_N(void, setStreamDimensions, backend::StreamHandle, 
 DECL_DRIVER_API_SYNCHRONOUS_N(int64_t, getStreamTimestamp, backend::StreamHandle, stream)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, updateStreams, backend::DriverApi*, driver)
 DECL_DRIVER_API_SYNCHRONOUS_N(backend::FenceStatus, getFenceStatus, backend::FenceHandle, fh)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::FenceConversionResult, getFenceFD, backend::FenceHandle, fh,
+        int32_t*, fd)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isTextureSwizzleSupported)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::TextureFormat, format)

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -147,6 +147,10 @@ int64_t NoopDriver::getStreamTimestamp(Handle<HwStream> sh) {
 void NoopDriver::updateStreams(CommandStream* driver) {
 }
 
+FenceConversionResult NoopDriver::getFenceFD(Handle<HwFence> fh, int32_t* fd) {
+    return FenceConversionResult::NOT_SUPPORTED;
+}
+
 void NoopDriver::destroyFence(Handle<HwFence> fh) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2235,6 +2235,22 @@ FenceStatus OpenGLDriver::getFenceStatus(Handle<HwFence> fh) {
     return FenceStatus::ERROR;
 }
 
+FenceConversionResult OpenGLDriver::getFenceFD(Handle<HwFence> fh, int32_t* fd) {
+    if (!fh) {
+        return FenceConversionResult::HANDLE_NOT_AVAILABLE;
+    }
+
+    GLFence* f = handle_cast<GLFence*>(fh);
+    if (f->fence == nullptr) {
+        if (!mPlatform.canCreateFence()) {
+            return FenceConversionResult::NOT_SUPPORTED;
+        }
+        return FenceConversionResult::HANDLE_NOT_AVAILABLE;
+    }
+
+    return mPlatform.getFenceFD(f->fence, fd);
+}
+
 bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
     const auto& ext = mContext.ext;
     if (isETC2Compression(format)) {

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -111,6 +111,10 @@ void OpenGLPlatform::destroyFence(
         UTILS_UNUSED Fence* fence) noexcept {
 }
 
+FenceConversionResult OpenGLPlatform::getFenceFD(Fence* fence, int32_t* fd) noexcept {
+    return FenceConversionResult::NOT_SUPPORTED;
+}
+
 FenceStatus OpenGLPlatform::waitFence(
         UTILS_UNUSED Fence* fence,
         UTILS_UNUSED uint64_t timeout) noexcept {

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -83,6 +83,7 @@ UTILS_PRIVATE PFNEGLGETCOMPOSITORTIMINGANDROIDPROC eglGetCompositorTimingANDROID
 UTILS_PRIVATE PFNEGLGETNEXTFRAMEIDANDROIDPROC eglGetNextFrameIdANDROID = {};
 UTILS_PRIVATE PFNEGLGETFRAMETIMESTAMPSUPPORTEDANDROIDPROC eglGetFrameTimestampSupportedANDROID = {};
 UTILS_PRIVATE PFNEGLGETFRAMETIMESTAMPSANDROIDPROC eglGetFrameTimestampsANDROID = {};
+UTILS_PRIVATE PFNEGLDUPNATIVEFENCEFDANDROIDPROC eglDupNativeFenceFDANDROID = {};
 }
 using namespace glext;
 
@@ -226,6 +227,8 @@ Driver* PlatformEGLAndroid::createDriver(void* sharedContext,
                 "eglGetFrameTimestampSupportedANDROID");
         eglGetFrameTimestampsANDROID = (PFNEGLGETFRAMETIMESTAMPSANDROIDPROC)eglGetProcAddress(
                 "eglGetFrameTimestampsANDROID");
+        eglDupNativeFenceFDANDROID =
+                (PFNEGLDUPNATIVEFENCEFDANDROIDPROC) eglGetProcAddress("eglDupNativeFenceFDANDROID");
     }
 
     mAssertNativeWindowIsValid = driverConfig.assertNativeWindowIsValid;
@@ -379,6 +382,20 @@ Platform::Stream* PlatformEGLAndroid::createStream(void* nativeStream) noexcept 
 
 void PlatformEGLAndroid::destroyStream(Platform::Stream* stream) noexcept {
     mExternalStreamManager.release(stream);
+}
+
+// For PlatformEGL on Android, create a fence that is exportable to an fd.
+Platform::Fence* PlatformEGLAndroid::createFence() noexcept {
+    return (Fence*) eglCreateSyncKHR(mEGLDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
+}
+
+FenceConversionResult PlatformEGLAndroid::getFenceFD(Platform::Fence* fence, int32_t* fd) noexcept {
+    EGLint tmpFd = eglDupNativeFenceFDANDROID(mEGLDisplay, (EGLSyncKHR) fence);
+    if (tmpFd == EGL_NO_NATIVE_FENCE_FD_ANDROID) {
+        return FenceConversionResult::ERROR;
+    }
+    *fd = tmpFd;
+    return FenceConversionResult::SUCCESS;
 }
 
 void PlatformEGLAndroid::attach(Stream* stream, intptr_t tname) noexcept {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -43,13 +43,26 @@ struct VulkanCmdFence {
 
     VkResult getStatus() { return status.load(std::memory_order_acquire); }
 
+    // Gets a reference to the underlying fence, so that it can be updated
+    // (as in for vkCreateFence), or fetched (for example, conversion to an
+    // external fence, where applicable).
+    VkFence& getVkFence() { return fence; }
+
 private:
+    VkFence fence;
     std::atomic<VkResult> status;
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {
     VulkanFence() {}
     std::shared_ptr<VulkanCmdFence> fence;
+
+    inline VkFence getVkFence() const noexcept {
+        if (fence == nullptr) {
+            return VK_NULL_HANDLE;
+        }
+        return fence->getVkFence();
+    }
 };
 
 struct VulkanTimerQuery : public HwTimerQuery, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -102,12 +102,19 @@ VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, VkDevice 
     vkCreateSemaphore(mDevice, &sci, VKALLOC, &mSubmission);
 
     VkFenceCreateInfo fenceCreateInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-    vkCreateFence(device, &fenceCreateInfo, VKALLOC, &mFence);
+    VkExportFenceCreateInfo exportFenceCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO,
+        .handleTypes = context.getFenceExportFlags()
+    };
+    fenceCreateInfo.pNext = &exportFenceCreateInfo;
+
+    vkCreateFence(device, &fenceCreateInfo, VKALLOC, &mFenceStatus->getVkFence());
 }
 
 VulkanCommandBuffer::~VulkanCommandBuffer() {
     vkDestroySemaphore(mDevice, mSubmission, VKALLOC);
-    vkDestroyFence(mDevice, mFence, VKALLOC);
+    vkDestroyFence(mDevice, mFenceStatus->getVkFence(), VKALLOC);
+    mFenceStatus->getVkFence() = VK_NULL_HANDLE;
 }
 
 void VulkanCommandBuffer::reset() noexcept {
@@ -121,7 +128,7 @@ void VulkanCommandBuffer::reset() noexcept {
     // gets, gets submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually
     // finishes executing the command buffer, the status changes to VK_SUCCESS.
     mFenceStatus = std::make_shared<VulkanCmdFence>(VK_INCOMPLETE);
-    vkResetFences(mDevice, 1, &mFence);
+    vkResetFences(mDevice, 1, &mFenceStatus->getVkFence());
 }
 
 void VulkanCommandBuffer::pushMarker(char const* marker) noexcept {
@@ -220,7 +227,7 @@ VkSemaphore VulkanCommandBuffer::submit() {
 
     mFenceStatus->setStatus(VK_NOT_READY);
     UTILS_UNUSED_IN_RELEASE VkResult result =
-        vkQueueSubmit(mQueue, 1, &submitInfo, mFence);
+            vkQueueSubmit(mQueue, 1, &submitInfo, mFenceStatus->getVkFence());
 
 #if FVK_ENABLED(FVK_DEBUG_COMMAND_BUFFER)
     if (result != VK_SUCCESS) {

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -101,9 +101,7 @@ struct VulkanCommandBuffer {
         return mFenceStatus;
     }
 
-    VkFence getVkFence() const {
-        return mFence;
-    }
+    VkFence getVkFence() const { return mFenceStatus->getVkFence(); }
 
     VkCommandBuffer buffer() const {
         return mBuffer;
@@ -125,7 +123,6 @@ private:
     fvkutils::StaticVector<VkPipelineStageFlags, 2> mWaitSemaphoreStages;
     VkCommandBuffer mBuffer;
     VkSemaphore mSubmission;
-    VkFence mFence;
     std::shared_ptr<VulkanCmdFence> mFenceStatus;
     std::vector<fvkmemory::resource_ptr<Resource>> mResources;
     uint32_t mAge;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -106,6 +106,10 @@ public:
         return mPhysicalDeviceProperties.properties.vendorID;
     }
 
+    inline VkExternalFenceHandleTypeFlags getFenceExportFlags() const noexcept {
+        return mFenceExportFlags;
+    }
+
     inline bool isImageCubeArraySupported() const noexcept {
         return mPhysicalDeviceFeatures.features.imageCubeArray == VK_TRUE;
     }
@@ -168,6 +172,9 @@ private:
         // non-conformant vulkan implementation).
         .imageView2DOn3DImage = VK_TRUE,
     };
+
+    VkExternalFenceHandleTypeFlags mFenceExportFlags = {};
+
     bool mDebugMarkersSupported = false;
     bool mDebugUtilsSupported = false;
     bool mLazilyAllocatedMemorySupported = false;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1033,6 +1033,19 @@ FenceStatus VulkanDriver::getFenceStatus(Handle<HwFence> fh) {
     return FenceStatus::TIMEOUT_EXPIRED;
 }
 
+FenceConversionResult VulkanDriver::getFenceFD(Handle<HwFence> fh, int32_t* fd) {
+    if (!fh) {
+        return FenceConversionResult::HANDLE_NOT_AVAILABLE;
+    }
+
+    VkFence fence = resource_ptr<VulkanFence>::cast(&mResourceManager, fh)->getVkFence();
+    if (fence == VK_NULL_HANDLE) {
+        return FenceConversionResult::HANDLE_NOT_AVAILABLE;
+    }
+
+    return mPlatform->getFenceFD(fence, fd);
+}
+
 // We create all textures using VK_IMAGE_TILING_OPTIMAL, so our definition of "supported" is that
 // the GPU supports the given texture format with non-zero optimal tiling features.
 bool VulkanDriver::isTextureFormatSupported(TextureFormat format) {

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -920,6 +920,8 @@ Driver* VulkanPlatform::createDriver(void* sharedContext,
     context.mBlittableDepthStencilFormats =
             findBlittableDepthStencilFormats(mImpl->mPhysicalDevice);
 
+    context.mFenceExportFlags = getFenceExportFlags();
+
     assert_invariant(context.mDepthStencilFormats.size() > 0);
 
 #if FVK_ENABLED(FVK_DEBUG_VALIDATION)
@@ -1036,6 +1038,15 @@ uint32_t VulkanPlatform::getProtectedGraphicsQueueIndex() const noexcept {
 
 VkQueue VulkanPlatform::getProtectedGraphicsQueue() const noexcept {
     return mImpl->mProtectedGraphicsQueue;
+}
+
+VkExternalFenceHandleTypeFlagBits VulkanPlatform::getFenceExportFlags() const noexcept {
+    // By default, fences should not be exportable.
+    return static_cast<VkExternalFenceHandleTypeFlagBits>(0);
+}
+
+FenceConversionResult VulkanPlatform::getFenceFD(VkFence fence, int32_t* fd) const noexcept {
+    return FenceConversionResult::NOT_SUPPORTED;
 }
 
 ExtensionSet VulkanPlatform::getSwapchainInstanceExtensions() const {

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -63,6 +63,7 @@ class Scene;
 class Skybox;
 class Stream;
 class SwapChain;
+class Sync;
 class Texture;
 class VertexBuffer;
 class View;
@@ -886,9 +887,19 @@ public:
      */
     Fence* UTILS_NONNULL createFence() noexcept;
 
+    /**
+     * Creates a Sync.
+     * @param callback A callback that will be invoked when the handle for
+     *                 the created sync is set
+     *
+     * @return A pointer to the newly created Sync.
+     */
+    Sync* UTILS_NONNULL createSync() noexcept;
+
     bool destroy(const BufferObject* UTILS_NULLABLE p);         //!< Destroys a BufferObject object.
     bool destroy(const VertexBuffer* UTILS_NULLABLE p);         //!< Destroys an VertexBuffer object.
     bool destroy(const Fence* UTILS_NULLABLE p);                //!< Destroys a Fence object.
+    bool destroy(const Sync* UTILS_NULLABLE p);                 //!< Destroys a Sync object.
     bool destroy(const IndexBuffer* UTILS_NULLABLE p);          //!< Destroys an IndexBuffer object.
     bool destroy(const SkinningBuffer* UTILS_NULLABLE p);       //!< Destroys a SkinningBuffer object.
     bool destroy(const MorphTargetBuffer* UTILS_NULLABLE p);    //!< Destroys a MorphTargetBuffer object.
@@ -922,6 +933,8 @@ public:
     bool isValid(const VertexBuffer* UTILS_NULLABLE p) const;
     /** Tells whether a Fence object is valid */
     bool isValid(const Fence* UTILS_NULLABLE p) const;
+    /** Tells whether a Sync object is valid */
+    bool isValid(const Sync* UTILS_NULLABLE p) const;
     /** Tells whether an IndexBuffer object is valid */
     bool isValid(const IndexBuffer* UTILS_NULLABLE p) const;
     /** Tells whether a SkinningBuffer object is valid */

--- a/filament/include/filament/Sync.h
+++ b/filament/include/filament/Sync.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_SYNC_H
+#define TNT_FILAMENT_SYNC_H
+
+#include <filament/FilamentAPI.h>
+
+#include <backend/DriverEnums.h>
+
+#include <functional>
+
+namespace filament {
+
+class UTILS_PUBLIC Sync : public FilamentAPI {
+public:
+    using SyncConversionResult = backend::FenceConversionResult;
+    using SyncConversionCallback = std::function<void(SyncConversionResult, int32_t)>;
+
+    /**
+     * Converts a sync object to one that can be used externally to
+     * wait for some GPU work to be completed within Filament before proceeding
+     *
+     * @param callback A function that will receive the external sync handle, if
+     *                 conversion was successful, along with a conversion result
+     *                 code (e.g. SUCCESS, ERROR, NOT_SUPPORTED).
+     */
+    void convertToExternalSync(SyncConversionCallback callback) noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Sync() = default;
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_SYNC_H

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -30,6 +30,7 @@
 #include "details/Skybox.h"
 #include "details/Stream.h"
 #include "details/SwapChain.h"
+#include "details/Sync.h"
 #include "details/Texture.h"
 #include "details/VertexBuffer.h"
 #include "details/View.h"
@@ -132,6 +133,8 @@ SwapChain* Engine::createSwapChain(uint32_t const width, uint32_t const height, 
     return downcast(this)->createSwapChain(width, height, flags);
 }
 
+Sync* Engine::createSync() noexcept { return downcast(this)->createSync(); }
+
 bool Engine::destroy(const BufferObject* p) {
     return downcast(this)->destroy(downcast(p));
 }
@@ -204,6 +207,8 @@ bool Engine::destroy(const SwapChain* p) {
     return downcast(this)->destroy(downcast(p));
 }
 
+bool Engine::destroy(const Sync* p) { return downcast(this)->destroy(downcast(p)); }
+
 bool Engine::destroy(const InstanceBuffer* p) {
     return downcast(this)->destroy(downcast(p));
 }
@@ -221,6 +226,7 @@ bool Engine::isValid(const VertexBuffer* p) const {
 bool Engine::isValid(const Fence* p) const {
     return downcast(this)->isValid(downcast(p));
 }
+bool Engine::isValid(const Sync* p) const { return downcast(this)->isValid(downcast(p)); }
 bool Engine::isValid(const IndexBuffer* p) const {
     return downcast(this)->isValid(downcast(p));
 }

--- a/filament/src/Sync.cpp
+++ b/filament/src/Sync.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "details/Sync.h"
+
+namespace filament {
+
+void Sync::convertToExternalSync(SyncConversionCallback callback) noexcept {
+    downcast(this)->convertToExternalSync(callback);
+}
+
+} // namespace filament

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -34,6 +34,7 @@
 #include "details/Skybox.h"
 #include "details/Stream.h"
 #include "details/SwapChain.h"
+#include "details/Sync.h"
 #include "details/Texture.h"
 #include "details/VertexBuffer.h"
 #include "details/View.h"
@@ -1006,6 +1007,15 @@ FSwapChain* FEngine::createSwapChain(uint32_t width, uint32_t height, uint64_t f
     return p;
 }
 
+FSync* FEngine::createSync() noexcept {
+    FSync* p = mHeapAllocator.make<FSync>(*this);
+    if (UTILS_LIKELY(p)) {
+        std::lock_guard const guard(mSyncListLock);
+        mSyncs.insert(p);
+    }
+    return p;
+}
+
 /*
  * Objects created with a component manager
  */
@@ -1196,6 +1206,11 @@ bool FEngine::destroy(const FSwapChain* p) {
 }
 
 UTILS_NOINLINE
+bool FEngine::destroy(const FSync* p) {
+    return terminateAndDestroyLocked(mSyncListLock, p, mSyncs);
+}
+
+UTILS_NOINLINE
 bool FEngine::destroy(const FStream* p) {
     return terminateAndDestroy(p, mStreams);
 }
@@ -1282,6 +1297,8 @@ bool FEngine::isValid(const FVertexBuffer* p) const {
 bool FEngine::isValid(const FFence* p) const {
     return isValid(p, mFences);
 }
+
+bool FEngine::isValid(const FSync* p) const { return isValid(p, mSyncs); }
 
 bool FEngine::isValid(const FIndexBuffer* p) const {
     return isValid(p, mIndexBuffers);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -40,10 +40,11 @@
 #include "details/Fence.h"
 #include "details/IndexBuffer.h"
 #include "details/InstanceBuffer.h"
+#include "details/MorphTargetBuffer.h"
 #include "details/RenderTarget.h"
 #include "details/SkinningBuffer.h"
-#include "details/MorphTargetBuffer.h"
 #include "details/Skybox.h"
+#include "details/Sync.h"
 
 #include "private/backend/CommandBufferQueue.h"
 #include "private/backend/CommandStream.h"
@@ -122,6 +123,7 @@ class FMaterialInstance;
 class FRenderer;
 class FScene;
 class FSwapChain;
+class FSync;
 class FView;
 
 class ResourceAllocator;
@@ -331,6 +333,7 @@ public:
     FScene* createScene() noexcept;
     FView* createView() noexcept;
     FFence* createFence() noexcept;
+    FSync* createSync() noexcept;
     FSwapChain* createSwapChain(void* nativeWindow, uint64_t flags) noexcept;
     FSwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t flags) noexcept;
 
@@ -342,6 +345,7 @@ public:
     bool destroy(const FBufferObject* p);
     bool destroy(const FVertexBuffer* p);
     bool destroy(const FFence* p);
+    bool destroy(const FSync* p);
     bool destroy(const FIndexBuffer* p);
     bool destroy(const FSkinningBuffer* p);
     bool destroy(const FMorphTargetBuffer* p);
@@ -362,6 +366,7 @@ public:
     bool isValid(const FBufferObject* p) const;
     bool isValid(const FVertexBuffer* p) const;
     bool isValid(const FFence* p) const;
+    bool isValid(const FSync* p) const;
     bool isValid(const FIndexBuffer* p) const;
     bool isValid(const FSkinningBuffer* p) const;
     bool isValid(const FMorphTargetBuffer* p) const;
@@ -612,6 +617,11 @@ private:
     // the fence list is accessed from multiple threads
     utils::Mutex mFenceListLock;
     ResourceList<FFence> mFences{"Fence"};
+
+    // the sync list is accessed from multiple threads, because they are
+    // synchronization objects.
+    utils::Mutex mSyncListLock;
+    ResourceList<FSync> mSyncs{ "Sync" };
 
     mutable uint32_t mMaterialId = 0;
 

--- a/filament/src/details/Sync.cpp
+++ b/filament/src/details/Sync.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "details/Sync.h"
+
+#include "details/Engine.h"
+
+#include <filament/Sync.h>
+
+namespace filament {
+
+using DriverApi = backend::DriverApi;
+
+FSync::FSync(FEngine& engine)
+    : mEngine(engine) {
+    DriverApi& driverApi = engine.getDriverApi();
+    mHwFence = driverApi.createFence();
+    driverApi.queueCommand([this]() {
+        {
+            std::lock_guard lock(mMutex);
+            mHasHandle = true;
+        }
+        processAllCallbacks();
+    });
+}
+
+void FSync::terminate(FEngine& engine) noexcept { engine.getDriverApi().destroyFence(mHwFence); }
+
+void FSync::convertToExternalSync(SyncConversionCallback callback) noexcept {
+    {
+        std::lock_guard lock(mMutex);
+        if (!mHasHandle) {
+            mConversionCallbacks.push_back(callback);
+            return;
+        }
+    }
+
+    processCallback(callback);
+}
+
+void FSync::processAllCallbacks() {
+    for (const auto& callback: mConversionCallbacks) {
+        processCallback(callback);
+    }
+}
+
+void FSync::processCallback(SyncConversionCallback callback) {
+    DriverApi& driverApi = mEngine.getDriverApi();
+    int32_t externalHandle;
+    SyncConversionResult result = driverApi.getFenceFD(mHwFence, &externalHandle);
+    callback(result, externalHandle);
+}
+
+} // namespace filament

--- a/filament/src/details/Sync.h
+++ b/filament/src/details/Sync.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DETAILS_SYNC_H
+#define TNT_FILAMENT_DETAILS_SYNC_H
+
+#include "downcast.h"
+
+#include <filament/Sync.h>
+
+#include <backend/Handle.h>
+
+#include <functional>
+#include <mutex>
+#include <vector>
+
+namespace filament {
+
+class FEngine;
+
+class FSync : public Sync {
+public:
+    FSync(FEngine& engine);
+
+    void terminate(FEngine& engine) noexcept;
+
+    backend::FenceHandle getHwHandle() const noexcept { return mHwFence; }
+
+    /**
+     * Converts a sync object to one that can be used externally to
+     * wait for some GPU work to be completed within Filament before proceeding
+     *
+     * @param callback A function that will receive the external sync handle, if
+     *                 conversion was successful, along with a conversion result
+     *                 code (e.g. SUCCESS, ERROR, NOT_SUPPORTED).
+     */
+    void convertToExternalSync(SyncConversionCallback callback) noexcept;
+
+private:
+    FEngine& mEngine;
+    backend::FenceHandle mHwFence;
+
+    std::mutex mMutex;
+    bool mHasHandle = false;
+    std::vector<SyncConversionCallback> mConversionCallbacks;
+
+    void processAllCallbacks();
+
+    void processCallback(SyncConversionCallback callback);
+};
+
+FILAMENT_DOWNCAST(Sync)
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_DETAILS_SYNC_H


### PR DESCRIPTION
Note: creating this review as a WIP so we can discuss the API in further depth.

Creates exportable Fences on the Android platform, with the possibility of exporting to other platforms in the future. Exposes them to the frontend as "Sync" objects, which can only be exported to external sync objects (e.g. Fences).