### PR TITLE
Support returning an inlined .mat of the given .mat in matc

### DIFF
--- a/libs/filament-matp/include/filament-matp/Config.h
+++ b/libs/filament-matp/include/filament-matp/Config.h
@@ -39,6 +39,7 @@ public:
     enum class OutputFormat {
         BLOB,
         C_HEADER,
+        MAT,
     };
 
     using Platform = filamat::MaterialBuilder::Platform;

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -157,7 +157,8 @@ static void usage(char* name) {
             "   --raw, -w\n"
             "       Compile a raw GLSL shader into a SPIRV binary chunk\n\n"
             "   --output-format, -f\n"
-            "       Specify output format: blob (default) or header\n\n"
+            "       Specify output format: blob (default), header or mat. When specifying the "
+            "       output as mat, it will return a mat with #include directives resolved.\n\n"
             "   --debug, -d\n"
             "       Generate extra data for debugging\n\n"
             "   --no-sampler-validation, -F\n"
@@ -275,8 +276,10 @@ bool CommandlineConfig::parse() {
                     mOutputFormat = OutputFormat::BLOB;
                 } else if (arg == "header") {
                     mOutputFormat = OutputFormat::C_HEADER;
+                } else if (arg == "mat") {
+                    mOutputFormat = OutputFormat::MAT;
                 } else {
-                    std::cerr << "Unrecognized output format flag. Must be 'blob'|'header'."
+                    std::cerr << "Unrecognized output format flag. Must be 'blob'|'header'|'mat'."
                             << std::endl;
                    return false;
                 }

--- a/tools/matc/src/matc/Compiler.cpp
+++ b/tools/matc/src/matc/Compiler.cpp
@@ -73,4 +73,19 @@ bool Compiler::writeBlobAsHeader(const Package &pkg, const matp::Config& config)
     return true;
 }
 
+bool Compiler::writeMat(
+        std::unique_ptr<const char[]>& buffer, ssize_t size, const matp::Config& config) const noexcept {
+    matp::Config::Output* output = config.getOutput();
+    if (!output->open()) {
+        std::cerr << "Unable to create header file." << std::endl;
+        return false;
+    }
+
+    std::ostream& file = output->getOutputStream();
+    file.write(buffer.get(), size);
+    output->close();
+
+    return true;
+}
+
 } // namespace matc

--- a/tools/matc/src/matc/Compiler.h
+++ b/tools/matc/src/matc/Compiler.h
@@ -52,6 +52,10 @@ protected:
     // Write package as a C++ array content. Use this to include material
     // in your executable/library.
     bool writeBlobAsHeader(const filamat::Package& pkg, const matp::Config& config) const noexcept;
+
+    // Write a .mat file.
+    bool writeMat(
+            std::unique_ptr<const char[]>& buffer, ssize_t size, const matp::Config& config) const noexcept;
 };
 
 } // namespace matc

--- a/tools/matc/src/matc/Includes.h
+++ b/tools/matc/src/matc/Includes.h
@@ -19,7 +19,7 @@
 
 #include "IncludeCallback.h"
 
-#include "utils/CString.h"
+#include <utils/CString.h>
 
 #include <vector>
 

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -96,6 +96,10 @@ bool MaterialCompiler::run(const matp::Config& config) {
     std::strncpy(modifiedBuffer.get(), result.text.c_str(), size);
     buffer = std::move(modifiedBuffer);
 
+    if (config.getOutputFormat() == matp::Config::OutputFormat::MAT) {
+        return writeMat(buffer, size, config);
+    }
+
     mParser.processTemplateSubstitutions(config, size, buffer);
 
     MaterialBuilder::init();


### PR DESCRIPTION
Support returning an inlined .mat of the given .mat in matc
(This is dependent on https://github.com/google/filament/pull/9374)