### PR TITLE
Fix g3 build

### DIFF
--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -986,7 +986,8 @@ void FView::updateUBOs(
 
     // We capture state shared between Scene and the update buffer callback, because the Scene could
     // be destroyed before the callback executes.
-    std::weak_ptr<SharedState>* const weakShared = new(std::nothrow) std::weak_ptr(mSharedState);
+    std::weak_ptr<SharedState>* const weakShared =
+            new (std::nothrow) std::weak_ptr<SharedState>(mSharedState);
 
     // update the UBO
     driver.resetBufferObject(mRenderableUbh);


### PR DESCRIPTION
This was failing to compile with this error:

```
View.cpp:989:70: error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr'
    std::weak_ptr<SharedState>* const weakShared = new(std::nothrow) std::weak_ptr(mSharedState);
```