### PR TITLE
renderdiff: disable SSR for transmission

### DIFF
--- a/test/renderdiff/tests/presubmit.json
+++ b/test/renderdiff/tests/presubmit.json
@@ -54,8 +54,7 @@
             "description": "transmission",
             "apply_presets": ["base", "transmission_models"],
             "rendering": {
-                "viewer.cameraFocalLength": 52.0,
-                "view.screenSpaceReflections.enabled": true
+                "viewer.cameraFocalLength": 52.0
             }
         },
         {


### PR DESCRIPTION
SSR is not required for transmission tests, and it seems to be flaky.

RDIFF_BRANCH=pf/renderdiff-disable-transmission