### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Filament release archives contains host-side tools that are required to generate
 Make sure you always use tools from the same release as the runtime library. This is particularly
 important for `matc` (material compiler).
 
-If you'd rather build Filament yourself, please refer to our [build manual](BUILDING.md).
+If you'd rather build Filament yourself, please refer to our [build manual](/BUILDING.md).
 
 ### Android
 
@@ -222,7 +222,7 @@ MaterialInstance* materialInstance = material->createInstance();
 ```
 
 To learn more about materials and `matc`, please refer to the
-[materials documentation](./docs/Materials.md.html).
+[materials documentation](https://google.github.io/filament/Materials.html).
 
 To render, simply pass the `View` to the `Renderer`:
 
@@ -240,7 +240,7 @@ in the `samples/` directory. These samples are all based on `libs/filamentapp/` 
 code that creates a native window with SDL2 and initializes the Filament engine, renderer and views.
 
 For more information on how to prepare environment maps for image-based lighting please refer to
-[BUILDING.md](https://github.com/google/filament/blob/main/BUILDING.md#running-the-native-samples).
+[BUILDING.md](/BUILDING.md#running-the-native-samples).
 
 ### Android
 
@@ -272,7 +272,7 @@ To get started you can use the textures and environment maps found respectively 
 refer to their respective `URL.txt` files to know more about the original authors.
 
 Environments must be pre-processed using
-[`cmgen`](https://github.com/google/filament/blob/main/BUILDING.md#running-the-native-samples) or
+[`cmgen`](/BUILDING.md#running-the-native-samples) or
 using the `libiblprefilter` library.
 
 ## How to make contributions

--- a/docs_src/build/duplicates.json
+++ b/docs_src/build/duplicates.json
@@ -2,9 +2,14 @@
     "README.md": {
         "dest": "dup/intro.md",
         "link_transforms": {
-            "BUILDING.md": "building.md",
+            "/BUILDING.md#running-the-native-samples": "building.md#running-the-native-samples",
+            "/BUILDING.md": "building.md",
             "/CONTRIBUTING.md": "contributing.md",
             "/CODE_STYLE.md": "code_style.md",
+            "/LICENSE": "https://github.com/google/filament/blob/main/LICENSE",
+            "https://google.github.io/filament/Filament.html": "../main/filament.md",
+            "https://google.github.io/filament/Materials.html": "../main/materials.md",
+            "https://google.github.io/filament/notes/material_properties.html": "../notes/material_properties.md",
             "docs/images/samples": "../images/samples"
         }
     },

--- a/docs_src/src_mdbook/src/main/README.md
+++ b/docs_src/src_mdbook/src/main/README.md
@@ -1,5 +1,5 @@
 # Core Concepts
 
 
-- [Filament](main/filament.md) - High-level designs; Filament's PBR/math assumptions; implementation details.
-- [Materials](main/materials.md) - A guide to Filament's material definition.
+- [Filament](filament.md) - High-level designs; Filament's PBR/math assumptions; implementation details.
+- [Materials](materials.md) - A guide to Filament's material definition.


### PR DESCRIPTION
 - Fix broken links in https://google.github.io/filament/main/
 - Make /README.md links consistent
 - Add additional replacement recipes for /README.md
 - Make /index.html redirect to /dup/intro.html because /index.html has the wrong relative links. This is essentially adding a redirect-only index.html to src_raw.