### PR TITLE
Refactor implicit DriverApi dependency

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -93,7 +93,7 @@ public:
     void init() noexcept;
     void terminate(backend::DriverApi& driver) noexcept;
 
-    void configureTemporalAntiAliasingMaterial(
+    void configureTemporalAntiAliasingMaterial(backend::DriverApi& driver,
             TemporalAntiAliasingOptions const& taaOptions) noexcept;
 
     // methods below are ordered relative to their position in the pipeline (as much as possible)
@@ -350,7 +350,7 @@ public:
 
         void terminate(FEngine& engine) noexcept;
 
-        FMaterial* getMaterial(FEngine& engine,
+        FMaterial* getMaterial(FEngine& engine, backend::DriverApi& driver,
                 PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept;
 
     private:
@@ -398,7 +398,7 @@ public:
 
     // Sets the necessary spec constants and uniforms common to both colorGrading.mat and
     // colorGradingAsSubpass.mat.
-    FMaterialInstance* configureColorGradingMaterial(
+    FMaterialInstance* configureColorGradingMaterial(backend::DriverApi& driver,
             PostProcessMaterial const& material, FColorGrading const* colorGrading,
             ColorGradingConfig const& colorGradingConfig, VignetteOptions const& vignetteOptions,
             uint32_t width, uint32_t height) noexcept;
@@ -419,9 +419,9 @@ private:
     }
 
     // Helper to get a MaterialInstance from a PostProcessMaterial.
-    FMaterialInstance* getMaterialInstance(FEngine& engine, PostProcessMaterial const& material,
+    FMaterialInstance* getMaterialInstance(FEngine& engine, backend::DriverApi& driver, PostProcessMaterial const& material,
             PostProcessVariant variant = PostProcessVariant::OPAQUE) {
-        FMaterial const* ma = material.getMaterial(engine, variant);
+        FMaterial const* ma = material.getMaterial(engine, driver, variant);
         return getMaterialInstance(ma);
     }
 
@@ -438,6 +438,9 @@ private:
 
     FEngine& mEngine;
 
+    backend::FeatureLevel mFeatureLevel;
+    bool mDepthStencilResolveSupported;
+    bool mDepthStencilBlitSupported;
     mutable SsrPassDescriptorSet mSsrPassDescriptorSet;
     mutable PostProcessDescriptorSet mPostProcessDescriptorSet;
     mutable StructureDescriptorSet mStructureDescriptorSet;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -84,9 +84,9 @@ RenderPassBuilder& RenderPassBuilder::customCommand(
     return *this;
 }
 
-RenderPass RenderPassBuilder::build(FEngine const& engine) const {
+RenderPass RenderPassBuilder::build(FEngine const& engine, backend::DriverApi& driver) const {
     assert_invariant(mRenderableSoa);
-    return RenderPass{ engine, *this };
+    return RenderPass{ engine, driver, *this };
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ void RenderPass::DescriptorSetHandleDeleter::operator()(DescriptorSetHandle hand
 
 // ------------------------------------------------------------------------------------------------
 
-RenderPass::RenderPass(FEngine const& engine,
+RenderPass::RenderPass(FEngine const& engine, backend::DriverApi& driver,
         RenderPassBuilder const& builder) noexcept
         : mRenderableSoa(*builder.mRenderableSoa),
           mColorPassDescriptorSet(builder.mColorPassDescriptorSet) {
@@ -139,7 +139,7 @@ RenderPass::RenderPass(FEngine const& engine,
         }
     }
 
-    appendCommands(engine, { commandBegin, commandCount },
+    appendCommands(engine, driver, { commandBegin, commandCount },
             builder.mVisibleRenderables,
             builder.mCommandTypeFlags,
             builder.mFlags,
@@ -182,7 +182,7 @@ RenderPass::Command* RenderPass::resize(Arena& arena, Command* const last) noexc
     return last;
 }
 
-void RenderPass::appendCommands(FEngine const& engine,
+void RenderPass::appendCommands(FEngine const& engine, backend::DriverApi& driver,
         Slice<Command> commands,
         Range<uint32_t> const visibleRenderables,
         CommandTypeFlags const commandTypeFlags,
@@ -244,7 +244,7 @@ void RenderPass::appendCommands(FEngine const& engine,
     for (Command const* first = curr, *last = curr + commandCount ; first != last ; ++first) {
         if (UTILS_LIKELY((first->key & CUSTOM_MASK) == uint64_t(CustomCommand::PASS))) {
             auto ma = first->info.mi->getMaterial();
-            ma->prepareProgram(first->info.materialVariant, CompilerPriorityQueue::CRITICAL);
+            ma->prepareProgram(driver, first->info.materialVariant, CompilerPriorityQueue::CRITICAL);
         }
     }
 }

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -416,11 +416,12 @@ public:
 private:
     friend class FRenderer;
     friend class RenderPassBuilder;
-    RenderPass(FEngine const& engine, RenderPassBuilder const& builder) noexcept;
+    friend class RenderPassBuilder;
+    RenderPass(FEngine const& engine, backend::DriverApi& driver, RenderPassBuilder const& builder) noexcept;
 
     // This is the main function of this class, this appends commands to the pass using
     // the current camera, geometry and flags set. This can be called multiple times if needed.
-    void appendCommands(FEngine const& engine,
+    void appendCommands(FEngine const& engine, backend::DriverApi& driver,
             utils::Slice<Command> commands,
             utils::Range<uint32_t> visibleRenderables,
             CommandTypeFlags commandTypeFlags,
@@ -580,7 +581,7 @@ public:
             uint32_t order,
             const RenderPass::Executor::CustomCommandFn& command);
 
-    RenderPass build(FEngine const& engine) const;
+    RenderPass build(FEngine const& engine, backend::DriverApi& driver) const;
 };
 
 

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -110,7 +110,7 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
                     data.color = builder.createTexture("Color Buffer", colorBufferDesc);
                 }
 
-                const bool canAutoResolveDepth = engine.getDriverApi().isAutoDepthResolveSupported();
+                const bool canAutoResolveDepth = config.isAutoDepthResolveSupported;
 
                 FrameGraphTexture::Usage depthStencilUsage = FrameGraphTexture::Usage::DEPTH_ATTACHMENT;
 
@@ -124,7 +124,7 @@ RendererUtils::ColorPassOutput RendererUtils::colorPass(
                             utils::StaticString{"Depth Buffer"};
 
                     bool const isES2 =
-                            engine.getDriverApi().getFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0;
+                            config.featureLevel == FeatureLevel::FEATURE_LEVEL_0;
 
                     TextureFormat const stencilFormat = isES2 ?
                             TextureFormat::DEPTH24_STENCIL8 : TextureFormat::DEPTH32F_STENCIL8;

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -71,6 +71,10 @@ public:
         bool hasScreenSpaceReflectionsOrRefractions;
         // Use a depth format with a stencil component.
         bool enabledStencilBuffer;
+        // Backend feature level
+        backend::FeatureLevel featureLevel;
+        // Auto depth resolve supported
+        bool isAutoDepthResolveSupported;
     };
 
     struct ColorPassInput {

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -123,10 +123,10 @@ public:
 
     // Updates all the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
-    ShadowTechnique update(Builder const& builder,
-            FEngine& engine, FView& view,
-            CameraInfo const& cameraInfo,
-            FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept;
+    ShadowTechnique update(backend::DriverApi& driver,
+            Builder const& builder, FEngine& engine,
+            FView& view,
+            CameraInfo const& cameraInfo, FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept;
 
     // Renders all the shadow maps.
     FrameGraphId<FrameGraphTexture> render(FEngine& engine, FrameGraph& fg,
@@ -238,6 +238,7 @@ private:
     bool const mIsDepthClampSupported;
     bool mInitialized = false;
     bool mFeatureShadowAllocator = false;
+    bool mDisableBlitIntoTextureArray = false;
 
     ShadowMap& getShadowMap(size_t const index) noexcept {
         assert_invariant(index < mShadowMapCache.size());

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -720,12 +720,11 @@ void FEngine::shutdown() {
     mJobSystem.emancipate();
 }
 
-void FEngine::prepare() {
+void FEngine::prepare(DriverApi& driver) {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
     // prepare() is called once per Renderer frame. Ideally we would upload the content of
     // UBOs that are visible only. It's not such a big issue because the actual upload() is
     // skipped if the UBO hasn't changed. Still we could have a lot of these.
-    DriverApi& driver = getDriverApi();
     const bool useUboBatching = isUboBatchingEnabled();
 
     if (useUboBatching) {
@@ -746,7 +745,7 @@ void FEngine::prepare() {
 
     if (useUboBatching) {
         assert_invariant(mUboManager != nullptr);
-        getUboManager()->finishBeginFrame(getDriverApi());
+        getUboManager()->finishBeginFrame(driver);
     }
 
     mMaterials.forEach([](FMaterial* material) {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -455,7 +455,7 @@ public:
         return mPlatform->pumpEvents();
     }
 
-    void prepare();
+    void prepare(backend::DriverApi& driver);
     void gc();
     void submitFrame();
 

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -134,11 +134,11 @@ public:
     // prepareProgram creates the program for the material's given variant at the backend level.
     // Must be called outside of backend render pass.
     // Must be called before getProgram() below.
-    void prepareProgram(Variant const variant,
+    void prepareProgram(backend::DriverApi& driver, Variant const variant,
             backend::CompilerPriorityQueue const priorityQueue) const noexcept {
         // prepareProgram() is called for each RenderPrimitive in the scene, so it must be efficient.
         if (UTILS_UNLIKELY(!isCached(variant))) {
-            prepareProgramSlow(variant, priorityQueue);
+            prepareProgramSlow(driver, variant, priorityQueue);
         }
     }
 
@@ -292,11 +292,11 @@ private:
     MaterialParser const& getMaterialParser() const noexcept;
 
     bool hasVariant(Variant variant) const noexcept;
-    void prepareProgramSlow(Variant variant,
+    void prepareProgramSlow(backend::DriverApi& driver, Variant variant,
             CompilerPriorityQueue priorityQueue) const noexcept;
-    void getSurfaceProgramSlow(Variant variant,
+    void getSurfaceProgramSlow(backend::DriverApi& driver, Variant variant,
             CompilerPriorityQueue priorityQueue) const noexcept;
-    void getPostProcessProgramSlow(Variant variant,
+    void getPostProcessProgramSlow(backend::DriverApi& driver, Variant variant,
             CompilerPriorityQueue priorityQueue) const noexcept;
     backend::Program getProgramWithVariants(Variant variant,
             Variant vertexVariant, Variant fragmentVariant) const;
@@ -304,9 +304,9 @@ private:
     utils::FixedCapacityVector<backend::Program::SpecializationConstant>
             processSpecializationConstants(Builder const& builder);
 
-    void precacheDepthVariants(FEngine& engine);
+    void precacheDepthVariants(backend::DriverApi& driver);
 
-    void createAndCacheProgram(backend::Program&& p, Variant variant) const noexcept;
+    void createAndCacheProgram(backend::DriverApi& driver, backend::Program&& p, Variant variant) const noexcept;
 
     backend::DescriptorSetLayout const& getPerViewDescriptorSetLayoutDescription(
             Variant const variant, bool const useVsmDescriptorSetLayout) const noexcept;
@@ -325,6 +325,11 @@ private:
     bool mIsDefaultMaterial = false;
 
     bool mUseUboBatching = false;
+    bool mIsStereoSupported = false;
+    bool mIsParallelShaderCompileSupported = false;
+    bool mDepthPrecacheDisabled = false;
+
+    FMaterial const* mDefaultMaterial = nullptr;
 
     // reserve some space to construct the default material instance
     mutable FMaterialInstance* mDefaultMaterialInstance = nullptr;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -45,6 +45,7 @@
 #include <limits>
 #include <mutex>
 #include <string_view>
+#include <variant>
 
 #include <stddef.h>
 #include <stdint.h>

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -196,8 +196,8 @@ private:
         return mCommandsHighWatermark;
     }
 
-    void renderInternal(FView const* view, bool flush);
-    void renderJob(RootArenaScope& rootArenaScope, FView& view);
+    void renderInternal(backend::DriverApi& driver, FView const* view, bool flush);
+    void renderJob(backend::DriverApi& driver, RootArenaScope& rootArenaScope, FView& view);
 
     static std::pair<float, math::float2> prepareUpscaler(math::float2 scale,
             TemporalAntiAliasingOptions const& taaOptions,
@@ -214,7 +214,11 @@ private:
     backend::TextureFormat mHdrTranslucent;
     backend::TextureFormat mHdrQualityMedium;
     backend::TextureFormat mHdrQualityHigh;
+    backend::FeatureLevel mFeatureLevel;
     bool mIsRGB8Supported : 1;
+    bool mIsFrameBufferFetchSupported : 1;
+    bool mIsFrameBufferFetchMultiSampleSupported : 1;
+    bool mIsAutoDepthResolveSupported : 1;
     Epoch mUserEpoch;
     math::float4 mShaderUserTime{};
     DisplayInfo mDisplayInfo;

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -394,8 +394,10 @@ bool FView::isSkyboxVisible() const noexcept {
     return skybox != nullptr && (skybox->getLayerMask() & mVisibleLayers);
 }
 
-void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableData,
-        FScene::LightSoa const& lightData, CameraInfo const& cameraInfo) noexcept {
+void FView::prepareShadowing(FEngine& engine, DriverApi& driver,
+        FScene::RenderableSoa& renderableData,
+        FScene::LightSoa const& lightData,
+        CameraInfo const& cameraInfo) noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     mHasShadowing = false;
@@ -404,7 +406,7 @@ void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableD
         return;
     }
 
-    auto& lcm = engine.getLightManager();
+    auto const& lcm = engine.getLightManager();
 
     ShadowMapManager::Builder builder;
 
@@ -461,8 +463,8 @@ void FView::prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableD
 
     if (builder.hasShadowMaps()) {
         ShadowMapManager::createIfNeeded(engine, mShadowMapManager);
-        auto const shadowTechnique = mShadowMapManager->update(builder, engine, *this,
-                cameraInfo, renderableData, lightData);
+        auto const shadowTechnique = mShadowMapManager->update(driver, builder, engine,
+                *this, cameraInfo, renderableData, lightData);
 
         mHasShadowing = any(shadowTechnique);
         mNeedsShadowMap = any(shadowTechnique & ShadowMapManager::ShadowTechnique::SHADOW_MAP);
@@ -685,7 +687,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         setFroxelizerSync(froxelizeLightsJob);
 
-        prepareShadowing(engine, renderableData, lightData, cameraInfo);
+        prepareShadowing(engine, driver, renderableData, lightData, cameraInfo);
 
         /*
          * Partition the SoA so that renderables are partitioned w.r.t their visibility into the

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -163,8 +163,8 @@ public:
             const Viewport& physicalViewport,
             const Viewport& logicalViewport) const noexcept;
 
-    void prepareShadowing(FEngine& engine, FScene::RenderableSoa& renderableData,
-            FScene::LightSoa const& lightData, CameraInfo const& cameraInfo) noexcept;
+    void prepareShadowing(FEngine& engine, backend::DriverApi& driver,
+            FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData, CameraInfo const& cameraInfo) noexcept;
     void prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexcept;
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;


### PR DESCRIPTION
Removed implicit dependency on FEngine::getDriverApi() in critical  rendering paths. This change makes the DriverApi dependency explicit by  passing it as a parameter.


Key changes:

- FRenderer: Now accepts DriverApi& in renderInternal and renderJob.  Caches feature levels and capability flags in the constructor.

- PostProcessManager: Caches feature flags and workaround flags in  init(). Updated PostProcessMaterial and configure* methods to accept  DriverApi&.

- FMaterial: Caches support flags (stereo, parallel shader compile) and default material pointer in the constructor. 
Updated precacheDepthVariants and prepareProgram to rely on these  cached values or passed parameters.

- ShadowMapManager: Caches workaround flags in the constructor.

- FEngine: Updated prepare() to accept DriverApi&.

- RenderPass: Updated to accept DriverApi& in constructor and  appendCommands.

- Removed implicit DriverApi calls from hot paths to reduce overhead  and improve safety.


One common pattern in this change is to cache getters in constructors so that we don't need the DriverApi dependency later during rendering. The intention here is to remove DriverApi& from as many places as possible so that we can later have multithreading for command recording.

This PR should not change any behavior.