### PR TITLE
buffer update opt: Improve the buffer growth algorithm

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -427,7 +427,7 @@ public:
          * reallocations, which can cause a minor performance stutter, at the cost of higher
          * initial memory usage.
          */
-        uint32_t sharedUboInitialSizeInBytes = 256 * 64;
+        uint32_t sharedUboInitialSizeInBytes = 16 * 64;
     };
 
 

--- a/filament/src/details/UboManager.cpp
+++ b/filament/src/details/UboManager.cpp
@@ -277,7 +277,6 @@ allocation_size_t UboManager::getAllocationOffset(AllocationId id) const {
 
 void UboManager::reallocate(DriverApi& driver, allocation_size_t requiredSize) {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
-    LOG(INFO) << "Reallocate from size: "<< mUboSize << " to size: "<<requiredSize;
     if (mUbHandle) {
         driver.destroyBufferObject(mUbHandle);
     }


### PR DESCRIPTION
The original buffer resizing approach calculates the new size from zero, totaling the required space for existing MIs and adding extra space for MIs that failed reallocation due to parameter updates. The flaw is that it didn't account for orphaned memory slots, which can lead to the newly calculated buffer size being insufficient if some of the material instances are updated in the following frames.

The new method improves this by starting the buffer growth from the current buffer size and only adding the necessary UBO size for each MI that explicitly requires additional space.

We probably want a shrinking strategy in the future to reduce the buffer size when MIs are not frequently updated, optimizing overall memory usage.

Also decrease the default initial buffer size since the original one might be too large. 