### PR TITLE
webgpu: step 1 in fixing test_Scissor by fixing WebGPUDriver::readPixels with mipmap

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -1499,10 +1499,9 @@ void WebGPUDriver::readPixels(Handle<HwRenderTarget> sourceRenderTargetHandle, c
     const uint32_t srcHeight {srcTexture.GetHeight()};
     const uint32_t srcMipLevelCount {srcTexture.GetMipLevelCount()};
 
-    const uint32_t mipLevelImageScale = 1 << srcMipLevel;
-    const uint32_t mipLeveledSrcWidth = srcWidth / mipLevelImageScale;
-    const uint32_t mipLeveledSrcHeight = srcHeight / mipLevelImageScale;
-    assert_invariant(mipLeveledSrcWidth > 0 && mipLeveledSrcHeight > 0);
+    constexpr uint32_t minValidTextureSize = 1;
+    const uint32_t mipLeveledSrcWidth = std::max(minValidTextureSize, srcWidth >> srcMipLevel);
+    const uint32_t mipLeveledSrcHeight = std::max(minValidTextureSize, srcHeight >> srcMipLevel);
 
     // Clamp read region to texture bounds
     if (UTILS_UNLIKELY(x >= mipLeveledSrcWidth || y >= mipLeveledSrcHeight)) {

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -32,7 +32,7 @@ using namespace filament;
 using namespace filament::backend;
 
 TEST_F(BackendTest, ScissorViewportRegion) {
-    // SKIP_IF(Backend::WEBGPU, "test cases fail in WebGPU, see b/424157731");
+    SKIP_IF(Backend::WEBGPU, "test cases fail in WebGPU, see b/424157731");
     auto& api = getDriverApi();
 
     constexpr int kSrcTexWidth = 1024;
@@ -83,12 +83,10 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         Handle<HwTexture> srcTexture = addCleanup(api.createTexture(SamplerType::SAMPLER_2D,
                 kNumLevels, kSrcTexFormat, 1, kSrcTexWidth, kSrcTexHeight, 1,
                 TextureUsage::SAMPLEABLE | TextureUsage::COLOR_ATTACHMENT TEXTURE_USAGE_READ_PIXELS));
-        Handle<HwTexture> depthTexture = addCleanup(api.createTexture(SamplerType::SAMPLER_2D, 1,
-                TextureFormat::DEPTH16, 1, 512, 512, 1, TextureUsage::SAMPLEABLE | TextureUsage::DEPTH_ATTACHMENT));
-        // Handle<HwTexture> srcTexture = addCleanup(
-        //         api.createTexture(SamplerType::SAMPLER_2D, 1, TextureFormat::RGBA8, 1, 512, 512, 1,
-        //                 TextureUsage::SAMPLEABLE |
-        //                         TextureUsage::COLOR_ATTACHMENT TEXTURE_USAGE_READ_PIXELS));
+
+        Handle<HwTexture> depthTexture =
+                addCleanup(api.createTexture(SamplerType::SAMPLER_2D, 1, TextureFormat::DEPTH16, 1,
+                        512, 512, 1, TextureUsage::DEPTH_ATTACHMENT | TextureUsage::SAMPLEABLE));
 
         // Render into the bottom-left quarter of the texture.
         Viewport srcRect = {
@@ -107,11 +105,8 @@ TEST_F(BackendTest, ScissorViewportRegion) {
         // We purposely set the render target width and height to smaller than the texture, to check
         // that this case is handled correctly.
         Handle<HwRenderTarget> rt = addCleanup(api.createRenderTarget(
-                TargetBufferFlags::COLOR, kSrcRtHeight, kSrcRtHeight,
-                1, 1, { srcTexture, kSrcLevel, 0 }, {}, {}));
-
-        // Handle<HwRenderTarget> rt = addCleanup(api.createRenderTarget(TargetBufferFlags::COLOR, 512,
-        //         512, 1, 1, { srcTexture, 0, 0 }, {depthTexture, 0, 0}, {}));
+                TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH, kSrcRtHeight, kSrcRtHeight, 1,
+                1, { srcTexture, kSrcLevel, 0 }, { depthTexture, 0, 0 }, {}));
 
         TrianglePrimitive triangle(api);
 
@@ -136,8 +131,6 @@ TEST_F(BackendTest, ScissorViewportRegion) {
 
         EXPECT_IMAGE(rt,
                 ScreenshotParams(kSrcTexWidth >> 1, kSrcTexHeight >> 1, "scissor", 15842520));
-        // EXPECT_IMAGE(rt,
-        //         ScreenshotParams(1024, 1024, "scissor", 15842520));
 
         api.commit(swapChain);
         api.endFrame(0);


### PR DESCRIPTION
- Correct WebGPUDriver::readPixels behavior when mipmap level > 0
   (except when blit is needed, which is a TODO)
- Add TextureUsage::SAMPLEABLE to the depth texture in test_Scissor,
   which is needed to draw the triangle if the test is enabled.

With these changes, test_Scissor in webgpu can successfully draw the
the triangle if the test is enabled. The test would still fail since scissor 
has not been implemented in webgpu.