### PR TITLE
Fix the multiple window sample

### DIFF
--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -115,6 +115,7 @@ int main(int argc, char *argv[]) {
     // if we are single-threaded. But we can't create the Filament objects
     // until after we have created the engine.
     auto engine = Engine::create(kBackend);
+    kBackend = engine->getBackend();
 
     for (auto &w : windows) {
         setup_window(w, engine);


### PR DESCRIPTION
Get the actual backend type from the engine to ensure correct type comparison during swapchain creation.