### PR TITLE
 Workaround a rendering corruption on Mali

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -507,20 +507,36 @@ void OpenGLContext::initBugs(Bugs* bugs, Extensions const& exts,
         } else if (strstr(renderer, "Mali")) {
             // ARM GPU
             bugs->vao_doesnt_store_element_array_buffer_binding = true;
+
+            // We have run into several problems with timer queries on Mali-Gxx:
+            // - timer queries seem to cause memory corruptions in some cases on some devices
+            //   (see b/233754398)
+            //          - appeared at least in: "OpenGL ES 3.2 v1.r26p0-01eac0"
+            //          - wasn't present in: "OpenGL ES 3.2 v1.r32p1-00pxl1"
+            // - timer queries sometime crash with an NPE (see b/273759031)
+            //   (see b/273759031)
+            //          - possibly not present in: "OpenGL ES 3.2 v1.r46p0"
+            bugs->dont_use_timer_query = true;
+
+            // at least some version of Mali have problems with framebuffer_fetch
+            // (see b/445721121, https://github.com/google/filament/issues/7794)
+            bugs->disable_framebuffer_fetch_extension = true;
+
             if (strstr(renderer, "Mali-T")) {
                 bugs->disable_glFlush = true;
                 bugs->disable_shared_context_draws = true;
-                // We have not verified that timer queries work on Mali-T, so we disable to be safe.
-                bugs->dont_use_timer_query = true;
             }
             if (strstr(renderer, "Mali-G")) {
-                // We have run into several problems with timer queries on Mali-Gxx:
-                // - timer queries seem to cause memory corruptions in some cases on some devices
-                //   (see b/233754398)
-                //          - appeared at least in: "OpenGL ES 3.2 v1.r26p0-01eac0"
-                //          - wasn't present in: "OpenGL ES 3.2 v1.r32p1-00pxl1"
-                // - timer queries sometime crash with an NPE (see b/273759031)
-                bugs->dont_use_timer_query = true;
+                int maj, min, driverVersion, driverRelease;
+                int const c = sscanf(version, "OpenGL ES %d.%d v%d.r%d",
+                        &maj, &min, &driverVersion, &driverRelease);
+                if (UTILS_LIKELY(c == 4)) {
+                    // we were able to parse the version string
+                    if (driverVersion > 1 || (driverVersion == 1 && driverRelease >= 53)) {
+                        // this driver version is known to be good
+                        bugs->disable_framebuffer_fetch_extension = false;
+                    }
+                }
             }
             // Mali seems to have no problem with this (which is good for us)
             bugs->allow_read_only_ancillary_feedback_loop = true;

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -338,6 +338,7 @@ public:
         //   'OpenGL error 0x502 (GL_INVALID_OPERATION) in "draw2" at line 4389'
         // This coincides with the use of framebuffer fetch (ColorGradingAsSubpass). We disable
         // framebuffer fetch in the case of llvmpipe.
+        // Some Mali drivers also have problems with this (b/445721121)
         bool disable_framebuffer_fetch_extension;
 
     } bugs = {};

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -146,7 +146,7 @@ protected:
     Platform mPlatform = Platform::DESKTOP;
     TargetApi mTargetApi = (TargetApi) 0;
     Optimization mOptimization = Optimization::PERFORMANCE;
-    Workarounds mWorkarounds = Workarounds::ALL;
+    Workarounds mWorkarounds = Workarounds::NONE;
     bool mPrintShaders = false;
     bool mSaveRawVariants = false;
     bool mGenerateDebugInfo = false;

--- a/libs/filament-matp/include/filament-matp/Config.h
+++ b/libs/filament-matp/include/filament-matp/Config.h
@@ -171,7 +171,7 @@ protected:
     StringReplacementMap mTemplateMap;
     StringReplacementMap mMaterialParameters;
     filament::UserVariantFilterMask mVariantFilter = 0;
-    Workarounds mWorkarounds = Workarounds::ALL;
+    Workarounds mWorkarounds = Workarounds::NONE;
     bool mIncludeEssl1 = true;
 };
 


### PR DESCRIPTION
The corruption seems to be triggered with a combination of using:
- spirv-opt
- RGBA16F (as opposed to e.g. RGBA8)
- framebuffer_fetch

In this CL we disable framebuffer_fetch for drivers we know have the
issue.

We also reenable NONE as the default for matc workarounds

FIXES=[445721121]
Fix https://github.com/google/filament/issues/7794