### PR TITLE
Optimize thread variables in ServiceThread

### DIFF
--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -238,9 +238,11 @@ protected:
     void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
     void debugCommandEnd(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
 
+#if UTILS_HAS_THREADING
     // Stops the `ServiceThread`. This method is called during destruction but may be called
     // explicitly if earlier shutdown is needed. This method is idempotent.
     void stopServiceThread() noexcept;
+#endif
 
 private:
     const Platform::DriverConfig mDriverConfig;
@@ -248,11 +250,13 @@ private:
     std::mutex mPurgeLock;
     std::vector<std::pair<void*, CallbackHandler::Callback>> mCallbacks;
 
+#if UTILS_HAS_THREADING
     std::thread mServiceThread;
     std::mutex mServiceThreadLock;
     std::condition_variable mServiceThreadCondition;
     std::vector<std::tuple<CallbackHandler*, CallbackHandler::Callback, void*>> mServiceThreadCallbackQueue;
     bool mExitRequested = false;
+#endif
 };
 
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -390,9 +390,9 @@ void OpenGLDriver::terminate() {
     if (getJobWorker()) {
         getJobWorker()->terminate();
     }
-    if constexpr (UTILS_HAS_THREADING) {
-        stopServiceThread();
-    }
+#if UTILS_HAS_THREADING
+    stopServiceThread();
+#endif
 
     mContext.terminate();
     mPlatform.terminate();


### PR DESCRIPTION
Wraps thread-related member variables in preprocessor checks to ensure they are excluded when multithreading is not supported. Previously, these variables were declared unconditionally, leading to unnecessary memory usage for platforms that don't support multithreading.