### PR TITLE
Rename DescriptorSetLayoutBinding to DescriptorSetLayoutDescriptor

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -499,7 +499,7 @@ using descriptor_set_t = uint8_t;
 
 using descriptor_binding_t = uint8_t;
 
-struct DescriptorSetLayoutBinding {
+struct DescriptorSetLayoutDescriptor {
     static bool isSampler(DescriptorType type) noexcept {
         return int(type) <= int(DescriptorType::SAMPLER_EXTERNAL);
     }
@@ -513,8 +513,8 @@ struct DescriptorSetLayoutBinding {
     DescriptorFlags flags = DescriptorFlags::NONE;
     uint16_t count = 0;
 
-    friend bool operator==(DescriptorSetLayoutBinding const& lhs,
-            DescriptorSetLayoutBinding const& rhs) noexcept {
+    friend bool operator==(DescriptorSetLayoutDescriptor const& lhs,
+            DescriptorSetLayoutDescriptor const& rhs) noexcept {
         return lhs.type == rhs.type &&
                lhs.flags == rhs.flags &&
                lhs.count == rhs.count &&
@@ -1385,7 +1385,7 @@ static_assert(sizeof(SamplerParams) <= sizeof(uint64_t),
 
 struct DescriptorSetLayout {
     std::variant<utils::StaticString, utils::CString, std::monostate> label;
-    utils::FixedCapacityVector<DescriptorSetLayoutBinding> bindings;
+    utils::FixedCapacityVector<DescriptorSetLayoutDescriptor> descriptors;
 };
 
 //! blending equation function

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -510,7 +510,7 @@ class MetalDescriptorSetLayout : public HwDescriptorSetLayout {
 public:
     MetalDescriptorSetLayout(DescriptorSetLayout&& layout) noexcept;
 
-    const auto& getBindings() const noexcept { return mLayout.bindings; }
+    const auto& getBindings() const noexcept { return mLayout.descriptors; }
 
     size_t getDynamicOffsetCount() const noexcept { return mDynamicOffsetCount; }
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -1441,7 +1441,7 @@ void MetalFence::cancel() {
 MetalDescriptorSetLayout::MetalDescriptorSetLayout(DescriptorSetLayout&& l) noexcept
     : mLayout(std::move(l)) {
     size_t dynamicBindings = 0;
-    for (const auto& binding : mLayout.bindings) {
+    for (const auto& binding : mLayout.descriptors) {
         if (any(binding.flags & DescriptorFlags::DYNAMIC_OFFSET)) {
             dynamicBindings++;
         }

--- a/filament/backend/src/opengl/BindingMap.h
+++ b/filament/backend/src/opengl/BindingMap.h
@@ -70,7 +70,7 @@ public:
         assert_invariant(binding < MAX_DESCRIPTOR_COUNT);
         assert_invariant(entry.binding < 128); // we reserve 1 bit for the type right now
         mStorage[set][binding] = { uint8_t(entry.binding),
-                                   DescriptorSetLayoutBinding::isSampler(entry.type) };
+                                   DescriptorSetLayoutDescriptor::isSampler(entry.type) };
         mActiveDescriptors[set].set(binding);
     }
 

--- a/filament/backend/src/opengl/GLDescriptorSet.cpp
+++ b/filament/backend/src/opengl/GLDescriptorSet.cpp
@@ -56,7 +56,7 @@ GLDescriptorSet::GLDescriptorSet(OpenGLContext& gl, DescriptorSetLayoutHandle ds
 
     // We have allocated enough storage for all descriptors. Now allocate the empty descriptor
     // themselves.
-    for (auto const& entry : layout->bindings) {
+    for (auto const& entry : layout->descriptors) {
         size_t const index = entry.binding;
 
         // now we'll initialize the alternative for each way we can handle this descriptor.
@@ -372,10 +372,10 @@ void GLDescriptorSet::validate(HandleAllocatorGL& allocator,
 
         UTILS_UNUSED_IN_RELEASE
         bool const pipelineLayoutMatchesDescriptorSetLayout = std::equal(
-                dsl->bindings.begin(), dsl->bindings.end(),
-                cur->bindings.begin(),
-                [](DescriptorSetLayoutBinding const& lhs,
-                        DescriptorSetLayoutBinding const& rhs) {
+                dsl->descriptors.begin(), dsl->descriptors.end(),
+                cur->descriptors.begin(),
+                [](DescriptorSetLayoutDescriptor const& lhs,
+                        DescriptorSetLayoutDescriptor const& rhs) {
                     return lhs.type == rhs.type &&
                            lhs.stageFlags == rhs.stageFlags &&
                            lhs.binding == rhs.binding &&

--- a/filament/backend/src/opengl/GLDescriptorSetLayout.h
+++ b/filament/backend/src/opengl/GLDescriptorSetLayout.h
@@ -33,12 +33,12 @@ struct GLDescriptorSetLayout : public HwDescriptorSetLayout, public DescriptorSe
     explicit GLDescriptorSetLayout(DescriptorSetLayout&& layout) noexcept
             : DescriptorSetLayout(std::move(layout)) {
 
-        std::sort(bindings.begin(), bindings.end(),
+        std::sort(descriptors.begin(), descriptors.end(),
                 [](auto&& lhs, auto&& rhs){
             return lhs.binding < rhs.binding;
         });
 
-        auto p = std::max_element(bindings.cbegin(), bindings.cend(),
+        auto p = std::max_element(descriptors.cbegin(), descriptors.cend(),
                 [](auto const& lhs, auto const& rhs) {
             return lhs.binding < rhs.binding;
         });

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -100,18 +100,18 @@ inline VkShaderStageFlags getVkStage(backend::ShaderStage stage) {
 using BitmaskGroup = VulkanDescriptorSetLayout::Bitmask;
 BitmaskGroup fromBackendLayout(DescriptorSetLayout const& layout) {
     BitmaskGroup mask;
-    for (auto const& binding: layout.bindings) {
-        switch (binding.type) {
+    for (auto const& descriptor: layout.descriptors) {
+        switch (descriptor.type) {
             case DescriptorType::UNIFORM_BUFFER: {
-                if ((binding.flags & DescriptorFlags::DYNAMIC_OFFSET) != DescriptorFlags::NONE) {
-                    fromStageFlags(binding.stageFlags, binding.binding, mask.dynamicUbo);
+                if ((descriptor.flags & DescriptorFlags::DYNAMIC_OFFSET) != DescriptorFlags::NONE) {
+                    fromStageFlags(descriptor.stageFlags, descriptor.binding, mask.dynamicUbo);
                 } else {
-                    fromStageFlags(binding.stageFlags, binding.binding, mask.ubo);
+                    fromStageFlags(descriptor.stageFlags, descriptor.binding, mask.ubo);
                 }
                 break;
             }
             case DescriptorType::SAMPLER_EXTERNAL:
-                fromStageFlags(binding.stageFlags, binding.binding, mask.externalSampler);
+                fromStageFlags(descriptor.stageFlags, descriptor.binding, mask.externalSampler);
                 UTILS_FALLTHROUGH;
 
             case DescriptorType::SAMPLER_2D_FLOAT:
@@ -139,11 +139,11 @@ BitmaskGroup fromBackendLayout(DescriptorSetLayout const& layout) {
             case DescriptorType::SAMPLER_2D_MS_ARRAY_FLOAT:
             case DescriptorType::SAMPLER_2D_MS_ARRAY_INT:
             case DescriptorType::SAMPLER_2D_MS_ARRAY_UINT: {
-                fromStageFlags(binding.stageFlags, binding.binding, mask.sampler);
+                fromStageFlags(descriptor.stageFlags, descriptor.binding, mask.sampler);
                 break;
             }
             case DescriptorType::INPUT_ATTACHMENT: {
-                fromStageFlags(binding.stageFlags, binding.binding, mask.inputAttachment);
+                fromStageFlags(descriptor.stageFlags, descriptor.binding, mask.inputAttachment);
                 break;
             }
             case DescriptorType::SHADER_STORAGE_BUFFER:

--- a/filament/backend/src/webgpu/WebGPUDescriptorSetLayout.cpp
+++ b/filament/backend/src/webgpu/WebGPUDescriptorSetLayout.cpp
@@ -73,15 +73,15 @@ WebGPUDescriptorSetLayout::WebGPUDescriptorSetLayout(DescriptorSetLayout const& 
     }
 
     const unsigned int samplerCount =
-            std::count_if(layout.bindings.begin(), layout.bindings.end(), [](auto& fEntry) {
-                return DescriptorSetLayoutBinding::isSampler(fEntry.type);
+            std::count_if(layout.descriptors.begin(), layout.descriptors.end(), [](auto& fEntry) {
+                return DescriptorSetLayoutDescriptor::isSampler(fEntry.type);
             });
 
     std::vector<wgpu::BindGroupLayoutEntry> wEntries;
-    wEntries.reserve(layout.bindings.size() + samplerCount);
+    wEntries.reserve(layout.descriptors.size() + samplerCount);
     mBindGroupEntries.reserve(wEntries.capacity());
 
-    for (auto fEntry: layout.bindings) {
+    for (auto fEntry: layout.descriptors) {
         auto& wEntry = wEntries.emplace_back();
         auto& entryInfo = mBindGroupEntries.emplace_back();
         wEntry.visibility = filamentStageToWGPUStage(fEntry.stageFlags);
@@ -198,13 +198,13 @@ WebGPUDescriptorSetLayout::WebGPUDescriptorSetLayout(DescriptorSetLayout const& 
     FWGPU_LOGD << "WebGPUDescriptorSetLayout:";
     FWGPU_LOGD << "  label: " << label;
     FWGPU_LOGD << "  wgpu::BindGroupLayout handle: " << mLayout.Get();
-    FWGPU_LOGD << "  Filament bindings (" << layout.bindings.size() << "):";
-    for (DescriptorSetLayoutBinding const& layoutBinding: layout.bindings) {
-        FWGPU_LOGD << "    binding:" << +layoutBinding.binding
-                   << " type:" << filamentDescriptorTypeToString(layoutBinding.type)
-                   << " stageFlags:" << filamentStageFlagsToString(layoutBinding.stageFlags)
-                   << " flags:" << filamentDescriptorFlagsToString(layoutBinding.flags)
-                   << " count:" << layoutBinding.count;
+    FWGPU_LOGD << "  Filament bindings (" << layout.descriptors.size() << "):";
+    for (DescriptorSetLayoutDescriptor const& descriptor: layout.descriptors) {
+        FWGPU_LOGD << "    binding:" << +descriptor.binding
+                   << " type:" << filamentDescriptorTypeToString(descriptor.type)
+                   << " stageFlags:" << filamentStageFlagsToString(descriptor.stageFlags)
+                   << " flags:" << filamentDescriptorFlagsToString(descriptor.flags)
+                   << " count:" << descriptor.count;
     }
 #endif
 }

--- a/filament/backend/test/Shader.cpp
+++ b/filament/backend/test/Shader.cpp
@@ -24,7 +24,7 @@ namespace test {
 using namespace filament::backend;
 
 Shader::Shader(DriverApi& api, Cleanup& cleanup, ShaderConfig config) : mCleanup(cleanup) {
-    utils::FixedCapacityVector<DescriptorSetLayoutBinding> kLayouts(config.uniforms.size());
+    utils::FixedCapacityVector<DescriptorSetLayoutDescriptor> kLayouts(config.uniforms.size());
     for (unsigned char i = 0; i < config.uniforms.size(); ++i) {
         kLayouts[i] = {
                 config.uniforms[i].type.value_or(DescriptorType::UNIFORM_BUFFER),
@@ -59,7 +59,7 @@ Shader::Shader(DriverApi& api, Cleanup& cleanup, ShaderConfig config) : mCleanup
 
     if (!kLayouts.empty()) {
         mDescriptorSetLayout = cleanup.add(
-                api.createDescriptorSetLayout(DescriptorSetLayout{ .bindings = kLayouts }));
+                api.createDescriptorSetLayout(DescriptorSetLayout{ .descriptors = kLayouts }));
     }
 }
 

--- a/filament/src/HwDescriptorSetLayoutFactory.cpp
+++ b/filament/src/HwDescriptorSetLayoutFactory.cpp
@@ -40,17 +40,17 @@ using namespace backend;
 
 size_t HwDescriptorSetLayoutFactory::Parameters::hash() const noexcept {
     return hash::murmurSlow(
-            reinterpret_cast<uint8_t const *>(dsl.bindings.data()),
-            dsl.bindings.size() * sizeof(DescriptorSetLayoutBinding),
+            reinterpret_cast<uint8_t const *>(dsl.descriptors.data()),
+            dsl.descriptors.size() * sizeof(DescriptorSetLayoutDescriptor),
             42);
 }
 
 bool operator==(HwDescriptorSetLayoutFactory::Parameters const& lhs,
         HwDescriptorSetLayoutFactory::Parameters const& rhs) noexcept {
-    return (lhs.dsl.bindings.size() == rhs.dsl.bindings.size()) &&
+    return (lhs.dsl.descriptors.size() == rhs.dsl.descriptors.size()) &&
            std::equal(
-                   lhs.dsl.bindings.begin(), lhs.dsl.bindings.end(),
-                   rhs.dsl.bindings.begin());
+                   lhs.dsl.descriptors.begin(), lhs.dsl.descriptors.end(),
+                   rhs.dsl.descriptors.begin());
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ void HwDescriptorSetLayoutFactory::terminate(DriverApi&) noexcept {
 auto HwDescriptorSetLayoutFactory::create(DriverApi& driver,
         DescriptorSetLayout dsl) noexcept -> Handle {
 
-    std::sort(dsl.bindings.begin(), dsl.bindings.end(),
+    std::sort(dsl.descriptors.begin(), dsl.descriptors.end(),
             [](auto&& lhs, auto&& rhs) {
         return lhs.binding < rhs.binding;
     });

--- a/filament/src/MaterialDefinition.cpp
+++ b/filament/src/MaterialDefinition.cpp
@@ -494,8 +494,8 @@ void MaterialDefinition::processDescriptorSets(FEngine& engine) {
             std::pair{ DescriptorSetBindingPoints::PER_VIEW,
                     this->perViewDescriptorSetLayoutDescription }}) {
         Program::DescriptorBindingsInfo& descriptors = programDescriptorBindings[+bindingPoint];
-        descriptors.reserve(dsl.bindings.size());
-        for (auto const& entry: dsl.bindings) {
+        descriptors.reserve(dsl.descriptors.size());
+        for (auto const& entry: dsl.descriptors) {
             auto const& name = descriptor_sets::getDescriptorName(bindingPoint, entry.binding);
             descriptors.push_back({ name, entry.type, entry.binding });
         }

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -792,7 +792,7 @@ bool ChunkDescriptorSetLayoutInfo::unflatten(Unflattener& unflattener,
     if (!unflattener.read(&descriptorCount)) {
         return false;
     }
-    auto& descriptors = container->bindings;
+    auto& descriptors = container->descriptors;
     descriptors.reserve(descriptorCount);
     for (size_t i = 0; i < descriptorCount; i++) {
         uint8_t type;

--- a/filament/src/ds/DescriptorSet.cpp
+++ b/filament/src/ds/DescriptorSet.cpp
@@ -159,8 +159,8 @@ void DescriptorSet::setBuffer(DescriptorSetLayout const& layout,
         backend::Handle<backend::HwBufferObject> boh, uint32_t const offset, uint32_t const size) {
 
     // Validate it's the right kind of descriptor
-    using DSLB = backend::DescriptorSetLayoutBinding;
-    FILAMENT_CHECK_PRECONDITION(DSLB::isBuffer(layout.getDescriptorType(binding)))
+    using DSLD = backend::DescriptorSetLayoutDescriptor;
+    FILAMENT_CHECK_PRECONDITION(DSLD::isBuffer(layout.getDescriptorType(binding)))
             << "descriptor " << +binding << "is not a buffer";
 
     auto& buffer = mDescriptors[binding].buffer;
@@ -179,11 +179,11 @@ void DescriptorSet::setSampler(
         backend::Handle<backend::HwTexture> th, backend::SamplerParams const params) {
 
     using namespace backend;
-    using DSLB = DescriptorSetLayoutBinding;
+    using DSLD = DescriptorSetLayoutDescriptor;
 
     // Validate it's the right kind of descriptor
     auto type = layout.getDescriptorType(binding);
-    FILAMENT_CHECK_PRECONDITION(DSLB::isSampler(type))
+    FILAMENT_CHECK_PRECONDITION(DSLD::isSampler(type))
             << "descriptor " << +binding << " is not a sampler";
 
     FILAMENT_CHECK_PRECONDITION(

--- a/filament/src/ds/DescriptorSetLayout.cpp
+++ b/filament/src/ds/DescriptorSetLayout.cpp
@@ -36,16 +36,16 @@ DescriptorSetLayout::DescriptorSetLayout(
         HwDescriptorSetLayoutFactory& factory,
         backend::DriverApi& driver,
         backend::DescriptorSetLayout descriptorSetLayout) noexcept  {
-    for (auto&& desc : descriptorSetLayout.bindings) {
+    for (auto&& desc : descriptorSetLayout.descriptors) {
         mMaxDescriptorBinding = std::max(mMaxDescriptorBinding, desc.binding);
-        mSamplers.set(desc.binding, backend::DescriptorSetLayoutBinding::isSampler(desc.type));
+        mSamplers.set(desc.binding, backend::DescriptorSetLayoutDescriptor::isSampler(desc.type));
         mUniformBuffers.set(desc.binding, desc.type == backend::DescriptorType::UNIFORM_BUFFER);
     }
 
     assert_invariant(mMaxDescriptorBinding < utils::bitset64::BIT_COUNT);
 
     mDescriptorTypes = utils::FixedCapacityVector<backend::DescriptorType>(mMaxDescriptorBinding + 1);
-    for (auto&& desc : descriptorSetLayout.bindings) {
+    for (auto&& desc : descriptorSetLayout.descriptors) {
         mDescriptorTypes[desc.binding] = desc.type;
     }
 

--- a/libs/filabridge/src/DescriptorSets.cpp
+++ b/libs/filabridge/src/DescriptorSets.cpp
@@ -41,7 +41,7 @@ namespace filament::descriptor_sets {
 using namespace backend;
 
 // used to generate shadow-maps, structure and postfx passes
-static constexpr std::initializer_list<DescriptorSetLayoutBinding> depthVariantDescriptorSetLayoutList = {
+static constexpr std::initializer_list<DescriptorSetLayoutDescriptor> depthVariantDescriptorSetLayoutList = {
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FRAME_UNIFORMS },
 };
 
@@ -50,7 +50,7 @@ static constexpr std::initializer_list<DescriptorSetLayoutBinding> depthVariantD
 // dedicated SSR vertex shader), which uses perViewDescriptorSetLayout.
 // This means that PerViewBindingPoints::SHADOWS must be in the layout even though it's not used
 // by the SSR variant.
-static constexpr std::initializer_list<DescriptorSetLayoutBinding> ssrVariantDescriptorSetLayoutList = {
+static constexpr std::initializer_list<DescriptorSetLayoutDescriptor> ssrVariantDescriptorSetLayoutList = {
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FRAME_UNIFORMS },
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::SHADOWS        },
     { DescriptorType::SAMPLER_2D_FLOAT,                          ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::STRUCTURE, DescriptorFlags::UNFILTERABLE },
@@ -72,7 +72,7 @@ static constexpr std::initializer_list<DescriptorSetLayoutBinding> ssrVariantDes
 //
 // The SamplerType to use depends on the Variant. Variant::VSM is set for all cases except PCM.
 //
-static constexpr std::initializer_list<DescriptorSetLayoutBinding> perViewDescriptorSetLayoutList = {
+static constexpr std::initializer_list<DescriptorSetLayoutDescriptor> perViewDescriptorSetLayoutList = {
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FRAME_UNIFORMS },
     { DescriptorType::UNIFORM_BUFFER, ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::SHADOWS        },
     { DescriptorType::UNIFORM_BUFFER,                            ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::LIGHTS         },
@@ -87,7 +87,7 @@ static constexpr std::initializer_list<DescriptorSetLayoutBinding> perViewDescri
     { DescriptorType::SAMPLER_CUBE_FLOAT,                        ShaderStageFlags::FRAGMENT,  +PerViewBindingPoints::FOG            },
 };
 
-static constexpr std::initializer_list<DescriptorSetLayoutBinding> perRenderableDescriptorSetLayoutList = {
+static constexpr std::initializer_list<DescriptorSetLayoutDescriptor> perRenderableDescriptorSetLayoutList = {
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::OBJECT_UNIFORMS, DescriptorFlags::DYNAMIC_OFFSET },
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::BONES_UNIFORMS,  DescriptorFlags::DYNAMIC_OFFSET },
     { DescriptorType::UNIFORM_BUFFER,           ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,  +PerRenderableBindingPoints::MORPHING_UNIFORMS         },
@@ -226,41 +226,41 @@ DescriptorSetLayout getPerViewDescriptorSetLayout(
             auto layout = perViewDescriptorSetLayout;
             // remove descriptors not needed for unlit materials
             if (!isLit) {
-                layout.bindings.erase(
-                        std::remove_if(layout.bindings.begin(), layout.bindings.end(),
+                layout.descriptors.erase(
+                        std::remove_if(layout.descriptors.begin(), layout.descriptors.end(),
                                 [](auto const& entry) {
                                     return  entry.binding == PerViewBindingPoints::IBL_DFG_LUT ||
                                             entry.binding == PerViewBindingPoints::IBL_SPECULAR;
                                 }),
-                        layout.bindings.end());
+                        layout.descriptors.end());
             }
             // remove descriptors not needed for SSRs
             if (!isSSR) {
-                layout.bindings.erase(
-                        std::remove_if(layout.bindings.begin(), layout.bindings.end(),
+                layout.descriptors.erase(
+                        std::remove_if(layout.descriptors.begin(), layout.descriptors.end(),
                                 [](auto const& entry) {
                                     return entry.binding == PerViewBindingPoints::SSR;
                                 }),
-                        layout.bindings.end());
+                        layout.descriptors.end());
 
             }
             // remove fog descriptor if filtered out
             if (!hasFog) {
-                layout.bindings.erase(
-                        std::remove_if(layout.bindings.begin(), layout.bindings.end(),
+                layout.descriptors.erase(
+                        std::remove_if(layout.descriptors.begin(), layout.descriptors.end(),
                                 [](auto const& entry) {
                                     return entry.binding == PerViewBindingPoints::FOG;
                                 }),
-                        layout.bindings.end());
+                        layout.descriptors.end());
             }
 
             // change the SHADOW_MAP descriptor type for VSM
             if (isVSM) {
-                auto const pos = std::find_if(layout.bindings.begin(), layout.bindings.end(),
+                auto const pos = std::find_if(layout.descriptors.begin(), layout.descriptors.end(),
                         [](auto const& v) {
                             return v.binding == PerViewBindingPoints::SHADOW_MAP;
                         });
-                if (pos != layout.bindings.end()) {
+                if (pos != layout.descriptors.end()) {
                     pos->type = DescriptorType::SAMPLER_2D_ARRAY_FLOAT;
                 }
             }

--- a/libs/filabridge/src/SamplerInterfaceBlock.cpp
+++ b/libs/filabridge/src/SamplerInterfaceBlock.cpp
@@ -152,12 +152,12 @@ SamplerInterfaceBlock::SamplerInfoList SamplerInterfaceBlock::filterSamplerList(
             std::remove_if(list.begin(), list.end(),
                     [&](auto const& entry) {
                         auto pos = std::find_if(
-                                descriptorSetLayout.bindings.begin(),
-                                descriptorSetLayout.bindings.end(),
+                                descriptorSetLayout.descriptors.begin(),
+                                descriptorSetLayout.descriptors.end(),
                                 [&entry](const auto& item) {
                                     return item.binding == entry.binding;
                                 });
-                        return pos == descriptorSetLayout.bindings.end();
+                        return pos == descriptorSetLayout.descriptors.end();
                     }), list.end());
 
     return list;

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -45,7 +45,7 @@ using SibVector = utils::FixedCapacityVector<BindingPointAndSib>;
 
 using DescriptorInfo = std::tuple<
         utils::CString,
-        filament::backend::DescriptorSetLayoutBinding,
+        filament::backend::DescriptorSetLayoutDescriptor,
         std::optional<filament::SamplerInterfaceBlock::SamplerInfo>>;
 using DescriptorSetInfo = utils::FixedCapacityVector<DescriptorInfo>;
 using DescriptorSets = std::array<DescriptorSetInfo, filament::backend::MAX_DESCRIPTOR_SET_COUNT>;


### PR DESCRIPTION
Since the struct refers to descriptors as opposed to specifically bindings (although they do contain binding information as well), this name is more appropriate