### PR TITLE
Validation layer issue nullsampler

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -60,7 +60,6 @@ public:
     void updateSamplerForExternalSamplerSet(fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t binding,
             fvkmemory::resource_ptr<VulkanTexture> texture) noexcept;
 
-
     void updateInputAttachment(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
             VulkanAttachment const& attachment) noexcept;
 


### PR DESCRIPTION
Addressing the validation layer issue where we encounter RGB samplers next to YUV.