### PR TITLE
fix disable_gpu_frame_complete_metric flag

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -780,7 +780,7 @@ public:
                 bool assert_texture_can_generate_mipmap = CORRECTNESS_ASSERTION_DEFAULT;
             } debug;
             struct {
-                bool disable_gpu_frame_complete_metric = false;
+                bool disable_gpu_frame_complete_metric = true;
             } frame_info;
         } engine;
         struct {


### PR DESCRIPTION
- set the flag to true (metrics disabled) until downstream is ready
- make sure to exit the JobQueue thread before destroying it

BUGS=[464370498]