### PR TITLE
Fix: Correctly handle unsupported SwapChain flags

### DIFF
--- a/filament/src/details/SwapChain.cpp
+++ b/filament/src/details/SwapChain.cpp
@@ -36,13 +36,12 @@ namespace filament {
 namespace {
 
 utils::CString getRemovedFlags(uint64_t originalFlags, uint64_t modifiedFlags) {
+    const uint64_t diffFlags = originalFlags ^ modifiedFlags;
     utils::CString removed;
-    if ((originalFlags & backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE) &&
-        !(modifiedFlags & backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE)) {
+    if (diffFlags & backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE) {
         removed += "SRGB_COLORSPACE ";
     }
-    if ((originalFlags & backend::SWAP_CHAIN_CONFIG_PROTECTED_CONTENT) &&
-        !(modifiedFlags & backend::SWAP_CHAIN_CONFIG_PROTECTED_CONTENT)) {
+    if (diffFlags & backend::SWAP_CHAIN_CONFIG_PROTECTED_CONTENT) {
         removed += "PROTECTED_CONTENT ";
     }
     return removed;


### PR DESCRIPTION
FSwapChain initialization logic would filter out unsupported flags but would incorrectly use the original, unfiltered flags when creating the swap chain.

This commit ensures the filtered flags are passed to the driver. It also adds the warning to log which ones are removed.

BUGS=[433327615]