### PR TITLE
fix: Make ZstdHelper compatible with UBSan

### DIFF
--- a/filament/src/ZstdHelper.cpp
+++ b/filament/src/ZstdHelper.cpp
@@ -27,7 +27,19 @@ bool ZstdHelper::isCompressed(const void* src, size_t src_size) noexcept {
     if (src_size < 4) {
         return false;
     }
-    const uint32_t magic = *static_cast<const uint32_t*>(src);
+
+    // `src` may not be aligned to 4 bytes, which is violating the alignment requirement of
+    // `UndefinedBehaviorSanitizer: misaligned-pointer-use`. So reconstruct the 32-bit integer from
+    // bytes in little-endian order as the expected byte sequence is 28 B5 2F FD and
+    // ZSTD_MAGICNUMBER refers to 0xFD2FB528. This should work correctly on both little-endian and
+    // big-endian systems.
+    const auto* p = static_cast<const uint8_t*>(src);
+    const uint32_t magic =
+            (uint32_t)p[0] |
+            (uint32_t)(p[1] << 8) |
+            (uint32_t)(p[2] << 16) |
+            (uint32_t)(p[3] << 24);
+
     return magic == ZSTD_MAGICNUMBER;
 }
 


### PR DESCRIPTION
In ZstdHelper::isCompressed call, `src` may not be aligned to 4 bytes, which is violating the alignment requirement of
`UndefinedBehaviorSanitizer: misaligned-pointer-use`, thereby resuling in a runtime failure with UBSan enabled. So reconstruct the 32-bit integer as a workaround.