### PR TITLE
VK: Only bypass the staging buffer when is not in use

### DIFF
--- a/filament/backend/src/vulkan/memory/Resource.h
+++ b/filament/backend/src/vulkan/memory/Resource.h
@@ -81,6 +81,8 @@ struct Resource {
         return getTypeEnum<D>() == restype;
     }
 
+    uint32_t getCount() const { return mCount; }
+
 private:
     inline void inc() noexcept {
         mCount++;


### PR DESCRIPTION
In the cases where a frame takes more than the vsync time, we start seeing some rendering artifacts because we write to a buffer that is currently in flight.

Not 100% sure why the current approach fails but for now, the staging buffer is bypassed only when the buffer is not in use or referenced by any other resource.

FIXED=[445455050]
FIXED=[477305399]