### PR TITLE
frameId must be monotonic in the SwapChain

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -113,8 +113,10 @@ public:
     /**
      * Retrieve a history of frame timing information. The maximum frame history size is
      * given by getMaxFrameHistorySize().
+     * All or part of the history can be lost when using a different SwapChain in beginFrame().
      * @param historySize requested history size. The returned vector could be smaller.
      * @return A vector of FrameInfo.
+     * @see beginFrame()
      */
     utils::FixedCapacityVector<FrameInfo> getFrameInfoHistory(
             size_t historySize = 1) const noexcept;
@@ -326,6 +328,8 @@ public:
      *                                 or 0 if unknown. This value should be the timestamp of
      *                                 the last h/w vsync. It is expressed in the
      *                                 std::chrono::steady_clock time base.
+     *                                 On Android this should be the frame time received from
+     *                                 a Choreographer.
      * @param swapChain A pointer to the SwapChain instance to use.
      *
      * @return
@@ -337,6 +341,8 @@ public:
      *
      * @note
      * All calls to render() must happen *after* beginFrame().
+     * It is recommended to use the same swapChain for every call to beginFrame, failing to do
+     * so can result is losing all or part of the FrameInfo history.
      *
      * @see
      * endFrame()

--- a/libs/utils/include/utils/MonotonicRingMap.h
+++ b/libs/utils/include/utils/MonotonicRingMap.h
@@ -56,6 +56,9 @@ public:
     //! Returns true if the map is full.
     bool full() const noexcept { return mSize == N; }
 
+    //! Clears the map entirely.
+    void clear() noexcept { mSize = 0; mHead = 0; }
+
     /**
      * Inserts a new key-value pair.
      * The key must be greater than the key of the last inserted element.
@@ -65,7 +68,7 @@ public:
      */
     UTILS_NOINLINE void insert(key_type key, mapped_type value) {
         assert(empty() || key > back().first); // assert monotonic
-        if (full()) {
+        if (UTILS_LIKELY(full())) {
             // container is full, replace the oldest element
             mStorage[mHead] = { key, value };
             mHead = (mHead + 1) % N;


### PR DESCRIPTION
The frameId coming from a Renderer must be monotonic when seen from a SwapChain (Specifically a ANativeWindow on Android), if it's not the case, we must clear that part of the history.

This can happen if a SwapChain is used with two different Renderer; at this point that SwapChain's history is no longer connected to that Renderer.