### PR TITLE
Refactor backend getShaderLanguage functions.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -197,6 +197,7 @@ constexpr std::string_view to_string(Backend const backend) noexcept {
  * - The Metal backend can prefer precompiled Metal libraries, while falling back to MSL.
  */
 enum class ShaderLanguage {
+    UNSPECIFIED = -1,
     ESSL1 = 0,
     ESSL3 = 1,
     SPIRV = 2,
@@ -219,6 +220,8 @@ constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguage) noex
             return "Metal precompiled library";
         case ShaderLanguage::WGSL:
             return "WGSL";
+        case ShaderLanguage::UNSPECIFIED:
+            return "Unspecified";
     }
     return "UNKNOWN";
 }

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -223,6 +223,27 @@ constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguage) noex
     return "UNKNOWN";
 }
 
+/*
+ * Sets a preferred shader language for Filament to use.
+ *
+ * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
+ * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
+ * used when materials contain both.
+ *
+ * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
+ * shaders if present within a material, falling back to MSL. Setting
+ * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
+ * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
+ * present.
+ *
+ * When using a non-Metal backend, setting this has no effect.
+ */
+enum class PreferredShaderLanguage {
+    DEFAULT = 0,
+    MSL = 1,
+    METAL_LIBRARY = 2,
+};
+
 enum class ShaderStage : uint8_t {
     VERTEX = 0,
     FRAGMENT = 1,

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -223,27 +223,6 @@ constexpr const char* shaderLanguageToString(ShaderLanguage shaderLanguage) noex
     return "UNKNOWN";
 }
 
-/*
- * Sets a preferred shader language for Filament to use.
- *
- * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
- * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
- * used when materials contain both.
- *
- * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
- * shaders if present within a material, falling back to MSL. Setting
- * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
- * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
- * present.
- *
- * When using a non-Metal backend, setting this has no effect.
- */
-enum class PreferredShaderLanguage {
-    DEFAULT = 0,
-    MSL = 1,
-    METAL_LIBRARY = 2,
-};
-
 enum class ShaderStage : uint8_t {
     VERTEX = 0,
     FRAGMENT = 1,

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -75,6 +75,9 @@ public:
     // The shader languages used for shaders for this driver in order of preference, used to inform
     // matdbg.
     //
+    // The `preferredLanguage` is only a hint. If the backend supports it, it will appear first in
+    // the list.
+    //
     // For OpenGL, this distinguishes whether the driver's shaders are powered by ESSL1 or ESSL3.
     // This information is used by matdbg to display the correct shader code to the web UI and patch
     // the correct chunk when rebuilding shaders live.

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -27,6 +27,7 @@
 #include <backend/AcquiredImage.h>
 
 #include <utils/CString.h>
+#include <utils/FixedCapacityVector.h>
 #include <utils/compiler.h>
 
 #include <functional>
@@ -79,7 +80,8 @@ public:
     //
     // Metal shaders can either be MSL or Metal libraries, but at time of writing, matdbg can only
     // interface with MSL.
-    virtual ShaderLanguage getShaderLanguage() const noexcept = 0;
+    virtual utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept = 0;
 
     // Returns the dispatcher. This is only called once during initialization of the CommandStream,
     // so it doesn't matter that it's virtual.

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -72,7 +72,8 @@ public:
 
     virtual ShaderModel getShaderModel() const noexcept = 0;
 
-    // The shader language used for shaders for this driver, used to inform matdbg.
+    // The shader languages used for shaders for this driver in order of preference, used to inform
+    // matdbg.
     //
     // For OpenGL, this distinguishes whether the driver's shaders are powered by ESSL1 or ESSL3.
     // This information is used by matdbg to display the correct shader code to the web UI and patch
@@ -80,8 +81,8 @@ public:
     //
     // Metal shaders can either be MSL or Metal libraries, but at time of writing, matdbg can only
     // interface with MSL.
-    virtual utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept = 0;
+    virtual utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept = 0;
 
     // Returns the dispatcher. This is only called once during initialization of the CommandStream,
     // so it doesn't matter that it's virtual.

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -70,8 +70,8 @@ private:
     MetalContext* mContext;
 
     ShaderModel getShaderModel() const noexcept final;
-    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept final;
 
     // Overrides the default implementation by wrapping the call to fn in an @autoreleasepool block.
     void execute(std::function<void(void)> const& fn) noexcept final;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -25,8 +25,9 @@
 
 #include <backend/SamplerDescriptor.h>
 
-#include <utils/compiler.h>
+#include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
+#include <utils/compiler.h>
 #include <utils/debug.h>
 
 #include <functional>
@@ -69,7 +70,8 @@ private:
     MetalContext* mContext;
 
     ShaderModel getShaderModel() const noexcept final;
-    ShaderLanguage getShaderLanguage() const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept final;
 
     // Overrides the default implementation by wrapping the call to fn in an @autoreleasepool block.
     void execute(std::function<void(void)> const& fn) noexcept final;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1005,7 +1005,7 @@ ShaderModel MetalDriver::getShaderModel() const noexcept {
 utils::FixedCapacityVector<ShaderLanguage> MetalDriver::getShaderLanguages(
         ShaderLanguage preferredLanguage) const noexcept {
     if (preferredLanguage == backend::ShaderLanguage::MSL) {
-        return { backend::ShaderLanguage::MSL, backend::ShaderLanguage::METAL_LIBRARY};
+        return { backend::ShaderLanguage::MSL, backend::ShaderLanguage::METAL_LIBRARY };
     }
     return { backend::ShaderLanguage::METAL_LIBRARY, backend::ShaderLanguage::MSL };
 }

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1002,8 +1002,12 @@ ShaderModel MetalDriver::getShaderModel() const noexcept {
 #endif
 }
 
-ShaderLanguage MetalDriver::getShaderLanguage() const noexcept {
-    return ShaderLanguage::MSL;
+utils::FixedCapacityVector<ShaderLanguage> MetalDriver::getShaderLanguage(
+        PreferredShaderLanguage preferredLanguage) const noexcept {
+    if (preferredLanguage == PreferredShaderLanguage::MSL) {
+        return { backend::ShaderLanguage::MSL, backend::ShaderLanguage::METAL_LIBRARY};
+    }
+    return { backend::ShaderLanguage::METAL_LIBRARY, backend::ShaderLanguage::MSL };
 }
 
 Handle<HwStream> MetalDriver::createStreamNative(void* stream, utils::CString tag) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1002,9 +1002,9 @@ ShaderModel MetalDriver::getShaderModel() const noexcept {
 #endif
 }
 
-utils::FixedCapacityVector<ShaderLanguage> MetalDriver::getShaderLanguage(
-        PreferredShaderLanguage preferredLanguage) const noexcept {
-    if (preferredLanguage == PreferredShaderLanguage::MSL) {
+utils::FixedCapacityVector<ShaderLanguage> MetalDriver::getShaderLanguages(
+        ShaderLanguage preferredLanguage) const noexcept {
+    if (preferredLanguage == backend::ShaderLanguage::MSL) {
         return { backend::ShaderLanguage::MSL, backend::ShaderLanguage::METAL_LIBRARY};
     }
     return { backend::ShaderLanguage::METAL_LIBRARY, backend::ShaderLanguage::MSL };

--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -134,6 +134,7 @@ bool MetalShaderCompiler::isParallelShaderCompileSupported() const noexcept {
             case ShaderLanguage::ESSL3:
             case ShaderLanguage::SPIRV:
             case ShaderLanguage::WGSL:
+            case ShaderLanguage::UNSPECIFIED:
                 break;
         }
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -45,8 +45,16 @@ ShaderModel NoopDriver::getShaderModel() const noexcept {
 #endif
 }
 
-ShaderLanguage NoopDriver::getShaderLanguage() const noexcept {
-    return ShaderLanguage::ESSL3;
+utils::FixedCapacityVector<ShaderLanguage> NoopDriver::getShaderLanguage(
+        PreferredShaderLanguage preferredLanguage) const noexcept {
+    return {
+        ShaderLanguage::ESSL1,
+        ShaderLanguage::ESSL3,
+        ShaderLanguage::SPIRV,
+        ShaderLanguage::MSL,
+        ShaderLanguage::METAL_LIBRARY,
+        ShaderLanguage::WGSL,
+    };
 }
 
 // explicit instantiation of the Dispatcher

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -45,11 +45,11 @@ ShaderModel NoopDriver::getShaderModel() const noexcept {
 #endif
 }
 
-utils::FixedCapacityVector<ShaderLanguage> NoopDriver::getShaderLanguage(
-        PreferredShaderLanguage preferredLanguage) const noexcept {
+utils::FixedCapacityVector<ShaderLanguage> NoopDriver::getShaderLanguages(
+        ShaderLanguage /*preferredLanguage*/) const noexcept {
     return {
-        ShaderLanguage::ESSL1,
         ShaderLanguage::ESSL3,
+        ShaderLanguage::ESSL1,
         ShaderLanguage::SPIRV,
         ShaderLanguage::MSL,
         ShaderLanguage::METAL_LIBRARY,

--- a/filament/backend/src/noop/NoopDriver.h
+++ b/filament/backend/src/noop/NoopDriver.h
@@ -35,8 +35,8 @@ public:
 
 private:
     ShaderModel getShaderModel() const noexcept final;
-    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept final;
 
     uint64_t nextFakeHandle = 1;
 

--- a/filament/backend/src/noop/NoopDriver.h
+++ b/filament/backend/src/noop/NoopDriver.h
@@ -20,6 +20,7 @@
 #include "private/backend/Driver.h"
 #include "DriverBase.h"
 
+#include <utils/FixedCapacityVector.h>
 #include <utils/compiler.h>
 
 namespace filament::backend {
@@ -34,7 +35,8 @@ public:
 
 private:
     ShaderModel getShaderModel() const noexcept final;
-    ShaderLanguage getShaderLanguage() const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept final;
 
     uint64_t nextFakeHandle = 1;
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -368,8 +368,8 @@ ShaderModel OpenGLDriver::getShaderModel() const noexcept {
     return mContext.getShaderModel();
 }
 
-utils::FixedCapacityVector<ShaderLanguage> OpenGLDriver::getShaderLanguage(
-        PreferredShaderLanguage /*preferredLanguage*/) const noexcept {
+utils::FixedCapacityVector<ShaderLanguage> OpenGLDriver::getShaderLanguages(
+        ShaderLanguage /*preferredLanguage*/) const noexcept {
     return { mContext.isES2() ? ShaderLanguage::ESSL1 : ShaderLanguage::ESSL3 };
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -368,8 +368,9 @@ ShaderModel OpenGLDriver::getShaderModel() const noexcept {
     return mContext.getShaderModel();
 }
 
-ShaderLanguage OpenGLDriver::getShaderLanguage() const noexcept {
-    return mContext.isES2() ? ShaderLanguage::ESSL1 : ShaderLanguage::ESSL3;
+utils::FixedCapacityVector<ShaderLanguage> OpenGLDriver::getShaderLanguage(
+        PreferredShaderLanguage /*preferredLanguage*/) const noexcept {
+    return { mContext.isES2() ? ShaderLanguage::ESSL1 : ShaderLanguage::ESSL3 };
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -233,8 +233,8 @@ private:
     }
 
     ShaderModel getShaderModel() const noexcept override;
-    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept override;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept override;
 
     /*
      * OpenGLDriver interface

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -233,7 +233,8 @@ private:
     }
 
     ShaderModel getShaderModel() const noexcept override;
-    ShaderLanguage getShaderLanguage() const noexcept override;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept override;
 
     /*
      * OpenGLDriver interface

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -319,8 +319,9 @@ ShaderModel VulkanDriver::getShaderModel() const noexcept {
 #endif
 }
 
-ShaderLanguage VulkanDriver::getShaderLanguage() const noexcept {
-    return ShaderLanguage::SPIRV;
+utils::FixedCapacityVector<ShaderLanguage> VulkanDriver::getShaderLanguage(
+        PreferredShaderLanguage /*prefferedLanguage*/) const noexcept {
+    return { ShaderLanguage::SPIRV };
 }
 
 void VulkanDriver::terminate() {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -319,8 +319,8 @@ ShaderModel VulkanDriver::getShaderModel() const noexcept {
 #endif
 }
 
-utils::FixedCapacityVector<ShaderLanguage> VulkanDriver::getShaderLanguage(
-        PreferredShaderLanguage /*prefferedLanguage*/) const noexcept {
+utils::FixedCapacityVector<ShaderLanguage> VulkanDriver::getShaderLanguages(
+        ShaderLanguage /*prefferedLanguage*/) const noexcept {
     return { ShaderLanguage::SPIRV };
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -43,6 +43,7 @@
 #include "DriverBase.h"
 #include "private/backend/Driver.h"
 
+#include <utils/FixedCapacityVector.h>
 #include <utils/Allocator.h>
 #include <utils/compiler.h>
 
@@ -100,7 +101,8 @@ private:
     Dispatcher getDispatcher() const noexcept final;
 
     ShaderModel getShaderModel() const noexcept final;
-    ShaderLanguage getShaderLanguage() const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept final;
 
     template<typename T>
     friend class ConcreteDispatcher;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -101,8 +101,8 @@ private:
     Dispatcher getDispatcher() const noexcept final;
 
     ShaderModel getShaderModel() const noexcept final;
-    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept final;
+    utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept final;
 
     template<typename T>
     friend class ConcreteDispatcher;

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -132,8 +132,8 @@ ShaderModel WebGPUDriver::getShaderModel() const noexcept {
 #endif
 }
 
-utils::FixedCapacityVector<ShaderLanguage> WebGPUDriver::getShaderLanguage(
-        PreferredShaderLanguage /*preferredLanguage*/) const noexcept {
+utils::FixedCapacityVector<ShaderLanguage> WebGPUDriver::getShaderLanguages(
+        ShaderLanguage /*preferredLanguage*/) const noexcept {
     return { ShaderLanguage::WGSL };
 }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -132,8 +132,9 @@ ShaderModel WebGPUDriver::getShaderModel() const noexcept {
 #endif
 }
 
-ShaderLanguage WebGPUDriver::getShaderLanguage() const noexcept {
-    return ShaderLanguage::WGSL;
+utils::FixedCapacityVector<ShaderLanguage> WebGPUDriver::getShaderLanguage(
+        PreferredShaderLanguage /*preferredLanguage*/) const noexcept {
+    return { ShaderLanguage::WGSL };
 }
 
 // explicit instantiation of the Dispatcher

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -33,6 +33,7 @@
 #include "private/backend/HandleAllocator.h"
 #include <backend/DriverEnums.h>
 
+#include <utils/FixedCapacityVector.h>
 #include <utils/compiler.h>
 
 #include "SpdMipmapGenerator/SpdMipmapGenerator.h"
@@ -65,7 +66,8 @@ public:
 private:
     WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
     [[nodiscard]] ShaderModel getShaderModel() const noexcept final;
-    [[nodiscard]] ShaderLanguage getShaderLanguage() const noexcept final;
+    [[nodiscard]] utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
+            PreferredShaderLanguage preferredLanguage) const noexcept final;
     [[nodiscard]] wgpu::Sampler makeSampler(SamplerParams const& params);
     [[nodiscard]] static wgpu::AddressMode fWrapModeToWAddressMode(const filament::backend::SamplerWrapMode& fUsage);
     void setDebugTag(HandleBase::HandleId handleId, utils::CString&& tag);

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -66,8 +66,8 @@ public:
 private:
     WebGPUDriver(WebGPUPlatform& platform, const Platform::DriverConfig& driverConfig) noexcept;
     [[nodiscard]] ShaderModel getShaderModel() const noexcept final;
-    [[nodiscard]] utils::FixedCapacityVector<ShaderLanguage> getShaderLanguage(
-            PreferredShaderLanguage preferredLanguage) const noexcept final;
+    [[nodiscard]] utils::FixedCapacityVector<ShaderLanguage> getShaderLanguages(
+            ShaderLanguage preferredLanguage) const noexcept final;
     [[nodiscard]] wgpu::Sampler makeSampler(SamplerParams const& params);
     [[nodiscard]] static wgpu::AddressMode fWrapModeToWAddressMode(const filament::backend::SamplerWrapMode& fUsage);
     void setDebugTag(HandleBase::HandleId handleId, utils::CString&& tag);

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -377,20 +377,20 @@ public:
         bool disableHandleUseAfterFreeCheck = false;
 
         /*
-        * Sets a preferred shader language for Filament to use.
-        *
-        * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
-        * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
-        * used when materials contain both.
-        *
-        * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
-        * shaders if present within a material, falling back to MSL. Setting
-        * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
-        * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
-        * present.
-        *
-        * When using a non-Metal backend, setting this has no effect.
-        */
+         * Sets a preferred shader language for Filament to use.
+         *
+         * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
+         * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
+         * used when materials contain both.
+         *
+         * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
+         * shaders if present within a material, falling back to MSL. Setting
+         * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
+         * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
+         * present.
+         *
+         * When using a non-Metal backend, setting this has no effect.
+         */
         enum class ShaderLanguage {
             DEFAULT = 0,
             MSL = 1,

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -192,7 +192,6 @@ public:
     using StereoscopicType = backend::StereoscopicType;
     using Driver = backend::Driver;
     using GpuContextPriority = backend::Platform::GpuContextPriority;
-    using ShaderLanguage = backend::PreferredShaderLanguage;
 
     /**
      * Config is used to define the memory footprint used by the engine, such as the
@@ -377,6 +376,26 @@ public:
          */
         bool disableHandleUseAfterFreeCheck = false;
 
+        /*
+        * Sets a preferred shader language for Filament to use.
+        *
+        * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
+        * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
+        * used when materials contain both.
+        *
+        * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
+        * shaders if present within a material, falling back to MSL. Setting
+        * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
+        * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
+        * present.
+        *
+        * When using a non-Metal backend, setting this has no effect.
+        */
+        enum class ShaderLanguage {
+            DEFAULT = 0,
+            MSL = 1,
+            METAL_LIBRARY = 2,
+        };
         ShaderLanguage preferredShaderLanguage = ShaderLanguage::DEFAULT;
 
         /*

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -192,6 +192,7 @@ public:
     using StereoscopicType = backend::StereoscopicType;
     using Driver = backend::Driver;
     using GpuContextPriority = backend::Platform::GpuContextPriority;
+    using ShaderLanguage = backend::PreferredShaderLanguage;
 
     /**
      * Config is used to define the memory footprint used by the engine, such as the
@@ -376,26 +377,6 @@ public:
          */
         bool disableHandleUseAfterFreeCheck = false;
 
-        /*
-         * Sets a preferred shader language for Filament to use.
-         *
-         * The Metal backend supports two shader languages: MSL (Metal Shading Language) and
-         * METAL_LIBRARY (precompiled .metallib). This option controls which shader language is
-         * used when materials contain both.
-         *
-         * By default, when preferredShaderLanguage is unset, Filament will prefer METAL_LIBRARY
-         * shaders if present within a material, falling back to MSL. Setting
-         * preferredShaderLanguage to ShaderLanguage::MSL will instead instruct Filament to check
-         * for the presence of MSL in a material first, falling back to METAL_LIBRARY if MSL is not
-         * present.
-         *
-         * When using a non-Metal backend, setting this has no effect.
-         */
-        enum class ShaderLanguage {
-            DEFAULT = 0,
-            MSL = 1,
-            METAL_LIBRARY = 2,
-        };
         ShaderLanguage preferredShaderLanguage = ShaderLanguage::DEFAULT;
 
         /*

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -69,6 +69,8 @@ constexpr std::pair<ChunkType, ChunkType> shaderLanguageToTags(ShaderLanguage co
             return { MaterialSpirv, DictionarySpirv };
         case ShaderLanguage::METAL_LIBRARY:
             return { MaterialMetalLibrary, DictionaryMetalLibrary };
+        case ShaderLanguage::UNSPECIFIED:
+            return {};
     }
 }
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -275,22 +275,7 @@ public:
 
         switch (mConfig.preferredShaderLanguage) {
             case Config::ShaderLanguage::DEFAULT:
-                switch (mBackend) {
-                    case Backend::DEFAULT:
-                    case Backend::OPENGL:
-                    case Backend::NOOP:
-                        preferredLanguage = backend::ShaderLanguage::ESSL3;
-                        break;
-                    case Backend::VULKAN:
-                        preferredLanguage = backend::ShaderLanguage::SPIRV;
-                        break;
-                    case Backend::METAL:
-                        preferredLanguage = backend::ShaderLanguage::MSL;
-                        break;
-                    case Backend::WEBGPU:
-                        preferredLanguage = backend::ShaderLanguage::WGSL;
-                        break;
-                }
+                preferredLanguage = backend::ShaderLanguage::UNSPECIFIED;
                 break;
             case Config::ShaderLanguage::MSL:
                 preferredLanguage = backend::ShaderLanguage::MSL;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -271,7 +271,37 @@ public:
 
     // Return a vector of shader languages, in order of preference.
     utils::FixedCapacityVector<backend::ShaderLanguage> getShaderLanguage() const noexcept {
-        return getDriver().getShaderLanguage(mConfig.preferredShaderLanguage);
+        backend::ShaderLanguage preferredLanguage;
+
+        switch (mConfig.preferredShaderLanguage) {
+            case Config::ShaderLanguage::DEFAULT:
+                switch (mBackend) {
+                    case Backend::DEFAULT:
+                    case Backend::OPENGL:
+                    case Backend::NOOP:
+                        preferredLanguage = backend::ShaderLanguage::ESSL3;
+                        break;
+                    case Backend::VULKAN:
+                        preferredLanguage = backend::ShaderLanguage::SPIRV;
+                        break;
+                    case Backend::METAL:
+                        preferredLanguage = backend::ShaderLanguage::MSL;
+                        break;
+                    case Backend::WEBGPU:
+                        preferredLanguage = backend::ShaderLanguage::WGSL;
+                        break;
+                }
+                break;
+            case Config::ShaderLanguage::MSL:
+                preferredLanguage = backend::ShaderLanguage::MSL;
+                break;
+            case Config::ShaderLanguage::METAL_LIBRARY:
+                preferredLanguage = backend::ShaderLanguage::METAL_LIBRARY;
+                break;
+        }
+
+
+        return getDriver().getShaderLanguages(preferredLanguage);
     }
 
     ResourceAllocatorDisposer& getResourceAllocatorDisposer() noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -271,16 +271,7 @@ public:
 
     // Return a vector of shader languages, in order of preference.
     utils::FixedCapacityVector<backend::ShaderLanguage> getShaderLanguage() const noexcept {
-        switch (mBackend) {
-            default:
-                return { getDriver().getShaderLanguage() };
-            case Backend::METAL:
-                const auto& lang = mConfig.preferredShaderLanguage;
-                if (lang == Config::ShaderLanguage::MSL) {
-                    return { backend::ShaderLanguage::MSL, backend::ShaderLanguage::METAL_LIBRARY};
-                }
-                return { backend::ShaderLanguage::METAL_LIBRARY, backend::ShaderLanguage::MSL };
-        }
+        return getDriver().getShaderLanguage(mConfig.preferredShaderLanguage);
     }
 
     ResourceAllocatorDisposer& getResourceAllocatorDisposer() noexcept {


### PR DESCRIPTION
Allow returning a list of supported shader languages instead of only one.

Notify the backend which is the preferred language. In the case of metal, the preferred language will be the first element in the list.

This change will allow a backend to support multiple languages as needed, in the case of the noop driver, it will support a material with any shader languages.