### PR TITLE
utils: split Slice into mutable and constant types

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -394,7 +394,7 @@ void OpenGLDriver::setPushConstant(ShaderStage const stage, uint8_t const index,
     }
 #endif
 
-    Slice<std::pair<GLint, ConstantType>> constants;
+    Slice<const std::pair<GLint, ConstantType>> constants;
     if (stage == ShaderStage::VERTEX) {
         constants = mCurrentPushConstants->vertexConstants;
     } else if (stage == ShaderStage::FRAGMENT) {

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -43,8 +43,8 @@ namespace filament::backend {
 class OpenGLDriver;
 
 struct PushConstantBundle {
-    utils::Slice<std::pair<GLint, ConstantType>> vertexConstants;
-    utils::Slice<std::pair<GLint, ConstantType>> fragmentConstants;
+    utils::Slice<const std::pair<GLint, ConstantType>> vertexConstants;
+    utils::Slice<const std::pair<GLint, ConstantType>> fragmentConstants;
 };
 
 class OpenGLProgram : public HwProgram {
@@ -94,8 +94,8 @@ public:
     PushConstantBundle getPushConstants() {
         auto fragBegin = mPushConstants.begin() + mPushConstantFragmentStageOffset;
         return {
-            .vertexConstants = utils::Slice(mPushConstants.begin(), fragBegin),
-            .fragmentConstants = utils::Slice(fragBegin, mPushConstants.end()),
+                .vertexConstants = { mPushConstants.begin(), fragBegin },
+                .fragmentConstants = { fragBegin, mPushConstants.end() },
         };
     }
 

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -985,7 +985,7 @@ void Froxelizer::froxelizePointAndSpotLight(
  */
 void Froxelizer::computeLightTree(
         LightTreeNode* lightTree,
-        Slice<const RecordBufferType> const& lightList,
+        Slice<const RecordBufferType> lightList,
         const FScene::LightSoa& lightData,
         size_t lightRecordsOffset) noexcept {
 

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -243,29 +243,28 @@ bool Froxelizer::prepare(
      */
 
     // froxel buffer (16 KiB with 4096 froxels)
-    mFroxelBufferUser = {
+    mFroxelBufferUser.set(
             driverApi.allocatePod<FroxelEntry>(mFroxelBufferEntryCount),
-            mFroxelBufferEntryCount };
+            mFroxelBufferEntryCount);
 
     // record buffer (64 KiB max)
-    mRecordBufferUser = {
+    mRecordBufferUser.set(
             driverApi.allocatePod<RecordBufferType>(mFroxelRecordBufferEntryCount),
-            mFroxelRecordBufferEntryCount };
+            mFroxelRecordBufferEntryCount);
 
     /*
      * Temporary allocations for processing all froxel data
      */
 
     // light records per froxel (~256 KiB with 4096 froxels)
-    mLightRecords = {
+    mLightRecords.set(
             rootArenaScope.allocate<LightRecord>(getFroxelBufferEntryCount(), CACHELINE_SIZE),
-            getFroxelBufferEntryCount() };
+            getFroxelBufferEntryCount());
 
     // froxel thread data (~256KiB with 8192 max froxels and 256 lights)
-    mFroxelShardedData = {
+    mFroxelShardedData.set(
             rootArenaScope.allocate<FroxelThreadData>(GROUP_COUNT, CACHELINE_SIZE),
-            uint32_t(GROUP_COUNT)
-    };
+            uint32_t(GROUP_COUNT));
 
     assert_invariant(mFroxelBufferUser.begin());
     assert_invariant(mRecordBufferUser.begin());
@@ -703,7 +702,7 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
 void Froxelizer::froxelizeAssignRecordsCompress() noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
-    Slice<FroxelThreadData> const froxelThreadData = mFroxelShardedData;
+    Slice<const FroxelThreadData> froxelThreadData = mFroxelShardedData;
 
     // Convert froxel data from N groups of M bits to LightRecord::bitset, so we can
     // easily compare adjacent froxels, for compaction. The conversion loops below get
@@ -986,7 +985,7 @@ void Froxelizer::froxelizePointAndSpotLight(
  */
 void Froxelizer::computeLightTree(
         LightTreeNode* lightTree,
-        Slice<RecordBufferType> const& lightList,
+        Slice<const RecordBufferType> const& lightList,
         const FScene::LightSoa& lightData,
         size_t lightRecordsOffset) noexcept {
 

--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -162,8 +162,8 @@ public:
     // We can't change this easily because the shader expects 16 indices per uint4
     using RecordBufferType = uint8_t;
 
-    const utils::Slice<FroxelEntry>& getFroxelBufferUser() const { return mFroxelBufferUser; }
-    const utils::Slice<RecordBufferType>& getRecordBufferUser() const { return mRecordBufferUser; }
+    utils::Slice<const FroxelEntry> getFroxelBufferUser() const { return mFroxelBufferUser; }
+    utils::Slice<const RecordBufferType> getRecordBufferUser() const { return mRecordBufferUser; }
 
     // This is chosen so froxelizePointAndSpotLight() vectorizes 4 froxel tests / spotlight
     // with 256 lights this implies 8 jobs (256 / 32) for froxelization.
@@ -224,7 +224,7 @@ private:
             math::mat4f const& projection, const LightParams& light) const noexcept;
 
     static void computeLightTree(LightTreeNode* lightTree,
-            utils::Slice<const RecordBufferType> const& lightList,
+            utils::Slice<const RecordBufferType> lightList,
             const FScene::LightSoa& lightData, size_t lightRecordsOffset) noexcept;
 
     static void updateBoundingSpheres(

--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -224,7 +224,7 @@ private:
             math::mat4f const& projection, const LightParams& light) const noexcept;
 
     static void computeLightTree(LightTreeNode* lightTree,
-            utils::Slice<RecordBufferType> const& lightList,
+            utils::Slice<const RecordBufferType> const& lightList,
             const FScene::LightSoa& lightData, size_t lightRecordsOffset) noexcept;
 
     static void updateBoundingSpheres(

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -355,7 +355,7 @@ public:
         // mSize == 0 if mMaterial is valid, otherwise mSize > 0
         mutable uint32_t mSize{};
         // the objects' must outlive the Slice<>
-        utils::Slice<StaticMaterialInfo::ConstantInfo> mConstants{};
+        utils::Slice<const StaticMaterialInfo::ConstantInfo> mConstants{};
     };
 
     void registerPostProcessMaterial(std::string_view name, StaticMaterialInfo const& info);

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -693,7 +693,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
         const bool shadowCaster = soaVisibility[i].castShadows & hasShadowing;
         const bool writeDepthForShadowCasters = depthContainsShadowCasters & shadowCaster;
 
-        Slice<const FRenderPrimitive> const& primitives = soaPrimitives[i];
+        Slice<const FRenderPrimitive> primitives = soaPrimitives[i];
         /*
          * This is our hot loop. It's written to avoid branches.
          * When modifying this code, always ensure it stays efficient.

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -693,7 +693,7 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
         const bool shadowCaster = soaVisibility[i].castShadows & hasShadowing;
         const bool writeDepthForShadowCasters = depthContainsShadowCasters & shadowCaster;
 
-        const Slice<FRenderPrimitive>& primitives = soaPrimitives[i];
+        Slice<const FRenderPrimitive> const& primitives = soaPrimitives[i];
         /*
          * This is our hot loop. It's written to avoid branches.
          * When modifying this code, always ensure it stays efficient.

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -345,8 +345,8 @@ public:
         friend class RenderPassBuilder;
 
         // these fields are constant after creation
-        utils::Slice<Command> mCommands;
-        utils::Slice<CustomCommandFn> mCustomCommands;
+        utils::Slice<const Command> mCommands;
+        utils::Slice<const CustomCommandFn> mCustomCommands;
         BufferObjectSharedHandle mInstancedUboHandle;
         DescriptorSetSharedHandle mInstancedDescriptorSetHandle;
         ColorPassDescriptorSet const* mColorPassDescriptorSet = nullptr;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -796,7 +796,7 @@ float4 ShadowMap::computeBoundingSphere(float3 const* vertices, size_t count) no
 Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
         float3 const* wsVertices, size_t const count) noexcept {
     Aabb bounds{};
-    Slice<float3> const vertices{ wsVertices, count };
+    Slice<const float3> vertices{ wsVertices, count };
     for (auto const& vertice : vertices) {
         const float3 v = mat4f::project(lightView, vertice);
         bounds.min.xy = min(bounds.min.xy, v.xy);

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -994,7 +994,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
             lightData.data<FScene::SHADOW_INFO>());
 
     ShadowTechnique shadowTechnique{};
-    utils::Slice<ShadowMap> const spotShadowMaps = getSpotShadowMaps();
+    utils::Slice<const ShadowMap> spotShadowMaps = getSpotShadowMaps();
     if (!spotShadowMaps.empty()) {
         shadowTechnique |= ShadowTechnique::SHADOW_MAP;
         for (ShadowMap const& shadowMap : spotShadowMaps) {

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -245,19 +245,26 @@ private:
     }
 
     ShadowMap const& getShadowMap(size_t const index) const noexcept {
-        return const_cast<ShadowMapManager*>(this)->getShadowMap(index);
+        assert_invariant(index < mShadowMapCache.size());
+        return *std::launder(reinterpret_cast<ShadowMap const*>(&mShadowMapCache[index]));
     }
 
     utils::Slice<ShadowMap> getCascadedShadowMap() noexcept {
+        ShadowMap* const p = &getShadowMap(0);
+        return { p, mDirectionalShadowMapCount };
+    }
+
+    utils::Slice<const ShadowMap> getCascadedShadowMap() const noexcept {
         ShadowMap const* const p = &getShadowMap(0);
         return { p, mDirectionalShadowMapCount };
     }
 
-    utils::Slice<ShadowMap> getCascadedShadowMap() const noexcept {
-        return const_cast<ShadowMapManager*>(this)->getCascadedShadowMap();
+    utils::Slice<ShadowMap> getSpotShadowMaps() noexcept {
+        ShadowMap* const p = &getShadowMap(CONFIG_MAX_SHADOW_CASCADES);
+        return { p, mSpotShadowMapCount };
     }
 
-    utils::Slice<ShadowMap> getSpotShadowMaps() const noexcept {
+    utils::Slice<const ShadowMap> getSpotShadowMaps() const noexcept {
         ShadowMap const* const p = &getShadowMap(CONFIG_MAX_SHADOW_CASCADES);
         return { p, mSpotShadowMapCount };
     }

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -37,7 +37,7 @@ void FCameraManager::terminate(FEngine& engine) noexcept {
     auto& manager = mManager;
     if (!manager.empty()) {
         DLOG(INFO) << "cleaning up " << manager.getComponentCount() << " leaked Camera components";
-        Slice<Entity> const entities{ manager.getEntities(), manager.getComponentCount() };
+        Slice<const Entity> entities{ manager.getEntities(), manager.getComponentCount() };
         for (Entity const e : entities) {
             destroy(engine, e);
         }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -557,7 +557,7 @@ void FRenderableManager::create(
 
     if (ci) {
         // create and initialize all needed RenderPrimitives
-        using size_type = Slice<FRenderPrimitive>::size_type;
+        using size_type = Slice<const FRenderPrimitive>::size_type;
         auto const * const entries = builder->mEntries.data();
         const size_t entryCount = builder->mEntries.size();
         FRenderPrimitive* rp = new FRenderPrimitive[entryCount];
@@ -691,7 +691,7 @@ void FRenderableManager::create(
                     primitives[i].setMorphingBufferOffset(morphing.offset);
                 }
             }
-            
+
             // When targetCount equal 0, boneCount>0 in this case, do an initialization for the
             // morphWeights uniform array to avoid crash on adreno gpu.
             if (UTILS_UNLIKELY(targetCount == 0 &&
@@ -778,7 +778,7 @@ void FRenderableManager::setMaterialInstanceAt(Instance const instance, uint8_t 
         size_t const primitiveIndex, FMaterialInstance const* mi) {
     assert_invariant(mi);
     if (instance) {
-        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size() && mi) {
             FMaterial const* material = mi->getMaterial();
 
@@ -806,7 +806,7 @@ void FRenderableManager::setMaterialInstanceAt(Instance const instance, uint8_t 
 void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t level,
         size_t primitiveIndex) {
     if (instance) {
-        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].setMaterialInstance(nullptr);
         }
@@ -816,7 +816,7 @@ void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t leve
 MaterialInstance* FRenderableManager::getMaterialInstanceAt(
         Instance const instance, uint8_t const level, size_t const primitiveIndex) const noexcept {
     if (instance) {
-        const Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<const FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             // We store the material instance as const because we don't want to change it internally
             // but when the user queries it, we want to allow them to call setParameter()
@@ -829,7 +829,7 @@ MaterialInstance* FRenderableManager::getMaterialInstanceAt(
 void FRenderableManager::setBlendOrderAt(Instance const instance, uint8_t const level,
         size_t const primitiveIndex, uint16_t const order) noexcept {
     if (instance) {
-        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].setBlendOrder(order);
         }
@@ -839,7 +839,7 @@ void FRenderableManager::setBlendOrderAt(Instance const instance, uint8_t const 
 void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance const instance, uint8_t const level,
         size_t const primitiveIndex, bool const enabled) noexcept {
     if (instance) {
-        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].setGlobalBlendOrderEnabled(enabled);
         }
@@ -849,7 +849,7 @@ void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance const instance, u
 AttributeBitset FRenderableManager::getEnabledAttributesAt(
         Instance const instance, uint8_t const level, size_t const primitiveIndex) const noexcept {
     if (instance) {
-        Slice<FRenderPrimitive> const& primitives = getRenderPrimitives(instance, level);
+        Slice<const FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             return primitives[primitiveIndex].getEnabledAttributes();
         }
@@ -861,7 +861,7 @@ void FRenderableManager::setGeometryAt(Instance const instance, uint8_t const le
         PrimitiveType const type, FVertexBuffer* vertices, FIndexBuffer* indices,
         size_t const offset, size_t const count) noexcept {
     if (instance) {
-        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        Slice<FRenderPrimitive> primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].set(mHwRenderPrimitiveFactory, mEngine.getDriverApi(),
                     type, vertices, indices, offset, count);

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -683,7 +683,7 @@ void FRenderableManager::create(
                         BufferUsage::DYNAMIC),
                 .count = targetCount };
 
-            Slice<FRenderPrimitive>& primitives = mManager[ci].primitives;
+            Slice<FRenderPrimitive> primitives = mManager[ci].primitives;
             mManager[ci].morphTargetBuffer = morphTargetBuffer;
             if (builder->mMorphTargetBuffer) {
                 for (size_t i = 0; i < entryCount; ++i) {
@@ -767,7 +767,7 @@ void FRenderableManager::destroyComponent(Instance const ci) noexcept {
 
 void FRenderableManager::destroyComponentPrimitives(
         HwRenderPrimitiveFactory& factory, DriverApi& driver,
-        Slice<FRenderPrimitive>& primitives) noexcept {
+        Slice<FRenderPrimitive> primitives) noexcept {
     for (auto& primitive : primitives) {
         primitive.terminate(factory, driver);
     }
@@ -960,7 +960,7 @@ void FRenderableManager::setMorphTargetBufferOffsetAt(Instance const instance, u
         size_t const offset) {
     if (instance) {
         assert_invariant(mManager[instance].morphTargetBuffer);
-        Slice<FRenderPrimitive>& primitives = mManager[instance].primitives;
+        Slice<FRenderPrimitive> primitives = mManager[instance].primitives;
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].setMorphingBufferOffset(offset);
         }

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -210,8 +210,8 @@ public:
     void setBlendOrderAt(Instance instance, uint8_t level, size_t primitiveIndex, uint16_t blendOrder) noexcept;
     void setGlobalBlendOrderEnabledAt(Instance instance, uint8_t level, size_t primitiveIndex, bool enabled) noexcept;
     AttributeBitset getEnabledAttributesAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
-    inline utils::Slice<FRenderPrimitive> const& getRenderPrimitives(Instance instance, uint8_t level) const noexcept;
-    inline utils::Slice<FRenderPrimitive>& getRenderPrimitives(Instance instance, uint8_t level) noexcept;
+    inline utils::Slice<const FRenderPrimitive> getRenderPrimitives(Instance instance, uint8_t level) const noexcept;
+    inline utils::Slice<FRenderPrimitive> getRenderPrimitives(Instance instance, uint8_t level) noexcept;
 
     struct Entry {
         VertexBuffer* vertices = nullptr;
@@ -476,12 +476,12 @@ FRenderableManager::getInstancesInfo(Instance const instance) const noexcept {
     return mManager[instance].instances;
 }
 
-utils::Slice<FRenderPrimitive> const& FRenderableManager::getRenderPrimitives(
+utils::Slice<const FRenderPrimitive> FRenderableManager::getRenderPrimitives(
         Instance const instance, UTILS_UNUSED uint8_t level) const noexcept {
-    return mManager[instance].primitives;
+    return utils::Slice<const FRenderPrimitive>(mManager[instance].primitives);
 }
 
-utils::Slice<FRenderPrimitive>& FRenderableManager::getRenderPrimitives(
+utils::Slice<FRenderPrimitive> FRenderableManager::getRenderPrimitives(
         Instance const instance, UTILS_UNUSED uint8_t level) noexcept {
     return mManager[instance].primitives;
 }

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -141,7 +141,8 @@ public:
     inline void setFogEnabled(Instance instance, bool enable) noexcept;
     inline bool getFogEnabled(Instance instance) const noexcept;
 
-    inline void setPrimitives(Instance instance, utils::Slice<FRenderPrimitive> const& primitives) noexcept;
+    inline void setPrimitives(Instance instance,
+            utils::Slice<FRenderPrimitive> primitives) noexcept;
 
     inline void setSkinning(Instance instance, bool enable);
     void setBones(Instance instance, Bone const* transforms, size_t boneCount, size_t offset = 0);
@@ -231,7 +232,7 @@ private:
     void destroyComponent(Instance ci) noexcept;
     static void destroyComponentPrimitives(
             HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
-            utils::Slice<FRenderPrimitive>& primitives) noexcept;
+            utils::Slice<FRenderPrimitive> primitives) noexcept;
 
     struct Bones {
         backend::Handle<backend::HwBufferObject> handle;
@@ -414,7 +415,7 @@ void FRenderableManager::setMorphing(Instance const instance, bool const enable)
 }
 
 void FRenderableManager::setPrimitives(Instance const instance,
-        utils::Slice<FRenderPrimitive> const& primitives) noexcept {
+        utils::Slice<FRenderPrimitive> primitives) noexcept {
     if (instance) {
         mManager[instance].primitives = primitives;
     }

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -115,7 +115,7 @@ public:
             uint8_t,                                    // CHANNELS
             uint8_t,                                    // LAYERS
             math::float3,                               // WORLD_AABB_EXTENT
-            utils::Slice<FRenderPrimitive>,             // PRIMITIVES
+            utils::Slice<const FRenderPrimitive>,       // PRIMITIVES
             uint32_t,                                   // SUMMED_PRIMITIVE_COUNT
             PerRenderableData,                          // UBO
             backend::DescriptorSetHandle,               // DESCRIPTOR_SET_HANDLE

--- a/filament/src/materials/antiAliasing/fxaa/fxaa.cpp
+++ b/filament/src/materials/antiAliasing/fxaa/fxaa.cpp
@@ -32,7 +32,7 @@ static const StaticMaterialInfo sMaterialList[] = {
         { "fxaa",                       MATERIAL(FXAA, FXAA) },
 };
 
-utils::Slice<StaticMaterialInfo> getFxaaMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getFxaaMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/antiAliasing/fxaa/fxaa.h
+++ b/filament/src/materials/antiAliasing/fxaa/fxaa.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getFxaaMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getFxaaMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/antiAliasing/taa/taa.cpp
+++ b/filament/src/materials/antiAliasing/taa/taa.cpp
@@ -32,7 +32,7 @@ static const StaticMaterialInfo sMaterialList[] = {
         { "taa",                        MATERIAL(TAA, TAA) },
 };
 
-utils::Slice<StaticMaterialInfo> getTaaMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getTaaMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/antiAliasing/taa/taa.h
+++ b/filament/src/materials/antiAliasing/taa/taa.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getTaaMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getTaaMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/bloom/bloom.cpp
+++ b/filament/src/materials/bloom/bloom.cpp
@@ -35,7 +35,7 @@ static const StaticMaterialInfo sMaterialList[] = {
     { "bloomUpsample",              MATERIAL(BLOOM, BLOOMUPSAMPLE) },
 };
 
-utils::Slice<StaticMaterialInfo> getBloomMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getBloomMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/bloom/bloom.h
+++ b/filament/src/materials/bloom/bloom.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getBloomMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getBloomMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/colorGrading/colorGrading.cpp
+++ b/filament/src/materials/colorGrading/colorGrading.cpp
@@ -34,7 +34,7 @@ static const StaticMaterialInfo sMaterialList[] = {
     { "customResolveAsSubpass",     MATERIAL(COLORGRADING, CUSTOMRESOLVEASSUBPASS) },
 };
 
-utils::Slice<StaticMaterialInfo> getColorGradingMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getColorGradingMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/colorGrading/colorGrading.h
+++ b/filament/src/materials/colorGrading/colorGrading.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getColorGradingMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getColorGradingMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/dof/dof.cpp
+++ b/filament/src/materials/dof/dof.cpp
@@ -40,7 +40,7 @@ static const StaticMaterialInfo sMaterialList[] = {
         { "dofTilesSwizzle",    MATERIAL(DOF, DOFTILESSWIZZLE) },
 };
 
-utils::Slice<StaticMaterialInfo> getDofMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getDofMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/dof/dof.h
+++ b/filament/src/materials/dof/dof.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getDofMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getDofMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/flare/flare.cpp
+++ b/filament/src/materials/flare/flare.cpp
@@ -32,7 +32,7 @@ static const StaticMaterialInfo sMaterialList[] = {
         { "flare",                      MATERIAL(FLARE, FLARE) },
 };
 
-utils::Slice<StaticMaterialInfo> getFlareMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getFlareMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/flare/flare.h
+++ b/filament/src/materials/flare/flare.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getFlareMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getFlareMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/fsr/fsr.cpp
+++ b/filament/src/materials/fsr/fsr.cpp
@@ -35,7 +35,7 @@ static const StaticMaterialInfo sMaterialList[] = {
     { "fsr_rcas",                   MATERIAL(FSR, FSR_RCAS) },
 };
 
-utils::Slice<StaticMaterialInfo> getFsrMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getFsrMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/fsr/fsr.h
+++ b/filament/src/materials/fsr/fsr.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getFsrMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getFsrMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/sgsr/sgsr.cpp
+++ b/filament/src/materials/sgsr/sgsr.cpp
@@ -32,7 +32,7 @@ static const StaticMaterialInfo sMaterialList[] = {
         { "sgsr1",                      MATERIAL(SGSR, SGSR1) },
 };
 
-utils::Slice<StaticMaterialInfo> getSgsrMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getSgsrMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/sgsr/sgsr.h
+++ b/filament/src/materials/sgsr/sgsr.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getSgsrMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getSgsrMaterialList() noexcept;
 
 } // namespace filament

--- a/filament/src/materials/ssao/ssao.cpp
+++ b/filament/src/materials/ssao/ssao.cpp
@@ -40,7 +40,7 @@ static const StaticMaterialInfo sMaterialList[] = {
 #endif
 };
 
-utils::Slice<StaticMaterialInfo> getSsaoMaterialList() noexcept {
+utils::Slice<const StaticMaterialInfo> getSsaoMaterialList() noexcept {
     return { std::begin(sMaterialList), std::end(sMaterialList) };
 }
 

--- a/filament/src/materials/ssao/ssao.h
+++ b/filament/src/materials/ssao/ssao.h
@@ -22,6 +22,6 @@
 
 namespace filament {
 
-utils::Slice<StaticMaterialInfo> getSsaoMaterialList() noexcept;
+utils::Slice<const StaticMaterialInfo> getSsaoMaterialList() noexcept;
 
 } // namespace filament

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -270,11 +270,11 @@ private:
 
 namespace VariantUtils {
 // list of lit variants
-utils::Slice<Variant> getLitVariants() noexcept UTILS_PURE;
+utils::Slice<const Variant> getLitVariants() noexcept UTILS_PURE;
 // list of unlit variants
-utils::Slice<Variant> getUnlitVariants() noexcept UTILS_PURE;
+utils::Slice<const Variant> getUnlitVariants() noexcept UTILS_PURE;
 // list of depth variants
-utils::Slice<Variant> getDepthVariants() noexcept UTILS_PURE;
+utils::Slice<const Variant> getDepthVariants() noexcept UTILS_PURE;
 }
 
 } // namespace filament

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -210,15 +210,15 @@ static_assert(fragment_variant_count() == 33 - (2 + 2 + 8) + 4 - 1);    // 24
 
 namespace VariantUtils {
 
-utils::Slice<Variant> getLitVariants() noexcept {
+utils::Slice<const Variant> getLitVariants() noexcept {
     return { details::gLitVariants.data(), details::gLitVariants.size() };
 }
 
-utils::Slice<Variant> getUnlitVariants() noexcept {
+utils::Slice<const Variant> getUnlitVariants() noexcept {
     return { details::gUnlitVariants.data(), details::gUnlitVariants.size() };
 }
 
-utils::Slice<Variant> getDepthVariants() noexcept {
+utils::Slice<const Variant> getDepthVariants() noexcept {
     return { details::gDepthVariants.data(), details::gDepthVariants.size() };
 }
 

--- a/libs/ibl/include/ibl/CubemapIBL.h
+++ b/libs/ibl/include/ibl/CubemapIBL.h
@@ -54,7 +54,7 @@ public:
      * @param updater           a callback for the caller to track progress
      */
     static void roughnessFilter(
-            utils::JobSystem& js, Cubemap& dst, const utils::Slice<Cubemap>& levels,
+            utils::JobSystem& js, Cubemap& dst, const utils::Slice<const Cubemap>& levels,
             float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
             Progress updater = nullptr, void* userdata = nullptr);
 

--- a/libs/ibl/include/ibl/CubemapIBL.h
+++ b/libs/ibl/include/ibl/CubemapIBL.h
@@ -54,7 +54,7 @@ public:
      * @param updater           a callback for the caller to track progress
      */
     static void roughnessFilter(
-            utils::JobSystem& js, Cubemap& dst, const utils::Slice<const Cubemap>& levels,
+            utils::JobSystem& js, Cubemap& dst, utils::Slice<const Cubemap> levels,
             float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
             Progress updater = nullptr, void* userdata = nullptr);
 

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -302,7 +302,7 @@ void CubemapIBL::roughnessFilter(
 }
 
 void CubemapIBL::roughnessFilter(
-        utils::JobSystem& js, Cubemap& dst, const utils::Slice<Cubemap>& levels,
+        utils::JobSystem& js, Cubemap& dst, const utils::Slice<const Cubemap>& levels,
         float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
         Progress updater, void* userdata)
 {

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -302,7 +302,7 @@ void CubemapIBL::roughnessFilter(
 }
 
 void CubemapIBL::roughnessFilter(
-        utils::JobSystem& js, Cubemap& dst, const utils::Slice<const Cubemap>& levels,
+        utils::JobSystem& js, Cubemap& dst, utils::Slice<const Cubemap> levels,
         float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
         Progress updater, void* userdata)
 {

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -178,6 +178,7 @@ set(TEST_SRCS
         test/test_QuadTreeArray.cpp
         test/test_RangeMap.cpp
         test/test_RefCountedMap.cpp
+        test/test_Slice.cpp
         test/test_StructureOfArrays.cpp
         test/test_sstream.cpp
         test/test_string.cpp

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -26,6 +26,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityInstance.h
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/FixedCapacityVector.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/Hash.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Invocable.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Log.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Logger.h

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -128,7 +128,7 @@ public:
         this->swap(rhs);
     }
 
-    FixedCapacityVector(utils::Slice<const T> const& rhs,
+    FixedCapacityVector(utils::Slice<const T> rhs,
             const allocator_type& alloc = allocator_type())
             : mSize(rhs.size()),
               mCapacityAllocator(mSize, alloc) {

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -17,6 +17,7 @@
 #ifndef TNT_UTILS_FIXEDCAPACITYVECTOR_H
 #define TNT_UTILS_FIXEDCAPACITYVECTOR_H
 
+#include <utils/Slice.h>
 #include <utils/compiler.h>
 #include <utils/compressed_pair.h>
 
@@ -127,6 +128,14 @@ public:
         this->swap(rhs);
     }
 
+    FixedCapacityVector(utils::Slice<const T> const& rhs,
+            const allocator_type& alloc = allocator_type())
+            : mSize(rhs.size()),
+              mCapacityAllocator(mSize, alloc) {
+        mData = this->allocator().allocate(this->capacity());
+        std::uninitialized_copy(rhs.cbegin(), rhs.cend(), begin());
+    }
+
     ~FixedCapacityVector() noexcept {
         destroy(begin(), end());
         allocator().deallocate(data(), capacity());
@@ -143,6 +152,29 @@ public:
     FixedCapacityVector& operator=(FixedCapacityVector&& rhs) noexcept {
         this->swap(rhs);
         return *this;
+    }
+
+    bool operator==(const FixedCapacityVector& rhs) const noexcept {
+        if (this == &rhs) {
+            return true;
+        }
+        if (size() != rhs.size()) {
+            return false;
+        }
+        return std::equal(begin(), end(), rhs.begin());
+    }
+
+    Slice<T> as_slice() noexcept {
+        return { begin(), end() };
+    }
+
+    Slice<const T> as_slice() const noexcept {
+        return { cbegin(), cend() };
+    }
+
+    template<typename Hash = std::hash<T>>
+    inline size_t hash() const noexcept {
+        return as_slice().template hash<Hash>();
     }
 
     allocator_type get_allocator() const noexcept {
@@ -433,5 +465,14 @@ private:
 };
 
 } // namespace utils
+
+namespace std {
+template<typename T>
+struct hash<utils::FixedCapacityVector<T>> {
+    inline size_t operator()(utils::FixedCapacityVector<T> const& lhs) const noexcept {
+        return lhs.hash();
+    }
+};
+} // namespace std
 
 #endif // TNT_UTILS_FIXEDCAPACITYVECTOR_H

--- a/libs/utils/include/utils/Slice.h
+++ b/libs/utils/include/utils/Slice.h
@@ -87,7 +87,7 @@ public:
         if (size() != rhs.size()) {
             return false;
         }
-        if (mBegin == rhs.mBegin) {
+        if (mBegin == rhs.cbegin()) {
             return true;
         }
         return std::equal(cbegin(), cend(), rhs.cbegin());
@@ -134,9 +134,10 @@ public:
 
     template<typename Hash = std::hash<T>>
     size_t hash() const noexcept {
+        Hash hasher;
         size_t seed = size();
         for (auto const& it : *this) {
-            utils::hash::combine_fast(seed, Hash{}(it));
+            utils::hash::combine_fast(seed, hasher(it));
         }
         return seed;
     }

--- a/libs/utils/include/utils/Slice.h
+++ b/libs/utils/include/utils/Slice.h
@@ -17,8 +17,10 @@
 #ifndef TNT_UTILS_SLICE_H
 #define TNT_UTILS_SLICE_H
 
+#include <utils/Hash.h>
 #include <utils/compiler.h>
 
+#include <algorithm>
 #include <utility>
 
 #include <assert.h>
@@ -26,116 +28,117 @@
 
 namespace utils {
 
-/*
- * A fixed-size slice of a container
+/** A fixed-size slice of a container.
+ *
+ * Analogous to std::span.
  */
-template <typename T>
+template<typename T>
 class Slice {
 public:
+    using element_type = T;
+    using value_type = std::remove_cv_t<T>;
+    using size_type = size_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
     using iterator = T*;
     using const_iterator = T const*;
-    using value_type = T;
-    using reference = T&;
-    using const_reference = T const&;
-    using pointer = T*;
-    using const_pointer = T const*;
-    using size_type = size_t;
 
-    Slice() noexcept = default;
+    Slice() = default;
+    Slice(iterator begin, iterator end) noexcept : mBegin(begin), mEnd(end) {}
+    Slice(pointer begin, size_type count) noexcept : mBegin(begin), mEnd(begin + count) {}
+    Slice(Slice<const value_type> const& rhs) : mBegin(rhs.begin()), mEnd(rhs.end()) {}
+    Slice(Slice<value_type> const& rhs) : mBegin(rhs.begin()), mEnd(rhs.end()) {}
 
-    Slice(const_iterator begin, const_iterator end) noexcept
-            : mBegin(const_cast<iterator>(begin)),
-              mEnd(const_cast<iterator>(end)) {
+    Slice& operator=(Slice<const value_type> const& rhs) noexcept {
+        mBegin = rhs.begin();
+        mEnd = rhs.end();
+        return *this;
     }
 
-    Slice(const_pointer begin, size_type count) noexcept
-            : mBegin(const_cast<iterator>(begin)),
-              mEnd(mBegin + count) {
+    Slice& operator=(Slice<value_type> const& rhs) noexcept {
+        mBegin = rhs.begin();
+        mEnd = rhs.end();
+        return *this;
     }
 
-    Slice(Slice const& rhs) noexcept = default;
-    Slice(Slice&& rhs) noexcept = default;
-    Slice& operator=(Slice const& rhs) noexcept = default;
-    Slice& operator=(Slice&& rhs) noexcept = default;
-
-    void set(pointer begin, size_type count) UTILS_RESTRICT noexcept {
+    void set(pointer begin, size_type count) noexcept {
         mBegin = begin;
         mEnd = begin + count;
     }
 
-    void set(iterator begin, iterator end) UTILS_RESTRICT noexcept {
+    void set(iterator begin, iterator end) noexcept {
         mBegin = begin;
         mEnd = end;
     }
 
-    void swap(Slice& rhs) UTILS_RESTRICT noexcept {
+    void swap(Slice<T>& rhs) noexcept {
         std::swap(mBegin, rhs.mBegin);
         std::swap(mEnd, rhs.mEnd);
     }
 
-    void clear() UTILS_RESTRICT noexcept {
+    void clear() noexcept {
         mBegin = nullptr;
         mEnd = nullptr;
     }
 
+    bool operator==(Slice<const value_type> const& rhs) const noexcept {
+        if (size() != rhs.size()) {
+            return false;
+        }
+        if (mBegin == rhs.mBegin) {
+            return true;
+        }
+        return std::equal(cbegin(), cend(), rhs.cbegin());
+    }
+
+    bool operator==(Slice<value_type> const& rhs) const noexcept {
+        return *this == Slice<const value_type>(rhs);
+    }
+
     // size
-    size_t size() const UTILS_RESTRICT noexcept { return mEnd - mBegin; }
-    size_t sizeInBytes() const UTILS_RESTRICT noexcept { return size() * sizeof(T); }
-    bool empty() const UTILS_RESTRICT noexcept { return size() == 0; }
+    size_t size() const noexcept { return mEnd - mBegin; }
+    size_t sizeInBytes() const noexcept { return size() * sizeof(T); }
+    bool empty() const noexcept { return size() == 0; }
 
     // iterators
-    iterator begin() UTILS_RESTRICT noexcept { return mBegin; }
-    const_iterator begin() const UTILS_RESTRICT noexcept { return mBegin; }
-    const_iterator cbegin() const UTILS_RESTRICT noexcept { return this->begin(); }
-    iterator end() UTILS_RESTRICT noexcept { return mEnd; }
-    const_iterator end() const UTILS_RESTRICT noexcept { return mEnd; }
-    const_iterator cend() const UTILS_RESTRICT noexcept { return this->end(); }
+    iterator begin() const noexcept { return mBegin; }
+    const_iterator cbegin() const noexcept { return this->begin(); }
+    iterator end() const noexcept { return mEnd; }
+    const_iterator cend() const noexcept { return this->end(); }
 
     // data access
-    reference operator[](size_t n) UTILS_RESTRICT noexcept {
+    reference operator[](size_t n) const noexcept {
         assert(n < size());
         return mBegin[n];
     }
 
-    const_reference operator[](size_t n) const UTILS_RESTRICT noexcept {
-        assert(n < size());
-        return mBegin[n];
-    }
-
-    reference at(size_t n) UTILS_RESTRICT noexcept {
+    reference at(size_t n) const noexcept {
         return operator[](n);
     }
 
-    const_reference at(size_t n) const UTILS_RESTRICT noexcept {
-        return operator[](n);
-    }
-
-    reference front() UTILS_RESTRICT noexcept {
+    reference front() const noexcept {
         assert(!empty());
         return *mBegin;
     }
 
-    const_reference front() const UTILS_RESTRICT noexcept {
-        assert(!empty());
-        return *mBegin;
-    }
-
-    reference back() UTILS_RESTRICT noexcept {
+    reference back() const noexcept {
         assert(!empty());
         return *(this->end() - 1);
     }
 
-    const_reference back() const UTILS_RESTRICT noexcept {
-        assert(!empty());
-        return *(this->end() - 1);
-    }
-
-    pointer data() UTILS_RESTRICT noexcept {
+    pointer data() const noexcept {
         return this->begin();
     }
 
-    const_pointer data() const UTILS_RESTRICT noexcept {
-        return this->begin();
+    template<typename Hash = std::hash<T>>
+    size_t hash() const noexcept {
+        size_t seed = size();
+        for (auto const& it : *this) {
+            utils::hash::combine_fast(seed, Hash{}(it));
+        }
+        return seed;
     }
 
 protected:
@@ -144,5 +147,14 @@ protected:
 };
 
 } // namespace utils
+
+namespace std {
+
+template<typename T>
+struct hash<utils::Slice<T>> {
+    inline size_t operator()(utils::Slice<T> const& lhs) const noexcept { return lhs.hash(); }
+};
+
+} // namespace std
 
 #endif // TNT_UTILS_SLICE_H

--- a/libs/utils/test/test_Slice.cpp
+++ b/libs/utils/test/test_Slice.cpp
@@ -21,63 +21,72 @@
 
 using namespace utils;
 
+namespace std {
+
+template<>
+struct hash<const int> {
+    inline size_t operator()(const int lhs) const noexcept { return lhs; }
+};
+
+} // namespace std
+
 TEST(SliceTest, HashIsEqual) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
-    Slice<const int32_t> slice1 = vec1.as_slice();
-    Slice<const int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {1, 3, 3, 7};
+    Slice<const int> slice1 = vec1.as_slice();
+    Slice<const int> slice2 = vec2.as_slice();
 
     EXPECT_TRUE(slice1.hash() == vec1.hash());
     EXPECT_TRUE(slice1.hash() == slice2.hash());
 }
 
 TEST(SliceTest, HashIsNotEqual) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {4, 2, 0};
-    Slice<const int32_t> slice1 = vec1.as_slice();
-    Slice<const int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {4, 2, 0};
+    Slice<const int> slice1 = vec1.as_slice();
+    Slice<const int> slice2 = vec2.as_slice();
 
     EXPECT_FALSE(slice1.hash() == slice2.hash());
 }
 
 TEST(SliceTest, ValueEqual) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
-    Slice<const int32_t> slice1 = vec1.as_slice();
-    Slice<const int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {1, 3, 3, 7};
+    Slice<const int> slice1 = vec1.as_slice();
+    Slice<const int> slice2 = vec2.as_slice();
 
     EXPECT_TRUE(slice1 == slice2);
 }
 
 TEST(SliceTest, ValueNotEqual) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {4, 2, 0};
-    Slice<const int32_t> slice1 = vec1.as_slice();
-    Slice<const int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {4, 2, 0};
+    Slice<const int> slice1 = vec1.as_slice();
+    Slice<const int> slice2 = vec2.as_slice();
 
     EXPECT_FALSE(slice1 == slice2);
 }
 
 TEST(SliceTest, CanCoerceMutableToConst) {
-    FixedCapacityVector<int32_t> vec = {1, 3, 3, 7};
-    Slice<int32_t> sliceMutable = vec.as_slice();
-    Slice<const int32_t> sliceConst = sliceMutable;
+    FixedCapacityVector<int> vec = {1, 3, 3, 7};
+    Slice<int> sliceMutable = vec.as_slice();
+    Slice<const int> sliceConst = sliceMutable;
 }
 
 TEST(SliceTest, CanCompareMutableWithConst) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
-    Slice<int32_t> slice1 = vec1.as_slice();
-    Slice<const int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {1, 3, 3, 7};
+    Slice<int> slice1 = vec1.as_slice();
+    Slice<const int> slice2 = vec2.as_slice();
 
     EXPECT_TRUE(slice1.hash() == slice2.hash());
 }
 
 TEST(SliceTest, CanCompareConstWithMutable) {
-    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
-    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
-    Slice<const int32_t> slice1 = vec1.as_slice();
-    Slice<int32_t> slice2 = vec2.as_slice();
+    FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int> vec2 = {1, 3, 3, 7};
+    Slice<const int> slice1 = vec1.as_slice();
+    Slice<int> slice2 = vec2.as_slice();
 
     EXPECT_TRUE(slice1.hash() == slice2.hash());
 }

--- a/libs/utils/test/test_Slice.cpp
+++ b/libs/utils/test/test_Slice.cpp
@@ -21,15 +21,6 @@
 
 using namespace utils;
 
-namespace std {
-
-template<>
-struct hash<const int> {
-    inline size_t operator()(const int lhs) const noexcept { return lhs; }
-};
-
-} // namespace std
-
 TEST(SliceTest, HashIsEqual) {
     FixedCapacityVector<int> vec1 = {1, 3, 3, 7};
     FixedCapacityVector<int> vec2 = {1, 3, 3, 7};

--- a/libs/utils/test/test_Slice.cpp
+++ b/libs/utils/test/test_Slice.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <utils/Slice.h>
+#include <utils/FixedCapacityVector.h>
+
+using namespace utils;
+
+TEST(SliceTest, HashIsEqual) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
+    Slice<const int32_t> slice1 = vec1.as_slice();
+    Slice<const int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_TRUE(slice1.hash() == vec1.hash());
+    EXPECT_TRUE(slice1.hash() == slice2.hash());
+}
+
+TEST(SliceTest, HashIsNotEqual) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {4, 2, 0};
+    Slice<const int32_t> slice1 = vec1.as_slice();
+    Slice<const int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_FALSE(slice1.hash() == slice2.hash());
+}
+
+TEST(SliceTest, ValueEqual) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
+    Slice<const int32_t> slice1 = vec1.as_slice();
+    Slice<const int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_TRUE(slice1 == slice2);
+}
+
+TEST(SliceTest, ValueNotEqual) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {4, 2, 0};
+    Slice<const int32_t> slice1 = vec1.as_slice();
+    Slice<const int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_FALSE(slice1 == slice2);
+}
+
+TEST(SliceTest, CanCoerceMutableToConst) {
+    FixedCapacityVector<int32_t> vec = {1, 3, 3, 7};
+    Slice<int32_t> sliceMutable = vec.as_slice();
+    Slice<const int32_t> sliceConst = sliceMutable;
+}
+
+TEST(SliceTest, CanCompareMutableWithConst) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
+    Slice<int32_t> slice1 = vec1.as_slice();
+    Slice<const int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_TRUE(slice1.hash() == slice2.hash());
+}
+
+TEST(SliceTest, CanCompareConstWithMutable) {
+    FixedCapacityVector<int32_t> vec1 = {1, 3, 3, 7};
+    FixedCapacityVector<int32_t> vec2 = {1, 3, 3, 7};
+    Slice<const int32_t> slice1 = vec1.as_slice();
+    Slice<int32_t> slice2 = vec2.as_slice();
+
+    EXPECT_TRUE(slice1.hash() == slice2.hash());
+}

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -639,7 +639,7 @@ int main(int argc, char** argv) {
         // pre-compile all material variants
         std::set<Material*> materials;
         RenderableManager const& rcm = app.engine->getRenderableManager();
-        Slice<Entity> const renderables{
+        Slice<const Entity> const renderables{
                 app.asset->getRenderableEntities(), app.asset->getRenderableEntityCount() };
         for (Entity const e: renderables) {
             auto ri = rcm.getInstance(e);


### PR DESCRIPTION
We were doing some Not Good™️ const casting stuff with `Slice`. This CL changes `Slice` to a const type and introduces `MutSlice`. If we expect that clients are depending on `Slice` and that this will be a breaking change for them, we can further rename `Slice` to `ConstSlice` and reintroduce a deprecated compatibility `Slice` which provides the old bad behavior.