### PR TITLE
make sure PixelParams::thickness is initialized

### DIFF
--- a/shaders/src/surface_light_indirect.fs
+++ b/shaders/src/surface_light_indirect.fs
@@ -506,11 +506,7 @@ vec3 evaluateRefraction(
 
     // compute transmission T
 #if defined(MATERIAL_HAS_ABSORPTION)
-#if defined(MATERIAL_HAS_THICKNESS) || defined(MATERIAL_HAS_MICRO_THICKNESS)
     vec3 T = min(vec3(1.0), exp(-pixel.absorption * ray.d));
-#else
-    vec3 T = 1.0 - pixel.absorption;
-#endif
 #endif
 
     // Roughness remapping so that an IOR of 1.0 means no microfacet refraction and an IOR

--- a/shaders/src/surface_shading_lit.fs
+++ b/shaders/src/surface_shading_lit.fs
@@ -117,15 +117,11 @@ void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel
     pixel.transmission = 1.0;
 #endif
 #if defined(MATERIAL_HAS_ABSORPTION)
-#if defined(MATERIAL_HAS_THICKNESS) || defined(MATERIAL_HAS_MICRO_THICKNESS)
     pixel.absorption = max(vec3(0.0), material.absorption);
-#else
-    pixel.absorption = saturate(material.absorption);
-#endif
 #else
     pixel.absorption = vec3(0.0);
 #endif
-#if defined(MATERIAL_HAS_THICKNESS)
+#if defined(SHADING_MODEL_SUBSURFACE) || defined(MATERIAL_HAS_REFRACTION)
     pixel.thickness = max(0.0, material.thickness);
 #endif
 #if defined(MATERIAL_HAS_MICRO_THICKNESS) && (REFRACTION_TYPE == REFRACTION_TYPE_THIN)


### PR DESCRIPTION
If screen-space refraction was used enabled but the thickness parameter wasn't explicitly set in the material, it would end-up being uninitialized. Now it's initialized to 0.5 by default, which is the value used for subsurface.

Also removed some calculations dependent on thickness being set, as they assumed a thickness of 0.