### PR TITLE
Fix Json lexeme attempting to allocate a string with a huge size due to underflow

### DIFF
--- a/libs/filament-matp/src/JsonishLexeme.h
+++ b/libs/filament-matp/src/JsonishLexeme.h
@@ -34,7 +34,7 @@ enum JsonType {
     COLUMN,
 };
 
-class JsonLexeme final: public Lexeme<JsonType > {
+class JsonLexeme final: public Lexeme<JsonType> {
 public:
     static const char* getTypeString(JsonType type) {
         switch (type) {
@@ -63,6 +63,13 @@ public:
         }
         const char *start = (*mStart == '"') ? mStart + 1 : mStart;
         const char *end = (*mEnd == '"') ? mEnd - 1 : mEnd;
+        // Edge case: If the string only contains a single double-quote, the end can be before the
+        // start, which causes Lexeme::getStringValue to allocate a string with a large size, since
+        // it under flows. So we don't trim in this case, though this will fail to parse.
+         if (start > end) {
+             start = mStart;
+             end = mEnd;
+         }
         return { mType, start, end, mLineNumber, mPosition };
     }
 

--- a/libs/filament-matp/src/MaterialParser.cpp
+++ b/libs/filament-matp/src/MaterialParser.cpp
@@ -287,8 +287,8 @@ utils::Status MaterialParser::parseMaterialAsJSON(const char* buffer, size_t siz
 
     JsonishParser parser(jlexer.getLexemes());
     std::unique_ptr<JsonishObject> json = parser.parse();
-    if (json == nullptr) {
-        return utils::Status::internal("Could not parse JSON material file");
+    if (json == nullptr || !parser.getParseStatus().isOk()) {
+        return parser.getParseStatus();
     }
 
     for (auto& entry : json->getEntries()) {

--- a/libs/filament-matp/tests/test_matp.cpp
+++ b/libs/filament-matp/tests/test_matp.cpp
@@ -332,6 +332,21 @@ TEST_F(MaterialLexer, JsonMaterialParserInvalidInputReturnsError) {
     EXPECT_EQ(root, nullptr);
 }
 
+TEST_F(MaterialLexer, JsonMaterialParserSingleDoubleQuoteDoesntCrash) {
+    static std::string singleDoubleQuote = R"(
+        material: {
+            name: ",
+        }
+    )";
+    matp::MaterialParser parser;
+    TestMaterialParser testParser(parser);
+    filamat::MaterialBuilder unused;
+    utils::Status result = testParser.parseMaterialAsJSON(
+            singleDoubleQuote.c_str(), singleDoubleQuote.size(), unused);
+
+    EXPECT_EQ(result.getCode(), utils::StatusCode::INVALID_ARGUMENT);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
This is an edge case when the given string is a just a single double-quote within the material source file.

`JasonLexeme::trim` trims `"`, which moves the end pointer before the start pointer, which then makes `Lexeme::getStringValue` allocate a string with a huge size since it underflows.

This was caught on Impress split engine fuzz test. Verified that the fuzz test passes with this fix.

FIXES=463444508