### PR TITLE
Fix a compile error

### DIFF
--- a/filament/src/MaterialDefinition.h
+++ b/filament/src/MaterialDefinition.h
@@ -109,6 +109,7 @@ struct MaterialDefinition {
 
 private:
     friend class MaterialCache;
+    friend class FMaterial;
 
     static std::unique_ptr<MaterialParser> createParser(backend::Backend const backend,
             utils::FixedCapacityVector<backend::ShaderLanguage> languages,


### PR DESCRIPTION
FMaterial accesses a private static method of the MaterialDefinition class, which incurs a compile error for certain compilers.