### PR TITLE
gl: Enable shared contexts for Windows

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformWGL.h
+++ b/filament/backend/include/backend/platforms/PlatformWGL.h
@@ -61,8 +61,12 @@ protected:
     HWND mHWnd = NULL;
     HDC mWhdc = NULL;
     PIXELFORMATDESCRIPTOR mPfd = {};
-    std::vector<HGLRC> mAdditionalContexts;
     std::vector<int> mAttribs;
+
+    // For shared contexts
+    static constexpr int SHARED_CONTEXT_NUM = 1;
+    std::vector<HGLRC> mAdditionalContexts;
+    std::atomic<int> mNextFreeSharedContextIndex{0};
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -124,8 +124,6 @@ Driver* PlatformWGL::createDriver(void* sharedGLContext,
             (PFNWGLCREATECONTEXTATTRIBSARBPROC) wglGetProcAddress("wglCreateContextAttribsARB");
 
     // try all versions down, from GL 4.5 to 4.1
-
-
     for (int minor = 5; minor >= 1; minor--) {
         mAttribs = {
                 WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
@@ -144,6 +142,18 @@ Driver* PlatformWGL::createDriver(void* sharedGLContext,
         goto error;
     }
 
+    // Create shared contexts here for use by other threads. This is a Windows specific workaround
+    // necessitated by the requirement that shared contexts must be initialized on the same thread
+    // as the primary context. If more shared contexts are necessary, the constant
+    // SHARED_CONTEXT_NUM must be updated.
+    for (int i = 0; i < SHARED_CONTEXT_NUM; ++i) {
+        HGLRC context = wglCreateContextAttribs(mWhdc, mContext, mAttribs.data());
+        if (context) {
+            mAdditionalContexts.push_back(context);
+        }
+    }
+
+    // Delete the temporary context
     wglMakeCurrent(NULL, NULL);
     wglDeleteContext(tempContext);
     tempContext = NULL;
@@ -169,13 +179,17 @@ error:
 }
 
 bool PlatformWGL::isExtraContextSupported() const noexcept {
-    return false;
+    return true;
 }
 
 void PlatformWGL::createContext(bool shared) {
-    HGLRC context = wglCreateContextAttribs(mWhdc, shared ? mContext : nullptr, mAttribs.data());
-    wglMakeCurrent(mWhdc, context);
-    mAdditionalContexts.push_back(context);
+    int nextIndex = mNextFreeSharedContextIndex.fetch_add(1, std::memory_order_relaxed);
+    FILAMENT_CHECK_PRECONDITION(nextIndex < SHARED_CONTEXT_NUM)
+            << "Shared context index out of range. Increase SHARED_CONTEXT_NUM.";
+
+    HGLRC context = mAdditionalContexts[nextIndex];
+    BOOL result = wglMakeCurrent(mWhdc, context);
+    FILAMENT_CHECK_POSTCONDITION(result) << "Failed to make current.";
 }
 
 void PlatformWGL::terminate() noexcept {


### PR DESCRIPTION
This change addresses a platform-specific issue on Windows where shared OpenGL contexts must be created on the same thread as the primary context.

To resolve this, we now pre-create a pool of shared contexts when the driver is initialized. These contexts are then distributed to other threads as needed, ensuring shared context creation requirement on Windows. This allows us to be able to use THREAD_POOL mode for shader compiler service on Windows. So Windows build uses THREAD_POOL mode instead of ASYNCHRONOUS mode as of this change.

This change also refactors the shader compiler service to catch and report errors in the same thread where the program compilation and linking actually performed as it's the correct way to use shared contexts. Otherwise it may crashes.