### PR TITLE
GL: Fix memory leak for external texture with non external sampler

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1948,7 +1948,7 @@ void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
                     if (UTILS_UNLIKELY(t->hwStream)) {
                         detachStream(t);
                     }
-                    if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
+                    if (UTILS_UNLIKELY(t->externalTexture)) {
                         mPlatform.destroyExternalImageTexture(t->externalTexture);
                     } else {
                         glDeleteTextures(1, &t->gl.id);


### PR DESCRIPTION
In EGLAndroid, external textures imported from an AHB that dont use a SAMPLER_EXTERNAL are not properly destroyed, causing a memory leak that eventually leads to an OOM.