### PR TITLE
Fix bones indices and weights sampler + descriptor set

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -344,7 +344,7 @@ void PostProcessManager::init() noexcept {
             engine.getDummyMorphTargetBuffer()->getTangentsHandle(), {});
 
     driver.updateDescriptorSetTexture(mDummyPerRenderableDsh,
-            +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS, engine.getZeroTextureArray(),
+            +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS, engine.getZeroTexture(),
             {});
 
     mSsrPassDescriptorSet.init(engine);

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -118,7 +118,7 @@ FView::FView(FEngine& engine)
 
     mCommonRenderableDescriptorSet.setSampler(layout,
             +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS,
-            engine.getZeroTextureArray(), {});
+            engine.getZeroTexture(), {});
 
 
     FDebugRegistry& debugRegistry = engine.getDebugRegistry();
@@ -823,7 +823,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
                 descriptorSet.setSampler(layout,
                         +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS,
-                        engine.getZeroTextureArray(), {});
+                        engine.getZeroTexture(), {});
 
                 if (UTILS_UNLIKELY(skinning.handle || morphing.handle)) {
                     descriptorSet.setBuffer(layout,

--- a/libs/filabridge/src/DescriptorSets.cpp
+++ b/libs/filabridge/src/DescriptorSets.cpp
@@ -98,7 +98,7 @@ static constexpr std::initializer_list<DescriptorSetLayoutBinding> perRenderable
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::MORPHING_UNIFORMS         },
     { DescriptorType::SAMPLER_2D_ARRAY_FLOAT,   ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::MORPH_TARGET_POSITIONS, DescriptorFlags::UNFILTERABLE },
     { DescriptorType::SAMPLER_2D_ARRAY_INT,     ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::MORPH_TARGET_TANGENTS     },
-    { DescriptorType::SAMPLER_2D_ARRAY_FLOAT,   ShaderStageFlags::VERTEX                             ,  +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS },
+    { DescriptorType::SAMPLER_2D_FLOAT,   ShaderStageFlags::VERTEX                                   ,  +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS, DescriptorFlags::UNFILTERABLE },
 };
 
 struct PairSamplerTypeFormatHasher {

--- a/libs/filamat/src/shaders/SibGenerator.cpp
+++ b/libs/filamat/src/shaders/SibGenerator.cpp
@@ -102,7 +102,7 @@ SamplerInterfaceBlock const& SibGenerator::getPerRenderableSib(Variant) noexcept
             .stageFlags(backend::ShaderStageFlags::VERTEX)
             .add({  {"positions",          +PerRenderableBindingPoints::MORPH_TARGET_POSITIONS,    Type::SAMPLER_2D_ARRAY, Format::FLOAT, Precision::HIGH, FILTERABLE,  !MULTISAMPLE, ALL_STAGES },
                     {"tangents",           +PerRenderableBindingPoints::MORPH_TARGET_TANGENTS,     Type::SAMPLER_2D_ARRAY, Format::INT,   Precision::HIGH, !FILTERABLE, !MULTISAMPLE, ALL_STAGES },
-                    {"indicesAndWeights",  +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS, Type::SAMPLER_2D,       Format::FLOAT, Precision::HIGH, FILTERABLE,  !MULTISAMPLE, ALL_STAGES }}
+                    {"indicesAndWeights",  +PerRenderableBindingPoints::BONES_INDICES_AND_WEIGHTS, Type::SAMPLER_2D,       Format::FLOAT, Precision::HIGH, !FILTERABLE, !MULTISAMPLE, ALL_STAGES }}
             )
             .build();
 


### PR DESCRIPTION
In some places, this sampler was incorrectly assumed to be sampler2darray, but it should be just a sampler2d.  Additionally, sampling from it should produce unfiltered values - this has been changed accordingly.