### PR TITLE
fix mat33 in UBOs at feature level 0

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -39,6 +39,7 @@
 #include <new>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -328,9 +329,40 @@ void OpenGLProgram::updateUniforms(
                 glUniform4iv(loc, u.size, bi);
                 break;
 
-            case UniformType::MAT3:
-                glUniformMatrix3fv(loc, u.size, GL_FALSE, bf);
+            case UniformType::MAT3: {
+                // glUniformMatrix3fv expect a packed mat3, but the UBO is in std140
+                // also, the GLES spec says:
+                // Locations for sequential array indices are not required to be sequential.
+                // The location for "a[1]" may or may not be equal to the location for "a[0]" + 1.
+                // Furthermore, since unused elements at the end of uniform arrays may be trimmed
+                // the location of the i + 1 array element may not be valid even if the location of
+                // the i element is valid. As a direct consequence, the value of the location of
+                // "a[0]" + 1 may refer to a different uniform entirely. Applications that wish to
+                // set individual array elements should query the locations of each element
+                // separately.
+
+                struct std140 {
+                    struct mat3 : public std::array<std::array<GLfloat, 4>, 3> {
+                    };
+                };
+                std140::mat3 const* const b = reinterpret_cast<std140::mat3 const*>(bf);
+
+                struct mat3 : public std::array<std::array<GLfloat, 3>, 3> {
+                    explicit mat3(std140::mat3 const& other) noexcept
+                        : std::array<std::array<GLfloat, 3>, 3>{ {
+                            { { other[0][0], other[0][1], other[0][2] } },
+                            { { other[1][0], other[1][1], other[1][2] } },
+                            { { other[2][0], other[2][1], other[2][2] } }
+                        } } {
+                    }
+                };
+
+                std::vector<mat3> const temp{ b, b + u.size };
+                glUniformMatrix3fv(loc, u.size, GL_FALSE,
+                        reinterpret_cast<GLfloat const*>(temp.data()));
                 break;
+            }
+
             case UniformType::MAT4:
                 glUniformMatrix4fv(loc, u.size, GL_FALSE, bf);
                 break;


### PR DESCRIPTION
When emulating UBOs for feature level 0, we need to use packed mat33 as source of glUniformMatrix3fv which doesn't expect the std140 alignments of UBOs.

FIXES=[468092808]