### PR TITLE
Guard against uninitialized thickness in refractionSolidSphere

### DIFF
--- a/shaders/src/surface_light_indirect.fs
+++ b/shaders/src/surface_light_indirect.fs
@@ -451,8 +451,13 @@ void refractionSolidSphere(const PixelParams pixel,
     const vec3 n, vec3 r, out Refraction ray) {
     r = refract(r, n, pixel.etaIR);
     float NoR = dot(n, r);
-    float d = pixel.thickness * -NoR;
+    float d = 0.0;
+#if defined(MATERIAL_HAS_THICKNESS)
+    d = pixel.thickness * -NoR;
     ray.position = vec3(shading_position + r * d);
+#else
+    ray.position = vec3(shading_position);
+#endif
     ray.d = d;
     vec3 n1 = normalize(NoR * r - n * 0.5);
     ray.direction = refract(r, n1,  pixel.etaRI);

--- a/shaders/src/surface_shading_lit.fs
+++ b/shaders/src/surface_shading_lit.fs
@@ -125,7 +125,7 @@ void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel
 #else
     pixel.absorption = vec3(0.0);
 #endif
-#if defined(MATERIAL_HAS_THICKNESS)
+#if defined(MATERIAL_HAS_THICKNESS) || defined(MATERIAL_HAS_REFRACTION)
     pixel.thickness = max(0.0, material.thickness);
 #endif
 #if defined(MATERIAL_HAS_MICRO_THICKNESS) && (REFRACTION_TYPE == REFRACTION_TYPE_THIN)


### PR DESCRIPTION
Duplicated from `refractionThinSphere`