### PR TITLE
backend: fix MRT test's layercount

### DIFF
--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -97,7 +97,7 @@ TEST_F(BackendTest, MRT) {
                 screenWidth(),                          // width
                 screenHeight(),                         // height
                 1,                                      // samples
-                0,                                      // layerCount
+                1,                                      // layerCount
                 {{textureA },{textureB }},              // color
                 {},                                     // depth
                 {}));                                   // stencil


### PR DESCRIPTION
layercount should be at least 1. This was causing a validation error for the vk backend when running the test.