### PR TITLE
VK: Better support for renderdoc captures

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -444,6 +444,11 @@ protected:
 
     virtual VkExternalFenceHandleTypeFlagBits getFenceExportFlags() const noexcept;
 
+    /**
+     * Query if transient attachments are supported by the backend.
+     */
+    bool isTransientAttachmentSupported() const noexcept;
+
 private:
     friend struct VulkanPlatformPrivate;
 };

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -214,4 +214,10 @@ constexpr static const int FVK_MAX_PIPELINE_AGE = FVK_MAX_COMMAND_BUFFERS;
 // destroying any unused pipeline object.
 static_assert(FVK_MAX_PIPELINE_AGE >= FVK_MAX_COMMAND_BUFFERS);
 
+// Indicates if the backend must be setup to allow doing a RenderDoc capture.
+//
+// If this is true, the features not supported by RenderDoc must be disabled, otherwise
+// when using RenderDoc the application will crash or will fail to do a capture.
+constexpr static const int FVK_RENDERDOC_CAPTURE_MODE = false;
+
 #endif


### PR DESCRIPTION
Doing a renderdoc capture when using transient memory or importing AHardwareBuffers into Vulkan, makes it fail, crash or not replay properly.

To improve the capture support, added a new constant to let the backend know when renderdoc is expected to be used and configure things appropietly.

- In the case of transient attachments that uses lazy allocated memory, it will be disabled.
- In the case of AHardwareBuffers, a more robust memory heap selection algorithm will be used.

Also a new VulkanPlatform function will be added, to let other subclasses know that the transient attachments are enabled or not.