### PR TITLE
A new froxel grid vizualization for FilamentApp 

### DIFF
--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -27,6 +27,7 @@
 #include <utils/FixedCapacityVector.h>
 
 #include <math/mathfwd.h>
+#include <math/mat4.h>
 
 #include <utility>
 
@@ -759,6 +760,27 @@ public:
 
     //! debugging: enable or disable froxel visualisation for this view.
     void setFroxelVizEnabled(bool enabled) noexcept;
+
+    //! debugging: returns information about the froxel configuration
+    struct FroxelConfigurationInfo {
+        uint8_t width;
+        uint8_t height;
+        uint8_t depth;
+        uint32_t viewportWidth;
+        uint32_t viewportHeight;
+        math::uint2 froxelDimension;
+        float zLightFar;
+        float linearizer;
+        math::mat4f p;
+        math::float4 clipTransform;
+    };
+
+    struct FroxelConfigurationInfoWithAge {
+        FroxelConfigurationInfo info;
+        uint32_t age;
+    };
+
+    FroxelConfigurationInfoWithAge getFroxelConfigurationInfo() const noexcept;
 
     /** Result of a picking query */
     struct PickingQueryResult {

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -757,6 +757,8 @@ public:
     //! debugging: returns a Camera from the point of view of *the* dominant directional light used for shadowing.
     utils::FixedCapacityVector<Camera const*> getDirectionalShadowCameras() const noexcept;
 
+    //! debugging: enable or disable froxel visualisation for this view.
+    void setFroxelVizEnabled(bool enabled) noexcept;
 
     /** Result of a picking query */
     struct PickingQueryResult {

--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -22,6 +22,7 @@
 #include "details/Scene.h"
 #include "details/Engine.h"
 
+#include <filament/View.h>
 #include <filament/Viewport.h>
 
 #include <backend/Handle.h>
@@ -31,6 +32,7 @@
 #include <utils/Slice.h>
 
 #include <math/mat4.h>
+#include <math/vec2.h>
 #include <math/vec4.h>
 
 namespace filament {
@@ -112,7 +114,8 @@ public:
      * return true if updateUniforms() needs to be called
      */
     bool prepare(backend::DriverApi& driverApi, RootArenaScope& rootArenaScope, Viewport const& viewport,
-            const math::mat4f& projection, float projectionNear, float projectionFar) noexcept;
+            const math::mat4f& projection, float projectionNear, float projectionFar,
+            math::float4 const& clipTransform) noexcept;
 
     Froxel getFroxelAt(size_t x, size_t y, size_t z) const noexcept;
     size_t getFroxelCountX() const noexcept { return mFroxelCountX; }
@@ -160,6 +163,8 @@ public:
     using LightGroupType = uint32_t;
 
     static size_t getFroxelBufferByteCount(FEngine::DriverApi& driverApi) noexcept;
+
+    View::FroxelConfigurationInfo getFroxelConfigurationInfo() const noexcept;
 
 private:
     size_t getFroxelBufferEntryCount() const noexcept {
@@ -260,9 +265,10 @@ private:
     uint16_t mFroxelCountZ = 0;
     uint32_t mFroxelCount = 0;
     math::uint2 mFroxelDimension = {};
+    math::float4 mClipTransform = { 1, 1, 0, 0 };
 
     math::mat4f mProjection;
-    float mLinearizer = 0.0f;
+    math::float2 mLinearizer{};
     float mClipToFroxelX = 0.0f;
     float mClipToFroxelY = 0.0f;
     backend::BufferObjectHandle mRecordsBuffer;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -81,6 +81,10 @@ void View::setFroxelVizEnabled(bool const enabled) noexcept {
     downcast(this)->setFroxelVizEnabled(enabled);
 }
 
+View::FroxelConfigurationInfoWithAge View::getFroxelConfigurationInfo() const noexcept {
+    return downcast(this)->getFroxelConfigurationInfo();
+}
+
 void View::setShadowingEnabled(bool const enabled) noexcept {
     downcast(this)->setShadowingEnabled(enabled);
 }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -77,6 +77,10 @@ utils::FixedCapacityVector<Camera const*> View::getDirectionalShadowCameras() co
     return downcast(this)->getDirectionalShadowCameras();
 }
 
+void View::setFroxelVizEnabled(bool const enabled) noexcept {
+    downcast(this)->setFroxelVizEnabled(enabled);
+}
+
 void View::setShadowingEnabled(bool const enabled) noexcept {
     downcast(this)->setShadowingEnabled(enabled);
 }

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -662,7 +662,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
                     cameraInfo.projection, cameraInfo.zn, cameraInfo.zf)) {
                 // TODO: might be more consistent to do this in prepareLighting(), but it's not
                 //       strictly necessary
-                getColorPassDescriptorSet().prepareDynamicLights(mFroxelizer);
+                getColorPassDescriptorSet().prepareDynamicLights(mFroxelizer, mFroxelVizEnabled);
             }
             // We need to pass viewMatrix by value here because it extends the scope of this
             // function.

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -659,10 +659,12 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
         if (hasDynamicLighting()) {
             auto& froxelizer = mFroxelizer;
             if (froxelizer.prepare(driver, rootArenaScope, viewport,
-                    cameraInfo.projection, cameraInfo.zn, cameraInfo.zf)) {
+                    cameraInfo.projection, cameraInfo.zn, cameraInfo.zf,
+                    cameraInfo.clipTransform)) {
                 // TODO: might be more consistent to do this in prepareLighting(), but it's not
                 //       strictly necessary
                 getColorPassDescriptorSet().prepareDynamicLights(mFroxelizer, mFroxelVizEnabled);
+                mFroxelConfigurationAge++;
             }
             // We need to pass viewMatrix by value here because it extends the scope of this
             // function.
@@ -1432,6 +1434,10 @@ View::PickingQuery& FView::pick(uint32_t const x, uint32_t const y, CallbackHand
 
 void FView::setStereoscopicOptions(const StereoscopicOptions& options) noexcept {
     mStereoscopicOptions = options;
+}
+
+View::FroxelConfigurationInfoWithAge FView::getFroxelConfigurationInfo() const noexcept {
+    return { mFroxelizer.getFroxelConfigurationInfo(), mFroxelConfigurationAge };
 }
 
 void FView::setMaterialGlobal(uint32_t const index, float4 const& value) {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -244,6 +244,8 @@ public:
         mFroxelVizEnabled = enabled;
     }
 
+    FroxelConfigurationInfoWithAge getFroxelConfigurationInfo() const noexcept;
+
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
         assert_invariant(!renderTarget || !mMultiSampleAntiAliasingOptions.enabled ||
                 !renderTarget->hasSampleableDepth());
@@ -557,6 +559,7 @@ private:
     mutable Froxelizer mFroxelizer;
     utils::JobSystem::Job* mFroxelizerSync = nullptr;
     bool mFroxelVizEnabled = false;
+    uint32_t mFroxelConfigurationAge = 0;
 
     Viewport mViewport;
     bool mCulling = true;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -240,6 +240,10 @@ public:
         return mShadowMapManager->getDirectionalShadowCameras();
     }
 
+    void setFroxelVizEnabled(bool const enabled) noexcept {
+        mFroxelVizEnabled = enabled;
+    }
+
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
         assert_invariant(!renderTarget || !mMultiSampleAntiAliasingOptions.enabled ||
                 !renderTarget->hasSampleableDepth());
@@ -552,6 +556,7 @@ private:
 
     mutable Froxelizer mFroxelizer;
     utils::JobSystem::Job* mFroxelizerSync = nullptr;
+    bool mFroxelVizEnabled = false;
 
     Viewport mViewport;
     bool mCulling = true;

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -372,12 +372,13 @@ void ColorPassDescriptorSet::prepareAmbientLight(FEngine const& engine, FIndirec
             });
 }
 
-void ColorPassDescriptorSet::prepareDynamicLights(Froxelizer& froxelizer) noexcept {
+void ColorPassDescriptorSet::prepareDynamicLights(Froxelizer& froxelizer, bool const enableFroxelViz) noexcept {
     auto& s = mUniforms.edit();
     froxelizer.updateUniforms(s);
     float const f = froxelizer.getLightFar();
     // TODO: make the falloff rate a parameter
     s.lightFarAttenuationParams = 0.5f * float2{ 10.0f, 10.0f / (f * f) };
+    s.enableFroxelViz = enableFroxelViz;
 }
 
 void ColorPassDescriptorSet::prepareShadowMapping(BufferObjectHandle shadowUniforms) noexcept {

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -118,7 +118,7 @@ public:
     void prepareAmbientLight(FEngine const& engine,
             FIndirectLight const& ibl, float intensity, float exposure) noexcept;
 
-    void prepareDynamicLights(Froxelizer& froxelizer) noexcept;
+    void prepareDynamicLights(Froxelizer& froxelizer, bool enableFroxelViz) noexcept;
 
     void prepareShadowVSM(TextureHandle texture,
             VsmShadowOptions const& options) noexcept;

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -672,7 +672,7 @@ TEST(FilamentTest, FroxelData) {
 
     Froxelizer froxelData(*engine);
     froxelData.setOptions(5, 100);
-    froxelData.prepare(engine->getDriverApi(), scope, vp, p, 0.1, 100);
+    froxelData.prepare(engine->getDriverApi(), scope, vp, p, 0.1, 100, {1,1,0,0});
 
     Froxel f = froxelData.getFroxelAt(0,0,0);
 

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -120,6 +120,10 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::uint3 fParams;                        // stride-x, stride-y, stride-z
     int32_t lightChannels;                      // light channel bits
     math::float2 froxelCountXY;
+    int enableFroxelViz;
+    int dynReserved0;
+    int dynReserved1;
+    int dynReserved2;
 
     // IBL
     float iblLuminance;
@@ -204,7 +208,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved2;
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[39];
+    math::float4 reserved[38];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -140,6 +140,10 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "fParams",                0, Type::UINT3                   },
             { "lightChannels",          0, Type::INT                     },
             { "froxelCountXY",          0, Type::FLOAT2                  },
+            { "enableFroxelViz",        0, Type::INT                     },
+            { "dynReserved0",           0, Type::INT                     },
+            { "dynReserved1",           0, Type::INT                     },
+            { "dynReserved2",           0, Type::INT                     },
 
             { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },

--- a/libs/filamentapp/CMakeLists.txt
+++ b/libs/filamentapp/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MATERIAL_DIR  "${GENERATION_ROOT}/generated/material")
 set(PUBLIC_HDRS
         include/filamentapp/Config.h
         include/filamentapp/Cube.h
+        include/filamentapp/Grid.h
         include/filamentapp/FilamentApp.h
         include/filamentapp/IBL.h
         include/filamentapp/IcoSphere.h
@@ -30,6 +31,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/Cube.cpp
+        src/Grid.cpp
         src/FilamentApp.cpp
         src/IBL.cpp
         src/IcoSphere.cpp

--- a/libs/filamentapp/include/filamentapp/FilamentApp.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp.h
@@ -111,6 +111,15 @@ public:
 
     void loadIBL(std::string_view path);
 
+
+    // debugging: enable/disable the froxel grid
+    void setCameraFrustumEnabled(bool enabled) noexcept;
+    void setDirectionalShadowFrustumEnabled(bool enabled) noexcept;
+    void setFroxelGridEnabled(bool enabled) noexcept;
+    bool isCameraFrustumEnabled() const noexcept;
+    bool isDirectionalShadowFrustumEnabled() const noexcept;
+    bool isFroxelGridEnabled() const noexcept;
+
     FilamentApp(const FilamentApp& rhs) = delete;
     FilamentApp(FilamentApp&& rhs) = delete;
     FilamentApp& operator=(const FilamentApp& rhs) = delete;
@@ -262,6 +271,10 @@ private:
     float mCameraNear = 0.1f;
     float mCameraFar = 100.0f;
     bool mReconfigureCameras = false;
+    uint8_t mFroxelInfoAge = 0x42;
+    uint8_t mFroxelGridEnabled = 0;
+    uint8_t mDirectionalShadowFrustumEnabled = 0x2;
+    uint8_t mCameraFrustumEnabled = 0x2;
 
 #if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
     filament::backend::VulkanPlatform* mVulkanPlatform = nullptr;

--- a/libs/filamentapp/include/filamentapp/Grid.h
+++ b/libs/filamentapp/include/filamentapp/Grid.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_SAMPLE_GRID_H
+#define TNT_FILAMENT_SAMPLE_GRID_H
+
+#include <filament/Engine.h>
+#include <filament/Box.h>
+#include <filament/Camera.h>
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+
+#include <math/mat4.h>
+#include <math/vec3.h>
+
+#include <utils/Entity.h>
+
+#include <functional>
+
+class Grid {
+public:
+
+    Grid(filament::Engine& engine, filament::Material const* material,
+        filament::math::float3 linearColor);
+
+    Grid(Grid const&) = delete;
+    Grid& operator=(Grid const&) = delete;
+
+    Grid(Grid&& rhs) noexcept;
+
+    utils::Entity getWireFrameRenderable() const {
+        return mWireFrameRenderable;
+    }
+
+    ~Grid();
+
+    using Generator = std::function<float(int index)>;
+
+    void update(uint32_t width, uint32_t height, uint32_t depth);
+
+    void update(uint32_t width, uint32_t height, uint32_t depth,
+            Generator const& genWidth, Generator const& genHeight, Generator const& genDepth);
+
+    void mapFrustum(filament::Engine& engine, filament::Camera const* camera);
+    void mapFrustum(filament::Engine& engine, filament::math::mat4 const& transform);
+    void mapAabb(filament::Engine& engine, filament::Box const& box);
+
+private:
+    filament::Engine& mEngine;
+    filament::VertexBuffer* mVertexBuffer = nullptr;
+    filament::IndexBuffer* mIndexBuffer = nullptr;
+    filament::Material const* mMaterial = nullptr;
+    filament::MaterialInstance* mMaterialInstanceWireFrame = nullptr;
+    utils::Entity mWireFrameRenderable{};
+};
+
+
+#endif // TNT_FILAMENT_SAMPLE_GRID_H

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -192,6 +192,7 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
     mScene = mEngine->createScene();
 
     window->mMainView->getView()->setVisibleLayers(0x4, 0x4);
+    window->mMainView->getView()->setFroxelVizEnabled(true);
 
     if (config.splitView) {
         auto& rcm = mEngine->getRenderableManager();

--- a/libs/filamentapp/src/Grid.cpp
+++ b/libs/filamentapp/src/Grid.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filamentapp/Grid.h>
+
+#include <filament/Box.h>
+#include <filament/Camera.h>
+#include <filament/Color.h>
+#include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
+#include <filament/Material.h>
+#include <filament/MaterialEnums.h>
+#include <filament/MaterialInstance.h>
+#include <filament/RenderableManager.h>
+#include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
+
+#include <utils/EntityManager.h>
+
+#include <math/vec3.h>
+#include <math/mat4.h>
+
+#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <vector>
+#include <utils/Log.h>
+
+using namespace filament;
+
+using namespace filament::math;
+using namespace filament;
+
+Grid::Grid(Engine& engine, Material const* material, float3 linearColor)
+        : mEngine(engine),
+          mMaterial(material) {
+
+    if (mMaterial) {
+        mMaterialInstanceWireFrame = mMaterial->createInstance();
+        mMaterialInstanceWireFrame->setDepthCulling(true);
+        mMaterialInstanceWireFrame->setParameter("color", RgbaType::LINEAR,
+                LinearColorA{linearColor.r, linearColor.g, linearColor.b, 0.25f});
+    }
+
+    utils::EntityManager& em = utils::EntityManager::get();
+    mWireFrameRenderable = em.create();
+
+    RenderableManager::Builder(1)
+            .boundingBox({ { -1.0f, -1.0f, -1.0f }, { 1.0f, 1.0f, 1.0f } })
+            .material(0, mMaterialInstanceWireFrame)
+            .priority(6)
+            .culling(false)
+            .build(engine, mWireFrameRenderable);
+}
+
+Grid::Grid(Grid&& rhs) noexcept
+        : mEngine(rhs.mEngine) {
+    using std::swap;
+    swap(rhs.mVertexBuffer, mVertexBuffer);
+    swap(rhs.mIndexBuffer, mIndexBuffer);
+    swap(rhs.mMaterial, mMaterial);
+    swap(rhs.mMaterialInstanceWireFrame, mMaterialInstanceWireFrame);
+    swap(rhs.mWireFrameRenderable, mWireFrameRenderable);
+}
+
+Grid::~Grid() {
+    mEngine.destroy(mVertexBuffer);
+    mEngine.destroy(mIndexBuffer);
+
+    // We don't own the material, only instances
+    mEngine.destroy(mWireFrameRenderable);
+
+    // material instances must be destroyed after the renderables
+    mEngine.destroy(mMaterialInstanceWireFrame);
+
+    utils::EntityManager& em = utils::EntityManager::get();
+    em.destroy(mWireFrameRenderable);
+}
+
+void Grid::mapFrustum(Engine& engine, Camera const* camera) {
+    // the Camera far plane is at infinity, but we want it closer for display
+    const mat4 vm(camera->getModelMatrix());
+    mat4 const p(vm * inverse(camera->getProjectionMatrix()));
+    mapFrustum(engine, p);
+}
+
+void Grid::mapFrustum(Engine& engine, mat4 const& transform) {
+    // the Camera far plane is at infinity, but we want it closer for display
+    mat4f const p(transform);
+    auto& tcm = engine.getTransformManager();
+    tcm.setTransform(tcm.getInstance(mWireFrameRenderable), p);
+}
+
+void Grid::mapAabb(Engine& engine, Box const& box) {
+    mat4 const p = mat4::translation(box.center) * mat4::scaling(box.halfExtent);
+    mapFrustum(engine, p);
+}
+
+void Grid::update(uint32_t width, uint32_t height, uint32_t depth) {
+    // [-1, 1] range (default behavior)
+    update(width, height, depth,
+            [](int const index) { return float(index) * 2.0f - 1.0f; },
+            [](int const index) { return float(index) * 2.0f - 1.0f; },
+            [](int const index) { return float(index) * 2.0f - 1.0f; });
+}
+
+void Grid::update(uint32_t const width, uint32_t const height, uint32_t const depth,
+            Generator const& genWidth, Generator const& genHeight, Generator const& genDepth) {
+
+    // First, destroy the existing buffers.
+    mEngine.destroy(mVertexBuffer);
+    mEngine.destroy(mIndexBuffer);
+
+    std::vector<float3> vertices;
+    std::vector<uint32_t> indices;
+    size_t const verticeCount = (depth + 1) * (height + 1) * (width + 1);
+    vertices.reserve(verticeCount);
+    indices.reserve(verticeCount * 2);
+
+    // Generate vertices
+    // The vertices are generated to form a grid in the [-1, 1] range on all axes.
+    for (int k = 0; k <= depth; ++k) {
+        auto const z = genDepth(k);
+        for (int j = 0; j <= height; ++j) {
+            auto const y = genHeight(j);
+            for (int i = 0; i <= width; ++i) {
+                auto const x = genWidth(i);
+                vertices.push_back({ x, y, z });
+            }
+        }
+    }
+
+    // Generate indices for the lines
+    // The indices connect the vertices to form the grid lines.
+    auto getVertexIndex = [=](uint32_t const i, uint32_t const j, uint32_t const k) {
+        return k * (width + 1) * (height + 1) + j * (width + 1) + i;
+    };
+
+    // Lines along X axis
+    for (uint32_t k = 0; k <= depth; ++k) {
+        for (uint32_t j = 0; j <= height; ++j) {
+            indices.push_back(getVertexIndex(0, j, k));
+            indices.push_back(getVertexIndex(width, j, k));
+        }
+    }
+
+    // Lines along Y axis
+    for (uint32_t k = 0; k <= depth; ++k) {
+        for (uint32_t i = 0; i <= width; ++i) {
+            indices.push_back(getVertexIndex(i, 0, k));
+            indices.push_back(getVertexIndex(i, height, k));
+        }
+    }
+
+    // Lines along Z axis
+    for (uint32_t j = 0; j <= height; ++j) {
+        for (uint32_t i = 0; i <= width; ++i) {
+            indices.push_back(getVertexIndex(i, j, 0));
+            indices.push_back(getVertexIndex(i, j, depth));
+        }
+    }
+
+    const size_t vertexCount = vertices.size();
+    mVertexBuffer = VertexBuffer::Builder()
+            .vertexCount(vertexCount)
+            .bufferCount(1)
+            .attribute(POSITION, 0, VertexBuffer::AttributeType::FLOAT3)
+            .build(mEngine);
+
+    auto vertexData = vertices.data();
+    mVertexBuffer->setBufferAt(mEngine, 0,
+            VertexBuffer::BufferDescriptor::make(
+                    vertexData, vertexCount * sizeof(vertices[0]),
+                    [v = std::move(vertices)](void*, size_t) {}));
+
+    const size_t indexCount = indices.size();
+    mIndexBuffer = IndexBuffer::Builder()
+            .indexCount(indexCount)
+            .build(mEngine);
+
+    auto indexData = indices.data();
+    mIndexBuffer->setBuffer(mEngine,
+            IndexBuffer::BufferDescriptor::make(
+                indexData, indexCount * sizeof(uint32_t),
+                [i = std::move(indices)](void*, size_t) {}));
+
+    auto& rcm = mEngine.getRenderableManager();
+    auto instance = rcm.getInstance(mWireFrameRenderable);
+    rcm.setGeometryAt(instance, 0, RenderableManager::PrimitiveType::LINES,
+            mVertexBuffer, mIndexBuffer, 0, indexCount);
+}

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -949,12 +949,22 @@ int main(int argc, char** argv) {
                                     "d.shadowmap.display_shadow_texture_channel"), 0, 3);
                     ImGui::Unindent();
                 }
+
+                bool cameraFrustum = FilamentApp::get().isCameraFrustumEnabled();
+                ImGui::Checkbox("Show Camera Frustum", &cameraFrustum);
+                FilamentApp::get().setCameraFrustumEnabled(cameraFrustum);
+
+                bool shadowFrustum = FilamentApp::get().isDirectionalShadowFrustumEnabled();
+                ImGui::Checkbox("Show Shadow Frustum", &shadowFrustum);
+                FilamentApp::get().setDirectionalShadowFrustumEnabled(shadowFrustum);
+
                 bool debugFroxelVisualization;
                 if (debug.getProperty("d.lighting.debug_froxel_visualization",
                         &debugFroxelVisualization)) {
                     ImGui::Checkbox("Froxel Visualization", &debugFroxelVisualization);
                     debug.setProperty("d.lighting.debug_froxel_visualization",
                             debugFroxelVisualization);
+                    FilamentApp::get().setFroxelGridEnabled(debugFroxelVisualization);
                 }
 
                 auto dataSource = debug.getDataSource("d.view.frame_info");

--- a/shaders/src/surface_light_punctual.fs
+++ b/shaders/src/surface_light_punctual.fs
@@ -247,7 +247,7 @@ void evaluatePunctualLights(const MaterialInputs material,
     }
 
     if (CONFIG_DEBUG_FROXEL_VISUALIZATION) {
-        if (froxel.count > 0u) {
+        if (froxel.count > 0u && frameUniforms.enableFroxelViz != 0) {
             const vec3 debugColors[17] = vec3[](
                 vec3(0.0,     0.0,     0.0),         // black
                 vec3(0.0,     0.0,     0.1647),      // darkest blue


### PR DESCRIPTION
FilamentApp now has debugging options to enable or disable the
camera and directional shadow frustums, as well as the new
"froxel grid" visualization.

"froxel grid" is automatically enabled when "froxel debugging" is
enabled in the debug gui in gltf_viewer.


New corresponding debugging APIs were added to View.