### PR TITLE
github: fix windows race

### DIFF
--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -70,6 +70,7 @@ if (TNT_DEV)
             filament_bimap_test.cpp
             filament_framegraph_test.cpp
             filament_test.cpp
+            filament_test_material.cpp
             ${RESGEN_SOURCE})
 
     target_link_libraries(test_${TARGET} PRIVATE filament gtest)

--- a/third_party/draco/tnt/CMakeLists.txt
+++ b/third_party/draco/tnt/CMakeLists.txt
@@ -469,6 +469,47 @@ add_library(draco_points_dec OBJECT ${draco_points_common_sources}
 add_library(draco_points_enc OBJECT ${draco_points_common_sources}
                               ${draco_points_enc_sources})
 
+# In parallel Windows builds, multiple object libraries might try to write to the same
+# internal 'generate.stamp' file, leading to 'Access denied' errors.
+# This dependency chain serializes their build order to prevent that race condition.
+set(draco_object_libraries
+    draco_attributes
+    draco_compression_attributes_dec
+    draco_compression_attributes_enc
+    draco_compression_attributes_pred_schemes_dec
+    draco_compression_attributes_pred_schemes_enc
+    draco_compression_bit_coders
+    draco_enc_config
+    draco_dec_config
+    draco_compression_decode
+    draco_compression_encode
+    draco_compression_entropy
+    draco_compression_mesh_traverser
+    draco_compression_mesh_dec
+    draco_compression_mesh_enc
+    draco_compression_point_cloud_dec
+    draco_compression_point_cloud_enc
+    draco_core
+    draco_io
+    draco_mesh
+    draco_metadata_dec
+    draco_metadata_enc
+    draco_metadata
+    draco_animation_dec
+    draco_animation_enc
+    draco_animation
+    draco_point_cloud
+    draco_points_dec
+    draco_points_enc
+)
+set(previous_library "")
+foreach(current_library ${draco_object_libraries})
+    if(NOT "${previous_library}" STREQUAL "")
+        add_dependencies(${current_library} ${previous_library})
+    endif()
+    set(previous_library ${current_library})
+endforeach()
+
 # Library targets that consume the object collections.
 add_library(dracodec
             dummy.c     # needed for Xcode


### PR DESCRIPTION
  
     A. Move filament_test_material.cpp to be part of test_filament
        (This won't be triggered during the windows build)
     B. Add chaining dependencies in third_party/draco/tnt so that
        there is no race in writing/reading generate.stamp
    
    -------------
    Failures
    -------------
    A.
    
    C:\a\filament\filament\out\cmake-mtd\filament\test\resources\filament_test_resources.c(1,1): error C1083: Cannot open source file: 'C:\a\filament\filament\out\cmake-mtd\filament\test\resources\filament_test_resources.c': Permission denied [C:\a\filament\filament\out\cmake-mtd\filament\test\test_material_parser.vcxproj]
    
    B.
    
    CUSTOMBUILD : CMake error : Cannot restore timestamp "C:/a/filament/filament/out/cmake-mtd/third_party/draco/tnt/CMakeFiles/generate.stamp": Access is denied. [C:\a\filament\filament\out\cmake-mtd\third_party\draco\tnt\draco_compression_bit_coders.vcxproj]

