### PR TITLE
Fix missing dep in CompressedStringChunk

### DIFF
--- a/libs/filamat/src/eiff/CompressedStringChunk.cpp
+++ b/libs/filamat/src/eiff/CompressedStringChunk.cpp
@@ -16,6 +16,7 @@
 
 #include "CompressedStringChunk.h"
 
+#include <stdint.h>
 #include <zstd.h>
 
 namespace filamat {
@@ -35,7 +36,7 @@ int toZstdCompressionLevel(CompressedStringChunk::CompressionLevel compressionLe
 
 void CompressedStringChunk::flatten(filamat::Flattener& f) {
     const size_t bufferBound = ZSTD_compressBound(mString.size());
-    std::vector<std::uint8_t> compressed(bufferBound);
+    std::vector<uint8_t> compressed(bufferBound);
 
     const size_t compressedSize = ZSTD_compress(
             compressed.data(), compressed.size(),


### PR DESCRIPTION
adding `<cstdint>` explicitly as we are seeing build failure in moohan:

```
external/third_party+/filament/libs/filamat/src/eiff/CompressedStringChunk.cpp:38:22: error: no member named 'uint8_t' in namespace 'std'
   38 |     std::vector<std::uint8_t> compressed(bufferBound);
      |                 ~~~~~^
1 error generated.
```