### PR TITLE
don't bucket (z-sort) opaque geometry

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -638,7 +638,6 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
         } else if constexpr (isDepthPass) {
             cmd.key = uint64_t(Pass::DEPTH);
             cmd.key |= uint64_t(CustomCommand::PASS);
-            cmd.key |= makeField(distanceBits >> 22u, Z_BUCKET_MASK, Z_BUCKET_SHIFT);
             cmd.info.materialVariant.setSkinning(hasSkinningOrMorphing);
             cmd.info.rasterState.inverseFrontFaces = inverseFrontFaces;
         }
@@ -773,12 +772,9 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
                             (mode == TransparencyMode::TWO_PASSES_ONE_SIDE) ?
                             SamplerCompareFunc::GE : cmd.info.rasterState.depthFunc;
                 } else {
-                    // color pass:
-                    // This will bucket objects by Z, front-to-back and then sort by material
-                    // in each buckets. We use the top 10 bits of the distance, which
-                    // bucketizes the depth by its log2 and in 4 linear chunks in each bucket.
+                    // opaque object are not z-sorted, because it's counter-productive on all modern
+                    // mobile GPUs.
                     cmd.key &= ~Z_BUCKET_MASK;
-                    cmd.key |= makeField(distanceBits >> 22u, Z_BUCKET_MASK, Z_BUCKET_SHIFT);
                 }
 
                 *curr = cmd;

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -83,7 +83,7 @@ public:
      *   DEPTH command (b00)
      *   |  3|1| 2| 2| 2|1| 3 | 2|  6   |   10     |               32               |
      *   +---+-+--+--+--+-+---+--+------+----------+--------------------------------+
-     *   |CCC|0|00|01|00|0|ppp|00|000000| Z-bucket |          material-id           |
+     *   |CCC|0|00|01|00|0|ppp|00|000000|0000000000|          material-id           |
      *   +---+-+--+--+--+-+---+--+------+----------+--------------------------------+
      *   | correctness        |      optimizations (truncation allowed)             |
      *
@@ -91,8 +91,8 @@ public:
      *   COLOR (b01) and REFRACT (b10) commands
      *   |  3|1| 2| 2| 2|1| 3 | 2|  6   |   10     |               32               |
      *   +---+-+--+--+--+-+---+--+------+----------+--------------------------------+
-     *   |CCC|0|01|01|00|a|ppp|00|000000| Z-bucket |          material-id           |
-     *   |CCC|0|10|01|00|a|ppp|00|000000| Z-bucket |          material-id           | refraction
+     *   |CCC|0|01|01|00|a|ppp|00|000000|0000000000|          material-id           |
+     *   |CCC|0|10|01|00|a|ppp|00|000000|0000000000|          material-id           | refraction
      *   +---+-+--+--+--+-+---+--+------+----------+--------------------------------+
      *   | correctness        |      optimizations (truncation allowed)             |
      *


### PR DESCRIPTION
All modern mobile GPUs do this sorting
automatically, similarly to using a v-buffer.
Sorting at the application level is 
counter-productive because prioritize depth
over state, which is much more important.

Transparents are still sorted for correctness.