### PR TITLE
Re-introduced Systrace

### DIFF
--- a/libs/utils/src/android/Tracing.cpp
+++ b/libs/utils/src/android/Tracing.cpp
@@ -17,6 +17,8 @@
 #include <utils/compiler.h>
 #include <private/utils/Tracing.h>
 
+#if FILAMENT_TRACING_ENABLED == true && defined(FILAMENT_TRACING_USES_PERFETTO)
+
 #include <perfetto/perfetto.h>
 
 PERFETTO_TRACK_EVENT_STATIC_STORAGE_IN_NAMESPACE(tracing);
@@ -37,3 +39,4 @@ UTILS_UNUSED SystraceStaticInitialization sTracingStaticInitialization{};
 
 }
 
+#endif


### PR DESCRIPTION
Added a way to switch the tracing mode between disabled, perfetto, and systrace.

I did those changes because I could not get Perfetto to work in my environment.
I learnt earlier that @pixelflinger is working on something similar, for a different reason (binary size impact of Perfetto).
Please let me know if you can use this (with eventual modifications), otherwise we can just drop the PR.

Note that I'll need to fix some of the BUILD files in g3 as well.