### PR TITLE
Disable amortized shader compile by default

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -156,7 +156,7 @@ public:
          * Set to `true` to forcibly disable amortized shader compilation in the backend.
          * Currently only honored by the GL backend.
          */
-        bool disableAmortizedShaderCompile = false;
+        bool disableAmortizedShaderCompile = true;
 
         /**
          * Disable backend handles use-after-free checks.

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -748,7 +748,7 @@ public:
                 bool enable_staging_buffer_bypass = false;
             } vulkan;
             bool disable_parallel_shader_compile = false;
-            bool disable_amortized_shader_compile = false;
+            bool disable_amortized_shader_compile = true;
             bool disable_handle_use_after_free_check = false;
             bool disable_heap_handle_tags = true; // FIXME: this should be false
         } backend;


### PR DESCRIPTION
This is a temporary resolution until we fix an underlying issue.