### PR TITLE
fix: material sandbox scene crashes during shutdown

### DIFF
--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -191,6 +191,8 @@ static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
 }
 
 static void cleanup(Engine* engine, View*, Scene*) {
+    g_meshSet.reset(nullptr);
+
     for (const auto& material : g_meshMaterialInstances) {
         engine->destroy(material.second);
     }
@@ -202,8 +204,6 @@ static void cleanup(Engine* engine, View*, Scene*) {
     for (auto& i : g_params.material) {
         engine->destroy(i);
     }
-
-    g_meshSet.reset(nullptr);
 
     engine->destroy(g_params.light);
     engine->destroy(g_params.spotLight);


### PR DESCRIPTION
Destroy renderables before material instances to prevent
```
reason: destroying MaterialInstance "LitOpaque" which is still in use by Renderable (entity=20, instance=12, index=0)
```