### PR TITLE
vk+webgpu: Fix timepoint overflow

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1171,7 +1171,12 @@ FenceStatus VulkanDriver::fenceWait(FenceHandle const fh, uint64_t const timeout
     using namespace std::chrono;
     auto const now = steady_clock::now();
     steady_clock::time_point until = steady_clock::time_point::max();
-    if (now <= steady_clock::time_point::max() - nanoseconds(timeout)) {
+
+    using TimeoutType = decltype(timeout);
+    constexpr TimeoutType maxTimeout = std::numeric_limits<TimeoutType>::max();
+    constexpr nanoseconds maxNano = nanoseconds::max();
+    if (timeout < maxNano.count() && timeout < maxTimeout && // Need to account for overflow
+        now <= steady_clock::time_point::max() - nanoseconds(timeout)) {
         until = now + nanoseconds(timeout);
     }
 

--- a/filament/backend/src/webgpu/WebGPUFence.cpp
+++ b/filament/backend/src/webgpu/WebGPUFence.cpp
@@ -39,9 +39,15 @@ FenceStatus WebGPUFence::wait(uint64_t timeout) {
     using namespace std::chrono;
     auto now = steady_clock::now();
     steady_clock::time_point until = steady_clock::time_point::max();
-    if (now <= steady_clock::time_point::max() - nanoseconds(timeout)) {
+
+    using TimeoutType = decltype(timeout);
+    constexpr TimeoutType maxTimeout = std::numeric_limits<TimeoutType>::max();
+    constexpr nanoseconds maxNano = nanoseconds::max();
+    if (timeout < maxNano.count() && timeout < maxTimeout && // Need to account for overflow
+            now <= steady_clock::time_point::max() - nanoseconds(timeout)) {
         until = now + nanoseconds(timeout);
     }
+
     {
         std::unique_lock<std::mutex> lock(mLock);
         bool const success = mCond.wait_until(lock, until, [this] {


### PR DESCRIPTION
nanosecond is long long and `timeout` is uint64_t.  This creates an overflow when timeout is too large (for example timeout = std::numeric_limits<uint64_t>::max() when waiting forver).