### PR TITLE
Remove unecessary assert on texture format + mipmappable

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -733,7 +733,6 @@ public:
                         CORRECTNESS_ASSERTION_DEFAULT;
                 bool assert_material_instance_texture_descriptor_set_compatible =
                         CORRECTNESS_ASSERTION_DEFAULT;
-                bool assert_texture_format_mipmappable = CORRECTNESS_ASSERTION_DEFAULT;
                 bool assert_texture_can_generate_mipmap = CORRECTNESS_ASSERTION_DEFAULT;
             } debug;
         } engine;
@@ -797,9 +796,6 @@ public:
             { "engine.debug.assert_material_instance_texture_descriptor_set_compatible",
               "Assert that the textures in a material instance are compatible with descriptor set.",
               &features.engine.debug.assert_material_instance_texture_descriptor_set_compatible, false },
-            { "engine.debug.assert_texture_format_mipmappable",
-              "Assert if a texture (with levels > 1) that the format is mipmappable.",
-              &features.engine.debug.assert_texture_format_mipmappable, false },
             { "engine.debug.assert_texture_can_generate_mipmap",
               "Assert if a texture has the correct usage set for generating mipmaps.",
               &features.engine.debug.assert_texture_can_generate_mipmap, false },

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -246,21 +246,12 @@ Texture* Texture::Builder::build(Engine& engine) {
 
     auto const& featureFlags = downcast(engine).features.engine.debug;
 
-    bool const formatMipmappable =
+    bool const formatGenMipmappable =
             downcast(engine).getDriverApi().isTextureFormatMipmappable(mImpl->mFormat);
-
-    FILAMENT_FLAG_GUARDED_CHECK_PRECONDITION(mImpl->mLevels == 1 || formatMipmappable,
-            featureFlags.assert_texture_format_mipmappable)
-            << "Texture levels is > 1 (levels=" << +mImpl->mLevels
-            << " dim=" << mImpl->mWidth << "x" << mImpl->mHeight
-            << ", but the format ("
-            << int(mImpl->mFormat) << ") "
-            << " is not mipmppable";
-
     // TODO: This exists for backwards compatibility, but should remove when safe.
     if (!featureFlags.assert_texture_can_generate_mipmap &&
             // Guess whether GEN_MIPMAPPABLE should be added or not based the following criteria.
-            (formatMipmappable &&
+            (formatGenMipmappable &&
                     mImpl->mLevels > 1 &&
                     (mImpl->mWidth > 1 || mImpl->mHeight > 1) &&
                     !mImpl->mExternal)) {


### PR DESCRIPTION
The backend call `isTextureFormatMipmappable` indicates whether a format can be used to generate bitmap through graphics API.

(The issue is that previously there was a check to validate whether a format is mipmappable and levels > 1. These two conditions do not need to imply one another.)