### PR TITLE
fix matc's -l option

### DIFF
--- a/libs/filament-matp/src/MaterialParser.cpp
+++ b/libs/filament-matp/src/MaterialParser.cpp
@@ -459,13 +459,6 @@ utils::Status MaterialParser::processTemplateSubstitutions(
 utils::Status MaterialParser::parse(filamat::MaterialBuilder& builder,
         const Config& config, ssize_t& size, std::unique_ptr<const char[]>& buffer) {
 
-    if (builder.getFeatureLevel() > config.getFeatureLevel()) {
-        utils::io::sstream errorMessage;
-        errorMessage << "Material feature level (" << +builder.getFeatureLevel()
-            << ") is higher than maximum allowed (" << +config.getFeatureLevel() << ")";
-        return utils::Status::invalidArgument(errorMessage.c_str());
-    }
-
     // Before attempting an expensive lex, let's find out if we were sent pure JSON.
     utils::Status parsedStatus;
     if (utils::Status validJson = isValidJsonStart(buffer.get(), size_t(size));
@@ -477,6 +470,13 @@ utils::Status MaterialParser::parse(filamat::MaterialBuilder& builder,
 
     if (!parsedStatus.isOk()) {
         return parsedStatus;
+    }
+
+    if (builder.getFeatureLevel() > config.getFeatureLevel()) {
+        utils::io::sstream errorMessage;
+        errorMessage << "Material feature level (" << +builder.getFeatureLevel()
+            << ") is higher than maximum allowed (" << +config.getFeatureLevel() << ")";
+        return utils::Status::invalidArgument(errorMessage.c_str());
     }
 
     switch (config.getReflectionTarget()) {


### PR DESCRIPTION
MaterialParser did the feature level check (-l) too early, before the material was parsed, so -l0 would always fail.