### PR TITLE
fix a possible deadlock on exit

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1039,6 +1039,8 @@ void MetalDriver::updateStreams(DriverApi* driver) {
 
 void MetalDriver::destroyFence(Handle<HwFence> fh) {
     if (fh) {
+        auto* fence = handle_cast<MetalFence>(fh);
+        fence->cancel();
         destruct_handle<MetalFence>(fh);
     }
 }

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -429,6 +429,8 @@ public:
     API_AVAILABLE(ios(12.0))
     void onSignal(MetalFenceSignalBlock block);
 
+    void cancel();
+
 private:
 
     MetalContext& context;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2287,9 +2287,14 @@ mat3f OpenGLDriver::getStreamTransformMatrix(Handle<HwStream> sh) {
 
 void OpenGLDriver::destroyFence(Handle<HwFence> fh) {
     if (fh) {
-        GLFence const* f = handle_cast<GLFence*>(fh);
+        GLFence const* const f = handle_cast<GLFence*>(fh);
         if (mPlatform.canCreateFence() || mContext.isES2()) {
             mPlatform.destroyFence(f->fence);
+        } else {
+            // signal waiters it's time to give-up
+            std::unique_lock const lock(f->state->lock);
+            f->state->status = FenceStatus::ERROR;
+            f->state->cond.notify_all();
         }
         destruct(fh, f);
     }

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -56,6 +56,10 @@ struct VulkanCmdFence {
     FenceStatus wait(VkDevice device, uint64_t timeout,
         std::chrono::steady_clock::time_point until);
 
+    void cancel() {
+        setStatus(VK_ERROR_UNKNOWN);
+    }
+
 private:
     std::shared_mutex mLock; // NOLINT(*-include-cleaner)
     std::condition_variable_any mCond;
@@ -70,28 +74,43 @@ struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {
     VulkanFence() {}
 
     void setFence(std::shared_ptr<VulkanCmdFence> fence) {
-        std::lock_guard lock(mState->lock);
+        std::lock_guard const lock(mState->lock);
         mState->sharedFence = std::move(fence);
         mState->cond.notify_all();
     }
 
     std::shared_ptr<VulkanCmdFence>& getSharedFence() {
-        std::lock_guard lock(mState->lock);
+        std::lock_guard const lock(mState->lock);
         return mState->sharedFence;
     }
 
-    std::shared_ptr<VulkanCmdFence> wait(std::chrono::steady_clock::time_point const until) {
+    std::pair<std::shared_ptr<VulkanCmdFence>, bool>
+            wait(std::chrono::steady_clock::time_point const until) {
         // hold a reference so that our state doesn't disappear while we wait
         std::shared_ptr state{ mState };
         std::unique_lock lock(state->lock);
-        state->cond.wait_until(lock, until, [&state] { return bool(state->sharedFence); });
+        state->cond.wait_until(lock, until, [&state] {
+            return bool(state->sharedFence) || state->canceled;
+        });
         // here mSharedFence will be null if we timed out
-        return state->sharedFence;
+        return { state->sharedFence, state->canceled };
     }
+
+    void cancel() const {
+        std::shared_ptr const state{ mState };
+        std::unique_lock const lock(state->lock);
+        if (state->sharedFence) {
+            state->sharedFence->cancel();
+        }
+        state->canceled = true;
+        state->cond.notify_all();
+    }
+
 private:
     struct State {
         std::mutex lock;
         std::condition_variable cond;
+        bool canceled = false;
         std::shared_ptr<VulkanCmdFence> sharedFence;
     };
     std::shared_ptr<State> mState{ std::make_shared<State>() };

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -234,7 +234,9 @@ public:
     explicit FrameInfoManager(backend::DriverApi& driver) noexcept;
 
     ~FrameInfoManager() noexcept;
-    void terminate(backend::DriverApi& driver) noexcept;
+
+    // The command queue must be empty before calling terminate()
+    void terminate(FEngine& engine) noexcept;
 
     // call this immediately after "make current"
     void beginFrame(backend::DriverApi& driver, Config const& config,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -184,7 +184,8 @@ void FRenderer::terminate(FEngine& engine) {
         // to initialize themselves, otherwise the engine tries to destroy invalid handles.
         engine.execute();
     }
-    mFrameInfoManager.terminate(driver);
+
+    mFrameInfoManager.terminate(engine);
     mFrameSkipper.terminate(driver);
     mResourceAllocator->terminate();
 }


### PR DESCRIPTION
The deadlock happened because FrameInfoManager needs to wait that all fences have signaled before it can be destroyed. 

The fix here is simply to destroy the fence without waiting (for safety we do wait after we destroy them).

This uncovered another problem where all backends didn't handle this  correctly.

We now explicitly handle this when destroying a fence: we make sure it unblocks all the waiters and returns an error.