### PR TITLE
vk: fix leaking swapchains again

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
@@ -62,7 +62,7 @@ struct VulkanPlatformSwapChainBase : public Platform::SwapChain {
     virtual bool queryFrameTimestamps(uint64_t frameId, FrameTimestamps* outFrameTimestamps) const;
 
 protected:
-    virtual void destroy() = 0;
+    virtual void destroy();
 
     VkImage createImage(VkExtent2D extent, VkFormat format, bool isProtected);
 


### PR DESCRIPTION
 - Adjust order of destroy call in both headless and platform swapchains.  We need to be careful of the order due to assumptions made by the base class's destroy().
 - remove `=0` since VulkanPlatformSwapChainBase::destroy() has an implementation.

Fixes #9403