### PR TITLE
fix OpenGL backend tests on macOS

### DIFF
--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -269,6 +269,10 @@ TEST_F(BlitTest, ColorResolve) {
     SKIP_IF(Backend::WEBGPU, "test cases fail in WebGPU, see b/424157731");
     auto& api = getDriverApi();
 
+    if (api.getFeatureLevel() < FeatureLevel::FEATURE_LEVEL_2) {
+        GTEST_SKIP() << "Skipping test because multi-sampled textures are not supported at Feature level < 2";
+    }
+
     constexpr int kSrcTexWidth = 256;
     constexpr int kSrcTexHeight = 256;
     constexpr int kDstTexWidth = 256;


### PR DESCRIPTION
multi-sampled textures are only supported at feature level 2, but on macOS OpenGL is only feature level 1.