### PR TITLE
Fix GCC type mismatch error in `Platform::debugUpdateStat`

### DIFF
--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -194,7 +194,7 @@ void Platform::debugUpdateStat(const char* key, uint64_t intValue) {
         callback = mDebugUpdateStat;
     }
     if (callback) {
-        (*callback)(key, intValue, "");
+        (*callback)(key, intValue, utils::CString(""));
     }
 }
 


### PR DESCRIPTION
With experimental GCC support enabled, `Platform::debugUpdateStat`'s callback invocation fails to compile due to an implicit string literal -> `utils::CString` conversion. Adding an explicit conversion fixes this issue.