### PR TITLE
Fix comments for TextureSampler::setAnisotropy

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/TextureSampler.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/TextureSampler.java
@@ -294,8 +294,8 @@ public class TextureSampler {
     /**
      * This controls anisotropic filtering.
      *
-     * @param anisotropy Amount of anisotropy, should be a power-of-two. The default is 0.
-     *                   The maximum permissible value is 7.
+     * @param anisotropy Amount of anisotropy, should be a power-of-two. The default is 1.
+     *                   The maximum permissible value is 128.
      */
     public void setAnisotropy(float anisotropy) {
         mSampler = nSetAnisotropy(mSampler, anisotropy);

--- a/filament/include/filament/TextureSampler.h
+++ b/filament/include/filament/TextureSampler.h
@@ -154,8 +154,8 @@ public:
 
     /**
      * This controls anisotropic filtering.
-     * @param anisotropy Amount of anisotropy, should be a power-of-two. The default is 0.
-     *                   The maximum permissible value is 7.
+     * @param anisotropy Amount of anisotropy, should be a power-of-two. The default is 1.
+     *                   The maximum permissible value is 128.
      */
     void setAnisotropy(float anisotropy) noexcept {
         const int log2 = ilogbf(anisotropy > 0 ? anisotropy : -anisotropy);


### PR DESCRIPTION
The default value for no anisotropy must be 1 instead of 0.