### PR TITLE
fix a regression in FMaterial::setConstant()

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -725,9 +725,11 @@ bool FMaterial::setConstant(uint32_t id, T value) noexcept {
         }
     }
 
-    mSpecializationConstants[id] = value;
-
-    return true;
+    if (std::get<T>(mSpecializationConstants[id]) != value) {
+        mSpecializationConstants[id] = value;
+        return true;
+    }
+    return false;
 }
 
 FixedCapacityVector<Program::SpecializationConstant>


### PR DESCRIPTION
it used to return false when setting the same value for the constant, which other code used to invalidate the material or not. but it was recently changed to always return true on success.

this reestablish the previous behavior.