### PR TITLE
Cache isMSAASwapChainSupported() result for EGL

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -28,6 +28,7 @@
 #include <utils/Invocable.h>
 
 #include <initializer_list>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -168,6 +169,9 @@ protected:
     EGLConfig mEGLConfig = EGL_NO_CONFIG_KHR;
     Config mContextAttribs;
     std::vector<EGLContext> mAdditionalContexts;
+    // A cache for MSAA support queries. The index of the vector corresponds to the power of 2 of
+    // the sample count. For example, index 0 is for 2 samples, 1 is for 4 samples, etc.
+    mutable std::vector<std::optional<bool>> mMSAASupport{4}; // caches for 2x, 4x, 8x, 16x
 
     // supported extensions detected at runtime
     struct {

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -28,7 +28,6 @@
 #include <utils/Invocable.h>
 
 #include <initializer_list>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -169,9 +168,7 @@ protected:
     EGLConfig mEGLConfig = EGL_NO_CONFIG_KHR;
     Config mContextAttribs;
     std::vector<EGLContext> mAdditionalContexts;
-    // A cache for MSAA support queries. The index of the vector corresponds to the power of 2 of
-    // the sample count. For example, index 0 is for 2 samples, 1 is for 4 samples, etc.
-    mutable std::vector<std::optional<bool>> mMSAASupport{4}; // caches for 2x, 4x, 8x, 16x
+    bool mMSAA4XSupport;
 
     // supported extensions detected at runtime
     struct {
@@ -222,6 +219,8 @@ private:
             return makeCurrent(mCurrentContext, drawSurface, readSurface);
         }
     } egl{ mEGLDisplay };
+
+    bool checkIfMSAASwapChainSupported(uint32_t samples) const noexcept;
 };
 
 } // namespace filament::backend

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -168,7 +168,7 @@ protected:
     EGLConfig mEGLConfig = EGL_NO_CONFIG_KHR;
     Config mContextAttribs;
     std::vector<EGLContext> mAdditionalContexts;
-    bool mMSAA4XSupport;
+    bool mMSAA4XSupport = false;
 
     // supported extensions detected at runtime
     struct {

--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -107,9 +107,7 @@ void PlatformEGL::clearGlError() noexcept {
 
 // ---------------------------------------------------------------------------------------------
 
-PlatformEGL::PlatformEGL() noexcept : OpenGLPlatform() {
-    mMSAA4XSupport = checkIfMSAASwapChainSupported(4);
-}
+PlatformEGL::PlatformEGL() noexcept = default;
 
 int PlatformEGL::getOSVersion() const noexcept {
     return 0;
@@ -324,6 +322,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext, const DriverConfig& drive
 
     mCurrentContextType = ContextType::UNPROTECTED;
     mContextAttribs = std::move(contextAttribs);
+    mMSAA4XSupport = checkIfMSAASwapChainSupported(4);
 
     initializeGlExtensions();
 
@@ -497,9 +496,7 @@ bool PlatformEGL::isMSAASwapChainSupported(uint32_t samples) const noexcept {
         return mMSAA4XSupport;
     }
 
-    // Other sample counts are not cached, retrieve it.
-    LOG(INFO) << "MSAA sample count " << samples << " is queried, consider caching it.";
-    return checkIfMSAASwapChainSupported(samples);
+    return false;
 }
 
 Platform::SwapChain* PlatformEGL::createSwapChain(


### PR DESCRIPTION
This change introduces a caching mechanism to store the results of MSAA support queries. The results are stored in a vector, indexed by the power-of-two of the sample count.