### PR TITLE
iOS: avoid use of typeof

### DIFF
--- a/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
@@ -318,7 +318,7 @@ const float kToastDelayDuration = 2.0f;
 
 - (void)issuePickingQuery {
     CGPoint tapLocation = [_singleTapRecognizer locationInView:self.modelView];
-    __weak typeof(self) weakSelf = self;
+    __weak decltype(self) weakSelf = self;
     [self.modelView issuePickQuery:tapLocation
                           callback:^(utils::Entity entity) {
                               NSString* name = [self.modelView getEntityName:entity];


### PR DESCRIPTION
`typeof` is a gcc extension, and is only supported when supplying compiler flags like `-std=gnu++20` (as opposed to `-std=c++20`).