### PR TITLE
initialize VirtualMachineEnv on the right thread

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -180,10 +180,6 @@ private:
 
     int32_t setProducerThrottlingEnabled(EGLNativeWindowType nativeWindow, bool enabled) const;
 
-    struct InitializeJvmForPerformanceManagerIfNeeded {
-        InitializeJvmForPerformanceManagerIfNeeded();
-    };
-
     struct ExternalTextureAndroid : public ExternalTexture {
         EGLImageKHR eglImage = EGL_NO_IMAGE;
     };
@@ -191,7 +187,6 @@ private:
     int mOSVersion;
     ExternalStreamManagerAndroid& mExternalStreamManager;
     AndroidDetails& mAndroidDetails;
-    InitializeJvmForPerformanceManagerIfNeeded const mInitializeJvmForPerformanceManagerIfNeeded;
     utils::PerformanceHintManager mPerformanceHintManager;
     utils::PerformanceHintManager::Session mPerformanceHintSession;
     using clock = std::chrono::high_resolution_clock;

--- a/libs/utils/include/utils/android/PerformanceHintManager.h
+++ b/libs/utils/include/utils/android/PerformanceHintManager.h
@@ -55,9 +55,14 @@ public:
         int reportActualWorkDuration(int64_t actualDurationNanos) noexcept;
     };
 
-    // caveat: This must be called on a Java thread
     PerformanceHintManager() noexcept;
     ~PerformanceHintManager() noexcept;
+
+    // caveat: This must be called on a Java thread
+    void init();
+
+    // caveat: This must be called on the same thread as init
+    void terminate();
 
     // Whether PerformanceHintManager APIs are supported (which doesn't mean PerformanceHintManager
     // itself is, use isValid()).

--- a/libs/utils/src/android/PerformanceHintManager.cpp
+++ b/libs/utils/src/android/PerformanceHintManager.cpp
@@ -39,13 +39,18 @@ struct PerformanceHintManager::SessionDetails {
     APerformanceHintSession* mSession = nullptr;
 };
 
-PerformanceHintManager::PerformanceHintManager() noexcept {
+PerformanceHintManager::PerformanceHintManager() noexcept = default;
+
+PerformanceHintManager::~PerformanceHintManager() noexcept = default;
+
+void PerformanceHintManager::init() {
     if (__builtin_available(android __ANDROID_API_T__, *)) {
         mImpl->mManager = APerformanceHint_getManager();
     }
 }
 
-PerformanceHintManager::~PerformanceHintManager() noexcept = default;
+void PerformanceHintManager::terminate() {
+}
 
 bool PerformanceHintManager::isSupported() noexcept {
     if (__builtin_available(android __ANDROID_API_T__, *)) {


### PR DESCRIPTION
PerformanceHint manager needs a java thread during initialization, so we need to attach a jvm to the thread that's going to be used. That thread is the filament backend thread, not necessarily the thread  the platform is created on.

So we make sure to do that from the backend thread.


FIXES=[427945768]