### PR TITLE
Add api level enforcement

### DIFF
--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -980,15 +980,15 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 if (v.stage == ShaderStage::VERTEX) {
                     shader = sg.createSurfaceVertexProgram(
                             shaderModel, targetApi, targetLanguage, featureLevel,
-                            info, v.variant, mInterpolation, mVertexDomain);
+                            info, v.variant, mInterpolation, mVertexDomain, mApiLevel);
                 } else if (v.stage == ShaderStage::FRAGMENT) {
                     shader = sg.createSurfaceFragmentProgram(
                             shaderModel, targetApi, targetLanguage, featureLevel,
-                            info, v.variant, mInterpolation, mVariantFilter);
+                            info, v.variant, mInterpolation, mVariantFilter, mApiLevel);
                 } else if (v.stage == ShaderStage::COMPUTE) {
                     shader = sg.createSurfaceComputeProgram(
                             shaderModel, targetApi, targetLanguage, featureLevel,
-                            info);
+                            info, mApiLevel);
                 }
 
                 // Write the variant to a file.
@@ -1532,15 +1532,15 @@ std::string MaterialBuilder::peek(backend::ShaderStage const stage,
         case ShaderStage::VERTEX:
             return sg.createSurfaceVertexProgram(
                     params.shaderModel, params.targetApi, params.targetLanguage,
-                    params.featureLevel, info, {}, mInterpolation, mVertexDomain);
+                    params.featureLevel, info, {}, mInterpolation, mVertexDomain, mApiLevel);
         case ShaderStage::FRAGMENT:
             return sg.createSurfaceFragmentProgram(
                     params.shaderModel, params.targetApi, params.targetLanguage,
-                    params.featureLevel, info, {}, mInterpolation, mVariantFilter);
+                    params.featureLevel, info, {}, mInterpolation, mVariantFilter, mApiLevel);
         case ShaderStage::COMPUTE:
             return sg.createSurfaceComputeProgram(
                     params.shaderModel, params.targetApi, params.targetLanguage,
-                    params.featureLevel, info);
+                    params.featureLevel, info, mApiLevel);
     }
     return {};
 }

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -43,7 +43,7 @@ io::sstream& CodeGenerator::generateSeparator(io::sstream& out) {
 }
 
 utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out, ShaderStage stage,
-        MaterialInfo const& material, filament::Variant v) const {
+        MaterialInfo const& material, filament::Variant v, uint32_t apiLevel) const {
     switch (mShaderModel) {
         case ShaderModel::MOBILE:
             // Vulkan requires version 310 or higher
@@ -385,6 +385,10 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
             generateDefine(out, "textureCubeLod", "textureLod");
         }
     }
+
+    // Api level enforcement.
+    generateDefine(out, "CLIENT_MATERIAL_API_LEVEL", apiLevel);
+    generateDefine(out, "UNSTABLE_MATERIAL_API_LEVEL", filament::UNSTABLE_MATERIAL_API_LEVEL);
 
     out << "\n";
     return out;

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -76,7 +76,7 @@ public:
 
     // generate prolog for the given shader
     utils::io::sstream& generateCommonProlog(utils::io::sstream& out, ShaderStage stage,
-            MaterialInfo const& material, filament::Variant v) const;
+            MaterialInfo const& material, filament::Variant v, uint32_t apiLevel) const;
 
     static utils::io::sstream& generateCommonEpilog(utils::io::sstream& out);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -377,7 +377,7 @@ std::string ShaderGenerator::createSurfaceVertexProgram(ShaderModel const shader
         MaterialBuilder::TargetApi const targetApi, MaterialBuilder::TargetLanguage const targetLanguage,
         MaterialBuilder::FeatureLevel const featureLevel,
         MaterialInfo const& material, const filament::Variant variant, Interpolation const interpolation,
-        VertexDomain const vertexDomain) const noexcept {
+        VertexDomain const vertexDomain, uint32_t apiLevel) const noexcept {
 
     assert_invariant(filament::Variant::isValid(variant));
     assert_invariant(mMaterialDomain != MaterialBuilder::MaterialDomain::COMPUTE);
@@ -385,14 +385,14 @@ std::string ShaderGenerator::createSurfaceVertexProgram(ShaderModel const shader
     if (mMaterialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
         return createPostProcessVertexProgram(
                 shaderModel, targetApi,
-                targetLanguage, featureLevel, material, variant.key);
+                targetLanguage, featureLevel, material, variant.key, apiLevel);
     }
 
     io::sstream vs;
 
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, featureLevel);
 
-    cg.generateCommonProlog(vs, ShaderStage::VERTEX, material, variant);
+    cg.generateCommonProlog(vs, ShaderStage::VERTEX, material, variant, apiLevel);
 
     generateUserSpecConstants(cg, vs, mConstants);
 
@@ -512,20 +512,21 @@ std::string ShaderGenerator::createSurfaceFragmentProgram(ShaderModel const shad
         MaterialBuilder::TargetApi const targetApi, MaterialBuilder::TargetLanguage const targetLanguage,
         MaterialBuilder::FeatureLevel const featureLevel,
         MaterialInfo const& material, const filament::Variant variant,
-        Interpolation const interpolation, UserVariantFilterMask const variantFilter) const noexcept {
+        Interpolation const interpolation, UserVariantFilterMask const variantFilter,
+        uint32_t apiLevel) const noexcept {
 
     assert_invariant(filament::Variant::isValid(variant));
     assert_invariant(mMaterialDomain != MaterialBuilder::MaterialDomain::COMPUTE);
 
     if (mMaterialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
         return createPostProcessFragmentProgram(shaderModel, targetApi, targetLanguage,
-                                                featureLevel, material, variant.key);
+                                                featureLevel, material, variant.key, apiLevel);
     }
 
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, featureLevel);
 
     io::sstream fs;
-    cg.generateCommonProlog(fs, ShaderStage::FRAGMENT, material, variant);
+    cg.generateCommonProlog(fs, ShaderStage::FRAGMENT, material, variant, apiLevel);
 
     generateUserSpecConstants(cg, fs, mConstants);
 
@@ -675,13 +676,13 @@ std::string ShaderGenerator::createSurfaceFragmentProgram(ShaderModel const shad
 std::string ShaderGenerator::createSurfaceComputeProgram(ShaderModel const shaderModel,
         MaterialBuilder::TargetApi const targetApi, MaterialBuilder::TargetLanguage const targetLanguage,
         MaterialBuilder::FeatureLevel const featureLevel,
-        MaterialInfo const& material) const noexcept {
+        MaterialInfo const& material, uint32_t apiLevel) const noexcept {
     assert_invariant(mMaterialDomain == MaterialBuilder::MaterialDomain::COMPUTE);
     assert_invariant(featureLevel >= FeatureLevel::FEATURE_LEVEL_2);
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, featureLevel);
     io::sstream s;
 
-    cg.generateCommonProlog(s, ShaderStage::COMPUTE, material, {});
+    cg.generateCommonProlog(s, ShaderStage::COMPUTE, material, {}, apiLevel);
 
     generateUserSpecConstants(cg, s, mConstants);
 
@@ -718,10 +719,11 @@ std::string ShaderGenerator::createSurfaceComputeProgram(ShaderModel const shade
 std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel const sm,
         MaterialBuilder::TargetApi const targetApi, MaterialBuilder::TargetLanguage const targetLanguage,
         MaterialBuilder::FeatureLevel const featureLevel,
-        MaterialInfo const& material, const filament::Variant::type_t variantKey) const noexcept {
+        MaterialInfo const& material, const filament::Variant::type_t variantKey,
+        uint32_t apiLevel) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage, featureLevel);
     io::sstream vs;
-    cg.generateCommonProlog(vs, ShaderStage::VERTEX, material, {});
+    cg.generateCommonProlog(vs, ShaderStage::VERTEX, material, {}, apiLevel);
 
     generateUserSpecConstants(cg, vs, mConstants);
 
@@ -762,10 +764,10 @@ std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel const sm
 std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel const sm,
         MaterialBuilder::TargetApi const targetApi, MaterialBuilder::TargetLanguage const targetLanguage,
         MaterialBuilder::FeatureLevel const featureLevel,
-        MaterialInfo const& material, uint8_t variant) const noexcept {
+        MaterialInfo const& material, uint8_t variant, uint32_t apiLevel) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage, featureLevel);
     io::sstream fs;
-    cg.generateCommonProlog(fs, ShaderStage::FRAGMENT, material, {});
+    cg.generateCommonProlog(fs, ShaderStage::FRAGMENT, material, {}, apiLevel);
 
     generateUserSpecConstants(cg, fs, mConstants);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -63,19 +63,19 @@ public:
             MaterialBuilder::FeatureLevel featureLevel,
             MaterialInfo const& material, filament::Variant variant,
             filament::Interpolation interpolation,
-            filament::VertexDomain vertexDomain) const noexcept;
+            filament::VertexDomain vertexDomain, uint32_t apiLevel) const noexcept;
 
     std::string createSurfaceFragmentProgram(filament::backend::ShaderModel shaderModel,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialBuilder::FeatureLevel featureLevel,
             MaterialInfo const& material, filament::Variant variant,
             filament::Interpolation interpolation,
-            filament::UserVariantFilterMask variantFilter) const noexcept;
+            filament::UserVariantFilterMask variantFilter, uint32_t apiLevel) const noexcept;
 
     std::string createSurfaceComputeProgram(filament::backend::ShaderModel shaderModel,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialBuilder::FeatureLevel featureLevel,
-            MaterialInfo const& material) const noexcept;
+            MaterialInfo const& material, uint32_t apiLevel) const noexcept;
 
     /**
      * When a GLSL shader is optimized we run it through an intermediate SPIR-V
@@ -111,12 +111,13 @@ private:
     std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialBuilder::FeatureLevel featureLevel,
-            MaterialInfo const& material, filament::Variant::type_t variantKey) const noexcept;
+            MaterialInfo const& material, filament::Variant::type_t variantKey,
+            uint32_t apiLevel) const noexcept;
 
     std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialBuilder::FeatureLevel featureLevel,
-            MaterialInfo const& material, uint8_t variant) const noexcept;
+            MaterialInfo const& material, uint8_t variant, uint32_t apiLevel) const noexcept;
 
     static void appendShader(utils::io::sstream& ss,
             const utils::CString& shader, size_t lineOffset) noexcept;


### PR DESCRIPTION
Api level is now enforced when generating code by appending #defines of client requested and unstable apis. This ensures that the client can only use unstable apis when they explicitly add `apiLevel` in their .mat file.

FIXES=468340631