### PR TITLE
renderdiff: add two params to local_test.sh

### DIFF
--- a/test/renderdiff/README.md
+++ b/test/renderdiff/README.md
@@ -51,14 +51,18 @@ renderings, do the following step
   bash test/renderdiff/generate.sh
   ```
 
-## Filtering Tests
+## Command-line Options
 
-You can run a subset of the tests by passing the `--test_filter` flag to `local_test.sh`. The
-filter supports wildcards (`*`) to match test names. For example, to run all tests in the
-`ClearCoat` suite, you can use the following command:
+You can control the behavior of the test scripts with the following flags passed to `local_test.sh`:
+
+- `--test_filter=<filter>`: Run a subset of tests. The filter supports wildcards (`*`) to match test names.
+- `--no_rebuild`: Skip rebuilding the `gltf_viewer` executable.
+- `--num_threads=<number>`: Set the number of threads for rendering. If not set, the system's default is used.
+
+For example, to run all `MSAA` tests without rebuilding and using 8 threads:
 
 ```
-bash test/renderdiff/local_test.sh --test_filter='ClearCoat.*.*'
+bash test/renderdiff/local_test.sh --test_filter='MSAA.*.*' --no_rebuild --num_threads=8
 ```
 
 ## Update the golden images

--- a/test/renderdiff/generate.sh
+++ b/test/renderdiff/generate.sh
@@ -41,7 +41,12 @@ function start_render_() {
     # -W enables the webgpu build
     # -f forces regeneration of cmake build files
     # -X points to the mesa directory, which contains the compiled gl and vk drivers.
-    CXX=`which clang++` CC=`which clang` ./build.sh -f -W -X ${MESA_DIR} -p desktop debug gltf_viewer
+    GLTF_VIEWER_PATH="$(pwd)/out/cmake-debug/samples/gltf_viewer"
+    if [[ "$NOREBUILD" == "true" ]] && [[ -f ${GLTF_VIEWER_PATH} ]]; then
+        echo "Skipping build of gltf_viewer"
+    else
+        CXX=`which clang++` CC=`which clang` ./build.sh -f -W -X ${MESA_DIR} -p desktop debug gltf_viewer
+    fi
 }
 
 function end_render_() {
@@ -63,6 +68,14 @@ case $i in
     TEST_FILTER="${i#*=}"
     shift # past argument=value
     ;;
+    --no_rebuild)
+    NOREBUILD="true"
+    shift # past argument with no value
+    ;;
+    --num_threads=*)
+    NUM_THREADS="${i#*=}"
+    shift # past argument=value
+    ;;
     *)
           # unknown option
     ;;
@@ -77,5 +90,6 @@ start_render_ && \
             --output_dir="${RENDER_OUTPUT_DIR}" \
             --opengl_lib="${MESA_LIB_DIR}" \
             --vk_icd="${MESA_VK_ICD_PATH}" \
-            ${TEST_FILTER:+--test_filter="$TEST_FILTER"} && \
+            ${TEST_FILTER:+--test_filter="$TEST_FILTER"} \
+            ${NUM_THREADS:+--num_threads="$NUM_THREADS"} && \
     end_render_

--- a/test/renderdiff/local_test.sh
+++ b/test/renderdiff/local_test.sh
@@ -35,5 +35,6 @@ bash `dirname $0`/generate.sh "$@" && \
             --out=${DIFF_OUTPUT_DIR} \
             --test="${RENDERDIFF_TEST_DIR}/tests/presubmit.json" "$@"
 
-    # $@ Pass arguments to compare.py, e.g. --test_filter
+    # $@ Pass arguments to generate.sh, e.g. --test_filter
 end_
+

--- a/test/renderdiff/src/render.py
+++ b/test/renderdiff/src/render.py
@@ -83,7 +83,8 @@ def _render_test_config(gltf_viewer,
             local_only=False,
             opengl_lib=None,
             vk_icd=None,
-            test_filter=None):
+            test_filter=None,
+            num_threads=None):
   assert os.path.isdir(output_dir), f"output directory {output_dir} does not exist"
   assert os.access(gltf_viewer, os.X_OK)
 
@@ -93,7 +94,7 @@ def _render_test_config(gltf_viewer,
   gltf_viewer_abs = os.path.abspath(gltf_viewer)
 
   results = []
-  with concurrent.futures.ThreadPoolExecutor() as executor:
+  with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
     futures = []
     for test in test_config.tests:
       test_json_path = os.path.abspath(
@@ -130,6 +131,7 @@ if __name__ == "__main__":
   parser.add_argument('--opengl_lib', help='Path to the folder containing OpenGL driver lib (for LD_LIBRARY_PATH)')
   parser.add_argument('--vk_icd', help='Path to VK ICD file')
   parser.add_argument('--test_filter', help='Filter for the tests to run')
+  parser.add_argument('--num_threads', help='Number of threads to use for rendering', type=int)
 
   args, _ = parser.parse_known_args(sys.argv[1:])
   test = test_config.parse_from_path(args.test)
@@ -140,7 +142,8 @@ if __name__ == "__main__":
                         args.output_dir,
                         opengl_lib=args.opengl_lib,
                         vk_icd=args.vk_icd,
-                        test_filter=args.test_filter)
+                        test_filter=args.test_filter,
+                        num_threads=args.num_threads)
 
   with open(f'{output_dir}/render_results.json', 'w') as f:
     f.write(json.dumps(results, indent=2))


### PR DESCRIPTION
 - --no_rebuild will skip building the gltf_viewer again
 - --num_threads will limit the number of threads used in running the rendering test.

Both of these options are meant for debugging locally.