### PR TITLE
Fix VB-GTAO on remote webui

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -1094,10 +1094,10 @@ UTILS_NOINLINE
     }
     return R"(
 // https://graphics.stanford.edu/%7Eseander/bithacks.html
-highp uint bitCount(highp uint value) {
+int bitCount(highp uint value) {
     value = value - ((value >> 1u) & 0x55555555u);
     value = (value & 0x33333333u) + ((value >> 2u) & 0x33333333u);
-    return ((value + (value >> 4u) & 0xF0F0F0Fu) * 0x1010101u) >> 24u;
+    return int(((value + (value >> 4u) & 0xF0F0F0Fu) * 0x1010101u) >> 24u);
 }
 )"sv;
 }


### PR DESCRIPTION
When toggling the GTAO option on remote web ui, the web tries to compile the shaders and use it in some way. Because `bitCount` is not supported until GLES 3.1, so the compilation failed and the ui freezed.

We solve it by inserting the `bitCount` function to the versions which don't have this function builtin.