### PR TITLE
backend: fix vulkan test with readPixels

### DIFF
--- a/filament/backend/test/Workarounds.h
+++ b/filament/backend/test/Workarounds.h
@@ -17,8 +17,7 @@
 #ifndef TNT_BACKEND_TEST_WORKAROUNDS_H
 #define TNT_BACKEND_TEST_WORKAROUNDS_H
 
-#if defined(FILAMENT_SUPPORTS_WEBGPU)
-// consider, if needed, adding (as Vulkan also has transient attachments): || defined(FILAMENT_SUPPORTS_VULKAN)
+#if defined(FILAMENT_SUPPORTS_WEBGPU) || defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
 // TODO: support TextureUsage::READ_PIXELS (or something like that)
 //        and search-and-replace TEXTURE_USAGE_READ_PIXELS with
 //       "| TextureUsage::READ_PIXELS" when it is available.

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -149,8 +149,6 @@ TEST_F(BufferUpdatesTest, VertexBufferUpdate) {
 
         api.stopCapture(0);
     }
-
-    executeCommands();
 }
 
 // This test renders two triangles in two separate draw calls. Between the draw calls, a uniform
@@ -182,7 +180,7 @@ TEST_F(BufferUpdatesTest, BufferObjectUpdateWithOffset) {
             api.createTexture(SamplerType::SAMPLER_2D, 1, TextureFormat::RGBA8, 1, screenWidth(),
                     screenHeight(), 1, TextureUsage::COLOR_ATTACHMENT TEXTURE_USAGE_READ_PIXELS));
     auto renderTarget = cleanup.add(api.createRenderTarget(TargetBufferFlags::COLOR0, screenWidth(),
-            screenHeight(), 1, 0, { { colorTexture } }, {}, {}));
+            screenHeight(), 1, 1, { { colorTexture } }, {}, {}));
 
     // Upload uniforms for the first triangle.
     // Upload the uniform, but with an offset to accommodate the padding in the shader's
@@ -233,22 +231,12 @@ TEST_F(BufferUpdatesTest, BufferObjectUpdateWithOffset) {
         api.bindRenderPrimitive(triangle.getRenderPrimitive());
         api.draw2(0, 3, 1);
         api.endRenderPass();
+        api.commit(swapChain);
+        api.endFrame(0);
     }
-
 
     EXPECT_IMAGE(renderTarget, ScreenshotParams(screenWidth(), screenHeight(),
                                        "BufferObjectUpdateWithOffset", 2320747245));
-
-    api.flush();
-    api.commit(swapChain);
-    api.endFrame(0);
-
-    // This ensures all driver commands have finished before exiting the test.
-    api.finish();
-
-    executeCommands();
-
-    getDriver().purge();
 }
 
 } // namespace test


### PR DESCRIPTION
filament/backend/test/Workarounds.h has a specific workaround with regards to readPixels and texture usage.  Originally this was introduced for the WebGPU backend. This is needed for the vulkan backend as well.

Also simplify BufferUpdatesTest.BufferObjectUpdateWithOffset
 - no need to call flush() or executeCommands(), these are called when the test terminates.
 - layerCount for a rendertarget should be at least 1.