### PR TITLE
fix a rare swapchain leak in PlatformEGL

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -618,8 +618,8 @@ void PlatformEGL::destroySwapChain(SwapChain* swapChain) noexcept {
             // - this is actually a bit too aggressive, but it is a rare operation.
             egl.makeCurrent(mEGLDummySurface, mEGLDummySurface);
             eglDestroySurface(mEGLDisplay, sc->sur);
-            delete sc;
         }
+        delete sc;
     }
 }
 


### PR DESCRIPTION
If createSwapChain() fails, a SwapChain object is always returned (this might itself be a problem, but we can address that later), however in that case, destroySwapChain() would leak the EGLSwapChain structure.