### PR TITLE
Add a new tone mapper

### DIFF
--- a/android/filament-android/src/main/cpp/ToneMapper.cpp
+++ b/android/filament-android/src/main/cpp/ToneMapper.cpp
@@ -53,6 +53,11 @@ Java_com_google_android_filament_ToneMapper_nCreatePBRNeutralToneMapper(JNIEnv*,
 }
 
 extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_ToneMapper_nCreateGT7ToneMapper(JNIEnv*, jclass) {
+    return (jlong) new GT7ToneMapper();
+}
+
+extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_ToneMapper_nCreateAgxToneMapper(JNIEnv*, jclass, jint look) {
     return (jlong) new AgxToneMapper(AgxToneMapper::AgxLook(look));
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -24,6 +24,7 @@ package com.google.android.filament;
  *   <li>ACESLegacyToneMapper</li>
  *   <li>FilmicToneMapper</li>
  *   <li>PBRNeutralToneMapper</li>
+ *   <li>GT7ToneMapper</li>
  * </ul>
  * <li>Debug/validation tone mapping operators</li>
  * <ul>
@@ -108,6 +109,19 @@ public class ToneMapper {
     public static class PBRNeutralToneMapper extends ToneMapper {
         public PBRNeutralToneMapper() {
             super(nCreatePBRNeutralToneMapper());
+        }
+    }
+
+    /**
+     * Gran Turismo 7 tone mapping operator. This tone mapper was designed
+     * to preserve the appearance of materials across lighting conditions while
+     * avoiding artifacts in the highlights in high dynamic range conditions.
+     * This tone mapper targets an SDR paper white value of 250 nits, with a
+     * reference luminance of 100 cd/m^2 (a value of 1.0 in the HDR framebuffer).
+     */
+    public static class GT7ToneMapper extends ToneMapper {
+        public GT7ToneMapper() {
+            super(nCreateGT7ToneMapper());
         }
     }
 
@@ -244,6 +258,7 @@ public class ToneMapper {
     private static native long nCreateACESLegacyToneMapper();
     private static native long nCreateFilmicToneMapper();
     private static native long nCreatePBRNeutralToneMapper();
+    private static native long nCreateGT7ToneMapper();
     private static native long nCreateAgxToneMapper(int look);
     private static native long nCreateGenericToneMapper(
             float contrast, float midGrayIn, float midGrayOut, float hdrMax);

--- a/filament/include/filament/ToneMapper.h
+++ b/filament/include/filament/ToneMapper.h
@@ -45,6 +45,7 @@ namespace filament {
  *   - ACESLegacyToneMapper
  *   - FilmicToneMapper
  *   - PBRNeutralToneMapper
+ *   - GT7ToneMapper
  * - Debug/validation tone mapping operators
  *   - LinearToneMapper
  *   - DisplayRangeToneMapper
@@ -72,15 +73,17 @@ struct UTILS_PUBLIC ToneMapper {
     /**
      * If true, then this function holds that f(x) = vec3(f(x.r), f(x.g), f(x.b))
      *
-     * This may be used to indicate that the color grading's LUT only requires a 1D texture instead
-     * of a 3D texture, potentially saving a significant amount of memory and generation time.
+     * This may be used to indicate that the color grading's LUT only requires a
+     * 1D texture instead of a 3D texture, potentially saving a significant amount
+     * of memory and generation time.
      */
     virtual bool isOneDimensional() const noexcept { return false; }
 
     /**
      * True if this tonemapper only works in low-dynamic-range.
      *
-     * This may be used to indicate that the color grading's LUT doesn't need to be log encoded.
+     * This may be used to indicate that the color grading's LUT doesn't need to be
+     * log encoded.
      */
     virtual bool isLDR() const noexcept { return false; }
 };
@@ -154,6 +157,26 @@ struct UTILS_PUBLIC PBRNeutralToneMapper final : public ToneMapper {
     math::float3 operator()(math::float3 x) const noexcept override;
     bool isOneDimensional() const noexcept override { return false; }
     bool isLDR() const noexcept override { return false; }
+};
+
+/**
+ * Gran Turismo 7 tone mapping operator. This tone mapper was designed
+ * to preserve the appearance of materials across lighting conditions while
+ * avoiding artifacts in the highlights in high dynamic range conditions.
+ * This tone mapper targets an SDR paper white value of 250 nits, with a
+ * reference luminance of 100 cd/m^2 (a value of 1.0 in the HDR framebuffer).
+ */
+struct UTILS_PUBLIC GT7ToneMapper final : public ToneMapper {
+    GT7ToneMapper() noexcept;
+    ~GT7ToneMapper() noexcept final;
+
+    math::float3 operator()(math::float3 x) const noexcept override;
+    bool isOneDimensional() const noexcept override { return false; }
+    bool isLDR() const noexcept override { return false; }
+
+private:
+    struct State;
+    State* mState;
 };
 
 /**

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -61,7 +61,8 @@ enum class ToneMapping : uint8_t {
     AGX           = 4,
     GENERIC       = 5,
     PBR_NEUTRAL   = 6,
-    DISPLAY_RANGE = 7,
+    GT7           = 7,
+    DISPLAY_RANGE = 8,
 };
 
 using AmbientOcclusionOptions = filament::View::AmbientOcclusionOptions;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -88,6 +88,7 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ToneMapp
     else if (0 == compare(tokens[i], jsonChunk, "AGX")) { *out = ToneMapping::AGX; }
     else if (0 == compare(tokens[i], jsonChunk, "GENERIC")) { *out = ToneMapping::GENERIC; }
     else if (0 == compare(tokens[i], jsonChunk, "PBR_NEUTRAL")) { *out = ToneMapping::PBR_NEUTRAL; }
+    else if (0 == compare(tokens[i], jsonChunk, "GT7")) { *out = ToneMapping::GT7; }
     else if (0 == compare(tokens[i], jsonChunk, "DISPLAY_RANGE")) { *out = ToneMapping::DISPLAY_RANGE; }
     else {
         slog.w << "Invalid ToneMapping: '" << STR(tokens[i], jsonChunk) << "'" << io::endl;
@@ -722,6 +723,7 @@ constexpr ToneMapper* createToneMapper(const ColorGradingSettings& settings) noe
                 settings.genericToneMapper.hdrMax
         );
         case ToneMapping::PBR_NEUTRAL: return new PBRNeutralToneMapper;
+        case ToneMapping::GT7: return new GT7ToneMapper;
         case ToneMapping::DISPLAY_RANGE: return new DisplayRangeToneMapper;
     }
 }
@@ -773,6 +775,7 @@ static std::ostream& operator<<(std::ostream& out, ToneMapping in) {
         case ToneMapping::AGX: return out << "\"AGX\"";
         case ToneMapping::GENERIC: return out << "\"GENERIC\"";
         case ToneMapping::PBR_NEUTRAL: return out << "\"PBR_NEUTRAL\"";
+        case ToneMapping::GT7: return out << "\"GT7\"";
         case ToneMapping::DISPLAY_RANGE: return out << "\"DISPLAY_RANGE\"";
     }
     return out << "\"INVALID\"";

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -178,6 +178,9 @@ static void computeToneMapPlot(ColorGradingSettings& settings, float* plot) {
         case ToneMapping::PBR_NEUTRAL:
             mapper = new PBRNeutralToneMapper;
             break;
+        case ToneMapping::GT7:
+            mapper = new GT7ToneMapper;
+            break;
         case ToneMapping::DISPLAY_RANGE:
             mapper = new DisplayRangeToneMapper;
             break;
@@ -229,7 +232,7 @@ static void colorGradingUI(Settings& settings, float* rangePlot, float* curvePlo
 
         int toneMapping = (int) colorGrading.toneMapping;
         ImGui::Combo("Tone-mapping", &toneMapping,
-                "Linear\0ACES (legacy)\0ACES\0Filmic\0AgX\0Generic\0PBR Neutral\0Display Range\0\0");
+                "Linear\0ACES (legacy)\0ACES\0Filmic\0AgX\0Generic\0PBR Neutral\0GT7\0Display Range\0\0");
         colorGrading.toneMapping = (decltype(colorGrading.toneMapping)) toneMapping;
         if (colorGrading.toneMapping == ToneMapping::GENERIC) {
             if (ImGui::CollapsingHeader("Tonemap parameters")) {


### PR DESCRIPTION
The new tone mapper, dubbed "GT7" in the code, is based on the Gran Turismo 7 tone mapper, as described in the SIGGRAPH 2025 presentation called "Driving Toward Reality: Physically Based Tone Mapping and Perceptual Fidelity in Gran Turismo 7".

This tone mapper exhibits fewer hue skews than the other tone mappers, at the exception of PBR Neutral. The GT7 tone mapper is however better at preserving the perception of high dynamic range.

The tone mapper, as implemented, targets an SDR paper white of 250 nits, using 100 cd/m^2 as the reference luminance (for values of 1.0 in the linear HDR framebuffer). This can result in an overall darker image compared to the other tone mappers but this can be controlled through camera settings, post- processing exposure, or lighting intensity.

The GT7 tone mapper also allows to target HDR output, and could be made customizable via APIs if desired. The current implementation offers a fixed aesthetic solution.

Here is a comparison of an HDR image under ACES:
![aces](https://github.com/user-attachments/assets/0e962954-e7c8-443d-9cb8-78a3315a8071)

And with GT7:
![gt7](https://github.com/user-attachments/assets/d1a1e92e-4e14-4b04-92a1-38544a5f3eb3)

Note how the blues don't skew towards purple as quickly in the GT7 variant.
