### PR TITLE
gl: small fixes to push constant implementation and test

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -437,7 +437,8 @@ void OpenGLDriver::setPushConstant(ShaderStage const stage, uint8_t const index,
     if (std::holds_alternative<bool>(value)) {
         assert_invariant(type == ConstantType::BOOL);
         bool const bval = std::get<bool>(value);
-        glUniform1i(location, bval ? 1 : 0);
+        // This must be the 'ui' version of glUniform1 due to a crash on M-series macbooks.
+        glUniform1ui(location, bval ? 1 : 0);
     } else if (std::holds_alternative<float>(value)) {
         assert_invariant(type == ConstantType::FLOAT);
         float const fval = std::get<float>(value);

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -254,8 +254,14 @@ void OpenGLProgram::initializeProgramState(OpenGLContext& context, GLuint progra
         mPushConstants.reserve(totalConstantCount);
         mPushConstantFragmentStageOffset = vertexConstants.size();
         auto const transformAndAdd = [&](Program::PushConstant const& constant) {
-            GLint const loc = glGetUniformLocation(program, constant.name.c_str());
-            mPushConstants.push_back({loc, constant.type});
+            if (!constant.name.empty()) {
+                GLint const loc = glGetUniformLocation(program, constant.name.c_str());
+                mPushConstants.push_back({loc, constant.type});
+            } else {
+                // If the constant is not named, then we assume it will not be referenced in this
+                // program.
+                mPushConstants.push_back({ -1, constant.type });
+            }
         };
         std::for_each(vertexConstants.cbegin(), vertexConstants.cend(), transformAndAdd);
         std::for_each(fragmentConstants.cbegin(), fragmentConstants.cend(), transformAndAdd);

--- a/filament/backend/test/test_PushConstants.cpp
+++ b/filament/backend/test/test_PushConstants.cpp
@@ -52,17 +52,17 @@ layout(push_constant) uniform Constants {
     float triangleScale;
     float triangleOffsetX;
     float triangleOffsetY;
-} pushConstants;
+} pushConstantsV;
 
 layout(location = 0) in vec4 mesh_position;
 void main() {
-    if (pushConstants.hideTriangle) {
+    if (pushConstantsV.hideTriangle) {
         // Test that bools are written correctly. All bits must be 0 if the bool is false.
         gl_Position = vec4(0.0);
         return;
     }
-    gl_Position = vec4(mesh_position.xy * pushConstants.triangleScale +
-            vec2(pushConstants.triangleOffsetX, pushConstants.triangleOffsetY), 0.0, 1.0);
+    gl_Position = vec4(mesh_position.xy * pushConstantsV.triangleScale +
+            vec2(pushConstantsV.triangleOffsetX, pushConstantsV.triangleOffsetY), 0.0, 1.0);
 #if defined(TARGET_VULKAN_ENVIRONMENT)
     // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
     gl_Position.y = -gl_Position.y;
@@ -76,12 +76,12 @@ layout(push_constant) uniform Constants {
     bool padding;       // test correct bool padding
     float green;
     float blue;
-} pushConstants;
+} pushConstantsF;
 
 precision mediump int; precision highp float;
 layout(location = 0) out vec4 fragColor;
 void main() {
-    fragColor = vec4(pushConstants.red, pushConstants.green, pushConstants.blue, 1.0);
+    fragColor = vec4(pushConstantsF.red, pushConstantsF.green, pushConstantsF.blue, 1.0);
 })";
 
 void initPushConstants() {
@@ -91,20 +91,19 @@ void initPushConstants() {
 
     gVertConstants.reserve(4);
     gVertConstants.resize(4);
-    gVertConstants[pushConstantIndex.TRIANGLE_HIDE] = {"hideTriangle", backend::ConstantType::BOOL};
-    gVertConstants[pushConstantIndex.TRIANGLE_SCALE] = {"triangleScale", backend::ConstantType::FLOAT};
-    gVertConstants[pushConstantIndex.TRIANGLE_OFFSET_X] = {"triangleOffsetX", backend::ConstantType::FLOAT};
-    gVertConstants[pushConstantIndex.TRIANGLE_OFFSET_Y] = {"triangleOffsetY", backend::ConstantType::FLOAT};
+    gVertConstants[pushConstantIndex.TRIANGLE_HIDE] = {"pushConstantsV.hideTriangle", backend::ConstantType::BOOL};
+    gVertConstants[pushConstantIndex.TRIANGLE_SCALE] = {"pushConstantsV.triangleScale", backend::ConstantType::FLOAT};
+    gVertConstants[pushConstantIndex.TRIANGLE_OFFSET_X] = {"pushConstantsV.triangleOffsetX", backend::ConstantType::FLOAT};
+    gVertConstants[pushConstantIndex.TRIANGLE_OFFSET_Y] = {"pushConstantsV.triangleOffsetY", backend::ConstantType::FLOAT};
 
     gFragConstants.reserve(4);
     gFragConstants.resize(4);
-    gFragConstants[pushConstantIndex.RED] = {"red", backend::ConstantType::FLOAT};
-    gFragConstants[pushConstantIndex.GREEN] = {"green", backend::ConstantType::FLOAT};
-    gFragConstants[pushConstantIndex.BLUE] = {"blue", backend::ConstantType::FLOAT};
+    gFragConstants[pushConstantIndex.RED] = {"pushConstantsF.red", backend::ConstantType::FLOAT};
+    gFragConstants[pushConstantIndex.GREEN] = {"pushConstantsF.green", backend::ConstantType::FLOAT};
+    gFragConstants[pushConstantIndex.BLUE] = {"pushConstantsF.blue", backend::ConstantType::FLOAT};
 }
 
 TEST_F(BackendTest, PushConstants) {
-    SKIP_IF(Backend::OPENGL, "see b/453757504");
     SKIP_IF(SkipEnvironment(OperatingSystem::CI, Backend::VULKAN), "see b/453776664");
     SKIP_IF(Backend::WEBGPU, "Push constants not supported on WebGPU");
 


### PR DESCRIPTION
 - Add code for handling empty/null constant name
 - Use glUniform1ui() instead of glUniform1i() to workaround crash on macbook pro (m4).
 - Fully specify the constant name in the test (e.g. `pushConstantsF.red` instead of `red`).
 - Make sure that the uniform names are different between vertex and fragment in the test. This is due to different constant structs being defined between the two stages.
 
 FIXES=453757504