### PR TITLE
Doc: Fix broken link

### DIFF
--- a/docs/main/index.html
+++ b/docs/main/index.html
@@ -160,8 +160,8 @@
                     <main>
                         <h1 id="core-concepts"><a class="header" href="#core-concepts">Core Concepts</a></h1>
 <ul>
-<li><a href="main/filament.html">Filament</a> - High-level designs; Filament's PBR/math assumptions; implementation details.</li>
-<li><a href="main/materials.html">Materials</a> - A guide to Filament's material definition.</li>
+<li><a href="../main/filament.html">Filament</a> - High-level designs; Filament's PBR/math assumptions; implementation details.</li>
+<li><a href="../main/materials.html">Materials</a> - A guide to Filament's material definition.</li>
 </ul>
 
                     </main>


### PR DESCRIPTION
The doc links to Filament and Materials pages on the index page are broken due to incorrect relative file location.