### PR TITLE
fix use-after-free of the EGL swapchain

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -422,12 +422,14 @@ void VulkanDriver::beginFrame(int64_t monotonic_clock_ns,
         int64_t refreshIntervalNs, uint32_t frameId) {
     FVK_PROFILE_MARKER(PROFILE_NAME_BEGINFRAME);
 
-    if (mCurrentSwapChain) { // This should be guaranteed
+    // if frameId is 0, it means we're not associated to a particular frame, which is the case
+    // for standalone views. And in this case we skip the frame info timing collection.
+    if (frameId && mCurrentSwapChain) { // This should be guaranteed
         mPlatform->setPresentFrameId(mCurrentSwapChain->swapChain, frameId);
     }
 
     // Check if any command have finished and reset all its used resources. The resources
-    // wont be destroyed but their reference count will decreased if the command is already
+    // won't be destroyed but their reference count will be decreased if the command is already
     // completed.
     //
     // This will let us check if any VulkanBuffer is currently in flight or not.

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -561,7 +561,6 @@ void FRenderer::renderStandaloneView(FView const* view) {
 
     if (UTILS_LIKELY(view->getScene())) {
         mPreviousRenderTargets.clear();
-        mFrameId++;
 
         // ask the engine to do what it needs to (e.g. updates light buffer, materials...)
         FEngine& engine = mEngine;
@@ -571,8 +570,7 @@ void FRenderer::renderStandaloneView(FView const* view) {
         driver.beginFrame(
                 steady_clock::now().time_since_epoch().count(),
                 mDisplayInfo.refreshRate == 0.0 ? 0 : int64_t(
-                        1'000'000'000.0 / mDisplayInfo.refreshRate),
-                mFrameId);
+                        1'000'000'000.0 / mDisplayInfo.refreshRate), 0);
 
         // because we don't have a "present" call, we use flush so the driver can submit
         // the command buffer; we do this before driver.endFrame() to mimic what would
@@ -581,7 +579,7 @@ void FRenderer::renderStandaloneView(FView const* view) {
 
         engine.submitFrame();
 
-        driver.endFrame(mFrameId);
+        driver.endFrame(0);
 
         // engine.flush() has already been called by renderInternal(), but we need an extra one
         // for endFrame() above. This operation in actually not too heavy, it just kicks the

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -209,7 +209,7 @@ private:
     backend::Handle<backend::HwRenderTarget> mRenderTargetHandle;
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
-    uint32_t mFrameId = 0;
+    uint32_t mFrameId = 1; // id 0 is reserved for standalone views
     FrameInfoManager mFrameInfoManager;
     backend::TextureFormat mHdrTranslucent;
     backend::TextureFormat mHdrQualityMedium;


### PR DESCRIPTION
PlatformEGLAndroid holds onto the current swapchain in order to use it when beginFrame is called. Usually the swapchain is set just before beginFrame is called. However, that's not the case for standalone views. These are independent of the swapchain and doing "swapchain stuff" for them is nonsensical.

So make sure that:

1. PlatfromEGLAndroid doesn't hold onto a dangling pointer when the  swapchain is destroyed. And add proper null checks.
2. Don't do the "swapchain stuff" when beginFrame is called in the context of a standalone view. We now reserve frameID 0 for that purpose (meaning the frameid is non sensical for these).

We're currently relying on frameID to not wrap-around. At 120 fps,  that's about 1 year. This will be addressed in a later PR.

FIXES=[462827028, 461399487]