### PR TITLE
Revert "Make check-headers test use c++20"

### DIFF
--- a/test/check-headers/test.sh
+++ b/test/check-headers/test.sh
@@ -66,6 +66,8 @@ for include in "${includes[@]}"; do
         echo "#define SYSTRACE_TAG SYSTRACE_TAG_DISABLED" >> ${TMP_FILE}
     fi
     echo "#include <${include}>" >> ${TMP_FILE}
+    # Filament is built internally with C++20, but we maintain C++17 compatibility (for the time
+    # being) in our public headers to support projects on older toolchains.
     clang -std=c++17 -I "${FILAMENT_HEADERS}" ${TMP_FILE} -c -o /dev/null
 done
 echo "Done!"


### PR DESCRIPTION
This reverts commit decf3168025c7b0eb1af840f2ecb9f3773fb8203.

Reverting this as some clients still rely on C++17-compatible public headers.