### PR TITLE
engine: change spec constants to simple list

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ We are chaning the way Vulkan buffers are handled. We need to switch over to a m
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- materials: include default values of spec constants in material metadata [⚠️ **Recompile Materials**]

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1703,6 +1703,8 @@ enum class Workaround : uint16_t {
     // prevents these stutters by not precaching depth variants of the default material for those
     // particular browsers.
     DISABLE_DEPTH_PRECACHE_FOR_DEFAULT_MATERIAL,
+    // Emulate an sRGB swapchain in shader code.
+    EMULATE_SRGB_SWAPCHAIN,
 };
 
 using StereoscopicType = backend::Platform::StereoscopicType;

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -713,6 +713,12 @@ enum class Precision : uint8_t {
     DEFAULT
 };
 
+union ConstantValue {
+    int32_t i;
+    float f;
+    bool b;
+};
+
 /**
  * Shader compiler priority queue
  *

--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -50,11 +50,7 @@ public:
         descriptor_binding_t binding;
     };
 
-    struct SpecializationConstant {
-        using Type = std::variant<int32_t, float, bool>;
-        uint32_t id;    // id set in glsl
-        Type value;     // value and type
-    };
+    using SpecializationConstant = std::variant<int32_t, float, bool>;
 
     struct Uniform { // For ES2 support
         utils::CString name;    // full qualified name of the uniform field

--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -153,14 +153,15 @@ bool MetalShaderCompiler::isParallelShaderCompileSupported() const noexcept {
 
         MTLFunctionConstantValues* constants = [MTLFunctionConstantValues new];
         auto const& specializationConstants = program.getSpecializationConstants();
-        for (auto const& sc : specializationConstants) {
+        for (size_t i = 0; i < specializationConstants.size(); i++) {
+            auto const& sc = specializationConstants[i];
             const std::array<MTLDataType, 3> types{
                     MTLDataTypeInt, MTLDataTypeFloat, MTLDataTypeBool };
-            std::visit([&sc, constants, type = types[sc.value.index()]](auto&& arg) {
+            std::visit([i, constants, type = types[sc.index()]](auto&& arg) {
                 [constants setConstantValue:&arg
                                        type:type
-                                    atIndex:sc.id];
-            }, sc.value);
+                                    atIndex:i];
+            }, sc);
         }
 
         id<MTLFunction> function = [library newFunctionWithName:@"main0"

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2617,6 +2617,8 @@ bool OpenGLDriver::isWorkaroundNeeded(Workaround const workaround) {
             return mContext.bugs.powervr_shader_workarounds;
         case Workaround::DISABLE_DEPTH_PRECACHE_FOR_DEFAULT_MATERIAL:
             return mContext.bugs.disable_depth_precache_for_default_material;
+        case Workaround::EMULATE_SRGB_SWAPCHAIN:
+            return mContext.isES2() && !mPlatform.isSRGBSwapChainSupported();
         default:
             return false;
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -764,29 +764,6 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
 void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program, CString&& tag) {
     DEBUG_MARKER()
 
-
-    if (UTILS_UNLIKELY(mContext.isES2())) {
-        // Here we patch the specialization constants to enable or not the rec709 output
-        // color space emulation in this program. Obviously, the backend shouldn't know about
-        // specific spec-constants, so we need to handle failures gracefully. This cannot be
-        // done at Material creation time because only the backend has access to
-        // Platform.isSRGBSwapChainSupported().
-        if (!mPlatform.isSRGBSwapChainSupported()) {
-            auto& specializationConstants = program.getSpecializationConstants();
-            auto const pos = std::find_if(specializationConstants.begin(), specializationConstants.end(),
-                    [](auto&& sc) {
-                        // This constant must match
-                        // ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION
-                        // which we can't use here because it's defined in EngineEnums.h.
-                        // (we're breaking layering here, but it's for the good cause).
-                        return sc.id == 3;
-                    });
-            if (pos != specializationConstants.end()) {
-                pos->value = true;
-            }
-        }
-    }
-
     construct<OpenGLProgram>(ph, *this, std::move(program));
     CHECK_GL_ERROR()
     mHandleAllocator.associateTagToHandle(ph.getId(), std::move(tag));

--- a/filament/backend/src/vulkan/utils/Spirv.h
+++ b/filament/backend/src/vulkan/utils/Spirv.h
@@ -21,12 +21,9 @@
 
 #include <utils/FixedCapacityVector.h>
 
-#include <tuple>
 #include <vector>
 
 namespace filament::backend::fvkutils {
-
-using SpecConstantValue = Program::SpecializationConstant::Type;
 
 // For certain drivers, using spec constant can lead to compile errors [1] or undesirable behaviors
 // [2]. In those instances, we simply change the spirv and set them to constants.
@@ -44,7 +41,7 @@ void workaroundSpecConstant(Program::ShaderBlob const& blob,
         std::vector<uint32_t>& output);
 
 // bindings for UBO, samplers, input attachment
-// This is no longer needed after the descriptor set refactor, but the code is good for reference. 
+// This is no longer needed after the descriptor set refactor, but the code is good for reference.
 // std::tuple<uint32_t, uint32_t, uint32_t> getProgramBindings(Program::ShaderBlob const& blob);
 
 } // namespace filament::backend::fvkutils

--- a/filament/backend/src/webgpu/WebGPUProgram.cpp
+++ b/filament/backend/src/webgpu/WebGPUProgram.cpp
@@ -57,8 +57,7 @@ namespace {
  */
 [[nodiscard]] std::string replaceSpecConstants(std::string_view shaderLabel,
         std::string_view shaderSource,
-        std::unordered_map<uint32_t, std::variant<int32_t, float, bool>> const&
-                specConstants) {
+        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants) {
     // this function is not expected to be called at all if no spec constants are to be replaced
     assert_invariant(!specConstants.empty());
     static constexpr std::string_view specConstantPrefix = "FILAMENT_SPEC_CONST_";
@@ -120,16 +119,7 @@ namespace {
                 constantId = static_cast<int>(tempConstantId);
             }
         }
-        const auto newValueItr = specConstants.find(static_cast<uint32_t>(constantId));
-        if (newValueItr == specConstants.end()) {
-            // The constant is not being overridden, so keep the default value.
-            processedShaderSource << std::string_view(sourceData + pos,
-                    posEndOfStatement + 1 - pos);
-            pos = posEndOfStatement + 1;
-            continue;
-        }
-        // need to override the constant...
-        const std::variant<int32_t, float, bool> newValue = newValueItr->second;
+        const std::variant<int32_t, float, bool> newValue = specConstants[constantId];
         // stream up to the equal sign...
         processedShaderSource << std::string_view(sourceData + pos, posOfEqual + 1 - pos);
         // stream the new value...
@@ -156,15 +146,13 @@ namespace {
  * @param program The "program" to compile/create the shader, which includes the shader source
  * @param stage The stage (e.g. vertex, fragment, etc.) to create the shader module
  * @param specConstants Override constants to apply when creating/compiling the shader module.
- * The expectation is that this is consistent with the program's spec constants, just in a map
- * format for quick access
  * @return the proper WebGPU shader module compiled/created from the input parameters. This might
  * wrap a null handle if the shader is not present (if the shader source is empty), such as
  * a missing fragment or compute shader.
  */
 [[nodiscard]] wgpu::ShaderModule createShaderModule(wgpu::Device const& device,
         Program const& program, const ShaderStage stage,
-        std::unordered_map<uint32_t, std::variant<int32_t, float, bool>> const& specConstants) {
+        utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants) {
     const char* const programName = program.getName().c_str_safe();
     std::array<utils::FixedCapacityVector<uint8_t>, Program::SHADER_TYPE_COUNT> const&
             shaderSource = program.getShadersSource();
@@ -260,26 +248,12 @@ namespace {
     return shaderModule;
 }
 
-/**
- * Convenience function to convert the array structure of constants to a map indexed by constant
- * id.
- * @param specConstants Original spec constant structure (immutable)
- * @param outConstantById Output map of spec constants indexed by constant id
- */
-void toMap(utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants,
-        std::unordered_map<uint32_t, std::variant<int32_t, float, bool>>& outConstantById) {
-    outConstantById.reserve(specConstants.size());
-    for (auto const& specConstant: specConstants) {
-        outConstantById.emplace(specConstant.id, specConstant.value);
-    }
-}
-
 }// namespace
 
 WebGPUProgram::WebGPUProgram(wgpu::Device const& device, Program const& program)
     : HwProgram{ program.getName() } {
-    std::unordered_map<uint32_t, std::variant<int32_t, float, bool>> specConstants;
-    toMap(program.getSpecializationConstants(), specConstants);
+    utils::FixedCapacityVector<Program::SpecializationConstant> const& specConstants =
+            program.getSpecializationConstants();
     // TODO: Consider creating/compiling these shaders in parallel.
     vertexShaderModule = createShaderModule(device, program, ShaderStage::VERTEX, specConstants);
     fragmentShaderModule =

--- a/filament/src/MaterialDefinition.cpp
+++ b/filament/src/MaterialDefinition.cpp
@@ -364,8 +364,7 @@ void MaterialDefinition::processSpecializationConstants(FEngine& engine) {
                             Workaround::METAL_STATIC_TEXTURE_TARGET_ERROR);
 
     specializationConstants[+ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION] =
-            mMaterialParser->getShaderLanguage() == ShaderLanguage::ESSL1 &&
-            !engine.getDriver().isSRGBSwapChainSupported();
+            engine.getDriverApi().isWorkaroundNeeded(Workaround::EMULATE_SRGB_SWAPCHAIN);
 
     // The 16u below denotes the 16 bytes in a uvec4, which is how the froxel buffer is stored.
     specializationConstants[+ReservedSpecializationConstants::CONFIG_FROXEL_BUFFER_HEIGHT] =

--- a/filament/src/MaterialDefinition.h
+++ b/filament/src/MaterialDefinition.h
@@ -99,10 +99,17 @@ struct MaterialDefinition {
     BindingUniformInfoContainer bindingUniformInfo;
     AttributeInfoContainer attributeInfo;
 
-    // Constants defined by this Material
+    // Constants defined by this material. Does not include reserved constants.
     utils::FixedCapacityVector<MaterialConstant> materialConstants;
-    // A map from the Constant name to the materialConstants index
+    // A map from the Constant name to the materialConstants index.
     std::unordered_map<std::string_view, uint32_t> specializationConstantsNameToIndex;
+    // A list of default values for spec constants. Includes reserved constants.
+    utils::FixedCapacityVector<backend::Program::SpecializationConstant> specializationConstants;
+
+    // current push constants for the HwProgram
+    std::array<utils::FixedCapacityVector<backend::Program::PushConstant>,
+            backend::Program::SHADER_TYPE_COUNT>
+            pushConstants;
 
     utils::CString name;
     uint64_t cacheId = 0;
@@ -120,7 +127,8 @@ private:
 
     void processMain();
     void processBlendingMode();
-    void processSpecializationConstants();
+    void processSpecializationConstants(FEngine& engine);
+    void processPushConstants();
     void processDescriptorSets(FEngine& engine);
 
     std::unique_ptr<MaterialParser> mMaterialParser;

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -800,6 +800,7 @@ bool ChunkMaterialConstants::unflatten(Unflattener& unflattener,
     for (uint64_t i = 0; i < numConstants; i++) {
         CString constantName;
         uint8_t constantType = 0;
+        ConstantValue defaultValue;
 
         if (!unflattener.read(&constantName)) {
             return false;
@@ -809,8 +810,13 @@ bool ChunkMaterialConstants::unflatten(Unflattener& unflattener,
             return false;
         }
 
+        if (!unflattener.read(&defaultValue.i)) {
+            return false;
+        }
+
         (*materialConstants)[i].name = constantName;
         (*materialConstants)[i].type = static_cast<ConstantType>(constantType);
+        (*materialConstants)[i].defaultValue = defaultValue;
     }
 
     return true;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -149,8 +149,7 @@ FMaterial::FMaterial(FEngine& engine, const Builder& builder, MaterialDefinition
           mIsDefaultMaterial(builder->mDefaultMaterial),
           mEngine(engine),
           mMaterialId(engine.getMaterialId()) {
-    processSpecializationConstants(engine, builder);
-    processPushConstants(engine);
+    mSpecializationConstants = processSpecializationConstants(builder);
     precacheDepthVariants(engine);
 
 #if FILAMENT_ENABLE_MATDBG
@@ -452,8 +451,10 @@ Program FMaterial::getProgramWithVariants(
             mDefinition.programDescriptorBindings[+DescriptorSetBindingPoints::PER_MATERIAL]);
     program.specializationConstants(mSpecializationConstants);
 
-    program.pushConstants(ShaderStage::VERTEX, mPushConstants[uint8_t(ShaderStage::VERTEX)]);
-    program.pushConstants(ShaderStage::FRAGMENT, mPushConstants[uint8_t(ShaderStage::FRAGMENT)]);
+    program.pushConstants(ShaderStage::VERTEX,
+            mDefinition.pushConstants[uint8_t(ShaderStage::VERTEX)]);
+    program.pushConstants(ShaderStage::FRAGMENT,
+            mDefinition.pushConstants[uint8_t(ShaderStage::FRAGMENT)]);
 
     program.cacheId(hash::combine(size_t(mDefinition.cacheId), variant.key));
 
@@ -701,110 +702,45 @@ std::optional<uint32_t> FMaterial::getSpecializationConstantId(std::string_view 
 
 template<typename T, typename>
 bool FMaterial::setConstant(uint32_t id, T value) noexcept {
-    size_t const maxId = mDefinition.materialConstants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
-    if (UTILS_LIKELY(id < maxId)) {
-        if (id >= CONFIG_MAX_RESERVED_SPEC_CONSTANTS) {
-            // Constant from the material itself (as opposed to the reserved ones)
-            auto const& constant = mDefinition.materialConstants[id - CONFIG_MAX_RESERVED_SPEC_CONSTANTS];
-            using ConstantType = ConstantType;
-            switch (constant.type) {
-                case ConstantType::INT:
-                    if (!std::is_same_v<T, int32_t>) return false;
-                    break;
-                case ConstantType::FLOAT:
-                    if (!std::is_same_v<T, float>) return false;
-                    break;
-                case ConstantType::BOOL:
-                    if (!std::is_same_v<T, bool>) return false;
-                    break;
-            }
-        }
+    if (UTILS_UNLIKELY(id >= mSpecializationConstants.size())) {
+        return false;
+    }
 
-        auto pos = std::find_if(
-                mSpecializationConstants.begin(), mSpecializationConstants.end(),
-                [id](Program::SpecializationConstant const& specializationConstant) {
-                    return specializationConstant.id == id;
-                });
-        if (pos != mSpecializationConstants.end()) {
-            if (std::get<T>(pos->value) != value) {
-                pos->value = value;
-                return true;
-            }
-        } else {
-            mSpecializationConstants.push_back({ id, value });
-            return true;
+    if (id >= CONFIG_MAX_RESERVED_SPEC_CONSTANTS) {
+        // Constant from the material itself (as opposed to the reserved ones)
+        auto const& constant =
+                mDefinition.materialConstants[id - CONFIG_MAX_RESERVED_SPEC_CONSTANTS];
+        using ConstantType = ConstantType;
+        switch (constant.type) {
+            case ConstantType::INT:
+                if (!std::is_same_v<T, int32_t>) return false;
+                break;
+            case ConstantType::FLOAT:
+                if (!std::is_same_v<T, float>) return false;
+                break;
+            case ConstantType::BOOL:
+                if (!std::is_same_v<T, bool>) return false;
+                break;
         }
     }
-    return false;
+
+    mSpecializationConstants[id] = value;
+
+    return true;
 }
 
-void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& builder) {
-    // TODO: migrate some or all of this into MaterialDefinition.
+FixedCapacityVector<Program::SpecializationConstant>
+FMaterial::processSpecializationConstants(Builder const& builder) {
+    FixedCapacityVector<Program::SpecializationConstant> specializationConstants =
+            mDefinition.specializationConstants;
 
-    // Verify that all the constant specializations exist in the material and that their types match.
-    // The first specialization constants are defined internally by Filament.
-    // The subsequent constants are user-defined in the material.
+    specializationConstants[+ReservedSpecializationConstants::CONFIG_SH_BANDS_COUNT] =
+            builder->mShBandsCount;
+    specializationConstants[+ReservedSpecializationConstants::CONFIG_SHADOW_SAMPLING_METHOD] =
+            int32_t(builder->mShadowSamplingQuality);
 
-    // Feature level 0 doesn't support instancing
-    int const maxInstanceCount = (engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)
-                                 ? 1 : CONFIG_MAX_INSTANCES;
-
-    // The 16u below denotes the 16 bytes in a uvec4, which is how the froxel buffer is stored.
-    int const maxFroxelBufferHeight =
-            int(Froxelizer::getFroxelBufferByteCount(engine.getDriverApi()) / 16u);
-
-    int const froxelRecordBufferHeight =
-            int(Froxelizer::getFroxelRecordBufferByteCount(engine.getDriverApi()) / 16u);
-
-    bool const staticTextureWorkaround =
-            engine.getDriverApi().isWorkaroundNeeded(Workaround::METAL_STATIC_TEXTURE_TARGET_ERROR);
-
-    bool const powerVrShaderWorkarounds =
-            engine.getDriverApi().isWorkaroundNeeded(Workaround::POWER_VR_SHADER_WORKAROUNDS);
-
-    mSpecializationConstants.reserve(
-            mDefinition.materialConstants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::BACKEND_FEATURE_LEVEL,
-            int(engine.getSupportedFeatureLevel()) });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_MAX_INSTANCES,
-            int(maxInstanceCount) });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_FROXEL_BUFFER_HEIGHT,
-            int(maxFroxelBufferHeight) });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_FROXEL_RECORD_BUFFER_HEIGHT,
-            int(froxelRecordBufferHeight) });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP,
-            engine.debug.shadowmap.debug_directional_shadowmap });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_DEBUG_FROXEL_VISUALIZATION,
-            engine.debug.lighting.debug_froxel_visualization });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND,
-            staticTextureWorkaround });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_POWER_VR_SHADER_WORKAROUNDS,
-            powerVrShaderWorkarounds });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_STEREO_EYE_COUNT,
-            int(engine.getConfig().stereoscopicEyeCount) });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_SH_BANDS_COUNT,
-            builder->mShBandsCount });
-    mSpecializationConstants.push_back({
-            +ReservedSpecializationConstants::CONFIG_SHADOW_SAMPLING_METHOD,
-            int32_t(builder->mShadowSamplingQuality) });
-    if (UTILS_UNLIKELY(
-            mDefinition.getMaterialParser().getShaderLanguage() == ShaderLanguage::ESSL1)) {
-        // The actual value of this spec-constant is set in the OpenGLDriver backend.
-        mSpecializationConstants.push_back({
-                +ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION,
-                false});
-    }
-
+    // Verify that all the constant specializations exist in the material and that their types
+    // match.
     for (auto const& [name, value] : builder->mConstantSpecializations) {
         std::string_view const key{ name.data(), name.size() };
         auto pos = mDefinition.specializationConstantsNameToIndex.find(key);
@@ -817,63 +753,26 @@ void FMaterial::processSpecializationConstants(FEngine& engine, Builder const& b
             case ConstantType::INT:
                 FILAMENT_CHECK_PRECONDITION(std::holds_alternative<int32_t>(value))
                         << "The constant parameter " << name.c_str() << " on material "
-                        << mDefinition.name.c_str_safe() << " is of type int, but " << types[value.index()]
-                        << " was provided.";
+                        << mDefinition.name.c_str_safe() << " is of type int, but "
+                        << types[value.index()] << " was provided.";
                 break;
             case ConstantType::FLOAT:
                 FILAMENT_CHECK_PRECONDITION(std::holds_alternative<float>(value))
                         << "The constant parameter " << name.c_str() << " on material "
-                        << mDefinition.name.c_str_safe() << " is of type float, but " << types[value.index()]
-                        << " was provided.";
+                        << mDefinition.name.c_str_safe() << " is of type float, but "
+                        << types[value.index()] << " was provided.";
                 break;
             case ConstantType::BOOL:
                 FILAMENT_CHECK_PRECONDITION(std::holds_alternative<bool>(value))
                         << "The constant parameter " << name.c_str() << " on material "
-                        << mDefinition.name.c_str_safe() << " is of type bool, but " << types[value.index()]
-                        << " was provided.";
+                        << mDefinition.name.c_str_safe() << " is of type bool, but "
+                        << types[value.index()] << " was provided.";
                 break;
         }
         uint32_t const index = pos->second + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
-        mSpecializationConstants.push_back({ index, value });
+        specializationConstants[index] = value;
     }
-}
-
-void FMaterial::processPushConstants(FEngine&) {
-    // TODO: move some or all of this into MaterialDefinition.
-
-    FixedCapacityVector<Program::PushConstant>& vertexConstants =
-            mPushConstants[uint8_t(ShaderStage::VERTEX)];
-    FixedCapacityVector<Program::PushConstant>& fragmentConstants =
-            mPushConstants[uint8_t(ShaderStage::FRAGMENT)];
-
-    CString structVarName;
-    FixedCapacityVector<MaterialPushConstant> pushConstants;
-    mDefinition.getMaterialParser().getPushConstants(&structVarName, &pushConstants);
-
-    vertexConstants.reserve(pushConstants.size());
-    fragmentConstants.reserve(pushConstants.size());
-
-    constexpr size_t MAX_NAME_LEN = 60;
-    char buf[MAX_NAME_LEN];
-    uint8_t vertexCount = 0, fragmentCount = 0;
-
-    std::for_each(pushConstants.cbegin(), pushConstants.cend(),
-            [&](MaterialPushConstant const& constant) {
-                snprintf(buf, sizeof(buf), "%s.%s", structVarName.c_str(), constant.name.c_str());
-
-                switch (constant.stage) {
-                    case ShaderStage::VERTEX:
-                        vertexConstants.push_back({CString(buf), constant.type});
-                        vertexCount++;
-                        break;
-                    case ShaderStage::FRAGMENT:
-                        fragmentConstants.push_back({CString(buf), constant.type});
-                        fragmentCount++;
-                        break;
-                    case ShaderStage::COMPUTE:
-                        break;
-                }
-            });
+    return specializationConstants;
 }
 
 void FMaterial::precacheDepthVariants(FEngine& engine) {

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -292,7 +292,8 @@ private:
             Variant vertexVariant, Variant fragmentVariant) const;
 
     utils::FixedCapacityVector<backend::Program::SpecializationConstant>
-    processSpecializationConstants(Builder const& builder);
+            processSpecializationConstants(Builder const& builder);
+
     void precacheDepthVariants(FEngine& engine);
 
     void createAndCacheProgram(backend::Program&& p, Variant variant) const noexcept;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -291,8 +291,8 @@ private:
     backend::Program getProgramWithVariants(Variant variant,
             Variant vertexVariant, Variant fragmentVariant) const;
 
-    void processSpecializationConstants(FEngine& engine, Builder const& builder);
-    void processPushConstants(FEngine& engine);
+    utils::FixedCapacityVector<backend::Program::SpecializationConstant>
+    processSpecializationConstants(Builder const& builder);
     void precacheDepthVariants(FEngine& engine);
 
     void createAndCacheProgram(backend::Program&& p, Variant variant) const noexcept;
@@ -312,11 +312,6 @@ private:
 
     // current specialization constants for the HwProgram
     utils::FixedCapacityVector<backend::Program::SpecializationConstant> mSpecializationConstants;
-
-    // current push constants for the HwProgram
-    std::array<utils::FixedCapacityVector<backend::Program::PushConstant>,
-            backend::Program::SHADER_TYPE_COUNT>
-            mPushConstants;
 
 #if FILAMENT_ENABLE_MATDBG
     matdbg::MaterialKey mDebuggerId;

--- a/libs/filabridge/include/private/filament/ConstantInfo.h
+++ b/libs/filabridge/include/private/filament/ConstantInfo.h
@@ -25,12 +25,15 @@ namespace filament {
 
 struct MaterialConstant {
     using ConstantType = backend::ConstantType;
+    using ConstantValue = backend::ConstantValue;
 
     utils::CString name;
     ConstantType type;
+    ConstantValue defaultValue;
 
     MaterialConstant() = default;
-    MaterialConstant(const char* name, ConstantType type) : name(name), type(type)  {}
+    MaterialConstant(utils::CString name, ConstantType type, ConstantValue defaultValue)
+            : name(std::move(name)), type(type), defaultValue(defaultValue) {}
 };
 
 }

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -85,7 +85,7 @@ enum class ReservedSpecializationConstants : uint8_t {
     CONFIG_SH_BANDS_COUNT = 9,
     CONFIG_SHADOW_SAMPLING_METHOD = 10,
     CONFIG_FROXEL_RECORD_BUFFER_HEIGHT = 11,
-    // check CONFIG_MAX_RESERVED_SPEC_CONSTANTS below
+    // check CONFIG_NEXT_RESERVED_SPEC_CONSTANT and CONFIG_MAX_RESERVED_SPEC_CONSTANTS below
 };
 
 enum class PushConstantIds : uint8_t  {
@@ -103,6 +103,8 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // the first constants (from 0 to CONFIG_MAX_RESERVED_SPEC_CONSTANTS - 1).
 // Updating this value necessitates a material version bump.
 constexpr size_t CONFIG_MAX_RESERVED_SPEC_CONSTANTS = 16;
+// The number of the next unassigned reserved spec constant.
+constexpr size_t CONFIG_NEXT_RESERVED_SPEC_CONSTANT = 12;
 
 // The maximum number of shadow maps possible.
 // There is currently a maximum limit of 128 shadow maps.

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -254,6 +254,7 @@ public:
     using AttributeType = filament::backend::UniformType;
     using UniformType = filament::backend::UniformType;
     using ConstantType = filament::backend::ConstantType;
+    using ConstantValue = filament::backend::ConstantValue;
     using SamplerType = filament::backend::SamplerType;
     using SubpassType = filament::backend::SubpassType;
     using SamplerFormat = filament::backend::SamplerFormat;
@@ -765,11 +766,7 @@ public:
     struct Constant {
         utils::CString name;
         ConstantType type;
-        union {
-            int32_t i;
-            float f;
-            bool b;
-        } defaultValue;
+        ConstantValue defaultValue;
     };
 
     struct PushConstant {

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
@@ -113,6 +113,7 @@ void MaterialConstantParametersChunk::flatten(Flattener& f) {
     for (const auto& constant : mConstants) {
         f.writeString(constant.name.c_str());
         f.writeUint8(static_cast<uint8_t>(constant.type));
+        f.writeUint32(static_cast<uint32_t>(constant.defaultValue.i));
     }
 }
 


### PR DESCRIPTION
For a shader program cache to be keyed on the set of spec constants that a program has set, we need to know full exact list of constants, including their default values. If we're going to always hold a list of all constants all the time, then we may as well store them as a simple list where each index is the ID number of the spec constant.

As part of this change, we now write the default values of spec constants into the material file metadata.