### PR TITLE
vk: add pool for VkSemaphore for re-use and lifetime tracking

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -217,6 +217,10 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanReadPixels.h
             src/vulkan/VulkanSamplerCache.cpp
             src/vulkan/VulkanSamplerCache.h
+            src/vulkan/VulkanSemaphore.cpp
+            src/vulkan/VulkanSemaphore.h
+            src/vulkan/VulkanSemaphoreManager.cpp
+            src/vulkan/VulkanSemaphoreManager.h
             src/vulkan/VulkanStagePool.cpp
             src/vulkan/VulkanStagePool.h
             src/vulkan/VulkanSwapChain.cpp

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -28,6 +28,7 @@
 #include "VulkanQueryManager.h"
 #include "VulkanReadPixels.h"
 #include "VulkanSamplerCache.h"
+#include "VulkanSemaphoreManager.h"
 #include "VulkanStagePool.h"
 #include "VulkanYcbcrConversionCache.h"
 #include "vulkan/VulkanDescriptorSetCache.h"
@@ -141,6 +142,7 @@ private:
 
     VulkanContext& mContext;
 
+    VulkanSemaphoreManager mSemaphoreManager;
     VulkanCommands mCommands;
     VulkanPipelineLayoutCache mPipelineLayoutCache;
     VulkanPipelineCache mPipelineCache;

--- a/filament/backend/src/vulkan/VulkanSemaphore.cpp
+++ b/filament/backend/src/vulkan/VulkanSemaphore.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulkan/VulkanSemaphore.h"
+#include "vulkan/VulkanSemaphoreManager.h"
+
+namespace filament::backend {
+
+VulkanSemaphore::VulkanSemaphore(VulkanSemaphoreManager* manager, VkSemaphore semaphore)
+    : mManager(manager), mSemaphore(semaphore) {}
+
+VulkanSemaphore::~VulkanSemaphore() {
+    mManager->recycle(mSemaphore);
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanSemaphore.h
+++ b/filament/backend/src/vulkan/VulkanSemaphore.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHORE_H
+#define TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHORE_H
+
+#include "memory/Resource.h"
+
+#include <bluevk/BlueVK.h>
+
+namespace filament::backend {
+
+class VulkanSemaphoreManager;
+
+struct VulkanSemaphore : public fvkmemory::Resource {
+public:
+    VulkanSemaphore(VulkanSemaphoreManager* manager, VkSemaphore semaphore);
+    ~VulkanSemaphore();
+
+    VkSemaphore getVkSemaphore() const { return mSemaphore; }
+
+private:
+    VulkanSemaphoreManager* mManager;
+    VkSemaphore mSemaphore;
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHORE_H

--- a/filament/backend/src/vulkan/VulkanSemaphoreManager.cpp
+++ b/filament/backend/src/vulkan/VulkanSemaphoreManager.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanSemaphoreManager.h"
+
+#include "VulkanConstants.h"
+
+using namespace bluevk;
+
+namespace {
+constexpr size_t INITIAL_POOL_SIZE = FVK_MAX_COMMAND_BUFFERS;
+
+VkSemaphore createSemaphore(VkDevice device) {
+    VkSemaphore semaphore;
+    VkSemaphoreCreateInfo semaphoreInfo = {
+        .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+    };
+    vkCreateSemaphore(device, &semaphoreInfo, VKALLOC, &semaphore);
+    return semaphore;
+}
+
+} // namespace
+
+namespace filament::backend {
+
+VulkanSemaphoreManager::VulkanSemaphoreManager(VkDevice device,
+        fvkmemory::ResourceManager* resourceManager)
+    : mDevice(device),
+      mResourceManager(resourceManager) {
+    for (size_t i= 0; i < INITIAL_POOL_SIZE; ++i) {
+        mPool.push_back(createSemaphore(mDevice));
+    }
+}
+
+void VulkanSemaphoreManager::terminate() {
+    for (VkSemaphore semaphore : mPool) {
+        vkDestroySemaphore(mDevice, semaphore, VKALLOC);
+    }
+    mPool.clear();
+}
+
+VulkanSemaphoreManager::Semaphore VulkanSemaphoreManager::acquire() {
+    VkSemaphore semaphore;
+    if (!mPool.empty()) {
+        semaphore = mPool.back();
+        mPool.pop_back();
+    } else {
+        semaphore = createSemaphore(mDevice);
+    }
+    return Semaphore::construct(mResourceManager, this, semaphore);
+}
+
+void VulkanSemaphoreManager::recycle(VkSemaphore semaphore) {
+    mPool.push_back(semaphore);
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanSemaphoreManager.h
+++ b/filament/backend/src/vulkan/VulkanSemaphoreManager.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHOREMANAGER_H
+#define TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHOREMANAGER_H
+
+#include "vulkan/VulkanSemaphore.h"
+#include "vulkan/memory/ResourceManager.h"
+#include "vulkan/memory/ResourcePointer.h"
+
+#include <bluevk/BlueVK.h>
+
+#include <vector>
+
+namespace filament::backend {
+
+class VulkanSemaphoreManager {
+public:
+    using Semaphore = fvkmemory::resource_ptr<VulkanSemaphore>;
+
+    VulkanSemaphoreManager(VkDevice device, fvkmemory::ResourceManager* resourceManager);
+    ~VulkanSemaphoreManager() = default;
+
+    void terminate();
+    Semaphore acquire();
+
+private:
+    friend struct VulkanSemaphore;
+    void recycle(VkSemaphore semaphore);
+
+    VkDevice mDevice;
+    fvkmemory::ResourceManager* mResourceManager;
+    std::vector<VkSemaphore> mPool;
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_VULKAN_VULKANSEMAPHOREMANAGER_H

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -116,6 +116,7 @@ private:
     // We create VulkanTextures based on VkImages. VulkanTexture has facilities for doing layout
     // transitions, which are useful here.
     utils::FixedCapacityVector<fvkmemory::resource_ptr<VulkanTexture>> mColors;
+    utils::FixedCapacityVector<fvkmemory::resource_ptr<VulkanSemaphore>> mFinishedDrawing;
     fvkmemory::resource_ptr<VulkanTexture> mDepth;
     VkExtent2D mExtent;
     uint32_t mLayerCount;

--- a/filament/backend/src/vulkan/memory/Resource.cpp
+++ b/filament/backend/src/vulkan/memory/Resource.cpp
@@ -40,6 +40,7 @@ template ResourceType getTypeEnum<VulkanFence>() noexcept;
 template ResourceType getTypeEnum<VulkanBuffer>() noexcept;
 template ResourceType getTypeEnum<VulkanSync>() noexcept;
 template ResourceType getTypeEnum<VulkanMemoryMappedBuffer>() noexcept;
+template ResourceType getTypeEnum<VulkanSemaphore>() noexcept;
 
 template<typename D>
 ResourceType getTypeEnum() noexcept {
@@ -100,6 +101,9 @@ ResourceType getTypeEnum() noexcept {
     if constexpr (std::is_same_v<D, VulkanMemoryMappedBuffer>) {
         return ResourceType::MEMORY_MAPPED_BUFFER;
     }
+    if constexpr (std::is_same_v<D, VulkanSemaphore>) {
+        return ResourceType::SEMAPHORE;
+    }
     return ResourceType::UNDEFINED_TYPE;
 }
 
@@ -143,6 +147,8 @@ std::string_view getTypeStr(ResourceType type) {
             return "Sync";
         case ResourceType::MEMORY_MAPPED_BUFFER:
             return "VulkanMemoryMappedBuffer";
+        case ResourceType::SEMAPHORE:
+            return "Semaphore";
         case ResourceType::UNDEFINED_TYPE:
             return "";
     }

--- a/filament/backend/src/vulkan/memory/Resource.h
+++ b/filament/backend/src/vulkan/memory/Resource.h
@@ -54,7 +54,8 @@ enum class ResourceType : uint8_t {
     STAGE_IMAGE = 16,
     SYNC = 17,
     MEMORY_MAPPED_BUFFER = 18,
-    UNDEFINED_TYPE = 19,    // Must be the last enum because we use it for iterating over the enums.
+    SEMAPHORE = 19,
+    UNDEFINED_TYPE = 20,    // Must be the last enum because we use it for iterating over the enums.
 };
 
 template<typename D>

--- a/filament/backend/src/vulkan/memory/ResourceManager.cpp
+++ b/filament/backend/src/vulkan/memory/ResourceManager.cpp
@@ -120,6 +120,9 @@ void ResourceManager::destroyWithType(ResourceType type, HandleId id) {
         case ResourceType::MEMORY_MAPPED_BUFFER:
             destruct<VulkanMemoryMappedBuffer>(Handle<VulkanMemoryMappedBuffer>(id));
             break;
+        case ResourceType::SEMAPHORE:
+            destruct<VulkanSemaphore>(Handle<VulkanSemaphore>(id));
+            break;
         case ResourceType::UNDEFINED_TYPE:
             break;
     }


### PR DESCRIPTION
 - Add a VulkanSemaphore ref-counted class to track the references of a semamphore - i.e. in a command buffer or in a present.
 - Add a VulkanSemaphoreManager class to keep a pool of VkSempahores for better re-use.

This fixes a validation error where we were re-using a semaphore that is associated with a command buffer while its being used in a present (as a wait signal).
Error ris VUID-vkQueueSubmit-pSignalSemaphores-00067