### PR TITLE
Add missing `#include <ios>`

### DIFF
--- a/libs/imageio/include/imageio/HDRDecoder.h
+++ b/libs/imageio/include/imageio/HDRDecoder.h
@@ -19,6 +19,8 @@
 
 #include <imageio/ImageDecoder.h>
 
+#include <ios>
+
 namespace image {
 
 class HDRDecoder : public ImageDecoder::Decoder {


### PR DESCRIPTION
This is needed to instantiate `std::streampos`. It currently relies on transitive header inclusion to get that, which is going away for libc++ in https://github.com/llvm/llvm-project/commit/ebcf1bf2ecba6b25ece3c2bbddb4485e76189387.