### PR TITLE
webgpu: fix FrameScheduled callback and test

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -134,9 +134,9 @@ void VulkanSwapChain::present(DriverBase& driver) {
     mAcquired = false;
     mIsFirstRenderPass = true;
 
-    if (frameScheduled.callback) {
-        driver.scheduleCallback(frameScheduled.handler,
-                [callback = frameScheduled.callback]() {
+    if (mFrameScheduled.callback) {
+        driver.scheduleCallback(mFrameScheduled.handler,
+                [callback = mFrameScheduled.callback]() {
                     PresentCallable noop = PresentCallable(PresentCallable::noopPresent, nullptr);
                     callback->operator()(noop);
                 });

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -84,12 +84,12 @@ struct VulkanSwapChain : public HwSwapChain, fvkmemory::Resource {
     inline void setFrameScheduledCallback(CallbackHandler* handler,
             FrameScheduledCallback&& callback) noexcept {
         if (!callback) {
-            frameScheduled.handler = nullptr;
-            frameScheduled.callback.reset();
+            mFrameScheduled.handler = nullptr;
+            mFrameScheduled.callback.reset();
             return;
         }
-        frameScheduled.handler = handler;
-        frameScheduled.callback = std::make_shared<FrameScheduledCallback>(std::move(callback));
+        mFrameScheduled.handler = handler;
+        mFrameScheduled.callback = std::make_shared<FrameScheduledCallback>(std::move(callback));
     }
 
 private:
@@ -110,8 +110,8 @@ private:
     // These fields store a callback to notify the client that Filament is commiting a frame.
     struct {
         CallbackHandler* handler = nullptr;
-        std::shared_ptr<FrameScheduledCallback> callback = nullptr;
-    } frameScheduled;
+        std::shared_ptr<FrameScheduledCallback> callback;
+    } mFrameScheduled;
 
     // We create VulkanTextures based on VkImages. VulkanTexture has facilities for doing layout
     // transitions, which are useful here.

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -1250,11 +1250,6 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> renderTargetHandle,
             customDepthStencilMsaaSidecarTextureView);
 
     mRenderPassEncoder = commandEncoder.BeginRenderPass(&renderPassDescriptor);
-
-    // Ensure viewport dimensions are not 0
-    FILAMENT_CHECK_POSTCONDITION(params.viewport.width > 0) << "viewport width is 0?";
-    FILAMENT_CHECK_POSTCONDITION(params.viewport.height > 0) << "viewport height is 0?";
-
     mRenderPassEncoder.SetViewport(
             static_cast<float>(params.viewport.left),
             static_cast<float>(params.viewport.bottom),

--- a/filament/backend/src/webgpu/WebGPUSwapChain.cpp
+++ b/filament/backend/src/webgpu/WebGPUSwapChain.cpp
@@ -390,11 +390,11 @@ void WebGPUSwapChain::present(DriverBase& driver) {
     if (!isHeadless()) {
         mSurface.Present();
     }
-    if (frameScheduled.callback) {
-        driver.scheduleCallback(frameScheduled.handler,
-                [callback = std::move(frameScheduled.callback)]() {
+    if (mFrameScheduled.callback) {
+        driver.scheduleCallback(mFrameScheduled.handler,
+                [callback = mFrameScheduled.callback]() {
                     PresentCallable noop = PresentCallable(PresentCallable::noopPresent, nullptr);
-                    callback(noop);
+                    callback->operator()(noop);
                 });
     }
 }

--- a/filament/backend/src/webgpu/WebGPUSwapChain.h
+++ b/filament/backend/src/webgpu/WebGPUSwapChain.h
@@ -23,6 +23,7 @@
 #include <backend/Platform.h>
 
 #include <cstdint>
+#include <memory>
 
 namespace filament::backend {
 
@@ -52,8 +53,13 @@ public:
     void present(DriverBase& driver);
 
     void setFrameScheduledCallback(CallbackHandler* handler, FrameScheduledCallback&& callback) {
-        frameScheduled.handler = handler;
-        frameScheduled.callback = std::move(callback);
+        if (!callback) {
+            mFrameScheduled.handler = nullptr;
+            mFrameScheduled.callback.reset();
+            return;
+        }
+        mFrameScheduled.handler = handler;
+        mFrameScheduled.callback = std::make_shared<FrameScheduledCallback>(std::move(callback));
     }
 
 private:
@@ -83,8 +89,8 @@ private:
 
     struct {
         CallbackHandler* handler = nullptr;
-        FrameScheduledCallback callback;
-    } frameScheduled;
+        std::shared_ptr<FrameScheduledCallback> callback;
+    } mFrameScheduled;
 };
 
 } // namespace filament::backend

--- a/filament/backend/test/test_Callbacks.cpp
+++ b/filament/backend/test/test_Callbacks.cpp
@@ -25,8 +25,6 @@ using namespace filament::backend;
 namespace test {
 
 TEST_F(BackendTest, FrameScheduledCallback) {
-    SKIP_IF(Backend::WEBGPU, "Frame callbacks are unsupported in WebGPU");
-
     auto& api = getDriverApi();
 
     // Create a SwapChain.
@@ -37,10 +35,13 @@ TEST_F(BackendTest, FrameScheduledCallback) {
     Handle<HwRenderTarget> renderTarget = addCleanup(api.createDefaultRenderTarget());
 
     int callbackCountA = 0;
-    api.setFrameScheduledCallback(swapChain, nullptr, [&callbackCountA](PresentCallable callable) {
-        callable();
-        callbackCountA++;
-    }, 0);
+    api.setFrameScheduledCallback(
+            swapChain, nullptr,
+            [&callbackCountA](PresentCallable callable) {
+                callable();
+                callbackCountA++;
+            },
+            0);
 
     // Render the first frame.
     api.makeCurrent(swapChain, swapChain);


### PR DESCRIPTION
Fix the callback by using a shared_ptr to store the callback. The same logic exists in all other backends.

Re-enable corresponding backend test for webgpu.

Remove viewport size check in beingRenderPass. There is no similar check in other backends.