### PR TITLE
Refactor FrameGraph pass API for flexibility

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -3154,7 +3154,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
                 // an "import".
                 builder.sideEffect();
                 data.color = builder.sample(history); // FIXME: an access must be declared for detach(), why?
-            }, [&current](FrameGraphResources const& resources, auto const& data, auto&) {
+            }, [&current](FrameGraphResources const& resources, auto const& data) {
                 resources.detach(data.color, &current.color, &current.desc);
             });
 
@@ -3805,7 +3805,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
 
     auto const& depthMipmapPass = fg.addPass<VsmMipData>("VSM Generate Mipmap Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
-                utils::StaticString name = builder.getName(input);
+                StaticString const name = builder.getName(input);
                 data.in = builder.sample(input);
 
                 auto out = builder.createSubresource(data.in, "Mip level", {

--- a/filament/src/fg/details/PassNode.h
+++ b/filament/src/fg/details/PassNode.h
@@ -26,7 +26,9 @@
 
 #include <backend/TargetBufferInfo.h>
 
+#include <cstdint>
 #include <unordered_set>
+#include <vector>
 
 namespace utils {
 class CString;
@@ -62,7 +64,7 @@ public:
     Vector<VirtualResource*> destroy;              // resources we need to destroy after executing
 };
 
-class RenderPassNode : public PassNode {
+class RenderPassNode final : public PassNode {
 public:
     class RenderPassData {
     public:
@@ -107,7 +109,7 @@ private:
     std::vector<RenderPassData> mRenderTargetData;
 };
 
-class PresentPassNode : public PassNode {
+class PresentPassNode final : public PassNode {
 public:
     explicit PresentPassNode(FrameGraph& fg) noexcept;
     PresentPassNode(PresentPassNode&& rhs) noexcept;


### PR DESCRIPTION
This commit simplifies and unifies the FrameGraph's `addPass` API. Key changes:
- The `addPass` method now uses a single, more flexible implementation that handles different lambda signatures for both the setup and execute stages.
- The execute lambda can now optionally omit the `DriverApi&` parameter, reducing boilerplate for simple passes.
- The `addTrivialSideEffectPass` helper has been removed. Side-effect-only passes can now be created directly with `addPass`