### PR TITLE
Fix race condition for cache prewarming

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -851,7 +851,7 @@ void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils
 
     // Base case - build the pipeline without any external samplers.
     mPipelineCache.asyncPrewarmCache(
-        *vprogram.get(),
+        vprogram,
         mPipelineLayoutCache.getLayout(vkLayouts, vprogram),
         stereoscopicType,
         mStereoscopicEyeCount,
@@ -888,7 +888,7 @@ void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils
         }
 
         mPipelineCache.asyncPrewarmCache(
-            *vprogram.get(),
+            vprogram,
             mPipelineLayoutCache.getLayout(vkLayouts, vprogram),
             stereoscopicType,
             mStereoscopicEyeCount,

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -104,7 +104,7 @@ public:
     // compiling the pipeline on the main thread at draw time. This is very dependent
     // on the implementation of the driver on the current device; it's expected to work
     // on devices with VK_EXT_vertex_input_dynamic_state and VK_KHR_dynamic_rendering.
-    void asyncPrewarmCache(const VulkanProgram& program, VkPipelineLayout layout,
+    void asyncPrewarmCache(resource_ptr<VulkanProgram> vprogram, VkPipelineLayout layout,
                            StereoscopicType stereoscopicType, uint8_t stereoscopicViewCount,
                            CompilerPriorityQueue priority);
 


### PR DESCRIPTION
Right now, if a material is destroyed just after creation, it's possible for prewarm to attempt to use destroyed shader modules. This ensures that the resources are kept until after any queued jobs have run.

While it is likely ideal to properly cancel the prewarm if the program has been destroyed, this seems like a rare occurrence in practice.