### PR TITLE
renderdiff: disable webgpu + bloom due to flake

### DIFF
--- a/test/renderdiff/src/render.py
+++ b/test/renderdiff/src/render.py
@@ -103,7 +103,7 @@ def _render_test_config(gltf_viewer,
       with open(test_json_path, 'w') as f:
         f.write(f'[{test.to_filament_format()}]')
 
-      for backend in test_config.backends:
+      for backend in test.backends:
         if backend == 'vulkan':
           assert vk_icd, "VK ICD must be specified when testing vulkan backend"
         for model in test.models:

--- a/test/renderdiff/src/test_config.py
+++ b/test/renderdiff/src/test_config.py
@@ -110,12 +110,14 @@ class PresetConfig(RenderingConfig):
         assert 0 <= tolerance['allowed_diff_pixels'] <= 100, "allowed_diff_pixels must be 0-100%"
 
 class TestConfig(RenderingConfig):
-  def __init__(self, data, existing_models, presets):
+  def __init__(self, data, existing_models, presets, backends):
     RenderingConfig.__init__(self, data)
     description = data.get('description')
     if description:
       assert _is_string(description)
       self.description = description
+
+    self.backends = data.get('backends', backends)
 
     apply_presets = data.get('apply_presets')
     rendering = {}
@@ -179,7 +181,6 @@ class RenderTestConfig():
     assert 'backends' in data
     backends = data['backends']
     assert _is_list_of_strings(backends)
-    self.backends = backends
 
     assert 'model_search_paths' in data
     model_search_paths = data.get('model_search_paths')
@@ -199,7 +200,7 @@ class RenderTestConfig():
       presets = [PresetConfig(p, self.models) for p in preset_data]
 
     assert 'tests' in data
-    self.tests = [TestConfig(t, self.models, presets) for t in data['tests']]
+    self.tests = [TestConfig(t, self.models, presets, backends) for t in data['tests']]
     test_names = list([t.name for t in self.tests])
 
     # We cannot have duplicate test names
@@ -224,4 +225,4 @@ if __name__ == "__main__":
   parser.add_argument('--test', help='Configuration of the test', required=True)
 
   args, _ = parser.parse_known_args(sys.argv[1:])
-  test = parse_test_config_from_path(args.test)
+  test = parse_from_path(args.test)

--- a/test/renderdiff/src/utils.py
+++ b/test/renderdiff/src/utils.py
@@ -14,6 +14,7 @@
 
 import subprocess
 import os
+import shutil
 import argparse
 import sys
 import pathlib
@@ -104,8 +105,7 @@ def mkdir_p(path_str):
   pathlib.Path(path_str).mkdir(parents=True, exist_ok=True)
 
 def mv_f(src_str, dst_str):
-  src = pathlib.Path(src_str)
-  src.replace(dst_str)
+  shutil.move(src_str, dst_str)
 
 def important_print(msg):
   lines = msg.split('\n')

--- a/test/renderdiff/tests/presubmit.json
+++ b/test/renderdiff/tests/presubmit.json
@@ -37,6 +37,8 @@
             "name": "Bloom",
             "description": "Bloom",
             "apply_presets": ["base", "bloom_models"],
+            // Do not include "webgpu" in the following backend since it is flaky (b/454921221)
+            "backends": ["opengl", "vulkan"],
             "rendering": {
                 "view.bloom.enabled": true
             }


### PR DESCRIPTION
WebGPU's rendering of bloom sems to be non-deterministic.  This is not expected.  For now, we disable bloom+webgpu to avoid hitting flakes in our CI.

This required a slight refactoring of the test configuration parsing and execution scripts.

RDIFF_BRANCH=pf/renderdiff-disable-bloom-webgpu