### PR TITLE
don't assume compositor and frame timing are always available

### DIFF
--- a/filament/backend/src/AndroidNativeWindow.cpp
+++ b/filament/backend/src/AndroidNativeWindow.cpp
@@ -61,6 +61,16 @@ int NativeWindow::enableFrameTimestamps(ANativeWindow* anw, bool enable) {
     return pWindow->perform(anw, ENABLE_FRAME_TIMESTAMPS, enable);
 }
 
+int NativeWindow::frameTimestampsSupportsPresent(ANativeWindow* anw, bool* outSupportsPresent) {
+    NativeWindow const* pWindow = reinterpret_cast<NativeWindow const*>(anw);
+    int value = 0;
+    bool const success = pWindow->perform(anw, FRAME_TIMESTAMPS_SUPPORTS_PRESENT, &value);
+    if (success) {
+        *outSupportsPresent = bool(value);
+    }
+    return success;
+}
+
 int NativeWindow::getCompositorTiming(ANativeWindow* anw,
         int64_t* compositeDeadline, int64_t* compositeInterval,
         int64_t* compositeToPresentLatency) {

--- a/filament/backend/src/AndroidNativeWindow.h
+++ b/filament/backend/src/AndroidNativeWindow.h
@@ -32,6 +32,7 @@ struct NativeWindow {
     // is valid query enum value
     enum {
         IS_VALID                = 17,
+        FRAME_TIMESTAMPS_SUPPORTS_PRESENT = 18,
         GET_NEXT_FRAME_ID       = 24,
         ENABLE_FRAME_TIMESTAMPS = 25,
         GET_COMPOSITOR_TIMING   = 26,
@@ -51,6 +52,7 @@ struct NativeWindow {
 
     static int getNextFrameId(ANativeWindow* anw, uint64_t* frameId);
     static int enableFrameTimestamps(ANativeWindow* anw, bool enable);
+    static int frameTimestampsSupportsPresent(ANativeWindow* anw, bool* outSupportsPresent);
     static int getCompositorTiming(ANativeWindow* anw,
             int64_t* compositeDeadline, int64_t* compositeInterval,
             int64_t* compositeToPresentLatency);

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -541,9 +541,15 @@ bool VulkanPlatformAndroid::queryCompositorTiming(SwapChain const* swapchain,
     outCompositorTiming->frameTime = preferredTimeline.frameTime;
     outCompositorTiming->expectedPresentTime = preferredTimeline.expectedPresentTime;
     outCompositorTiming->frameTimelineDeadline = preferredTimeline.frameTimelineDeadline;
+    outCompositorTiming->compositeDeadline = CompositorTiming::INVALID;
+    outCompositorTiming->compositeInterval = CompositorTiming::INVALID;
+    outCompositorTiming->compositeToPresentLatency = CompositorTiming::INVALID;
+
+    // From this point on, we always return "success" because some timings were returned.
 
     auto vulkanSwapchain = static_cast<VulkanPlatformSwapChainBase const *>(swapchain);
-    return vulkanSwapchain->queryCompositorTiming(outCompositorTiming);
+    vulkanSwapchain->queryCompositorTiming(outCompositorTiming);
+    return true;
 }
 
 bool VulkanPlatformAndroid::setPresentFrameId(SwapChain const* swapchain, uint64_t frameId) noexcept {

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -361,13 +361,15 @@ bool VulkanPlatformSurfaceSwapChain::queryCompositorTiming(
         CompositorTiming* outCompositorTiming) const {
 #ifdef __ANDROID__
     // fallback to private APIs
-    int const status = NativeWindow::getCompositorTiming(
-            static_cast<ANativeWindow*>(mNativeWindow),
-            &outCompositorTiming->compositeDeadline,
-            &outCompositorTiming->compositeInterval,
-            &outCompositorTiming->compositeToPresentLatency);
-    if (status == 0) {
-        return true;
+    if (UTILS_VERY_LIKELY(mNativeWindow)) {
+        int const status = NativeWindow::getCompositorTiming(
+                static_cast<ANativeWindow*>(mNativeWindow),
+                &outCompositorTiming->compositeDeadline,
+                &outCompositorTiming->compositeInterval,
+                &outCompositorTiming->compositeToPresentLatency);
+        if (status == 0) {
+            return true;
+        }
     }
 #endif
     return VulkanPlatformSwapChainBase::queryCompositorTiming(outCompositorTiming);


### PR DESCRIPTION
- this is not true fro headless swapchains
- and potentially some timings might not be available on a given nativewindow

Previously the code would handle these errors gracefully, but the  errors were still generated. Now, we query the availability and only make the calls  if supported.