### PR TITLE
add a feature flag for FrameInfo::gpuFrameComplete

### DIFF
--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -256,7 +256,7 @@ public:
         uint32_t historySize;
     };
 
-    explicit FrameInfoManager(backend::DriverApi& driver) noexcept;
+    explicit FrameInfoManager(FEngine& engine, backend::DriverApi& driver) noexcept;
 
     ~FrameInfoManager() noexcept;
 
@@ -296,6 +296,7 @@ private:
     utils::AsyncJobQueue mJobQueue;
     FSwapChain* mLastSeenSwapChain = nullptr;
     bool const mHasTimerQueries = false;
+    bool const mDisableGpuFrameComplete = false;
 };
 
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -758,6 +758,9 @@ public:
                         CORRECTNESS_ASSERTION_DEFAULT;
                 bool assert_texture_can_generate_mipmap = CORRECTNESS_ASSERTION_DEFAULT;
             } debug;
+            struct {
+                bool disable_gpu_frame_complete_metric = true;
+            } frame_info;
         } engine;
         struct {
             struct {
@@ -829,6 +832,9 @@ public:
             { "material.enable_material_instance_uniform_batching",
               "Make all MaterialInstances share a common large uniform buffer and use sub-allocations within it.",
               &features.material.enable_material_instance_uniform_batching, false },
+            { "engine.frame_info.disable_gpu_complete_metric",
+              "Disable Renderer::FrameInfo::gpuFrameComplete reporting",
+              &features.engine.frame_info.disable_gpu_frame_complete_metric, false },
     }};
 
     utils::Slice<const FeatureFlag> getFeatureFlags() const noexcept {

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -93,7 +93,7 @@ FRenderer::FRenderer(FEngine& engine) :
         mEngine(engine),
         mFrameSkipper(),
         mRenderTargetHandle(engine.getDefaultRenderTarget()),
-        mFrameInfoManager(engine.getDriverApi()),
+        mFrameInfoManager(engine, engine.getDriverApi()),
         mHdrTranslucent(TextureFormat::RGBA16F),
         mHdrQualityMedium(TextureFormat::R11F_G11F_B10F),
         mHdrQualityHigh(TextureFormat::RGB16F),


### PR DESCRIPTION
There are several race conditions caused by this feature. So we add this flag and disable it by default, for now.