### PR TITLE
Fix ES2 shader compile error

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -1089,9 +1089,16 @@ UTILS_NOINLINE
 
 /* static */ std::string_view process_countBits(OpenGLContext& context) noexcept {
     using namespace std::literals;
+    // bitCount is available in GL 4.0 and GLES 3.1.
     if (context.isAtLeastGL<4, 0>() || context.isAtLeastGLES<3, 1>()) {
         return ""sv;
     }
+
+    // GLES 2.0 does not support bitwise operations or unsigned integers.
+    if (context.isES2()) {
+        return ""sv;
+    }
+
     return R"(
 // https://graphics.stanford.edu/%7Eseander/bithacks.html
 int bitCount(highp uint value) {


### PR DESCRIPTION
VB-GTAO uses `bitCount` for occlusion calculation, and we provide a polyfill when the function is not built-in. 
However, this polyfill fails to compile on GLES 2.0 because the environment lacks support for `uint` types and bitwise shift operations, which caused `FL0` test failures.

Since GLES 2.0 does not support GTAO at all, this PR disables the polyfill for ES2 contexts to resolve the compilation issues.