### PR TITLE
vk: fix VulkanPlatform CString usage

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -201,7 +201,9 @@ ExtensionSet getInstanceExtensions(ExtensionSet const& externallyRequiredExts = 
             fvkutils::enumerate(vkEnumerateInstanceExtensionProperties,
                     static_cast<char const*>(nullptr) /* pLayerName */);
     for (auto const& extension: availableExts) {
-        utils::CString name { extension.extensionName };
+        // The cast is to force the non-literal constructor of CString, which assumes
+        // null-terminated strings.
+        utils::CString name{ (char const*) extension.extensionName };
 
         // To workaround an Adreno bug where the extension name could be of 0 length.
         if (name.size() == 0) {
@@ -243,7 +245,9 @@ ExtensionSet getDeviceExtensions(VkPhysicalDevice device) {
             = fvkutils::enumerate(vkEnumerateDeviceExtensionProperties, device,
                     static_cast<const char*>(nullptr) /* pLayerName */);
     for (auto const& extension: extensions) {
-        utils::CString name { extension.extensionName };
+        // The cast is to force the non-literal constructor of CString, which assumes
+        // null-terminated strings.
+        utils::CString name { (char const*) extension.extensionName };
 
         // To workaround an Adreno bug where the extension name could be of 0 length.
         if (name.size() == 0) {


### PR DESCRIPTION
Since #9259, CString in VulkanPlatform fall into the literal constructor path. But we really want the null-terminated (char const*) path.  So we cast the strings to (char const*) to enforce null-teriminated behavior.