### PR TITLE
Improve getEyeFromViewMatrix()

### DIFF
--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -209,12 +209,12 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved2;
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[38];
+    math::float4 reserved[22];
 };
 
 // 2 KiB == 128 float4s
-static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 144,
-        "PerViewUib should be 16 x 144 bytes");
+static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 128,
+        "PerViewUib should be exactly 2KiB");
 
 // ------------------------------------------------------------------------------------------------
 // MARK: -

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -52,8 +52,18 @@ highp mat4 getEyeFromViewMatrix() {
 }
 
 /** @public-api */
+highp mat4 getEyeFromViewMatrix(int eyeIndex) {
+    return frameUniforms.eyeFromViewMatrix[eyeIndex];
+}
+
+/** @public-api */
 highp mat4 getClipFromWorldMatrix() {
     return frameUniforms.clipFromWorldMatrix[getEyeIndex()];
+}
+
+/** @public-api */
+highp mat4 getClipFromWorldMatrix(int eyeIndex) {
+    return frameUniforms.clipFromWorldMatrix[eyeIndex];
 }
 
 /** @public-api */


### PR DESCRIPTION
Make the size of PerViewUib 2KiB again.

Add overloading functions for getEyeFromViewMatrix() and getClipFromWorldMatrix().

BUGS=[441127971]