### PR TITLE
Fix several problems with RenderPass descriptor sets

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -217,16 +217,17 @@ void FMaterial::terminate(FEngine& engine) {
 
 filament::DescriptorSetLayout const& FMaterial::getPerViewDescriptorSetLayout(
         Variant const variant, bool const useVsmDescriptorSetLayout) const noexcept {
-    if (Variant::isValidDepthVariant(variant)) {
-        assert_invariant(mDefinition.materialDomain == MaterialDomain::SURFACE);
-        return mEngine.getPerViewDescriptorSetLayoutDepthVariant();
+    if (mDefinition.materialDomain == MaterialDomain::SURFACE) {
+        // `variant` is only sensical for MaterialDomain::SURFACE
+        if (Variant::isValidDepthVariant(variant)) {
+            return mEngine.getPerViewDescriptorSetLayoutDepthVariant();
+        }
+        if (Variant::isSSRVariant(variant)) {
+            return mEngine.getPerViewDescriptorSetLayoutSsrVariant();
+        }
     }
-    if (Variant::isSSRVariant(variant)) {
-        assert_invariant(mDefinition.materialDomain == MaterialDomain::SURFACE);
-        return mEngine.getPerViewDescriptorSetLayoutSsrVariant();
-    }
+    // mDefinition.perViewDescriptorSetLayout{Vsm} is already resolved for MaterialDomain
     if (useVsmDescriptorSetLayout) {
-        assert_invariant(mDefinition.materialDomain == MaterialDomain::SURFACE);
         return mDefinition.perViewDescriptorSetLayoutVsm;
     }
     return mDefinition.perViewDescriptorSetLayout;

--- a/filament/src/ds/PostProcessDescriptorSet.cpp
+++ b/filament/src/ds/PostProcessDescriptorSet.cpp
@@ -39,7 +39,7 @@ void PostProcessDescriptorSet::init(FEngine& engine) noexcept {
     // create the descriptor-set layout
     mDescriptorSetLayout = filament::DescriptorSetLayout{
             engine.getDescriptorSetLayoutFactory(),
-            engine.getDriverApi(), descriptor_sets::getPostProcessLayout() };
+            engine.getDriverApi(), descriptor_sets::getDepthVariantLayout() };
 
     // create the descriptor-set from the layout
     mDescriptorSet = DescriptorSet{ "PostProcessDescriptorSet", mDescriptorSetLayout };

--- a/libs/filabridge/include/private/filament/DescriptorSets.h
+++ b/libs/filabridge/include/private/filament/DescriptorSets.h
@@ -28,9 +28,9 @@
 
 namespace filament::descriptor_sets {
 
-backend::DescriptorSetLayout const& getPostProcessLayout() noexcept;
 backend::DescriptorSetLayout const& getDepthVariantLayout() noexcept;
 backend::DescriptorSetLayout const& getSsrVariantLayout() noexcept;
+
 backend::DescriptorSetLayout const& getPerRenderableLayout() noexcept;
 
 backend::DescriptorSetLayout getPerViewDescriptorSetLayout(

--- a/libs/filabridge/src/DescriptorSets.cpp
+++ b/libs/filabridge/src/DescriptorSets.cpp
@@ -40,12 +40,7 @@ namespace filament::descriptor_sets {
 
 using namespace backend;
 
-// used for post-processing passes
-static constexpr std::initializer_list<DescriptorSetLayoutBinding> postProcessDescriptorSetLayoutList = {
-    { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FRAME_UNIFORMS },
-};
-
-// used to generate shadow-maps
+// used to generate shadow-maps, structure and postfx passes
 static constexpr std::initializer_list<DescriptorSetLayoutBinding> depthVariantDescriptorSetLayoutList = {
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FRAME_UNIFORMS },
 };
@@ -142,10 +137,6 @@ static const std::unordered_map<
         {{ SamplerType::SAMPLER_EXTERNAL, SamplerFormat::FLOAT }, DescriptorType::SAMPLER_EXTERNAL }
 };
 
-// used for post-processing passes
-static DescriptorSetLayout const postProcessDescriptorSetLayout{ utils::StaticString("postProcess"),
-    postProcessDescriptorSetLayoutList };
-
 // used to generate shadow-maps
 static DescriptorSetLayout const depthVariantDescriptorSetLayout{
     utils::StaticString("depthVariant"), depthVariantDescriptorSetLayoutList
@@ -162,10 +153,6 @@ static DescriptorSetLayout perViewDescriptorSetLayout = { utils::StaticString("p
 static DescriptorSetLayout perRenderableDescriptorSetLayout = {
     utils::StaticString("perRenderable"), perRenderableDescriptorSetLayoutList
 };
-
-DescriptorSetLayout const& getPostProcessLayout() noexcept {
-    return postProcessDescriptorSetLayout;
-}
 
 DescriptorSetLayout const& getDepthVariantLayout() noexcept {
     return depthVariantDescriptorSetLayout;
@@ -280,10 +267,10 @@ DescriptorSetLayout getPerViewDescriptorSetLayout(
             return layout;
         }
         case MaterialDomain::POST_PROCESS:
-            return postProcessDescriptorSetLayout;
+            return depthVariantDescriptorSetLayout;
         case MaterialDomain::COMPUTE:
             // TODO: what's the layout for compute?
-            return postProcessDescriptorSetLayout;
+            return depthVariantDescriptorSetLayout;
     }
 }
 


### PR DESCRIPTION
The root of the problem is that in the main rendering loop we need to set the correct per-view descriptor-set based on the material and variants.

But we have two cases, either the descriptor set is always constant,  which is the case with ssr, structure, shadows and postfx passes, or it need to be dynamically changed based on the material & variant.

In the 2nd case, where was a problem where the postfx descriptor set could be used, which is wrong (e.g. while rendering shadows we need the shadow UBO, even with a postfx material), and would corrupt the correct descriptor set, which would never be set back.

Another issue was related to running a custom command, it could  change the state without updating the local copy, causing corruptions or validation errors.

In this CL we:
- use the same descriptorsetlayout for both postfx and depth
- invalidate the state after a custom command
- only switch to postfx descriptor set in dynamic mode (color pass)


This fixes setChannelDepthClearEnabled() which could cause  validation error, corruption or crashes.

FIXES=[459567258]