### PR TITLE
pass backend tags by && reference

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -321,7 +321,7 @@ DECL_DRIVER_API_N(bindDescriptorSet,
 DECL_DRIVER_API_N(destroyVertexBuffer,          backend::VertexBufferHandle, vbh)
 DECL_DRIVER_API_N(destroyVertexBufferInfo,      backend::VertexBufferInfoHandle, vbih)
 DECL_DRIVER_API_N(destroyIndexBuffer,           backend::IndexBufferHandle, ibh)
-DECL_DRIVER_API_N(destroyBufferObject,          backend::BufferObjectHandle, ibh)
+DECL_DRIVER_API_N(destroyBufferObject,          backend::BufferObjectHandle, boh)
 DECL_DRIVER_API_N(destroyRenderPrimitive,       backend::RenderPrimitiveHandle, rph)
 DECL_DRIVER_API_N(destroyProgram,               backend::ProgramHandle, ph)
 DECL_DRIVER_API_N(destroyTexture,               backend::TextureHandle, th)
@@ -373,7 +373,7 @@ DECL_DRIVER_API_SYNCHRONOUS_0(size_t, getMaxArrayTextureLayers)
 DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage2, backend::Platform::ExternalImageHandleRef, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)
-DECL_DRIVER_API_SYNCHRONOUS_N(backend::TimerQueryResult, getTimerQueryValue, backend::TimerQueryHandle, query, uint64_t*, elapsedTime)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::TimerQueryResult, getTimerQueryValue, backend::TimerQueryHandle, tqh, uint64_t*, elapsedTime)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isWorkaroundNeeded, backend::Workaround, workaround)
 DECL_DRIVER_API_SYNCHRONOUS_0(backend::FeatureLevel, getFeatureLevel)
 
@@ -398,16 +398,16 @@ DECL_DRIVER_API_N(updateBufferObject,
         uint32_t, byteOffset)
 
 DECL_DRIVER_API_N(registerBufferObjectStreams,
-        backend::BufferObjectHandle, ibh,
+        backend::BufferObjectHandle, boh,
         backend::BufferObjectStreamDescriptor&&, streams)
 
 DECL_DRIVER_API_N(updateBufferObjectUnsynchronized,
-        backend::BufferObjectHandle, ibh,
+        backend::BufferObjectHandle, boh,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
 DECL_DRIVER_API_N(resetBufferObject,
-        backend::BufferObjectHandle, ibh)
+        backend::BufferObjectHandle, boh)
 
 DECL_DRIVER_API_N(update3DImage,
         backend::TextureHandle, th,
@@ -436,10 +436,10 @@ DECL_DRIVER_API_0(endRenderPass)
 DECL_DRIVER_API_0(nextSubpass)
 
 DECL_DRIVER_API_N(beginTimerQuery,
-        backend::TimerQueryHandle, query)
+        backend::TimerQueryHandle, tqh)
 
 DECL_DRIVER_API_N(endTimerQuery,
-        backend::TimerQueryHandle, query)
+        backend::TimerQueryHandle, tqh)
 
 DECL_DRIVER_API_N(compilePrograms,
         backend::CompilerPriorityQueue, priority,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -108,11 +108,15 @@
     DECL_DRIVER_API_RETURN(R, N, PAIR_ARGS_N(ARG, ##__VA_ARGS__), PAIR_ARGS_N(PARAM, ##__VA_ARGS__))
 
 #define DECL_DRIVER_API_TAGGED_R_N(R, N, ...) \
-    DECL_DRIVER_API_RETURN(R, N, PAIR_ARGS_N(ARG, ##__VA_ARGS__, utils::CString, tag = {}), \
-            PAIR_ARGS_N(PARAM, ##__VA_ARGS__, utils::CString, tag))
+    DECL_DRIVER_API_RETURN(R, N, PAIR_ARGS_N(ARG, ##__VA_ARGS__, utils::CString&&, tag = {}), \
+            PAIR_ARGS_N(PARAM, ##__VA_ARGS__, utils::CString&&, tag))
 
 #define DECL_DRIVER_API_SYNCHRONOUS_N(R, N, ...) \
     DECL_DRIVER_API_SYNCHRONOUS(R, N, PAIR_ARGS_N(ARG, ##__VA_ARGS__), PAIR_ARGS_N(PARAM, ##__VA_ARGS__))
+
+#define DECL_DRIVER_API_SYNCHRONOUS_TAGGED_N(R, N, ...) \
+    DECL_DRIVER_API_SYNCHRONOUS(R, N, PAIR_ARGS_N(ARG, ##__VA_ARGS__, utils::CString, tag = {}), \
+            PAIR_ARGS_N(PARAM, ##__VA_ARGS__, utils::CString, tag))
 
 // on some compilers the ##__VA_ARGS__ hack is not supported, so we can't handle 0-parameter APIs
 // with DECL_DRIVER_API_SYNCHRONOUS_N
@@ -340,8 +344,8 @@ DECL_DRIVER_API_N(destroyDescriptorSet,         backend::DescriptorSetHandle, ds
  */
 
 DECL_DRIVER_API_SYNCHRONOUS_0(void, terminate)
-DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStreamNative, void*, stream, utils::CString, tag)
-DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStreamAcquired, utils::CString, tag)
+DECL_DRIVER_API_SYNCHRONOUS_TAGGED_N(backend::StreamHandle, createStreamNative, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_TAGGED_N(backend::StreamHandle, createStreamAcquired)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setAcquiredImage, backend::StreamHandle, stream, void*, image, const math::mat3f&, transform, backend::CallbackHandler*, handler, backend::StreamCallback, cb, void*, userData)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setStreamDimensions, backend::StreamHandle, stream, uint32_t, width, uint32_t, height)
 DECL_DRIVER_API_SYNCHRONOUS_N(int64_t, getStreamTimestamp, backend::StreamHandle, stream)

--- a/filament/backend/src/BackendUtils.cpp
+++ b/filament/backend/src/BackendUtils.cpp
@@ -18,10 +18,16 @@
 
 #include "DataReshaper.h"
 
+#include <backend/PixelBufferDescriptor.h>
 #include <backend/DriverEnums.h>
 
+#include <utils/BitmaskEnum.h>
+#include <utils/compiler.h>
 #include <utils/CString.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <utility>
 #include <string_view>
 
 namespace filament::backend {
@@ -636,7 +642,7 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
     switch (data.type) {
         case PixelDataType::BYTE:
         case PixelDataType::UBYTE: {
-            uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
+            uint8_t* bytes = static_cast<uint8_t*>(malloc(reshapedSize));
             DataReshaper::reshape<uint8_t, 3, 4>(bytes, data.buffer, data.size);
             PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
                     data.alignment, data.left, data.top, data.stride, freeFunc);
@@ -646,7 +652,7 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
         case PixelDataType::SHORT:
         case PixelDataType::USHORT:
         case PixelDataType::HALF: {
-            uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
+            uint8_t* bytes = static_cast<uint8_t*>(malloc(reshapedSize));
             DataReshaper::reshape<uint16_t, 3, 4>(bytes, data.buffer, data.size);
             PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
                     data.alignment, data.left, data.top, data.stride, freeFunc);
@@ -655,7 +661,7 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
         }
         case PixelDataType::INT:
         case PixelDataType::UINT: {
-            uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
+            uint8_t* bytes = static_cast<uint8_t*>(malloc(reshapedSize));
             DataReshaper::reshape<uint32_t, 3, 4>(bytes, data.buffer, data.size);
             PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
                     data.alignment, data.left, data.top, data.stride, freeFunc);
@@ -663,7 +669,7 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
             return true;
         }
         case PixelDataType::FLOAT: {
-            uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
+            uint8_t* bytes = static_cast<uint8_t*>(malloc(reshapedSize));
             DataReshaper::reshape<float, 3, 4>(bytes, data.buffer, data.size);
             PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
                     data.alignment, data.left, data.top, data.stride, freeFunc);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -418,14 +418,14 @@ void MetalDriver::finish(int) {
 }
 
 void MetalDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vbih, uint8_t bufferCount,
-        uint8_t attributeCount, AttributeArray attributes, utils::CString tag) {
+        uint8_t attributeCount, AttributeArray attributes, utils::CString&& tag) {
     construct_handle<MetalVertexBufferInfo>(vbih, *mContext,
             bufferCount, attributeCount, attributes);
     mHandleAllocator.associateTagToHandle(vbih.getId(), std::move(tag));
 }
 
 void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh,
-        uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih, utils::CString tag) {
+        uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih, utils::CString&& tag) {
     MetalVertexBufferInfo const* const vbi = handle_cast<const MetalVertexBufferInfo>(vbih);
     construct_handle<MetalVertexBuffer>(vbh, *mContext, vertexCount, vbi->bufferCount, vbih);
     mHandleAllocator.associateTagToHandle(vbh.getId(), std::move(tag));
@@ -433,7 +433,7 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh,
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, utils::CString tag) {
+        uint32_t indexCount, BufferUsage usage, utils::CString&& tag) {
     auto elementSize = (uint8_t)getElementTypeSize(elementType);
     auto* indexBuffer =
             construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
@@ -445,7 +445,7 @@ void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elem
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, utils::CString tag) {
+        BufferObjectBinding bindingType, BufferUsage usage, utils::CString&& tag) {
     auto* bufferObject =
             construct_handle<MetalBufferObject>(boh, *mContext, bindingType, usage, byteCount);
     FILAMENT_CHECK_POSTCONDITION(bufferObject->getBuffer()->wasAllocationSuccessful())
@@ -486,7 +486,7 @@ inline const char* stringify(SamplerType samplerType) {
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
-        uint32_t depth, TextureUsage usage, utils::CString tag) {
+        uint32_t depth, TextureUsage usage, utils::CString&& tag) {
     // Clamp sample count to what the device supports.
     auto& sc = mContext->sampleCountLookup;
     samples = sc[std::min(MAX_SAMPLE_COUNT, samples)];
@@ -503,7 +503,7 @@ void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8
 }
 
 void MetalDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> srch,
-        uint8_t baseLevel, uint8_t levelCount, utils::CString tag) {
+        uint8_t baseLevel, uint8_t levelCount, utils::CString&& tag) {
     MetalTexture const* src = handle_cast<MetalTexture>(srch);
     mContext->textures.insert(
             construct_handle<MetalTexture>(th, *mContext, src, baseLevel, levelCount));
@@ -512,7 +512,7 @@ void MetalDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> src
 
 void MetalDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTexture> srch,
         backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
-        backend::TextureSwizzle a, utils::CString tag) {
+        backend::TextureSwizzle a, utils::CString&& tag) {
     MetalTexture const* src = handle_cast<MetalTexture>(srch);
     mContext->textures.insert(construct_handle<MetalTexture>(th, *mContext, src, r, g, b, a));
     mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
@@ -522,13 +522,13 @@ void MetalDriver::createTextureExternalImage2R(Handle<HwTexture> th,
         backend::SamplerType target,
         backend::TextureFormat format,
         uint32_t width, uint32_t height, backend::TextureUsage usage,
-        Platform::ExternalImageHandleRef image, utils::CString tag) {
+        Platform::ExternalImageHandleRef image, utils::CString&& tag) {
     // FIXME: implement createTextureExternalImage2R
 }
 
 void MetalDriver::createTextureExternalImageR(Handle<HwTexture> th, backend::SamplerType target,
         backend::TextureFormat format, uint32_t width, uint32_t height, backend::TextureUsage usage,
-        void* image, utils::CString tag) {
+        void* image, utils::CString&& tag) {
     mContext->textures.insert(construct_handle<MetalTexture>(
             th, *mContext, format, width, height, usage, (CVPixelBufferRef)image));
     // This release matches the retain call in setupExternalImage. The MetalTexture will have
@@ -539,7 +539,7 @@ void MetalDriver::createTextureExternalImageR(Handle<HwTexture> th, backend::Sam
 
 void MetalDriver::createTextureExternalImagePlaneR(Handle<HwTexture> th,
         backend::TextureFormat format, uint32_t width, uint32_t height, backend::TextureUsage usage,
-        void* image, uint32_t plane, utils::CString tag) {
+        void* image, uint32_t plane, utils::CString&& tag) {
     mContext->textures.insert(construct_handle<MetalTexture>(
             th, *mContext, format, width, height, usage, (CVPixelBufferRef)image, plane));
     // This release matches the retain call in setupExternalImage. The MetalTexture will have
@@ -551,7 +551,7 @@ void MetalDriver::createTextureExternalImagePlaneR(Handle<HwTexture> th,
 void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
         SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
-        uint32_t depth, TextureUsage usage, utils::CString tag) {
+        uint32_t depth, TextureUsage usage, utils::CString&& tag) {
     id<MTLTexture> metalTexture = (id<MTLTexture>) CFBridgingRelease((void*) i);
     FILAMENT_CHECK_PRECONDITION(metalTexture.width == width)
             << "Imported id<MTLTexture> width (" << metalTexture.width
@@ -573,13 +573,13 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
 
 void MetalDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        PrimitiveType pt, utils::CString tag) {
+        PrimitiveType pt, utils::CString&& tag) {
     construct_handle<MetalRenderPrimitive>(rph);
     MetalDriver::setRenderPrimitiveBuffer(rph, pt, vbh, ibh);
     mHandleAllocator.associateTagToHandle(rph.getId(), std::move(tag));
 }
 
-void MetalDriver::createProgramR(Handle<HwProgram> rph, Program&& program, utils::CString tag) {
+void MetalDriver::createProgramR(Handle<HwProgram> rph, Program&& program, utils::CString&& tag) {
 #if FILAMENT_METAL_DEBUG_LOG
     auto handleId = rph.getId();
     DEBUG_LOG("createProgramR(rph = %d, program = ", handleId);
@@ -589,7 +589,7 @@ void MetalDriver::createProgramR(Handle<HwProgram> rph, Program&& program, utils
     mHandleAllocator.associateTagToHandle(rph.getId(), std::move(tag));
 }
 
-void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils::CString tag) {
+void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils::CString&& tag) {
     construct_handle<MetalRenderTarget>(rth, mContext);
     mHandleAllocator.associateTagToHandle(rth.getId(), std::move(tag));
 }
@@ -597,7 +597,7 @@ void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils::
 void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, uint8_t layerCount, MRT color,
-        TargetBufferInfo depth, TargetBufferInfo stencil, utils::CString tag) {
+        TargetBufferInfo depth, TargetBufferInfo stencil, utils::CString&& tag) {
     FILAMENT_CHECK_PRECONDITION(!isInRenderPass(mContext))
             << "createRenderTarget must be called outside of a render pass.";
     // Clamp sample count to what the device supports.
@@ -644,14 +644,14 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     mHandleAllocator.associateTagToHandle(rth.getId(), std::move(tag));
 }
 
-void MetalDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
+void MetalDriver::createFenceR(Handle<HwFence> fh, utils::CString&& tag) {
     auto* fence = handle_cast<MetalFence>(fh);
     fence->encode();
     mHandleAllocator.associateTagToHandle(fh.getId(), std::move(tag));
 }
 
 void MetalDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags,
-        utils::CString tag) {
+        utils::CString&& tag) {
     // TODO: support MSAA swapchain
 
     if (UTILS_UNLIKELY(flags & SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER)) {
@@ -668,18 +668,18 @@ void MetalDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, 
 }
 
 void MetalDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
-        uint32_t width, uint32_t height, uint64_t flags, utils::CString tag) {
+        uint32_t width, uint32_t height, uint64_t flags, utils::CString&& tag) {
     construct_handle<MetalSwapChain>(sch, *mContext, mPlatform, width, height, flags);
     mHandleAllocator.associateTagToHandle(sch.getId(), std::move(tag));
 }
 
-void MetalDriver::createSyncR(Handle<HwSync> sh, utils::CString tag) {
+void MetalDriver::createSyncR(Handle<HwSync> sh, utils::CString&& tag) {
     // TODO: Ensure sync is active, and then invoke and clear all pending
     // callbacks.
     mHandleAllocator.associateTagToHandle(sh.getId(), std::move(tag));
 }
 
-void MetalDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString tag) {
+void MetalDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString&& tag) {
     // nothing to do, timer query was constructed in createTimerQueryS
     mHandleAllocator.associateTagToHandle(tqh.getId(), std::move(tag));
 }
@@ -718,7 +718,7 @@ const char* toString(DescriptorFlags flags) {
 }
 
 void MetalDriver::createDescriptorSetLayoutR(
-        Handle<HwDescriptorSetLayout> dslh, DescriptorSetLayout&& info, utils::CString tag) {
+        Handle<HwDescriptorSetLayout> dslh, DescriptorSetLayout&& info, utils::CString&& tag) {
 #if FILAMENT_METAL_DEBUG_LOG == 1
     const char* labelStr = "";
     std::visit([&labelStr](auto&& arg) {
@@ -743,7 +743,7 @@ void MetalDriver::createDescriptorSetLayoutR(
 }
 
 void MetalDriver::createDescriptorSetR(
-        Handle<HwDescriptorSet> dsh, Handle<HwDescriptorSetLayout> dslh, utils::CString tag) {
+        Handle<HwDescriptorSet> dsh, Handle<HwDescriptorSetLayout> dslh, utils::CString&& tag) {
     DEBUG_LOG("createDescriptorSetR(dsh = %d, dslh = %d)\n", dsh.getId(), dslh.getId());
     MetalDescriptorSetLayout* layout = handle_cast<MetalDescriptorSetLayout>(dslh);
     construct_handle<MetalDescriptorSet>(dsh, layout);

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -21,12 +21,14 @@
 
 #include <backend/platforms/OpenGLPlatform.h>
 #include <backend/DriverEnums.h>
+#include <backend/Platform.h>
 
 #include <utils/Logger.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/ostream.h>
 
+#include <algorithm>
 #include <functional>
 #include <string_view>
 #include <utility>

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -54,7 +54,6 @@
 #include <utils/Logger.h>
 #include <utils/Panic.h>
 #include <utils/Slice.h>
-#include <utils/Systrace.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/ostream.h>
@@ -151,8 +150,8 @@ namespace filament::backend {
 
 namespace {
 
-static CallbackHandler::Callback syncCallbackWrapper = [](void* userData) {
-    std::unique_ptr<OpenGLDriver::GLSyncFence::CallbackData> cbData(
+CallbackHandler::Callback syncCallbackWrapper = [](void* userData) {
+    std::unique_ptr<OpenGLDriver::GLSyncFence::CallbackData> const cbData(
             static_cast<OpenGLDriver::GLSyncFence::CallbackData*>(userData));
     // This assumes the sync has not yet been destroyed. If it has, this will be
     // undefined behavior.
@@ -379,12 +378,12 @@ void OpenGLDriver::resetState(int) {
     mContext.resetState();
 }
 
-void OpenGLDriver::bindSampler(GLuint unit, GLuint sampler) noexcept {
+void OpenGLDriver::bindSampler(GLuint const unit, GLuint const sampler) noexcept {
     mContext.bindSampler(unit, sampler);
 }
 
-void OpenGLDriver::setPushConstant(ShaderStage stage, uint8_t index,
-        PushConstantVariant value) {
+void OpenGLDriver::setPushConstant(ShaderStage const stage, uint8_t const index,
+        PushConstantVariant const value) {
     assert_invariant(stage == ShaderStage::VERTEX || stage == ShaderStage::FRAGMENT);
 
 #if FILAMENT_ENABLE_MATDBG
@@ -423,7 +422,7 @@ void OpenGLDriver::setPushConstant(ShaderStage stage, uint8_t index,
     }
 }
 
-void OpenGLDriver::bindTexture(GLuint unit, GLTexture const* t) noexcept {
+void OpenGLDriver::bindTexture(GLuint const unit, GLTexture const* t) noexcept {
     assert_invariant(t != nullptr);
     mContext.bindTexture(unit, t->gl.target, t->gl.id, t->gl.external);
 }
@@ -456,7 +455,7 @@ bool OpenGLDriver::useProgram(OpenGLProgram* p) noexcept {
 }
 
 
-void OpenGLDriver::setRasterState(RasterState rs) noexcept {
+void OpenGLDriver::setRasterState(RasterState const rs) noexcept {
     auto& gl = mContext;
 
     mRenderPassColorWrite |= rs.colorWrite;
@@ -516,7 +515,7 @@ void OpenGLDriver::setRasterState(RasterState rs) noexcept {
     }
 }
 
-void OpenGLDriver::setStencilState(StencilState ss) noexcept {
+void OpenGLDriver::setStencilState(StencilState const ss) noexcept {
     auto& gl = mContext;
 
     mRenderPassStencilWrite |= ss.stencilWrite;
@@ -656,7 +655,7 @@ void OpenGLDriver::createVertexBufferInfoR(
         uint8_t bufferCount,
         uint8_t attributeCount,
         AttributeArray attributes,
-        utils::CString tag) {
+        CString tag) {
     DEBUG_MARKER()
     construct<GLVertexBufferInfo>(vbih, bufferCount, attributeCount, attributes);
     mHandleAllocator.associateTagToHandle(vbih.getId(), std::move(tag));
@@ -666,7 +665,7 @@ void OpenGLDriver::createVertexBufferR(
         Handle<HwVertexBuffer> vbh,
         uint32_t vertexCount,
         Handle<HwVertexBufferInfo> vbih,
-        utils::CString tag) {
+        CString tag) {
     DEBUG_MARKER()
     construct<GLVertexBuffer>(vbh, vertexCount, vbih);
     mHandleAllocator.associateTagToHandle(vbh.getId(), std::move(tag));
@@ -674,17 +673,17 @@ void OpenGLDriver::createVertexBufferR(
 
 void OpenGLDriver::createIndexBufferR(
         Handle<HwIndexBuffer> ibh,
-        ElementType elementType,
+        ElementType const elementType,
         uint32_t indexCount,
-        BufferUsage usage,
-        utils::CString tag) {
+        BufferUsage const usage,
+        CString tag) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
     uint8_t const elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     GLIndexBuffer* ib = construct<GLIndexBuffer>(ibh, elementSize, indexCount);
     glGenBuffers(1, &ib->gl.buffer);
-    GLsizeiptr const size = elementSize * indexCount;
+    GLsizeiptr const size = elementSize * GLsizeiptr(indexCount);
     gl.bindVertexArray(nullptr);
     gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
@@ -693,7 +692,7 @@ void OpenGLDriver::createIndexBufferR(
 }
 
 void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, utils::CString tag) {
+        BufferObjectBinding bindingType, BufferUsage usage, CString tag) {
     DEBUG_MARKER()
     assert_invariant(byteCount > 0);
 
@@ -720,7 +719,7 @@ void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byte
 
 void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        PrimitiveType pt, utils::CString tag) {
+        PrimitiveType const pt, CString tag) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
@@ -728,7 +727,7 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
     GLIndexBuffer const* const ib = handle_cast<const GLIndexBuffer*>(ibh);
     assert_invariant(ib->elementSize == 2 || ib->elementSize == 4);
 
-    GLVertexBuffer* const vb = handle_cast<GLVertexBuffer*>(vbh);
+    GLVertexBuffer const* const vb = handle_cast<GLVertexBuffer*>(vbh);
     GLRenderPrimitive* const rp = handle_cast<GLRenderPrimitive*>(rph);
     rp->gl.indicesShift = (ib->elementSize == 4u) ? 2u : 1u;
     rp->gl.indicesType  = (ib->elementSize == 4u) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
@@ -756,7 +755,7 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
     mHandleAllocator.associateTagToHandle(rph.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils::CString tag) {
+void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, CString tag) {
     DEBUG_MARKER()
 
 
@@ -768,7 +767,7 @@ void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils
         // Platform.isSRGBSwapChainSupported().
         if (!mPlatform.isSRGBSwapChainSupported()) {
             auto& specializationConstants = program.getSpecializationConstants();
-            auto pos = std::find_if(specializationConstants.begin(), specializationConstants.end(),
+            auto const pos = std::find_if(specializationConstants.begin(), specializationConstants.end(),
                     [](auto&& sc) {
                         // This constant must match
                         // ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION
@@ -789,7 +788,7 @@ void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils
 
 UTILS_NOINLINE
 void OpenGLDriver::textureStorage(GLTexture* t,
-        uint32_t width, uint32_t height, uint32_t depth, bool useProtectedMemory) noexcept {
+        uint32_t const width, uint32_t const height, uint32_t const depth, bool useProtectedMemory) noexcept {
 
     auto& gl = mContext;
 
@@ -888,8 +887,8 @@ void OpenGLDriver::textureStorage(GLTexture* t,
 }
 
 void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
-        TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
-        TextureUsage usage, utils::CString tag) {
+        TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
+        TextureUsage usage, CString tag) {
     DEBUG_MARKER()
 
     GLenum internalFormat = getInternalFormat(format);
@@ -910,9 +909,9 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
         usage |= TextureUsage::SAMPLEABLE;
     }
 
-    auto& gl = mContext;
+    auto const& gl = mContext;
     samples = std::clamp(samples, uint8_t(1u), uint8_t(gl.gets.max_samples));
-    GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
+    GLTexture* t = construct<GLTexture>(th, target, levels, samples, width, height, depth, format, usage);
     if (UTILS_LIKELY(usage & TextureUsage::SAMPLEABLE)) {
 
         if (UTILS_UNLIKELY(gl.isES2())) {
@@ -968,13 +967,13 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 #endif
             }
 
-            textureStorage(t, w, h, depth, bool(usage & TextureUsage::PROTECTED));
+            textureStorage(t, width, height, depth, bool(usage & TextureUsage::PROTECTED));
         }
     } else {
         t->gl.internalFormat = internalFormat;
         t->gl.target = GL_RENDERBUFFER;
         glGenRenderbuffers(1, &t->gl.id);
-        renderBufferStorage(t->gl.id, internalFormat, w, h, samples);
+        renderBufferStorage(t->gl.id, internalFormat, width, height, samples);
     }
 
     CHECK_GL_ERROR()
@@ -982,7 +981,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 }
 
 void OpenGLDriver::createTextureViewR(Handle<HwTexture> th,
-        Handle<HwTexture> srch, uint8_t baseLevel, uint8_t levelCount, utils::CString tag) {
+        Handle<HwTexture> srch, uint8_t const baseLevel, uint8_t const levelCount, CString tag) {
     DEBUG_MARKER()
     GLTexture const* const src = handle_cast<GLTexture const*>(srch);
 
@@ -1015,8 +1014,8 @@ void OpenGLDriver::createTextureViewR(Handle<HwTexture> th,
         srcBaseLevel = 0;
         srcMaxLevel = 127;
     }
-    t->gl.baseLevel = (int8_t)std::min(127, srcBaseLevel + baseLevel);
-    t->gl.maxLevel  = (int8_t)std::min(127, srcBaseLevel + baseLevel + levelCount - 1);
+    t->gl.baseLevel = int8_t(std::min(127, srcBaseLevel + baseLevel));
+    t->gl.maxLevel  = int8_t(std::min(127, srcBaseLevel + baseLevel + levelCount - 1));
 
     // increase reference count to this texture handle
     t->ref = src->ref;
@@ -1029,8 +1028,8 @@ void OpenGLDriver::createTextureViewR(Handle<HwTexture> th,
 }
 
 void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTexture> srch,
-        TextureSwizzle r, TextureSwizzle g, TextureSwizzle b, TextureSwizzle a,
-        utils::CString tag) {
+        TextureSwizzle const r, TextureSwizzle const g, TextureSwizzle const b, TextureSwizzle const a,
+        CString tag) {
 
     DEBUG_MARKER()
     GLTexture const* const src = handle_cast<GLTexture const*>(srch);
@@ -1060,7 +1059,7 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
     t->gl.sidecarRenderBufferMS = 0;
     t->gl.sidecarSamples = 1;
 
-    auto getChannel = [&swizzle = src->gl.swizzle](TextureSwizzle ch) {
+    auto getChannel = [&swizzle = src->gl.swizzle](TextureSwizzle const ch) {
         switch (ch) {
             case TextureSwizzle::SUBSTITUTE_ZERO:
             case TextureSwizzle::SUBSTITUTE_ONE:
@@ -1074,6 +1073,7 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
             case TextureSwizzle::CHANNEL_3:
                 return swizzle[3];
         }
+        return ch;
     };
 
     t->gl.swizzle = {
@@ -1085,7 +1085,7 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 
     // increase reference count to this texture handle
     t->ref = src->ref;
-    GLTextureRef* ref = handle_cast<GLTextureRef*>(t->ref);
+    GLTextureRef* const ref = handle_cast<GLTextureRef*>(t->ref);
     assert_invariant(ref);
     ref->count++;
 
@@ -1095,13 +1095,13 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 
 void OpenGLDriver::createTextureExternalImage2R(Handle<HwTexture> th, SamplerType target,
     TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage,
-    Platform::ExternalImageHandleRef image, utils::CString tag) {
+    Platform::ExternalImageHandleRef image, CString tag) {
     DEBUG_MARKER()
 
     usage |= TextureUsage::SAMPLEABLE;
     usage &= ~TextureUsage::UPLOADABLE;
 
-    auto& gl = mContext;
+    auto const& gl = mContext;
     GLenum internalFormat = getInternalFormat(format);
     if (UTILS_UNLIKELY(gl.isES2())) {
         // on ES2, format and internal format must match
@@ -1147,13 +1147,13 @@ void OpenGLDriver::createTextureExternalImage2R(Handle<HwTexture> th, SamplerTyp
 
 void OpenGLDriver::createTextureExternalImageR(Handle<HwTexture> th, SamplerType target,
         TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage, void* image,
-        utils::CString tag) {
+        CString tag) {
     DEBUG_MARKER()
 
     usage |= TextureUsage::SAMPLEABLE;
     usage &= ~TextureUsage::UPLOADABLE;
 
-    auto& gl = mContext;
+    auto const& gl = mContext;
     GLenum internalFormat = getInternalFormat(format);
     if (UTILS_UNLIKELY(gl.isES2())) {
         // on ES2, format and internal format must match
@@ -1198,20 +1198,20 @@ void OpenGLDriver::createTextureExternalImageR(Handle<HwTexture> th, SamplerType
 
 void OpenGLDriver::createTextureExternalImagePlaneR(Handle<HwTexture> th,
         TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage,
-        void* image, uint32_t plane, utils::CString tag) {
+        void* image, uint32_t plane, CString tag) {
     // not relevant for the OpenGL backend
 }
 
-void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
+void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t const id,
         SamplerType target, uint8_t levels, TextureFormat format, uint8_t samples,
-        uint32_t w, uint32_t h, uint32_t depth, TextureUsage usage, utils::CString tag) {
+        uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage, CString tag) {
     DEBUG_MARKER()
 
-    auto& gl = mContext;
+    auto const& gl = mContext;
     samples = std::clamp(samples, uint8_t(1u), uint8_t(gl.gets.max_samples));
-    GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
+    GLTexture* t = construct<GLTexture>(th, target, levels, samples, width, height, depth, format, usage);
 
-    t->gl.id = (GLuint)id;
+    t->gl.id = GLuint(id);
     t->gl.imported = true;
     t->gl.internalFormat = getInternalFormat(format);
     assert_invariant(t->gl.internalFormat);
@@ -1270,7 +1270,7 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
         // The VAO for the given render primitive must already be bound.
         GLint vaoBinding;
         glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vaoBinding);
-        assert_invariant(vaoBinding == (GLint)rp->gl.vao[gl.contextIndex]);
+        assert_invariant(vaoBinding == GLint(rp->gl.vao[gl.contextIndex]));
     }
 #endif
 
@@ -1293,7 +1293,7 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
 
             gl.bindBuffer(GL_ARRAY_BUFFER, vb->gl.buffers[bi]);
             GLuint const index = i;
-            GLint const size = (GLint)getComponentCount(attribute.type);
+            GLint const size = GLint(getComponentCount(attribute.type));
             GLenum const type = getComponentType(attribute.type);
             GLboolean const normalized = getNormalization(attribute.flags & Attribute::FLAG_NORMALIZED);
             GLsizei const stride = attribute.stride;
@@ -1348,11 +1348,11 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
 }
 
 void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
-        GLRenderTarget const* rt, GLenum attachment, uint8_t layerCount) noexcept {
+        GLRenderTarget const* rt, GLenum attachment, uint8_t const layerCount) noexcept {
 
 #if !defined(NDEBUG)
     // Only used by assert_invariant() checks below
-    UTILS_UNUSED_IN_RELEASE auto valueForLevel = [](size_t level, size_t value) {
+    UTILS_UNUSED_IN_RELEASE auto valueForLevel = [](size_t const level, size_t const value) {
         return std::max(size_t(1), value >> level);
     };
 #endif
@@ -1629,7 +1629,7 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
     CHECK_GL_FRAMEBUFFER_STATUS(GL_FRAMEBUFFER)
 }
 
-void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32_t width, // NOLINT(readability-convert-member-functions-to-static)
+void OpenGLDriver::renderBufferStorage(GLuint const rbo, GLenum internalformat, uint32_t width, // NOLINT(readability-convert-member-functions-to-static)
         uint32_t height, uint8_t samples) const noexcept {
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
     if (samples > 1) {
@@ -1646,11 +1646,11 @@ void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32
         {
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             glRenderbufferStorageMultisample(GL_RENDERBUFFER,
-                    samples, internalformat, (GLsizei)width, (GLsizei)height);
+                    samples, internalformat, GLsizei(width), GLsizei(height));
 #endif
         }
     } else {
-        glRenderbufferStorage(GL_RENDERBUFFER, internalformat, (GLsizei)width, (GLsizei)height);
+        glRenderbufferStorage(GL_RENDERBUFFER, internalformat, GLsizei(width), GLsizei(height));
     }
     // unbind the renderbuffer, to avoid any later confusion
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
@@ -1659,7 +1659,7 @@ void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32
 }
 
 void OpenGLDriver::createDefaultRenderTargetR(
-        Handle<HwRenderTarget> rth, utils::CString tag) {
+        Handle<HwRenderTarget> rth, CString tag) {
     DEBUG_MARKER()
 
     construct<GLRenderTarget>(rth, 0, 0);  // FIXME: we don't know the width/height
@@ -1674,15 +1674,15 @@ void OpenGLDriver::createDefaultRenderTargetR(
 }
 
 void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
-        TargetBufferFlags targets,
+        TargetBufferFlags const targets,
         uint32_t width,
         uint32_t height,
         uint8_t samples,
-        uint8_t layerCount,
+        uint8_t const layerCount,
         MRT color,
         TargetBufferInfo depth,
         TargetBufferInfo stencil,
-        utils::CString tag) {
+        CString tag) {
     DEBUG_MARKER()
 
     GLRenderTarget* rt = construct<GLRenderTarget>(rth, width, height);
@@ -1730,7 +1730,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
 
     UTILS_UNUSED_IN_RELEASE vec2<uint32_t> tmin = { std::numeric_limits<uint32_t>::max() };
     UTILS_UNUSED_IN_RELEASE vec2<uint32_t> tmax = { 0 };
-    auto checkDimensions = [&tmin, &tmax](GLTexture const* t, uint8_t level) {
+    auto checkDimensions = [&tmin, &tmax](GLTexture const* t, uint8_t const level) {
         const auto twidth = std::max(1u, t->width >> level);
         const auto theight = std::max(1u, t->height >> level);
         tmin = { std::min(tmin.x, twidth), std::min(tmin.y, theight) };
@@ -1752,7 +1752,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             }
         }
         if (UTILS_LIKELY(!getContext().isES2())) {
-            glDrawBuffers((GLsizei)maxDrawBuffers, bufs);
+            glDrawBuffers(GLsizei(maxDrawBuffers), bufs);
         }
         CHECK_GL_ERROR()
     }
@@ -1798,7 +1798,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     mHandleAllocator.associateTagToHandle(rth.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
+void OpenGLDriver::createFenceR(Handle<HwFence> fh, CString tag) {
     DEBUG_MARKER()
 
     GLFence* f = handle_cast<GLFence*>(fh);
@@ -1809,10 +1809,9 @@ void OpenGLDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
     }
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     else {
-        std::weak_ptr<GLFence::State> const weak = f->state;
+        std::weak_ptr const weak = f->state;
         whenGpuCommandsComplete([weak](){
-            auto state = weak.lock();
-            if (state) {
+            if (auto const state = weak.lock()) {
                 std::lock_guard const lock(state->lock);
                 state->status = FenceStatus::CONDITION_SATISFIED;
                 state->cond.notify_all();
@@ -1823,12 +1822,12 @@ void OpenGLDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
     mHandleAllocator.associateTagToHandle(fh.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createSyncR(Handle<HwSync> sh, utils::CString tag) {
+void OpenGLDriver::createSyncR(Handle<HwSync> sh, CString tag) {
     DEBUG_MARKER()
 
     GLSyncFence* s = handle_cast<GLSyncFence*>(sh);
     {
-        std::lock_guard<std::mutex> guard(s->lock);
+        std::lock_guard const guard(s->lock);
         s->sync = mPlatform.createSync();
     }
 
@@ -1841,8 +1840,8 @@ void OpenGLDriver::createSyncR(Handle<HwSync> sh, utils::CString tag) {
     mHandleAllocator.associateTagToHandle(sh.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags,
-        utils::CString tag) {
+void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t const flags,
+        CString tag) {
     DEBUG_MARKER()
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
@@ -1864,7 +1863,7 @@ void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 }
 
 void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
-        uint32_t width, uint32_t height, uint64_t flags, utils::CString tag) {
+        uint32_t const width, uint32_t const height, uint64_t const flags, CString tag) {
     DEBUG_MARKER()
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
@@ -1886,7 +1885,7 @@ void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
     mHandleAllocator.associateTagToHandle(sch.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString tag) {
+void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, CString tag) {
     DEBUG_MARKER()
     GLTimerQuery* tq = handle_cast<GLTimerQuery*>(tqh);
     mContext.createTimerQuery(tq);
@@ -1894,14 +1893,14 @@ void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString ta
 }
 
 void OpenGLDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh,
-        DescriptorSetLayout&& info, utils::CString tag) {
+        DescriptorSetLayout&& info, CString tag) {
     DEBUG_MARKER()
     construct<GLDescriptorSetLayout>(dslh, std::move(info));
     mHandleAllocator.associateTagToHandle(dslh.getId(), std::move(tag));
 }
 
 void OpenGLDriver::createDescriptorSetR(Handle<HwDescriptorSet> dsh,
-        Handle<HwDescriptorSetLayout> dslh, utils::CString tag) {
+        Handle<HwDescriptorSetLayout> dslh, CString tag) {
     DEBUG_MARKER()
     GLDescriptorSetLayout const* dsl = handle_cast<GLDescriptorSetLayout*>(dslh);
     construct<GLDescriptorSet>(dsh, mContext, dslh, dsl);
@@ -1980,7 +1979,7 @@ void OpenGLDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 void OpenGLDriver::destroyProgram(Handle<HwProgram> ph) {
     DEBUG_MARKER()
     if (ph) {
-        OpenGLProgram* p = handle_cast<OpenGLProgram*>(ph);
+        OpenGLProgram const* p = handle_cast<OpenGLProgram*>(ph);
         destruct(ph, p);
     }
 }
@@ -2040,7 +2039,7 @@ void OpenGLDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
 
     if (rth) {
         auto& gl = mContext;
-        GLRenderTarget* rt = handle_cast<GLRenderTarget*>(rth);
+        GLRenderTarget const* rt = handle_cast<GLRenderTarget*>(rth);
         if (rt->gl.fbo) {
             // first unbind this framebuffer if needed
             gl.unbindFramebuffer(GL_FRAMEBUFFER);
@@ -2080,7 +2079,7 @@ void OpenGLDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     DEBUG_MARKER()
 
     if (sch) {
-        GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
+        GLSwapChain const* sc = handle_cast<GLSwapChain*>(sch);
         mPlatform.destroySwapChain(sc->swapChain);
         destruct(sch, sc);
     }
@@ -2090,11 +2089,11 @@ void OpenGLDriver::destroyStream(Handle<HwStream> sh) {
     DEBUG_MARKER()
 
     if (sh) {
-        GLStream* s = handle_cast<GLStream*>(sh);
+        GLStream const* s = handle_cast<GLStream*>(sh);
 
         // if this stream is still attached to a texture, detach it first
         auto& texturesWithStreamsAttached = mTexturesWithStreamsAttached;
-        auto pos = std::find_if(
+        auto const pos = std::find_if(
                 texturesWithStreamsAttached.begin(), texturesWithStreamsAttached.end(),
                 [s](GLTexture const* t) {
                     return t->hwStream == s;
@@ -2118,7 +2117,7 @@ void OpenGLDriver::destroySync(Handle<HwSync> sh) {
     DEBUG_MARKER()
 
     if (sh) {
-        GLSyncFence* s = handle_cast<GLSyncFence*>(sh);
+        GLSyncFence const* s = handle_cast<GLSyncFence*>(sh);
         mPlatform.destroySync(s->sync);
         destruct(sh, s);
     }
@@ -2137,7 +2136,7 @@ void OpenGLDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
 void OpenGLDriver::destroyDescriptorSetLayout(Handle<HwDescriptorSetLayout> dslh) {
     DEBUG_MARKER()
     if (dslh) {
-        GLDescriptorSetLayout* dsl = handle_cast<GLDescriptorSetLayout*>(dslh);
+        GLDescriptorSetLayout const* dsl = handle_cast<GLDescriptorSetLayout*>(dslh);
         destruct(dslh, dsl);
     }
 }
@@ -2151,7 +2150,7 @@ void OpenGLDriver::destroyDescriptorSet(Handle<HwDescriptorSet> dsh) {
                 bound = {};
             }
         }
-        GLDescriptorSet* ds = handle_cast<GLDescriptorSet*>(dsh);
+        GLDescriptorSet const* ds = handle_cast<GLDescriptorSet*>(dsh);
         destruct(dsh, ds);
     }
 }
@@ -2161,14 +2160,14 @@ void OpenGLDriver::destroyDescriptorSet(Handle<HwDescriptorSet> dsh) {
 // These are called on the application's thread
 // ------------------------------------------------------------------------------------------------
 
-Handle<HwStream> OpenGLDriver::createStreamNative(void* nativeStream, utils::CString tag) {
+Handle<HwStream> OpenGLDriver::createStreamNative(void* nativeStream, CString tag) {
     Platform::Stream* stream = mPlatform.createStream(nativeStream);
     auto handle = initHandle<GLStream>(stream);
     mHandleAllocator.associateTagToHandle(handle.getId(), std::move(tag));
     return handle;
 }
 
-Handle<HwStream> OpenGLDriver::createStreamAcquired(utils::CString tag) {
+Handle<HwStream> OpenGLDriver::createStreamAcquired(CString tag) {
     auto handle = initHandle<GLStream>();
     mHandleAllocator.associateTagToHandle(handle.getId(), std::move(tag));
     return handle;
@@ -2180,8 +2179,8 @@ Handle<HwStream> OpenGLDriver::createStreamAcquired(utils::CString tag) {
 // setAcquiredImage should be called by the user outside of beginFrame / endFrame, and should be
 // called only once per frame. If the user pushes images to the same stream multiple times in a
 // single frame, we emit a warning and honor only the final image, but still invoke all callbacks.
-void OpenGLDriver::setAcquiredImage(Handle<HwStream> sh, void* hwbuffer, const math::mat3f& transform,
-        CallbackHandler* handler, StreamCallback cb, void* userData) {
+void OpenGLDriver::setAcquiredImage(Handle<HwStream> sh, void* hwbuffer, const mat3f& transform,
+        CallbackHandler* handler, StreamCallback const cb, void* userData) {
     GLStream* glstream = handle_cast<GLStream*>(sh);
     assert_invariant(glstream->streamType == StreamType::ACQUIRED);
 
@@ -2220,7 +2219,7 @@ void OpenGLDriver::updateStreams(DriverApi* driver) {
             driver->queueCommand([this, s, image = s->user_thread.acquired.image, previousImage, transform = s->user_thread.transform]() {
 
                 auto& streams = mTexturesWithStreamsAttached;
-                auto pos = std::find_if(streams.begin(), streams.end(),
+                auto const pos = std::find_if(streams.begin(), streams.end(),
                         [s](GLTexture const* t) {
                             return t->hwStream == s;
                         });
@@ -2245,7 +2244,7 @@ void OpenGLDriver::updateStreams(DriverApi* driver) {
     }
 }
 
-void OpenGLDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint32_t height) {
+void OpenGLDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t const width, uint32_t const height) {
     if (sh) {
         GLStream* s = handle_cast<GLStream*>(sh);
         s->width = width;
@@ -2255,27 +2254,27 @@ void OpenGLDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint
 
 int64_t OpenGLDriver::getStreamTimestamp(Handle<HwStream> sh) {
     if (sh) {
-        GLStream* s = handle_cast<GLStream*>(sh);
+        GLStream const* s = handle_cast<GLStream*>(sh);
         return s->user_thread.timestamp;
     }
     return 0;
 }
 
-math::mat3f OpenGLDriver::getStreamTransformMatrix(Handle<HwStream> sh) {
+mat3f OpenGLDriver::getStreamTransformMatrix(Handle<HwStream> sh) {
     if (sh) {
-        GLStream* s = handle_cast<GLStream*>(sh);
+        GLStream const* s = handle_cast<GLStream*>(sh);
         if (s->streamType == StreamType::NATIVE) {
             return mPlatform.getTransformMatrix(s->stream);
         } else {
             return s->transform;
         }
     }
-    return math::mat3f();
+    return mat3f();
 }
 
 void OpenGLDriver::destroyFence(Handle<HwFence> fh) {
     if (fh) {
-        GLFence* f = handle_cast<GLFence*>(fh);
+        GLFence const* f = handle_cast<GLFence*>(fh);
         if (mPlatform.canCreateFence() || mContext.isES2()) {
             mPlatform.destroyFence(f->fence);
         }
@@ -2313,7 +2312,7 @@ FenceStatus OpenGLDriver::getFenceStatus(Handle<HwFence> fh) {
 }
 
 void OpenGLDriver::getPlatformSync(Handle<HwSync> sh, CallbackHandler* handler,
-        Platform::SyncCallback cb, void* userData) {
+        Platform::SyncCallback const cb, void* userData) {
     if (!sh) {
         return;
     }
@@ -2327,7 +2326,7 @@ void OpenGLDriver::getPlatformSync(Handle<HwSync> sh, CallbackHandler* handler,
     // If we haven't already set the handle, toss the conversion callback in the
     // back of the list.
     {
-        std::lock_guard guard(s->lock);
+        std::lock_guard const guard(s->lock);
         if (s->sync == nullptr) {
             s->conversionCallbacks.push_back(std::move(cbData));
             return;
@@ -2339,7 +2338,7 @@ void OpenGLDriver::getPlatformSync(Handle<HwSync> sh, CallbackHandler* handler,
     scheduleCallback(cbData->handler, cbData.release(), syncCallbackWrapper);
 }
 
-bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
+bool OpenGLDriver::isTextureFormatSupported(TextureFormat const format) {
     const auto& ext = mContext.ext;
     if (isETC2Compression(format)) {
         return ext.EXT_texture_compression_etc2 ||
@@ -2382,7 +2381,7 @@ bool OpenGLDriver::isTextureSwizzleSupported() {
 #endif
 }
 
-bool OpenGLDriver::isTextureFormatMipmappable(TextureFormat format) {
+bool OpenGLDriver::isTextureFormatMipmappable(TextureFormat const format) {
     // The OpenGL spec for GenerateMipmap stipulates that it returns INVALID_OPERATION unless
     // the sized internal format is both color-renderable and texture-filterable.
     switch (format) {
@@ -2397,11 +2396,11 @@ bool OpenGLDriver::isTextureFormatMipmappable(TextureFormat format) {
     }
 }
 
-bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
+bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat const format) {
     // Supported formats per http://docs.gl/es3/glRenderbufferStorage, note that desktop OpenGL may
     // support more formats, but it requires querying GL_INTERNALFORMAT_SUPPORTED which is not
     // available in OpenGL ES.
-    auto& gl = mContext;
+    auto const& gl = mContext;
     if (UTILS_UNLIKELY(gl.isES2())) {
         auto [es2format, type] = textureFormatToFormatAndType(format);
         return es2format != GL_NONE && type != GL_NONE;
@@ -2477,7 +2476,7 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
 }
 
 bool OpenGLDriver::isFrameBufferFetchSupported() {
-    auto& gl = mContext;
+    auto const& gl = mContext;
     return gl.ext.EXT_shader_framebuffer_fetch;
 }
 
@@ -2504,7 +2503,7 @@ bool OpenGLDriver::isSRGBSwapChainSupported() {
     return mPlatform.isSRGBSwapChainSupported();
 }
 
-bool OpenGLDriver::isMSAASwapChainSupported(uint32_t samples) {
+bool OpenGLDriver::isMSAASwapChainSupported(uint32_t const samples) {
     return mPlatform.isMSAASwapChainSupported(samples);
 }
 
@@ -2526,6 +2525,7 @@ bool OpenGLDriver::isStereoSupported() {
         case StereoscopicType::NONE:
             return false;
     }
+    return false;
 }
 
 bool OpenGLDriver::isParallelShaderCompileSupported() {
@@ -2558,7 +2558,7 @@ bool OpenGLDriver::isDepthClampSupported() {
     return getContext().ext.EXT_depth_clamp;
 }
 
-bool OpenGLDriver::isWorkaroundNeeded(Workaround workaround) {
+bool OpenGLDriver::isWorkaroundNeeded(Workaround const workaround) {
     switch (workaround) {
         case Workaround::SPLIT_EASU:
             return mContext.bugs.split_easu;
@@ -2598,7 +2598,7 @@ size_t OpenGLDriver::getMaxUniformBufferSize() {
     return mContext.gets.max_uniform_block_size;
 }
 
-size_t OpenGLDriver::getMaxTextureSize(SamplerType target) {
+size_t OpenGLDriver::getMaxTextureSize(SamplerType const target) {
     switch (target) {
         case SamplerType::SAMPLER_2D:
         case SamplerType::SAMPLER_2D_ARRAY:
@@ -2631,8 +2631,7 @@ void OpenGLDriver::commit(Handle<HwSwapChain> sch) {
     auto& fs = sc->frameScheduled;
     if (fs.callback) {
         scheduleCallback(fs.handler, [callback = std::move(fs.callback)]() {
-            PresentCallable noop = PresentCallable(PresentCallable::noopPresent, nullptr);
-            callback(noop);
+            callback(PresentCallable{ PresentCallable::noopPresent, nullptr });
         });
     }
 
@@ -2651,11 +2650,11 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
     DEBUG_MARKER()
 
     GLSwapChain* scDraw = handle_cast<GLSwapChain*>(schDraw);
-    GLSwapChain* scRead = handle_cast<GLSwapChain*>(schRead);
+    GLSwapChain const* scRead = handle_cast<GLSwapChain*>(schRead);
 
     mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain,
             [this]() {
-                for (auto t: mTexturesWithStreamsAttached) {
+                for (auto const t: mTexturesWithStreamsAttached) {
                     if (t->hwStream->streamType == StreamType::NATIVE) {
                         mPlatform.detach(t->hwStream->stream);
                     }
@@ -2663,8 +2662,8 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
                 // OpenGL context is about to change, unbind everything
                 mContext.unbindEverything();
             },
-            [this](size_t index) {
-                for (auto t: mTexturesWithStreamsAttached) {
+            [this](size_t const index) {
+                for (auto const t: mTexturesWithStreamsAttached) {
                     if (t->hwStream->streamType == StreamType::NATIVE) {
                         if (t->externalTexture) {
                             glGenTextures(1, &t->externalTexture->id);
@@ -2702,11 +2701,11 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 // ------------------------------------------------------------------------------------------------
 
 void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
-        uint32_t index, Handle<HwBufferObject> boh) {
+        uint32_t const index, Handle<HwBufferObject> boh) {
    DEBUG_MARKER()
 
     GLVertexBuffer* vb = handle_cast<GLVertexBuffer *>(vbh);
-    GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
+    GLBufferObject const* bo = handle_cast<GLBufferObject *>(boh);
 
     assert_invariant(bo->gl.binding == GL_ARRAY_BUFFER);
 
@@ -2725,16 +2724,16 @@ void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
 }
 
 void OpenGLDriver::updateIndexBuffer(
-        Handle<HwIndexBuffer> ibh, BufferDescriptor&& p, uint32_t byteOffset) {
+        Handle<HwIndexBuffer> ibh, BufferDescriptor&& p, uint32_t const byteOffset) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
+    GLIndexBuffer const* ib = handle_cast<GLIndexBuffer *>(ibh);
     assert_invariant(ib->elementSize == 2 || ib->elementSize == 4);
 
     gl.bindVertexArray(nullptr);
     gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
-    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, (GLsizeiptr)p.size, p.buffer);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, GLsizeiptr(p.size), p.buffer);
 
     scheduleDestroy(std::move(p));
 
@@ -2744,7 +2743,7 @@ void OpenGLDriver::updateIndexBuffer(
 void OpenGLDriver::registerBufferObjectStreams(Handle<HwBufferObject> boh, BufferObjectStreamDescriptor&& streams) {
     DEBUG_MARKER()
 
-    GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
+    GLBufferObject const* bo = handle_cast<GLBufferObject*>(boh);
     mStreamUniformDescriptors[bo->gl.id] = std::move(streams);
 }
 
@@ -2774,7 +2773,7 @@ static void copyMat3f(void* addr, size_t const offset, const mat3f& v) noexcept 
 }
 
 void OpenGLDriver::updateBufferObject(
-        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t byteOffset) {
+        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t const byteOffset) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
@@ -2787,7 +2786,7 @@ void OpenGLDriver::updateBufferObject(
     }
 
     if (UTILS_UNLIKELY(!mStreamUniformDescriptors.empty())) {
-        auto streamDescriptors = mStreamUniformDescriptors.find(bo->gl.id);
+        auto const streamDescriptors = mStreamUniformDescriptors.find(bo->gl.id);
         if (streamDescriptors != mStreamUniformDescriptors.end()) {
             for (auto const& [offset, stream, associationType] : streamDescriptors->second.mStreams) {
                 if (associationType == BufferObjectStreamAssociationType::TRANSFORM_MATRIX) {
@@ -2808,11 +2807,11 @@ void OpenGLDriver::updateBufferObject(
         gl.bindBuffer(bo->gl.binding, bo->gl.id);
         if (byteOffset == 0 && bd.size == bo->byteCount) {
             // it looks like it's generally faster (or not worse) to use glBufferData()
-            glBufferData(bo->gl.binding, (GLsizeiptr)bd.size, bd.buffer, getBufferUsage(bo->usage));
+            glBufferData(bo->gl.binding, GLsizeiptr(bd.size), bd.buffer, getBufferUsage(bo->usage));
         } else {
             // glBufferSubData() could be catastrophically inefficient if several are
             // issued during the same frame. Currently, we're not doing that though.
-            glBufferSubData(bo->gl.binding, byteOffset, (GLsizeiptr)bd.size, bd.buffer);
+            glBufferSubData(bo->gl.binding, byteOffset, GLsizeiptr(bd.size), bd.buffer);
         }
     }
 
@@ -2822,7 +2821,7 @@ void OpenGLDriver::updateBufferObject(
 }
 
 void OpenGLDriver::updateBufferObjectUnsynchronized(
-        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t byteOffset) {
+        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t const byteOffset) {
     DEBUG_MARKER()
 
     if (UTILS_UNLIKELY(mContext.isES2())) {
@@ -2834,7 +2833,7 @@ void OpenGLDriver::updateBufferObjectUnsynchronized(
     if constexpr (!HAS_MAPBUFFERS) {
         updateBufferObject(boh, std::move(bd), byteOffset);
     } else {
-        GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
+        GLBufferObject const* bo = handle_cast<GLBufferObject*>(boh);
 
         assert_invariant(bo->gl.id);
         assert_invariant(bd.size + byteOffset <= bo->byteCount);
@@ -2846,7 +2845,7 @@ void OpenGLDriver::updateBufferObjectUnsynchronized(
             auto& gl = mContext;
             gl.bindBuffer(bo->gl.binding, bo->gl.id);
 retry:
-            void* const vaddr = glMapBufferRange(bo->gl.binding, byteOffset, (GLsizeiptr)bd.size,
+            void* const vaddr = glMapBufferRange(bo->gl.binding, byteOffset, GLsizeiptr(bd.size),
                     GL_MAP_WRITE_BIT |
                     GL_MAP_INVALIDATE_RANGE_BIT |
                     GL_MAP_UNSYNCHRONIZED_BIT);
@@ -2860,7 +2859,7 @@ retry:
                 }
             } else {
                 // handle mapping error, revert to glBufferSubData()
-                glBufferSubData(bo->gl.binding, byteOffset, (GLsizeiptr)bd.size, bd.buffer);
+                glBufferSubData(bo->gl.binding, byteOffset, GLsizeiptr(bd.size), bd.buffer);
             }
             scheduleDestroy(std::move(bd));
         }
@@ -2873,7 +2872,7 @@ void OpenGLDriver::resetBufferObject(Handle<HwBufferObject> boh) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
+    GLBufferObject const* bo = handle_cast<GLBufferObject*>(boh);
 
     if (UTILS_UNLIKELY(bo->bindingType == BufferObjectBinding::UNIFORM && gl.isES2())) {
         // nothing to do here
@@ -2885,12 +2884,12 @@ void OpenGLDriver::resetBufferObject(Handle<HwBufferObject> boh) {
 }
 
 void OpenGLDriver::update3DImage(Handle<HwTexture> th,
-        uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-        uint32_t width, uint32_t height, uint32_t depth,
+        uint32_t const level, uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& data) {
     DEBUG_MARKER()
 
-    GLTexture* t = handle_cast<GLTexture *>(th);
+    GLTexture const* t = handle_cast<GLTexture *>(th);
     if (data.type == PixelDataType::COMPRESSED) {
         setCompressedTextureData(t,
                 level, xoffset, yoffset, zoffset, width, height, depth, std::move(data));
@@ -2904,7 +2903,7 @@ void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    GLTexture* t = handle_cast<GLTexture *>(th);
+    GLTexture const* t = handle_cast<GLTexture *>(th);
 #if defined(BACKEND_OPENGL_LEVEL_GLES31)
     assert_invariant(t->gl.target != GL_TEXTURE_2D_MULTISAMPLE);
 #endif
@@ -2918,9 +2917,9 @@ void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     CHECK_GL_ERROR()
 }
 
-void OpenGLDriver::setTextureData(GLTexture const* t, uint32_t level,
-        uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-        uint32_t width, uint32_t height, uint32_t depth,
+void OpenGLDriver::setTextureData(GLTexture const* t, uint32_t const level,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& p) {
     auto& gl = mContext;
 
@@ -2937,7 +2936,7 @@ void OpenGLDriver::setTextureData(GLTexture const* t, uint32_t level,
     GLenum glFormat;
     GLenum glType;
     if (mContext.isES2()) {
-        auto formatAndType = textureFormatToFormatAndType(t->format);
+        auto const formatAndType = textureFormatToFormatAndType(t->format);
         glFormat = formatAndType.first;
         glType = formatAndType.second;
     } else {
@@ -3027,9 +3026,9 @@ void OpenGLDriver::setTextureData(GLTexture const* t, uint32_t level,
     CHECK_GL_ERROR()
 }
 
-void OpenGLDriver::setCompressedTextureData(GLTexture const* t, uint32_t level,
-        uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-        uint32_t width, uint32_t height, uint32_t depth,
+void OpenGLDriver::setCompressedTextureData(GLTexture const* t, uint32_t const level,
+        uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
+        uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& p) {
     auto& gl = mContext;
 
@@ -3122,7 +3121,7 @@ void OpenGLDriver::setupExternalImage(void* image) {
 }
 
 void OpenGLDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
-    auto& gl = mContext;
+    auto const& gl = mContext;
     if (gl.ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()
 
@@ -3164,12 +3163,12 @@ UTILS_NOINLINE
 void OpenGLDriver::detachStream(GLTexture* t) noexcept {
     auto& gl = mContext;
     auto& texturesWithStreamsAttached = mTexturesWithStreamsAttached;
-    auto pos = std::find(texturesWithStreamsAttached.begin(), texturesWithStreamsAttached.end(), t);
+    auto const pos = std::find(texturesWithStreamsAttached.begin(), texturesWithStreamsAttached.end(), t);
     if (pos != texturesWithStreamsAttached.end()) {
         texturesWithStreamsAttached.erase(pos);
     }
 
-    GLStream* s = static_cast<GLStream*>(t->hwStream); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+    GLStream const* s = static_cast<GLStream*>(t->hwStream); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     switch (s->streamType) {
         case StreamType::NATIVE:
             mPlatform.detach(t->hwStream->stream);
@@ -3198,7 +3197,7 @@ void OpenGLDriver::replaceStream(GLTexture* texture, GLStream* newStream) noexce
     // This could be implemented via detachStream + attachStream but inlining allows
     // a few small optimizations, like not touching the mExternalStreams list.
 
-    GLStream* oldStream = static_cast<GLStream*>(texture->hwStream); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+    GLStream const* oldStream = static_cast<GLStream*>(texture->hwStream); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     switch (oldStream->streamType) {
         case StreamType::NATIVE:
             mPlatform.detach(texture->hwStream->stream);
@@ -3245,7 +3244,7 @@ TimerQueryResult OpenGLDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint
 }
 
 void OpenGLDriver::compilePrograms(CompilerPriorityQueue,
-        CallbackHandler* handler, CallbackHandler::Callback callback, void* user) {
+        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user) {
     if (callback) {
         getShaderCompilerService().notifyWhenAllProgramsAreReady(handler, callback, user);
     }
@@ -3262,7 +3261,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     mRenderPassTarget = rth;
     mRenderPassParams = params;
 
-    GLRenderTarget* rt = handle_cast<GLRenderTarget*>(rth);
+    GLRenderTarget const* rt = handle_cast<GLRenderTarget*>(rth);
 
     // If we're rendering into the default render target (i.e. into the current SwapChain),
     // get the value of the output colorspace from there, otherwise it's always linear.
@@ -3281,8 +3280,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     if (gl.ext.EXT_discard_framebuffer
             && !gl.bugs.disable_invalidate_framebuffer) {
         AttachmentArray attachments; // NOLINT
-        GLsizei const attachmentCount = getAttachments(attachments, discardFlags, !fbo);
-        if (attachmentCount) {
+        if (GLsizei const attachmentCount = getAttachments(attachments, discardFlags, !fbo)) {
             gl.procs.invalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
         }
         CHECK_GL_ERROR()
@@ -3306,7 +3304,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
 
     if (any(clearFlags)) {
         clearWithRasterPipe(clearFlags,
-                params.clearColor, (GLfloat)params.clearDepth, (GLint)params.clearStencil);
+                params.clearColor, GLfloat(params.clearDepth), GLint(params.clearStencil));
     }
 
     // we need to reset those after we call clearWithRasterPipe()
@@ -3316,8 +3314,8 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
 
     static_assert(sizeof(GLsizei) >= sizeof(uint32_t));
     gl.viewport(params.viewport.left, params.viewport.bottom,
-            (GLsizei)std::min(uint32_t(std::numeric_limits<int32_t>::max()), params.viewport.width),
-            (GLsizei)std::min(uint32_t(std::numeric_limits<int32_t>::max()), params.viewport.height));
+            GLsizei(std::min(uint32_t(std::numeric_limits<int32_t>::max()), params.viewport.width)),
+            GLsizei(std::min(uint32_t(std::numeric_limits<int32_t>::max()), params.viewport.height)));
 
     gl.depthRange(params.depthRange.near, params.depthRange.far);
 
@@ -3368,8 +3366,7 @@ void OpenGLDriver::endRenderPass(int) {
             // we wouldn't have to bind the framebuffer if we had glInvalidateNamedFramebuffer()
             GLuint const fbo = gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
             AttachmentArray attachments; // NOLINT
-            GLsizei const attachmentCount = getAttachments(attachments, effectiveDiscardFlags, !fbo);
-            if (attachmentCount) {
+            if (GLsizei const attachmentCount = getAttachments(attachments, effectiveDiscardFlags, !fbo)) {
                 gl.procs.invalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
             }
            CHECK_GL_ERROR()
@@ -3391,8 +3388,8 @@ void OpenGLDriver::endRenderPass(int) {
 void OpenGLDriver::nextSubpass(int) {}
 
 
-void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
-        TargetBufferFlags discardFlags) noexcept {
+void OpenGLDriver::resolvePass(ResolveAction const action, GLRenderTarget const* rt,
+        TargetBufferFlags const discardFlags) noexcept {
 
     if (UTILS_UNLIKELY(getContext().isES2())) {
         // ES2 doesn't have manual resolve capabilities
@@ -3410,8 +3407,8 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         assert_invariant(!(rt->targets &
                 (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
 
-        GLint read = (GLint)rt->gl.fbo_read;
-        GLint draw = (GLint)rt->gl.fbo;
+        GLint read = GLint(rt->gl.fbo_read);
+        GLint draw = GLint(rt->gl.fbo);
         if (action == ResolveAction::STORE) {
             std::swap(read, draw);
         }
@@ -3422,15 +3419,15 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         CHECK_GL_FRAMEBUFFER_STATUS(GL_DRAW_FRAMEBUFFER)
 
         gl.disable(GL_SCISSOR_TEST);
-        glBlitFramebuffer(0, 0, (GLint)rt->width, (GLint)rt->height,
-                0, 0, (GLint)rt->width, (GLint)rt->height, mask, GL_NEAREST);
+        glBlitFramebuffer(0, 0, GLint(rt->width), GLint(rt->height),
+                0, 0, GLint(rt->width), GLint(rt->height), mask, GL_NEAREST);
         CHECK_GL_ERROR()
     }
 #endif
 }
 
 GLsizei OpenGLDriver::getAttachments(AttachmentArray& attachments,
-        TargetBufferFlags buffers, bool isDefaultFramebuffer) noexcept {
+        TargetBufferFlags const buffers, bool const isDefaultFramebuffer) noexcept {
     GLsizei attachmentCount = 0;
     // the default framebuffer uses different constants!!!
 
@@ -3502,7 +3499,7 @@ void OpenGLDriver::setScissor(Viewport const& scissor) noexcept {
 void OpenGLDriver::insertEventMarker(char const* string) {
 #ifndef __EMSCRIPTEN__
 #ifdef GL_EXT_debug_marker
-    auto& gl = mContext;
+    auto const& gl = mContext;
     if (gl.ext.EXT_debug_marker) {
         glInsertEventMarkerEXT(GLsizei(strlen(string)), string);
     }
@@ -3555,7 +3552,7 @@ void OpenGLDriver::stopCapture(int) {
 // ------------------------------------------------------------------------------------------------
 
 void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
-        uint32_t x, uint32_t y, uint32_t width, uint32_t height,
+        uint32_t const x, uint32_t const y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     DEBUG_MARKER()
     auto& gl = mContext;
@@ -3595,8 +3592,8 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
     using PBD = PixelBufferDescriptor;
 
     // The PBO only needs to accommodate the area we're reading, with alignment.
-    auto const pboSize = (GLsizeiptr)PBD::computeDataSize(
-            p.format, p.type, width, height, p.alignment);
+    auto const pboSize = GLsizeiptr(PBD::computeDataSize(
+            p.format, p.type, width, height, p.alignment));
 
     if (UTILS_UNLIKELY(gl.isES2())) {
         void* buffer = malloc(pboSize);
@@ -3609,10 +3606,10 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
             size_t const stride = p.stride ? p.stride : width;
             size_t const bpp = PBD::computeDataSize(p.format, p.type, 1, 1, 1);
             size_t const dstBpr = PBD::computeDataSize(p.format, p.type, stride, 1, p.alignment);
-            char* pDst = (char*)p.buffer + p.left * bpp + dstBpr * (p.top + height - 1);
+            char* pDst = static_cast<char*>(p.buffer) + p.left * bpp + dstBpr * (p.top + height - 1);
 
             size_t const srcBpr = PBD::computeDataSize(p.format, p.type, width, 1, p.alignment);
-            char const* pSrc = (char const*)buffer;
+            char const* pSrc = static_cast<char const*>(buffer);
             for (size_t i = 0; i < height; ++i) {
                 memcpy(pDst, pSrc, bpp * width);
                 pSrc += srcBpr;
@@ -3644,7 +3641,7 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         PixelBufferDescriptor& p = *pUserBuffer;
         auto& gl = mContext;
         gl.bindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
-        void* vaddr = nullptr;
+        void const* vaddr = nullptr;
 #if defined(__EMSCRIPTEN__)
         std::unique_ptr<uint8_t[]> clientBuffer = std::make_unique<uint8_t[]>(pboSize);
         glGetBufferSubData(GL_PIXEL_PACK_BUFFER, 0, pboSize, clientBuffer.get());
@@ -3657,10 +3654,10 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
             size_t const stride = p.stride ? p.stride : width;
             size_t const bpp = PBD::computeDataSize(p.format, p.type, 1, 1, 1);
             size_t const dstBpr = PBD::computeDataSize(p.format, p.type, stride, 1, p.alignment);
-            char* pDst = (char*)p.buffer + p.left * bpp + dstBpr * (p.top + height - 1);
+            char* pDst = static_cast<char*>(p.buffer) + p.left * bpp + dstBpr * (p.top + height - 1);
 
             size_t const srcBpr = PBD::computeDataSize(p.format, p.type, width, 1, p.alignment);
-            char const* pSrc = (char const*)vaddr;
+            char const* pSrc = static_cast<char const*>(vaddr);
 
             for (size_t i = 0; i < height; ++i) {
                 memcpy(pDst, pSrc, bpp * width);
@@ -3681,7 +3678,7 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
 }
 
 void OpenGLDriver::readBufferSubData(BufferObjectHandle boh,
-        uint32_t offset, uint32_t size, BufferDescriptor&& p) {
+        uint32_t const offset, uint32_t size, BufferDescriptor&& p) {
     UTILS_UNUSED_IN_RELEASE auto& gl = mContext;
     assert_invariant(!gl.isES2());
 
@@ -3708,8 +3705,7 @@ void OpenGLDriver::readBufferSubData(BufferObjectHandle boh,
             BufferDescriptor& p = *pUserBuffer;
             auto& gl = mContext;
             gl.bindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
-            void* vaddr = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, size, GL_MAP_READ_BIT);
-            if (vaddr) {
+            if (void const* vaddr = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, size, GL_MAP_READ_BIT)) {
                 memcpy(p.buffer, vaddr, size);
                 glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
             }
@@ -3723,8 +3719,7 @@ void OpenGLDriver::readBufferSubData(BufferObjectHandle boh,
         gl.bindBuffer(bo->gl.binding, bo->gl.id);
         // TODO: this glMapBufferRange may stall. Ideally we want to use whenGpuCommandsComplete
         //       but that's tricky because boh could be destroyed right after this call.
-        void* vaddr = glMapBufferRange(bo->gl.binding, offset, size, GL_MAP_READ_BIT);
-        if (vaddr) {
+        if (void const* vaddr = glMapBufferRange(bo->gl.binding, offset, size, GL_MAP_READ_BIT)) {
             memcpy(p.buffer, vaddr, size);
             glUnmapBuffer(bo->gl.binding);
         }
@@ -3806,9 +3801,9 @@ void OpenGLDriver::tick(int) {
 }
 
 void OpenGLDriver::beginFrame(
-        UTILS_UNUSED int64_t monotonic_clock_ns,
-        UTILS_UNUSED int64_t refreshIntervalNs,
-        UTILS_UNUSED uint32_t frameId) {
+        UTILS_UNUSED int64_t const monotonic_clock_ns,
+        UTILS_UNUSED int64_t const refreshIntervalNs,
+        UTILS_UNUSED uint32_t const frameId) {
     PROFILE_MARKER(PROFILE_NAME_BEGINFRAME)
     auto& gl = mContext;
     insertEventMarker("beginFrame");
@@ -3841,12 +3836,12 @@ void OpenGLDriver::setFrameCompletedCallback(Handle<HwSwapChain>,
     DEBUG_MARKER()
 }
 
-void OpenGLDriver::setPresentationTime(int64_t monotonic_clock_ns) {
+void OpenGLDriver::setPresentationTime(int64_t const monotonic_clock_ns) {
     DEBUG_MARKER()
     mPlatform.setPresentationTime(monotonic_clock_ns);
 }
 
-void OpenGLDriver::endFrame(UTILS_UNUSED uint32_t frameId) {
+void OpenGLDriver::endFrame(UTILS_UNUSED uint32_t const frameId) {
     PROFILE_MARKER(PROFILE_NAME_ENDFRAME)
 #if defined(__EMSCRIPTEN__)
     // WebGL builds are single-threaded so users might manipulate various GL state after we're
@@ -3869,9 +3864,9 @@ void OpenGLDriver::endFrame(UTILS_UNUSED uint32_t frameId) {
 
 void OpenGLDriver::updateDescriptorSetBuffer(
         DescriptorSetHandle dsh,
-        descriptor_binding_t binding,
+        descriptor_binding_t const binding,
         BufferObjectHandle boh,
-        uint32_t offset, uint32_t size) {
+        uint32_t const offset, uint32_t const size) {
     GLDescriptorSet* ds = handle_cast<GLDescriptorSet*>(dsh);
     GLBufferObject* bo = boh ? handle_cast<GLBufferObject*>(boh) : nullptr;
     ds->update(mContext, binding, bo, offset, size);
@@ -3879,16 +3874,16 @@ void OpenGLDriver::updateDescriptorSetBuffer(
 
 void OpenGLDriver::updateDescriptorSetTexture(
         DescriptorSetHandle dsh,
-        descriptor_binding_t binding,
+        descriptor_binding_t const binding,
         TextureHandle th,
-        SamplerParams params) {
+        SamplerParams const params) {
     GLDescriptorSet* ds = handle_cast<GLDescriptorSet*>(dsh);
     ds->update(mContext, mHandleAllocator, binding, th, params);
 }
 
 void OpenGLDriver::flush(int) {
     DEBUG_MARKER()
-    auto& gl = mContext;
+    auto const& gl = mContext;
     if (!gl.bugs.disable_glFlush) {
         glFlush();
     }
@@ -3911,8 +3906,8 @@ void OpenGLDriver::finish(int) {
 }
 
 UTILS_NOINLINE
-void OpenGLDriver::clearWithRasterPipe(TargetBufferFlags clearFlags,
-        float4 const& linearColor, GLfloat depth, GLint stencil) noexcept {
+void OpenGLDriver::clearWithRasterPipe(TargetBufferFlags const clearFlags,
+        float4 const& linearColor, GLfloat const depth, GLint const stencil) noexcept {
 
     if (any(clearFlags & TargetBufferFlags::COLOR_ALL)) {
         mContext.colorMask(GL_TRUE);
@@ -3985,8 +3980,8 @@ void OpenGLDriver::clearWithRasterPipe(TargetBufferFlags clearFlags,
 }
 
 void OpenGLDriver::resolve(
-        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
-        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
+        Handle<HwTexture> dst, uint8_t const srcLevel, uint8_t const srcLayer,
+        Handle<HwTexture> src, uint8_t const dstLevel, uint8_t const dstLayer) {
     DEBUG_MARKER()
     GLTexture const* const s = handle_cast<GLTexture*>(src);
     GLTexture const* const d = handle_cast<GLTexture*>(dst);
@@ -4005,17 +4000,17 @@ void OpenGLDriver::resolve(
 }
 
 void OpenGLDriver::blit(
-        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, uint2 dstOrigin,
-        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, uint2 srcOrigin,
-        uint2 size) {
+        Handle<HwTexture> dst, uint8_t const srcLevel, uint8_t const srcLayer, uint2 const dstOrigin,
+        Handle<HwTexture> src, uint8_t const dstLevel, uint8_t const dstLayer, uint2 const srcOrigin,
+        uint2 const size) {
     DEBUG_MARKER()
     UTILS_UNUSED_IN_RELEASE auto& gl = mContext;
     assert_invariant(!gl.isES2());
 
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
 
-    GLTexture* d = handle_cast<GLTexture*>(dst);
-    GLTexture* s = handle_cast<GLTexture*>(src);
+    GLTexture const* d = handle_cast<GLTexture*>(dst);
+    GLTexture const* s = handle_cast<GLTexture*>(src);
     assert_invariant(d);
     assert_invariant(s);
 
@@ -4035,7 +4030,7 @@ void OpenGLDriver::blit(
         DEPTH_STENCIL = GL_DEPTH_STENCIL_ATTACHMENT,
     };
 
-    auto getFormatType = [](TextureFormat format) -> AttachmentType {
+    auto getFormatType = [](TextureFormat const format) -> AttachmentType {
         bool const depth = isDepthFormat(format);
         bool const stencil = isStencilFormat(format);
         if (depth && stencil) return AttachmentType::DEPTH_STENCIL;
@@ -4122,8 +4117,8 @@ void OpenGLDriver::blit(
 
     gl.disable(GL_SCISSOR_TEST);
     glBlitFramebuffer(
-            srcOrigin.x, srcOrigin.y, srcOrigin.x + size.x, srcOrigin.y + size.y,
-            dstOrigin.x, dstOrigin.y, dstOrigin.x + size.x, dstOrigin.y + size.y,
+            GLint(srcOrigin.x), GLint(srcOrigin.y), GLint(srcOrigin.x + size.x), GLint(srcOrigin.y + size.y),
+            GLint(dstOrigin.x), GLint(dstOrigin.y), GLint(dstOrigin.x + size.x), GLint(dstOrigin.y + size.y),
             mask, GL_NEAREST);
     CHECK_GL_ERROR()
 
@@ -4133,10 +4128,10 @@ void OpenGLDriver::blit(
 #endif
 }
 
-void OpenGLDriver::blitDEPRECATED(TargetBufferFlags buffers,
-        Handle<HwRenderTarget> dst, Viewport dstRect,
-        Handle<HwRenderTarget> src, Viewport srcRect,
-        SamplerMagFilter filter) {
+void OpenGLDriver::blitDEPRECATED(TargetBufferFlags const buffers,
+        Handle<HwRenderTarget> dst, Viewport const dstRect,
+        Handle<HwRenderTarget> src, Viewport const srcRect,
+        SamplerMagFilter const filter) {
 
     // Note: blitDEPRECATED is only used by Renderer::copyFrame
 
@@ -4236,7 +4231,7 @@ void OpenGLDriver::bindRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 
 void OpenGLDriver::bindDescriptorSet(
         DescriptorSetHandle dsh,
-        descriptor_set_t set,
+        descriptor_set_t const set,
         DescriptorSetOffsetArray&& offsets) {
 
     if (UTILS_UNLIKELY(!dsh)) {
@@ -4247,8 +4242,7 @@ void OpenGLDriver::bindDescriptorSet(
     }
 
     // handle_cast<> here also serves to validate the handle (it actually cannot return nullptr)
-    GLDescriptorSet const* const ds = handle_cast<GLDescriptorSet*>(dsh);
-    if (ds) {
+    if (GLDescriptorSet const* const ds = handle_cast<GLDescriptorSet*>(dsh)) {
         assert_invariant(set < MAX_DESCRIPTOR_SET_COUNT);
         if (mBoundDescriptorSets[set].dsh != dsh) {
             // if the descriptor itself changed, we mark this descriptor binding
@@ -4269,17 +4263,17 @@ void OpenGLDriver::bindDescriptorSet(
     }
 }
 
-void OpenGLDriver::updateDescriptors(bitset8 invalidDescriptorSets) noexcept {
+void OpenGLDriver::updateDescriptors(bitset8 const invalidDescriptorSets) noexcept {
     assert_invariant(mBoundProgram);
     auto const offsetOnly = mInvalidDescriptorSetBindingOffsets & ~mInvalidDescriptorSetBindings;
     invalidDescriptorSets.forEachSetBit([this, offsetOnly,
             &boundDescriptorSets = mBoundDescriptorSets,
             &context = mContext,
-            &boundProgram = *mBoundProgram](size_t set) {
+            &boundProgram = *mBoundProgram](size_t const set) {
         assert_invariant(set < MAX_DESCRIPTOR_SET_COUNT);
         auto const& entry = boundDescriptorSets[set];
         if (entry.dsh) {
-            GLDescriptorSet* const ds = handle_cast<GLDescriptorSet*>(entry.dsh);
+            GLDescriptorSet const* const ds = handle_cast<GLDescriptorSet*>(entry.dsh);
 #ifndef NDEBUG
             if (UTILS_UNLIKELY(!offsetOnly[set])) {
                 // validate that this descriptor-set layout matches the layout set in the pipeline
@@ -4295,7 +4289,7 @@ void OpenGLDriver::updateDescriptors(bitset8 invalidDescriptorSets) noexcept {
     mInvalidDescriptorSetBindingOffsets.clear();
 }
 
-void OpenGLDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
+void OpenGLDriver::draw2(uint32_t const indexOffset, uint32_t const indexCount, uint32_t const instanceCount) {
     DEBUG_MARKER()
     assert_invariant(!mContext.isES2());
     assert_invariant(mBoundRenderPrimitive);
@@ -4316,10 +4310,10 @@ void OpenGLDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t ins
 
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     GLRenderPrimitive const* const rp = mBoundRenderPrimitive;
-    glDrawElementsInstanced(GLenum(rp->type), (GLsizei)indexCount,
+    glDrawElementsInstanced(GLenum(rp->type), GLsizei(indexCount),
             rp->gl.getIndicesType(),
             reinterpret_cast<const void*>(indexOffset << rp->gl.indicesShift),
-            (GLsizei)instanceCount);
+            GLsizei(instanceCount));
 #endif
 
 #if FILAMENT_ENABLE_MATDBG
@@ -4330,7 +4324,7 @@ void OpenGLDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t ins
 }
 
 // This is the ES2 version of draw2().
-void OpenGLDriver::draw2GLES2(uint32_t indexOffset, uint32_t indexCount, uint32_t instanceCount) {
+void OpenGLDriver::draw2GLES2(uint32_t const indexOffset, uint32_t const indexCount, uint32_t const instanceCount) {
     DEBUG_MARKER()
     assert_invariant(mContext.isES2());
     assert_invariant(mBoundRenderPrimitive);
@@ -4351,7 +4345,7 @@ void OpenGLDriver::draw2GLES2(uint32_t indexOffset, uint32_t indexCount, uint32_
 
     GLRenderPrimitive const* const rp = mBoundRenderPrimitive;
     assert_invariant(instanceCount == 1);
-    glDrawElements(GLenum(rp->type), (GLsizei)indexCount, rp->gl.getIndicesType(),
+    glDrawElements(GLenum(rp->type), GLsizei(indexCount), rp->gl.getIndicesType(),
             reinterpret_cast<const void*>(indexOffset << rp->gl.indicesShift));
 
 #if FILAMENT_ENABLE_MATDBG
@@ -4361,7 +4355,7 @@ void OpenGLDriver::draw2GLES2(uint32_t indexOffset, uint32_t indexCount, uint32_
 #endif
 }
 
-void OpenGLDriver::scissor(Viewport scissor) {
+void OpenGLDriver::scissor(Viewport const scissor) {
     DEBUG_MARKER()
     setScissor(scissor);
 }
@@ -4369,7 +4363,7 @@ void OpenGLDriver::scissor(Viewport scissor) {
 void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,
         uint32_t const indexOffset, uint32_t const indexCount, uint32_t const instanceCount) {
     DEBUG_MARKER()
-    GLRenderPrimitive* const rp = handle_cast<GLRenderPrimitive*>(rph);
+    GLRenderPrimitive const* const rp = handle_cast<GLRenderPrimitive*>(rph);
     state.primitiveType = rp->type;
     state.vertexBufferInfo = rp->vbih;
     bindPipeline(state);
@@ -4381,7 +4375,7 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph,
     }
 }
 
-void OpenGLDriver::dispatchCompute(Handle<HwProgram> program, uint3 workGroupCount) {
+void OpenGLDriver::dispatchCompute(Handle<HwProgram> program, uint3 const workGroupCount) {
     DEBUG_MARKER()
     getShaderCompilerService().tick();
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -655,7 +655,7 @@ void OpenGLDriver::createVertexBufferInfoR(
         uint8_t bufferCount,
         uint8_t attributeCount,
         AttributeArray attributes,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
     construct<GLVertexBufferInfo>(vbih, bufferCount, attributeCount, attributes);
     mHandleAllocator.associateTagToHandle(vbih.getId(), std::move(tag));
@@ -665,7 +665,7 @@ void OpenGLDriver::createVertexBufferR(
         Handle<HwVertexBuffer> vbh,
         uint32_t vertexCount,
         Handle<HwVertexBufferInfo> vbih,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
     construct<GLVertexBuffer>(vbh, vertexCount, vbih);
     mHandleAllocator.associateTagToHandle(vbh.getId(), std::move(tag));
@@ -676,7 +676,7 @@ void OpenGLDriver::createIndexBufferR(
         ElementType const elementType,
         uint32_t indexCount,
         BufferUsage const usage,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
@@ -692,7 +692,7 @@ void OpenGLDriver::createIndexBufferR(
 }
 
 void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, CString tag) {
+        BufferObjectBinding bindingType, BufferUsage usage, CString&& tag) {
     DEBUG_MARKER()
     assert_invariant(byteCount > 0);
 
@@ -719,7 +719,7 @@ void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byte
 
 void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        PrimitiveType const pt, CString tag) {
+        PrimitiveType const pt, CString&& tag) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
@@ -755,7 +755,7 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
     mHandleAllocator.associateTagToHandle(rph.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, CString tag) {
+void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, CString&& tag) {
     DEBUG_MARKER()
 
 
@@ -888,7 +888,7 @@ void OpenGLDriver::textureStorage(GLTexture* t,
 
 void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
-        TextureUsage usage, CString tag) {
+        TextureUsage usage, CString&& tag) {
     DEBUG_MARKER()
 
     GLenum internalFormat = getInternalFormat(format);
@@ -981,7 +981,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 }
 
 void OpenGLDriver::createTextureViewR(Handle<HwTexture> th,
-        Handle<HwTexture> srch, uint8_t const baseLevel, uint8_t const levelCount, CString tag) {
+        Handle<HwTexture> srch, uint8_t const baseLevel, uint8_t const levelCount, CString&& tag) {
     DEBUG_MARKER()
     GLTexture const* const src = handle_cast<GLTexture const*>(srch);
 
@@ -1029,7 +1029,7 @@ void OpenGLDriver::createTextureViewR(Handle<HwTexture> th,
 
 void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTexture> srch,
         TextureSwizzle const r, TextureSwizzle const g, TextureSwizzle const b, TextureSwizzle const a,
-        CString tag) {
+        CString&& tag) {
 
     DEBUG_MARKER()
     GLTexture const* const src = handle_cast<GLTexture const*>(srch);
@@ -1095,7 +1095,7 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 
 void OpenGLDriver::createTextureExternalImage2R(Handle<HwTexture> th, SamplerType target,
     TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage,
-    Platform::ExternalImageHandleRef image, CString tag) {
+    Platform::ExternalImageHandleRef image, CString&& tag) {
     DEBUG_MARKER()
 
     usage |= TextureUsage::SAMPLEABLE;
@@ -1147,7 +1147,7 @@ void OpenGLDriver::createTextureExternalImage2R(Handle<HwTexture> th, SamplerTyp
 
 void OpenGLDriver::createTextureExternalImageR(Handle<HwTexture> th, SamplerType target,
         TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage, void* image,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
 
     usage |= TextureUsage::SAMPLEABLE;
@@ -1198,13 +1198,13 @@ void OpenGLDriver::createTextureExternalImageR(Handle<HwTexture> th, SamplerType
 
 void OpenGLDriver::createTextureExternalImagePlaneR(Handle<HwTexture> th,
         TextureFormat format, uint32_t width, uint32_t height, TextureUsage usage,
-        void* image, uint32_t plane, CString tag) {
+        void* image, uint32_t plane, CString&&) {
     // not relevant for the OpenGL backend
 }
 
 void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t const id,
         SamplerType target, uint8_t levels, TextureFormat format, uint8_t samples,
-        uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage, CString tag) {
+        uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage, CString&& tag) {
     DEBUG_MARKER()
 
     auto const& gl = mContext;
@@ -1659,7 +1659,7 @@ void OpenGLDriver::renderBufferStorage(GLuint const rbo, GLenum internalformat, 
 }
 
 void OpenGLDriver::createDefaultRenderTargetR(
-        Handle<HwRenderTarget> rth, CString tag) {
+        Handle<HwRenderTarget> rth, CString&& tag) {
     DEBUG_MARKER()
 
     construct<GLRenderTarget>(rth, 0, 0);  // FIXME: we don't know the width/height
@@ -1682,7 +1682,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         MRT color,
         TargetBufferInfo depth,
         TargetBufferInfo stencil,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
 
     GLRenderTarget* rt = construct<GLRenderTarget>(rth, width, height);
@@ -1798,7 +1798,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     mHandleAllocator.associateTagToHandle(rth.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createFenceR(Handle<HwFence> fh, CString tag) {
+void OpenGLDriver::createFenceR(Handle<HwFence> fh, CString&& tag) {
     DEBUG_MARKER()
 
     GLFence* f = handle_cast<GLFence*>(fh);
@@ -1822,7 +1822,7 @@ void OpenGLDriver::createFenceR(Handle<HwFence> fh, CString tag) {
     mHandleAllocator.associateTagToHandle(fh.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createSyncR(Handle<HwSync> sh, CString tag) {
+void OpenGLDriver::createSyncR(Handle<HwSync> sh, CString&& tag) {
     DEBUG_MARKER()
 
     GLSyncFence* s = handle_cast<GLSyncFence*>(sh);
@@ -1841,7 +1841,7 @@ void OpenGLDriver::createSyncR(Handle<HwSync> sh, CString tag) {
 }
 
 void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t const flags,
-        CString tag) {
+        CString&& tag) {
     DEBUG_MARKER()
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
@@ -1863,7 +1863,7 @@ void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 }
 
 void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
-        uint32_t const width, uint32_t const height, uint64_t const flags, CString tag) {
+        uint32_t const width, uint32_t const height, uint64_t const flags, CString&& tag) {
     DEBUG_MARKER()
 
     GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
@@ -1885,7 +1885,7 @@ void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
     mHandleAllocator.associateTagToHandle(sch.getId(), std::move(tag));
 }
 
-void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, CString tag) {
+void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, CString&& tag) {
     DEBUG_MARKER()
     GLTimerQuery* tq = handle_cast<GLTimerQuery*>(tqh);
     mContext.createTimerQuery(tq);
@@ -1893,14 +1893,14 @@ void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, CString tag) {
 }
 
 void OpenGLDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh,
-        DescriptorSetLayout&& info, CString tag) {
+        DescriptorSetLayout&& info, CString&& tag) {
     DEBUG_MARKER()
     construct<GLDescriptorSetLayout>(dslh, std::move(info));
     mHandleAllocator.associateTagToHandle(dslh.getId(), std::move(tag));
 }
 
 void OpenGLDriver::createDescriptorSetR(Handle<HwDescriptorSet> dsh,
-        Handle<HwDescriptorSetLayout> dslh, CString tag) {
+        Handle<HwDescriptorSetLayout> dslh, CString&& tag) {
     DEBUG_MARKER()
     GLDescriptorSetLayout const* dsl = handle_cast<GLDescriptorSetLayout*>(dslh);
     construct<GLDescriptorSet>(dsh, mContext, dslh, dsl);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -502,7 +502,7 @@ void VulkanDriver::finish(int dummy) {
 
 void VulkanDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        PrimitiveType pt, utils::CString tag) {
+        PrimitiveType pt, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto vb = resource_ptr<VulkanVertexBuffer>::cast(&mResourceManager, vbh);
     auto ib = resource_ptr<VulkanIndexBuffer>::cast(&mResourceManager, ibh);
@@ -521,7 +521,7 @@ void VulkanDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 }
 
 void VulkanDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vbih, uint8_t bufferCount,
-        uint8_t attributeCount, AttributeArray attributes, utils::CString tag) {
+        uint8_t attributeCount, AttributeArray attributes, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto vbi = resource_ptr<VulkanVertexBufferInfo>::make(&mResourceManager, vbih, bufferCount,
             attributeCount, attributes);
@@ -539,7 +539,7 @@ void VulkanDriver::destroyVertexBufferInfo(Handle<HwVertexBufferInfo> vbih) {
 }
 
 void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint32_t vertexCount,
-        Handle<HwVertexBufferInfo> vbih, utils::CString tag) {
+        Handle<HwVertexBufferInfo> vbih, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto vbi = resource_ptr<VulkanVertexBufferInfo>::cast(&mResourceManager, vbih);
     auto vb = resource_ptr<VulkanVertexBuffer>::make(&mResourceManager, vbh, mContext, mStagePool,
@@ -558,7 +558,7 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 }
 
 void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, utils::CString tag) {
+        uint32_t indexCount, BufferUsage usage, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto ib = resource_ptr<VulkanIndexBuffer>::make(&mResourceManager, ibh, mContext, mAllocator,
@@ -577,7 +577,7 @@ void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
 }
 
 void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, utils::CString tag) {
+        BufferObjectBinding bindingType, BufferUsage usage, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto bo = resource_ptr<VulkanBufferObject>::make(&mResourceManager, boh, mContext, mAllocator,
             mStagePool, mBufferCache, byteCount, bindingType);
@@ -596,7 +596,7 @@ void VulkanDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
 
 void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
-        TextureUsage usage, utils::CString tag) {
+        TextureUsage usage, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mPlatform->getDevice(),
             mPlatform->getPhysicalDevice(), mContext, mAllocator, &mResourceManager, &mCommands,
@@ -613,7 +613,7 @@ void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 }
 
 void VulkanDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> srch,
-        uint8_t baseLevel, uint8_t levelCount, utils::CString tag) {
+        uint8_t baseLevel, uint8_t levelCount, utils::CString&& tag) {
     auto src = resource_ptr<VulkanTexture>::cast(&mResourceManager, srch);
     auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mPlatform->getDevice(),
             mPlatform->getPhysicalDevice(), mContext, mAllocator, &mCommands, src, baseLevel,
@@ -624,7 +624,7 @@ void VulkanDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> sr
 
 void VulkanDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTexture> srch,
         backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
-        backend::TextureSwizzle a, utils::CString tag) {
+        backend::TextureSwizzle a, utils::CString&& tag) {
     TextureSwizzle const swizzleArray[] = { r, g, b, a };
     VkComponentMapping const swizzle = fvkutils::getSwizzleMap(swizzleArray);
     auto src = resource_ptr<VulkanTexture>::cast(&mResourceManager, srch);
@@ -636,7 +636,7 @@ void VulkanDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 
 void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::SamplerType target,
         backend::TextureFormat format, uint32_t width, uint32_t height, backend::TextureUsage usage,
-        Platform::ExternalImageHandleRef externalImage, utils::CString tag) {
+        Platform::ExternalImageHandleRef externalImage, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto metadata = mPlatform->extractExternalImageMetadata(externalImage);
 
@@ -687,7 +687,7 @@ void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::S
 
 void VulkanDriver::createTextureExternalImageR(Handle<HwTexture> th, backend::SamplerType target,
         backend::TextureFormat format, uint32_t width, uint32_t height, backend::TextureUsage usage,
-        void* externalImage, utils::CString tag) {
+        void* externalImage, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     assert_invariant(false && "Not supported in Vulkan backend");
     // not supported in this backend
@@ -695,14 +695,14 @@ void VulkanDriver::createTextureExternalImageR(Handle<HwTexture> th, backend::Sa
 
 void VulkanDriver::createTextureExternalImagePlaneR(Handle<HwTexture> th,
         backend::TextureFormat format, uint32_t width, uint32_t height, backend::TextureUsage usage,
-        void* image, uint32_t plane, utils::CString tag) {
+        void* image, uint32_t plane, utils::CString&& tag) {
     assert_invariant(false && "Not supported in Vulkan backend");
 }
 
 void VulkanDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
         SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
-        TextureUsage usage, utils::CString tag) {
+        TextureUsage usage, utils::CString&& tag) {
     // not supported in this backend
     assert_invariant(false && "Not supported in Vulkan backend");
     mResourceManager.associateHandle(th.getId(), std::move(tag));
@@ -718,7 +718,7 @@ void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
     mExternalImageManager.removeExternallySampledTexture(texture);
 }
 
-void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils::CString tag) {
+void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto vprogram = resource_ptr<VulkanProgram>::make(&mResourceManager, ph, mPlatform->getDevice(),
             program);
@@ -734,7 +734,7 @@ void VulkanDriver::destroyProgram(Handle<HwProgram> ph) {
     vprogram.dec();
 }
 
-void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils::CString tag) {
+void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils::CString&& tag) {
     assert_invariant(mDefaultRenderTarget); // Default render target should already exist.
 
     auto renderTarget = resource_ptr<VulkanRenderTarget>::make(&mResourceManager, rth,
@@ -747,7 +747,7 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, utils:
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
         uint8_t layerCount, MRT color, TargetBufferInfo depth, TargetBufferInfo stencil,
-        utils::CString tag) {
+        utils::CString&& tag) {
 
     FVK_SYSTRACE_SCOPE();
 
@@ -824,7 +824,7 @@ void VulkanDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     }
 }
 
-void VulkanDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
+void VulkanDriver::createFenceR(Handle<HwFence> fh, utils::CString&& tag) {
     VulkanCommandBuffer* cmdbuf;
     if (mCurrentRenderPass.commandBuffer) {
         cmdbuf = mCurrentRenderPass.commandBuffer;
@@ -839,7 +839,7 @@ void VulkanDriver::createFenceR(Handle<HwFence> fh, utils::CString tag) {
     mResourceManager.associateHandle(fh.getId(), std::move(tag));
 }
 
-void VulkanDriver::createSyncR(Handle<HwSync> sh, utils::CString tag) {
+void VulkanDriver::createSyncR(Handle<HwSync> sh, utils::CString&& tag) {
     auto sync = resource_ptr<VulkanSync>::cast(&mResourceManager, sh);
     VkFence fence = VK_NULL_HANDLE;
     std::shared_ptr<VulkanCmdFence> fenceStatus;
@@ -870,7 +870,7 @@ void VulkanDriver::createSyncR(Handle<HwSync> sh, utils::CString tag) {
 }
 
 void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     // Running gc() to guard against an edge case where the old swapchains need to have been
     // destroyed before the new swapchain can be created. Otherwise, we would fail
@@ -899,7 +899,7 @@ void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 }
 
 void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t width,
-        uint32_t height, uint64_t flags, utils::CString tag) {
+        uint32_t height, uint64_t flags, utils::CString&& tag) {
     if ((flags & backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE) != 0 && !isSRGBSwapChainSupported()) {
         FVK_LOGW << "sRGB swapchain requested, but Platform does not support it";
         flags = flags | ~(backend::SWAP_CHAIN_CONFIG_SRGB_COLORSPACE);
@@ -912,13 +912,13 @@ void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t wi
     mResourceManager.associateHandle(sch.getId(), std::move(tag));
 }
 
-void VulkanDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString tag) {
+void VulkanDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString&& tag) {
     // nothing to do, timer query was constructed in createTimerQueryS
     mResourceManager.associateHandle(tqh.getId(), std::move(tag));
 }
 
 void VulkanDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh,
-        backend::DescriptorSetLayout&& info, utils::CString tag) {
+        backend::DescriptorSetLayout&& info, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     auto layout = mDescriptorSetLayoutCache.createLayout(dslh, std::move(info));
     layout.inc();
@@ -926,7 +926,7 @@ void VulkanDriver::createDescriptorSetLayoutR(Handle<HwDescriptorSetLayout> dslh
 }
 
 void VulkanDriver::createDescriptorSetR(Handle<HwDescriptorSet> dsh,
-        Handle<HwDescriptorSetLayout> dslh, utils::CString tag) {
+        Handle<HwDescriptorSetLayout> dslh, utils::CString&& tag) {
     FVK_SYSTRACE_SCOPE();
     fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout =
             fvkmemory::resource_ptr<VulkanDescriptorSetLayout>::cast(&mResourceManager, dslh);

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -450,7 +450,7 @@ Handle<HwTexture> WebGPUDriver::createTextureExternalImagePlaneS() noexcept {
 // ------------------------------------------------------------------------------------------------
 
 void WebGPUDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
-        const uint64_t flags, utils::CString tag) {
+        const uint64_t flags, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
 
     // TODO: support MSAA swapchain
@@ -480,7 +480,7 @@ void WebGPUDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
 }
 
 void WebGPUDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t width,
-        uint32_t height, uint64_t flags, utils::CString tag) {
+        uint32_t height, uint64_t flags, utils::CString&& tag) {
      wgpu::Extent2D extent = { .width = width, .height = height };
      mSwapChain = constructHandle<WebGPUSwapChain>(sch, extent, mAdapter,
             mDevice, flags);
@@ -493,7 +493,7 @@ void WebGPUDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch, uint32_t wi
 
 void WebGPUDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
         const uint8_t bufferCount, const uint8_t attributeCount, const AttributeArray attributes,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPUVertexBufferInfo>(vertexBufferInfoHandle, bufferCount, attributeCount,
             attributes, mDeviceLimits);
@@ -502,7 +502,7 @@ void WebGPUDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vertexBuff
 
 void WebGPUDriver::createVertexBufferR(Handle<HwVertexBuffer> vertexBufferHandle,
         const uint32_t vertexCount, Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     const auto vertexBufferInfo = handleCast<WebGPUVertexBufferInfo>(vertexBufferInfoHandle);
     constructHandle<WebGPUVertexBuffer>(vertexBufferHandle, vertexCount,
@@ -512,7 +512,7 @@ void WebGPUDriver::createVertexBufferR(Handle<HwVertexBuffer> vertexBufferHandle
 
 void WebGPUDriver::createIndexBufferR(Handle<HwIndexBuffer> indexBufferHandle,
         const ElementType elementType, const uint32_t indexCount, const BufferUsage usage,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     const auto elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     constructHandle<WebGPUIndexBuffer>(indexBufferHandle, mDevice, elementSize, indexCount);
@@ -521,7 +521,7 @@ void WebGPUDriver::createIndexBufferR(Handle<HwIndexBuffer> indexBufferHandle,
 
 void WebGPUDriver::createBufferObjectR(Handle<HwBufferObject> bufferObjectHandle,
         const uint32_t byteCount, const BufferObjectBinding bindingType, const BufferUsage usage,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPUBufferObject>(bufferObjectHandle, mDevice, bindingType, byteCount);
     setDebugTag(bufferObjectHandle.getId(), std::move(tag));
@@ -530,7 +530,7 @@ void WebGPUDriver::createBufferObjectR(Handle<HwBufferObject> bufferObjectHandle
 void WebGPUDriver::createTextureR(Handle<HwTexture> textureHandle, const SamplerType target,
         const uint8_t levels, const TextureFormat format, const uint8_t samples,
         const uint32_t width, const uint32_t height, const uint32_t depth,
-        const TextureUsage usage, utils::CString tag) {
+        const TextureUsage usage, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPUTexture>(textureHandle, target, levels, format, samples, width, height,
             depth, usage, mDevice);
@@ -539,7 +539,7 @@ void WebGPUDriver::createTextureR(Handle<HwTexture> textureHandle, const Sampler
 
 void WebGPUDriver::createTextureViewR(Handle<HwTexture> textureHandle,
         Handle<HwTexture> sourceTextureHandle, const uint8_t baseLevel, const uint8_t levelCount,
-        utils::CString tag) {
+        utils::CString&& tag) {
     auto source = handleCast<WebGPUTexture>(sourceTextureHandle);
 
     constructHandle<WebGPUTexture>(textureHandle, source, baseLevel, levelCount);
@@ -550,7 +550,7 @@ void WebGPUDriver::createTextureViewR(Handle<HwTexture> textureHandle,
 void WebGPUDriver::createTextureViewSwizzleR(Handle<HwTexture> textureHandle,
         Handle<HwTexture> sourceTextureHandle, const backend::TextureSwizzle r,
         const backend::TextureSwizzle g, const backend::TextureSwizzle b,
-        const backend::TextureSwizzle a, utils::CString tag) {
+        const backend::TextureSwizzle a, utils::CString&& tag) {
 
     if (!isTextureSwizzleSupported()) {
         FWGPU_LOGW << "WebGPUDriver::createTextureViewSwizzleR called while texture swizzling is "
@@ -577,7 +577,7 @@ void WebGPUDriver::createTextureViewSwizzleR(Handle<HwTexture> textureHandle,
 void WebGPUDriver::createTextureExternalImage2R(Handle<HwTexture> textureHandle,
         const backend::SamplerType target, const backend::TextureFormat format,
         const uint32_t width, const uint32_t height, const backend::TextureUsage usage,
-        Platform::ExternalImageHandleRef externalImage, utils::CString tag) {
+        Platform::ExternalImageHandleRef externalImage, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     PANIC_POSTCONDITION("External WebGPU Texture is not supported");
 }
@@ -585,27 +585,27 @@ void WebGPUDriver::createTextureExternalImage2R(Handle<HwTexture> textureHandle,
 void WebGPUDriver::createTextureExternalImageR(Handle<HwTexture> textureHandle,
         const backend::SamplerType target, const backend::TextureFormat format,
         const uint32_t width, const uint32_t height, const backend::TextureUsage usage,
-        void* externalImage, utils::CString tag) {
+        void* externalImage, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     PANIC_POSTCONDITION("External WebGPU Texture is not supported");
 }
 
 void WebGPUDriver::createTextureExternalImagePlaneR(Handle<HwTexture> textureHandle,
         const backend::TextureFormat format, const uint32_t width, const uint32_t height,
-        const backend::TextureUsage usage, void* image, const uint32_t plane, utils::CString tag) {
+        const backend::TextureUsage usage, void* image, const uint32_t plane, utils::CString&& tag) {
     PANIC_POSTCONDITION("External WebGPU Texture is not supported");
 }
 
 void WebGPUDriver::importTextureR(Handle<HwTexture> textureHandle, const intptr_t id,
         const SamplerType target, const uint8_t levels, const TextureFormat format,
         const uint8_t samples, const uint32_t width, const uint32_t height, const uint32_t depth,
-        const TextureUsage usage, utils::CString tag) {
+        const TextureUsage usage, utils::CString&& tag) {
     PANIC_POSTCONDITION("Import WebGPU Texture is not supported");
 }
 
 void WebGPUDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> renderPrimitiveHandle,
         Handle<HwVertexBuffer> vertexBufferHandle, Handle<HwIndexBuffer> indexBufferHandle,
-        const PrimitiveType primitiveType, utils::CString tag) {
+        const PrimitiveType primitiveType, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     assert_invariant(mDevice);
     const auto renderPrimitive = constructHandle<WebGPURenderPrimitive>(renderPrimitiveHandle);
@@ -618,14 +618,14 @@ void WebGPUDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> renderPrimit
 }
 
 void WebGPUDriver::createProgramR(Handle<HwProgram> programHandle, Program&& program,
-        utils::CString tag) {
+        utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPUProgram>(programHandle, mDevice, program);
     setDebugTag(programHandle.getId(), std::move(tag));
 }
 
 void WebGPUDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> renderTargetHandle,
-        utils::CString tag) {
+        utils::CString&& tag) {
     assert_invariant(!mDefaultRenderTarget);
     mDefaultRenderTarget = constructHandle<WebGPURenderTarget>(renderTargetHandle);
     assert_invariant(mDefaultRenderTarget);
@@ -638,7 +638,7 @@ void WebGPUDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> renderTarge
 void WebGPUDriver::createRenderTargetR(Handle<HwRenderTarget> renderTargetHandle,
         const TargetBufferFlags targetFlags, const uint32_t width, const uint32_t height,
         const uint8_t samples, const uint8_t layerCount, const MRT color,
-        const TargetBufferInfo depth, const TargetBufferInfo stencil, utils::CString tag) {
+        const TargetBufferInfo depth, const TargetBufferInfo stencil, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPURenderTarget>(
             renderTargetHandle, width, height, samples, layerCount, color, depth, stencil,
@@ -650,7 +650,7 @@ void WebGPUDriver::createRenderTargetR(Handle<HwRenderTarget> renderTargetHandle
     setDebugTag(renderTargetHandle.getId(), std::move(tag));
 }
 
-void WebGPUDriver::createFenceR(Handle<HwFence> fenceHandle, utils::CString tag) {
+void WebGPUDriver::createFenceR(Handle<HwFence> fenceHandle, utils::CString&& tag) {
     // The handle is constructed synchronously in createFenceS.
     const auto fence = handleCast<WebGPUFence>(fenceHandle);
     assert_invariant(mQueue);
@@ -658,24 +658,24 @@ void WebGPUDriver::createFenceR(Handle<HwFence> fenceHandle, utils::CString tag)
     setDebugTag(fenceHandle.getId(), std::move(tag));
 }
 
-void WebGPUDriver::createSyncR(Handle<HwSync> syncHandle, utils::CString tag) {
+void WebGPUDriver::createSyncR(Handle<HwSync> syncHandle, utils::CString&& tag) {
     // TODO: Ensure sync is active, and then invoke and clear all pending
     // callbacks.
     setDebugTag(syncHandle.getId(), std::move(tag));
 }
 
-void WebGPUDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString tag) {}
+void WebGPUDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, utils::CString&& tag) {}
 
 void WebGPUDriver::createDescriptorSetLayoutR(
         Handle<HwDescriptorSetLayout> descriptorSetLayoutHandle,
-        backend::DescriptorSetLayout&& info, utils::CString tag) {
+        backend::DescriptorSetLayout&& info, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     constructHandle<WebGPUDescriptorSetLayout>(descriptorSetLayoutHandle, std::move(info), mDevice);
     setDebugTag(descriptorSetLayoutHandle.getId(), std::move(tag));
 }
 
 void WebGPUDriver::createDescriptorSetR(Handle<HwDescriptorSet> descriptorSetHandle,
-        Handle<HwDescriptorSetLayout> descriptorSetLayoutHandle, utils::CString tag) {
+        Handle<HwDescriptorSetLayout> descriptorSetLayoutHandle, utils::CString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
     auto layout = handleCast<WebGPUDescriptorSetLayout>(descriptorSetLayoutHandle);
     constructHandle<WebGPUDescriptorSet>(descriptorSetHandle, layout->getLayout(),
@@ -2091,7 +2091,7 @@ void WebGPUDriver::bindDescriptorSet(Handle<HwDescriptorSet> descriptorSetHandle
         .offsets = std::move(offsets) };
 }
 
-void WebGPUDriver::setDebugTag(HandleBase::HandleId handleId, utils::CString tag) {
+void WebGPUDriver::setDebugTag(HandleBase::HandleId handleId, utils::CString&& tag) {
     //todo
 }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -68,7 +68,7 @@ private:
     [[nodiscard]] ShaderLanguage getShaderLanguage() const noexcept final;
     [[nodiscard]] wgpu::Sampler makeSampler(SamplerParams const& params);
     [[nodiscard]] static wgpu::AddressMode fWrapModeToWAddressMode(const filament::backend::SamplerWrapMode& fUsage);
-    void setDebugTag(HandleBase::HandleId handleId, utils::CString tag);
+    void setDebugTag(HandleBase::HandleId handleId, utils::CString&& tag);
 
     // The platform (e.g. OS) specific aspects of the WebGPU backend are strictly only
     // handled in the WebGPUPlatform.

--- a/filament/src/details/BufferObject.cpp
+++ b/filament/src/details/BufferObject.cpp
@@ -76,7 +76,7 @@ FBufferObject::FBufferObject(FEngine& engine, const Builder& builder)
         : mByteCount(builder->mByteCount), mBindingType(builder->mBindingType) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType,
-            backend::BufferUsage::STATIC, builder.getName());
+            backend::BufferUsage::STATIC, utils::CString{ builder.getName() });
 }
 
 void FBufferObject::terminate(FEngine& engine) {

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -686,7 +686,7 @@ void FMaterial::createAndCacheProgram(Program&& p, Variant const variant) const 
         }
     }
 
-    auto const program = driverApi.createProgram(std::move(p), mName);
+    auto const program = driverApi.createProgram(std::move(p), CString{ mName });
     assert_invariant(program);
     mCachedPrograms[variant.key] = program;
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -81,7 +81,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material,
     size_t const uboSize = std::max(size_t(16), material->getUniformInterfaceBlock().getSize());
     mUniforms = UniformBuffer(uboSize);
     mUbHandle = driver.createBufferObject(mUniforms.getSize(), BufferObjectBinding::UNIFORM,
-            BufferUsage::STATIC, material->getName());
+            BufferUsage::STATIC, utils::CString{ material->getName() });
 
     // set the UBO, always descriptor 0
     mDescriptorSet.setBuffer(material->getDescriptorSetLayout(),
@@ -148,7 +148,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
 
     mUniforms.setUniforms(other->getUniformBuffer());
     mUbHandle = driver.createBufferObject(mUniforms.getSize(), BufferObjectBinding::UNIFORM,
-            BufferUsage::DYNAMIC, material->getName());
+            BufferUsage::DYNAMIC, CString{ material->getName() });
 
     // set the UBO, always descriptor 0
     mDescriptorSet.setBuffer(mMaterial->getDescriptorSetLayout(),

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -128,7 +128,7 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
             getHeight(mVertexCount),
             mCount,
             TextureUsage::DEFAULT,
-            builder.getName());
+            utils::CString{ builder.getName() });
 
     mTbHandle = driver.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
             TextureFormat::RGBA16I, 1,
@@ -136,7 +136,7 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
             getHeight(mVertexCount),
             mCount,
             TextureUsage::DEFAULT,
-            builder.getName());
+            utils::CString{ builder.getName() });
 }
 
 void FMorphTargetBuffer::terminate(FEngine& engine) {

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -221,7 +221,7 @@ FRenderTarget::FRenderTarget(FEngine& engine, const Builder& builder)
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createRenderTarget(mAttachmentMask,
             builder.mImpl->mWidth, builder.mImpl->mHeight, builder.mImpl->mSamples,
-            builder.mImpl->mLayerCount, mrt, dinfo, {}, builder.getName());
+            builder.mImpl->mLayerCount, mrt, dinfo, {}, utils::CString{ builder.getName() });
 }
 
 void FRenderTarget::terminate(FEngine& engine) {

--- a/filament/src/details/SkinningBuffer.cpp
+++ b/filament/src/details/SkinningBuffer.cpp
@@ -91,7 +91,7 @@ FSkinningBuffer::FSkinningBuffer(FEngine& engine, const Builder& builder)
             getPhysicalBoneCount(mBoneCount) * sizeof(PerRenderableBoneUib::BoneData),
             BufferObjectBinding::UNIFORM,
             BufferUsage::DYNAMIC,
-            builder.getName());
+            utils::CString{ builder.getName() });
 
     if (builder->mInitialize) {
         // initialize the bones to identity (before rounding up)

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -313,7 +313,7 @@ FTexture::FTexture(FEngine& engine, const Builder& builder)
         return;
     }
 
-    auto tag = builder.getName();
+    CString tag{ builder.getName() };
     if (tag.empty()) {
         tag = CString{"FTexture"};
     }

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -280,7 +280,8 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const Builder& builder)
     mVertexBufferInfoHandle = engine.getVertexBufferInfoFactory().create(driver,
             mBufferCount, mDeclaredAttributes.count(), mAttributes);
 
-    mHandle = driver.createVertexBuffer(mVertexCount, mVertexBufferInfoHandle, builder.getName());
+    mHandle = driver.createVertexBuffer(mVertexCount, mVertexBufferInfoHandle,
+            utils::CString{ builder.getName() });
 
     // calculate buffer sizes
     size_t bufferSizes[MAX_VERTEX_BUFFER_COUNT] = {};
@@ -307,7 +308,8 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const Builder& builder)
                 assert_invariant(bufferSizes[i] > 0);
                 if (!mBufferObjects[i]) {
                     BufferObjectHandle const bo = driver.createBufferObject(bufferSizes[i],
-                            BufferObjectBinding::VERTEX, BufferUsage::STATIC, builder.getName());
+                            BufferObjectBinding::VERTEX, BufferUsage::STATIC,
+                            utils::CString{ builder.getName() });
                     driver.setVertexBufferObject(mHandle, i, bo);
                     mBufferObjects[i] = bo;
                 }
@@ -323,7 +325,8 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const Builder& builder)
                 assert_invariant(bufferSizes[i] > 0);
                 if (!mBufferObjects[i]) {
                     BufferObjectHandle const bo = driver.createBufferObject(bufferSizes[i],
-                            BufferObjectBinding::VERTEX, BufferUsage::STATIC, builder.getName());
+                            BufferObjectBinding::VERTEX, BufferUsage::STATIC,
+                            utils::CString{ builder.getName() });
                     driver.setVertexBufferObject(mHandle, i, bo);
                     mBufferObjects[i] = bo;
                 }


### PR DESCRIPTION
This saves a CString copy on the backend side and this forces the
frontend to make a copy explicitly.

In theory the CString should now ever be copied just once.