### PR TITLE
add overload of loadTexture that loads bitmap from ByteArray

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
@@ -40,7 +40,21 @@ fun loadTexture(engine: Engine, resources: Resources, resourceId: Int, type: Tex
     options.inPremultiplied = type == TextureType.COLOR
 
     val bitmap = BitmapFactory.decodeResource(resources, resourceId, options)
+    return buildTexture(engine, bitmap, type)
+}
 
+fun loadTexture(engine: Engine, bytes: ByteArray, type: TextureType, offset: Int = 0, length: Int = bytes.size): Texture {
+    val options = BitmapFactory.Options()
+    // Color is the only type of texture we want to pre-multiply with the alpha channel
+    // Pre-multiplication is the default behavior, so we need to turn it off here
+    options.inPremultiplied = type == TextureType.COLOR
+
+    val bitmap = BitmapFactory.decodeByteArray(bytes, offset, length, options)
+    return buildTexture(engine, bitmap, type)
+}
+
+
+private fun buildTexture(engine: Engine, bitmap: Bitmap, type: TextureType): Texture {
     val texture = Texture.Builder()
             .width(bitmap.width)
             .height(bitmap.height)


### PR DESCRIPTION
Implements Issue #9411 

Added an overload filament-utils.TextureLoader.loadTexture that uses the Android BitmapFactory.decodeByteArray to contruct a bitmap from a ByteArray.
The section of the code that uses the bitmap to build the texture was separated in a private function to avoid code duplicity, and making it easy to implement the other BitmapFactory factories if needed.