### PR TITLE
Signal handler calls non-async-safe function (`std::cout`)

### DIFF
--- a/tools/cmgen/src/ProgressUpdater.cpp
+++ b/tools/cmgen/src/ProgressUpdater.cpp
@@ -25,19 +25,18 @@ static void moveCursorUp(size_t n) {
     std::cout << "\033[" << n << "F";
 }
 
-static void showCursor() {
-    signal(SIGINT, SIG_DFL);
-    std::cout << "\033[?25h" << std::flush;
+static void showCursorSafe() {
+    write(STDOUT_FILENO, "\033[?25h", 6);  // Async-signal-safe function
 }
 
 static void showCursorFromSignal(int) {
-    showCursor();
+    showCursorSafe();  // Use the safe version in signal handler
     raise(SIGINT);
 }
 
 static void hideCursor() {
     signal(SIGINT, showCursorFromSignal);
-    std::cout << "\033[?25l" << std::flush;
+    write(STDOUT_FILENO, "\033[?25l", 6);  // Use write() here too
 }
 
 static inline void printProgress(float v, size_t width) {


### PR DESCRIPTION
In the current implementation, the function `std::cout` is used inside a signal handler. This is problematic because `std::cout` is **not async-signal-safe**. According to POSIX standards, only a small set of functions are guaranteed to be safe when called from signal handlers, and `std::cout` is **not** one of them. Using non-async-signal-safe functions inside signal handlers leads to undefined behavior and can cause crashes, deadlocks, or other unpredictable issues.

### Why this is an issue
Signal handlers are executed asynchronously in response to external events (such as SIGINT). During the execution of a signal handler, you can only safely use a limited set of functions that are considered **async-signal-safe**. Functions like `std::cout`, which involve complex internal state, mutexes, and memory allocations, can lead to race conditions or deadlocks when invoked inside signal handlers. 

In the code, you are using `std::cout` inside the signal handler `showCursorFromSignal`, which can cause issues when a signal is raised while another signal handler is already executing.

### The correct approach
Instead of using `std::cout` in signal handlers, you should use low-level functions that are guaranteed to be async-signal-safe, such as `write()`. The `write()` system call directly writes to file descriptors and is safe to use in signal handlers. 

#### Current signal handler:

```cpp
static void showCursor() {
    signal(SIGINT, SIG_DFL);
    std::cout << "\033[?25h" << std::flush; <---- HERE
}
```


Reference

POSIX standards explicitly state that only a small set of functions are safe to call from signal handlers. You can find the list of async-signal-safe functions in the POSIX documentation. Functions like `std::cout` are not part of that list, and using them in signal handlers is considered unsafe.

By making these changes, we avoid undefined behavior and ensure the program can handle signals safely.