### PR TITLE
utils: RefCountedInternPool/RefCountedMap

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -38,6 +38,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/Path.h
         ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation.h
         ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation-impl.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/RefCountedInternPool.h
         ${PUBLIC_HDR_DIR}/${TARGET}/RefCountedMap.h
         ${PUBLIC_HDR_DIR}/${TARGET}/SingleInstanceComponentManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Slice.h

--- a/libs/utils/include/utils/RefCountedInternPool.h
+++ b/libs/utils/include/utils/RefCountedInternPool.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TNT_UTILS_REFCOUNTEDINTERNPOOL_H
+#define TNT_UTILS_REFCOUNTEDINTERNPOOL_H
+
+#include <utils/Slice.h>
+#include <utils/FixedCapacityVector.h>
+#include <utils/Hash.h>
+#include <utils/Panic.h>
+#include <utils/debug.h>
+
+#include <tsl/robin_map.h>
+
+namespace utils {
+
+/** A reference-counted intern pool of slices of T. */
+template<typename T, typename Hash = std::hash<T>>
+class RefCountedInternPool {
+    struct HashSlice {
+        inline size_t operator()(Slice<const T> const& slice) const noexcept {
+            return slice.template hash<Hash>();
+        }
+    };
+
+    struct Entry {
+        uint32_t referenceCount;
+        FixedCapacityVector<T> value;
+    };
+
+    using Map = tsl::robin_map<Slice<const T>, Entry, HashSlice>;
+
+    static constexpr const char* UTILS_NONNULL MISSING_ENTRY_ERROR_STRING =
+            "RefCountedInternPool is missing entry";
+
+public:
+    RefCountedInternPool() = default;
+    RefCountedInternPool(RefCountedInternPool const& rhs) = delete;
+    RefCountedInternPool& operator=(RefCountedInternPool const& rhs) = delete;
+    RefCountedInternPool(RefCountedInternPool&& rhs) = default;
+    RefCountedInternPool& operator=(RefCountedInternPool&& rhs) = default;
+
+    /** Acquire an interned copy of value. */
+    Slice<const T> acquire(Slice<const T> slice, size_t hash) noexcept {
+        if (slice.empty()) {
+            return { nullptr, nullptr };
+        }
+        auto it = mMap.find(slice, hash);
+        if (it != mMap.end()) {
+            it.value().referenceCount++;
+            return it.key();
+        }
+        FixedCapacityVector<T> value(slice);
+        // TODO: how to use above computed hash here?
+        return mMap.insert({ value.as_slice(), Entry{
+                .referenceCount = 1,
+                .value = std::move(value),
+            }}).first.key();
+    }
+
+    inline Slice<const T> acquire(Slice<const T> slice) noexcept {
+        return acquire(slice, HashSlice{}(slice));
+    }
+
+    Slice<const T> acquire(FixedCapacityVector<T>&& value, size_t hash) noexcept {
+        if (value.empty()) {
+            return { nullptr, nullptr };
+        }
+        Slice<const T> slice = value.as_slice();
+        auto it = mMap.find(slice, hash);
+        if (it != mMap.end()) {
+            it.value().referenceCount++;
+            return it.key();
+        }
+        // TODO: how to use above computed hash here?
+        return mMap.insert({ slice, Entry{
+                .referenceCount = 1,
+                .value = std::move(value),
+            }}).first.key();
+    }
+
+    inline Slice<const T> acquire(FixedCapacityVector<T>&& value) noexcept {
+        return acquire(std::move(value), HashSlice{}(value.as_slice()));
+    }
+
+    inline Slice<const T> acquire(FixedCapacityVector<T> const& value, size_t hash) noexcept {
+        return acquire(value.as_slice(), hash);
+    }
+
+    inline Slice<const T> acquire(FixedCapacityVector<T> const& value) noexcept {
+        Slice slice = value.as_slice();
+        return acquire(slice, HashSlice{}(slice));
+    }
+
+    /** Release interned value. */
+    void release(Slice<const T> slice, size_t hash) noexcept {
+        if (slice.empty()) {
+            return;
+        }
+        auto it = mMap.find(slice, hash);
+        FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
+        if (--it.value().referenceCount == 0) {
+            // TODO: change to erase_fast
+            mMap.erase(it);
+        }
+    }
+
+    inline void release(Slice<const T> slice) noexcept {
+        return release(slice, HashSlice{}(slice));
+    }
+
+    inline void release(FixedCapacityVector<T> const& value, size_t hash) noexcept {
+        return release(value.as_slice(), hash);
+    }
+
+    inline void release(FixedCapacityVector<T> const& value) noexcept {
+        Slice slice = value.as_slice();
+        return release(slice, HashSlice{}(slice));
+    }
+
+    /** Returns true if the pool is empty. */
+    inline bool empty() const noexcept { return mMap.empty(); }
+
+    /** Returns hash of value. */
+    static size_t hash(Slice<const T> slice) noexcept {
+        return HashSlice{}(slice);
+    }
+
+    static size_t hash(FixedCapacityVector<T> const& value) noexcept {
+        return HashSlice{}(value.as_slice());
+    }
+
+private:
+    Map mMap;
+};
+
+}
+
+#endif  // TNT_UTILS_REFCOUNTEDINTERNPOOL_H

--- a/libs/utils/include/utils/RefCountedMap.h
+++ b/libs/utils/include/utils/RefCountedMap.h
@@ -49,6 +49,13 @@ struct PointerTraits<T, std::enable_if_t<IsPointer<T>>> {
     using element_type = typename std::pointer_traits<T>::element_type;
 };
 
+template<typename T>
+struct DefaultValue {
+    T operator()() const noexcept {
+        return {};
+    }
+};
+
 } // namespace refcountedmap
 
 /** A reference-counted map.
@@ -56,7 +63,8 @@ struct PointerTraits<T, std::enable_if_t<IsPointer<T>>> {
  * Don't use RAII here, both because we sometimes want to deliberately leak memory, and because
  * we're managing GL resources that require more managed destruction.
  */
-template<typename Key, typename T, typename Hash = std::hash<Key>>
+template<typename Key, typename T, typename Hash = std::hash<Key>,
+         typename NullValue = refcountedmap::DefaultValue<T>>
 class RefCountedMap {
     // Use references for the key if the size of the key type is greater than the size of a pointer.
     using KeyRef = std::conditional_t<(sizeof(Key) > sizeof(void*)), const Key&, Key>;
@@ -87,14 +95,14 @@ class RefCountedMap {
 
     static constexpr const char* UTILS_NONNULL MISSING_ENTRY_ERROR_STRING =
             "Cache is missing entry";
+    static constexpr const char* UTILS_NONNULL MISSING_VALUE_ERROR_STRING =
+            "Attempted to get missing value";
 
 public:
-    /** Acquire a new reference to value by key, initializing it with F if it doesn't exist.
+    /** Acquire and return a value by key, initializing it with F if it doesn't exist.
      *
-     * If T is a pointer type, F returns T, where nullptr indicates a failure to create the object.
-     * Otherwise, F returns std::optional<T>, where nullopt indicates a failure to create the
-     * object, and the returned pointer is valid only as long as the next call to acquire() or
-     * release().
+     * If F returns NullValue{}(), this indicates a failure to create the object. If T is a value
+     * type, the returned pointer is valid only as long as the next call to acquire() or release().
      */
     template<typename F>
     TValue* UTILS_NULLABLE acquire(KeyRef key, size_t hash, F factory) noexcept {
@@ -103,21 +111,15 @@ public:
             it.value().referenceCount++;
             return &deref(it.value().value);
         }
-        if constexpr (refcountedmap::IsPointer<T>) {
-            T r = factory();
-            if (r) {
-                // TODO: how to use above computed hash here?
-                return &*mMap.insert({key, Entry{ 1, std::move(r) }}).first.value().value;
-            }
-            return nullptr;
-        } else {
-            std::optional<T> r = factory();
-            if (r) {
-                // TODO: how to use above computed hash here?
-                return &mMap.insert({key, Entry{ 1, std::move(r.value()) }}).first.value().value;
-            }
+        T r = factory();
+        if (r == NullValue{}()) {
             return nullptr;
         }
+        // TODO: how to use above computed hash here?
+        return &deref(mMap.insert({key, Entry{
+                        .referenceCount = 1,
+                        .value = std::move(r),
+                    }}).first.value().value);
     }
 
     template<typename F>
@@ -125,18 +127,30 @@ public:
         return acquire(key, Hash{}(key), std::move(factory));
     }
 
-    /** Acquire a reference to value by key, panicking if it doesn't exist.
+    /** Acquire and return a pointer to the value if one exists.
      *
-     * This reference is valid only as long as the next call to acquire() or release().
+     * It's possible to acquire a key before its value is initialized, in which case this function
+     * returns nullptr.
+     *
+     * If T is a value type, this pointer is valid only as long as the next call to acquire() or
+     * release().
      */
-    TValue& acquire(KeyRef key, size_t hash) noexcept {
+    TValue* UTILS_NULLABLE acquire(KeyRef key, size_t hash) noexcept {
         auto it = mMap.find(key, hash);
-        FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
-        it.value().referenceCount++;
-        return deref(it.value().value);
+        if (it != mMap.end()) {
+            it.value().referenceCount++;
+            return &deref(it.value().value);
+        }
+        // TODO: how to use above computed hash here?
+        const T value = NullValue{}();
+        mMap.insert({key, Entry{
+                .referenceCount = 1,
+                .value = value,
+            }});
+        return nullptr;
     }
 
-    inline TValue& acquire(KeyRef key) noexcept {
+    inline TValue* UTILS_NULLABLE acquire(KeyRef key) noexcept {
         return acquire(key, Hash{}(key));
     }
 
@@ -149,7 +163,9 @@ public:
         auto it = mMap.find(key, hash);
         FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
         if (--it.value().referenceCount == 0) {
-            releaser(deref(it.value().value));
+            if (it.value().value != NullValue{}()){
+                releaser(deref(it.value().value));
+            }
             // TODO: change to erase_fast
             mMap.erase(it);
         }
@@ -177,6 +193,30 @@ public:
         release(key, Hash{}(key));
     }
 
+    /** Get a value by key, initializing it with F if it doesn't exist.
+     *
+     * If F returns NullValue{}(), this indicates a failure to create the object. If T is a value
+     * type, the returned pointer is valid only as long as the next call to acquire() or release().
+     */
+    template<typename F>
+    TValue* UTILS_NULLABLE get(KeyRef key, size_t hash, F factory) noexcept {
+        auto it = mMap.find(key, hash);
+        FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
+        const T nullValue = NullValue{}();
+        if (it.value().value == nullValue) {
+            it.value().value = factory();
+            if (it.value().value == nullValue) {
+                return nullptr;
+            }
+        }
+        return &deref(it.value().value);
+    }
+
+    template<typename F>
+    inline TValue* UTILS_NULLABLE get(KeyRef key, F factory) noexcept {
+        return get(key, Hash{}(key), std::move(factory));
+    }
+
     /** Return reference to existing value by key.
      *
      * This reference is valid only as long as the next call to acquire() or release().
@@ -186,6 +226,8 @@ public:
     TValue& get(KeyRef key, size_t hash) noexcept {
         auto it = mMap.find(key);
         FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
+        FILAMENT_CHECK_PRECONDITION(it.value().value != NullValue{}())
+                << MISSING_VALUE_ERROR_STRING;
         return deref(it.value().value);
     }
 
@@ -194,6 +236,8 @@ public:
     TValue const& get(KeyRef key, size_t hash) const noexcept {
         auto it = mMap.find(key);
         FILAMENT_CHECK_PRECONDITION(it != mMap.end()) << MISSING_ENTRY_ERROR_STRING;
+        FILAMENT_CHECK_PRECONDITION(it.value().value != NullValue{}())
+                << MISSING_VALUE_ERROR_STRING;
         return deref(it->second.value);
     }
 


### PR DESCRIPTION
First, introduce RefCountedInternPool, a reference counted intern pool of Slice<const T>. Just acquire() a slice that you want and you're guaranteed to get exactly one canonical value-equal Slice<const T> back.

Additionally, introduce the concept of NullValue to RefCountedMap. A NullValue defines what should be considered an uninitialized value; by default, it's the default value of that type (0 for ints, nullptr for pointers, etc). This allows us to lazily-initialize values in the map. A client can acquire() a bunch of different resources which will be initialized only when get(factory) is called. If a client attempts to get() a value without specifying a factory, and the value is not initialized (i.e. equal to NullValue{}()), RefCountedMap will panic.