### PR TITLE
vk: remove renderstandalone workaround

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -585,12 +585,6 @@ void FRenderer::renderStandaloneView(FView const* view) {
         // for endFrame() above. This operation in actually not too heavy, it just kicks the
         // driver thread, which is mostlikely already running.
         engine.flush();
-
-        // FIXME: This is a workaround for internal bug b/361822355.
-        //        properly address the bug and remove this workaround.
-        if (engine.getBackend() == Backend::VULKAN) {
-            engine.flushAndWait();
-        }
     }
 }
 


### PR DESCRIPTION
The bug might have been addressed by PR #8952. This workaround is no longer needed.