### PR TITLE
Correctly add flag to guard camera near/far assertion (#9472)

### DIFF
--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -33,20 +33,12 @@ using namespace math;
 
 void Camera::setProjection(double const fovInDegrees, double const aspect,
         double const near, double const far, Fov const direction) {
-
-    setCustomProjection(
-            projection(direction, fovInDegrees, aspect, near),
-            projection(direction, fovInDegrees, aspect, near, far),
-            near, far);
+    downcast(this)->setProjection(fovInDegrees, aspect, near, far, direction);
 }
 
 void Camera::setLensProjection(double const focalLengthInMillimeters,
         double const aspect, double const near, double const far) {
-
-    setCustomProjection(
-            projection(focalLengthInMillimeters, aspect, near),
-            projection(focalLengthInMillimeters, aspect, near, far),
-            near, far);
+    downcast(this)->setLensProjection(focalLengthInMillimeters, aspect, near, far);
 }
 
 mat4f Camera::inverseProjection(const mat4f& p) noexcept {

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -48,6 +48,11 @@ public:
 
     void terminate(FEngine&) noexcept { }
 
+    void setProjection(double const fovInDegrees, double const aspect,
+            double const near, double const far, Fov const direction);
+
+    void setLensProjection(double const focalLengthInMillimeters,
+            double const aspect, double const near, double const far);
 
     // Sets the projection matrices (viewing and culling). The viewing matrice has infinite far.
     void setProjection(Projection projection,


### PR DESCRIPTION
The previous attempt changed the precondition checks and made them too aggressive.  For instance, near=0 is allowed with an ORTHO projection.