### PR TITLE
AtlasAllocator: Implement free() and upgrade to Buddy Allocator

### DIFF
--- a/filament/src/AtlasAllocator.h
+++ b/filament/src/AtlasAllocator.h
@@ -34,10 +34,18 @@ class AtlasAllocator_AllocateMixed2_Test;
 
 namespace filament {
 
-/*
- * A 2D allocator. Allocations must be square and have a power-of-two size.
+/**
+ * A 2D allocator based on a QuadTree (Buddy Allocator).
+ *
+ * Allocations must be square and have a power-of-two size.
  * AtlasAllocator hard codes a depth of 4, that is only 4 allocation sizes are permitted.
  * This doesn't actually allocate memory, just manages space within an abstract 2D image.
+ *
+ * The allocator supports both allocation and deallocation.
+ * - Allocation uses a "best-fit" strategy, preferring to split nodes that already have children
+ *   to preserve large contiguous blocks.
+ * - Deallocation (free) automatically coalesces empty sibling nodes back into larger parent blocks
+ *   (standard Buddy Allocator behavior).
  */
 class AtlasAllocator {
 
@@ -73,25 +81,58 @@ class AtlasAllocator {
     using NodeId = QuadTree::NodeId;
 
 public:
-    /*
-     * Create allocator and specify the maximum texture size. Must be a power of two.
-     * Allocations size allowed are the four power-of-two smaller or equal to this size.
+    /**
+     * Create allocator and specify the maximum texture size.
+     *
+     * @param maxTextureSize The maximum size of the texture atlas. Must be a power of two.
+     *                       Allocations size allowed are the four power-of-two smaller or equal
+     *                       to this size.
      */
     explicit AtlasAllocator(size_t maxTextureSize) noexcept;
 
-    /*
-     * Allocates a square of size `textureSize`. Must be one of the power-of-two allowed
-     * (see above).
-     * Returns the location of the allocation within the maxTextureSize^2 square.
+    /**
+     * Represents a successful allocation within the atlas.
      */
     struct Allocation {
-        int32_t layer = -1;
+        /** The viewport of the allocation within the atlas layer. */
         Viewport viewport;
+        /** The layer index of the allocation (for texture arrays). 0xffff if invalid. */
+        uint16_t layer = 0xffff;
+        /** Internal Morton code used for deallocation. */
+        uint16_t code = 0;
+        /** Internal QuadTree level used for deallocation. */
+        int8_t level = 0;
+        /** Returns true if the allocation is valid. */
+        bool isValid() const noexcept { return layer != 0xffff; }
     };
+
+    /**
+     * Allocates a square region of the specified size.
+     *
+     * @param textureSize The size of the square to allocate. Must be a power of two.
+     *                    If the size is not a power of two, it will be rounded down to the
+     *                    nearest power of two.
+     * @return An Allocation struct containing the viewport and layer of the allocated region.
+     *         If the allocation fails (e.g. no space left or size too small/large),
+     *         an invalid Allocation is returned (isValid() returns false).
+     */
     Allocation allocate(size_t textureSize) noexcept;
 
-    /*
-     * Frees all allocations and reset the maximum texture size.
+    /**
+     * Frees an allocation returned by allocate().
+     *
+     * This method marks the region as free and attempts to coalesce empty sibling nodes
+     * into larger parent blocks, making them available for future large allocations.
+     *
+     * @param allocation The allocation to free. If the allocation is invalid, this method does nothing.
+     */
+    void free(Allocation const& allocation) noexcept;
+
+    /**
+     * Frees all allocations and resets the allocator with a new maximum texture size.
+     *
+     * @param maxTextureSize The new maximum size of the texture atlas. Defaults to 1024.
+     *                       Must be a power of two.
      */
     void clear(size_t maxTextureSize = 1024) noexcept;
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -1055,11 +1055,11 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
         ShadowMap* pShadowMap) mutable {
         // Allocate shadowmap from our Atlas Allocator
         auto const& options = pShadowMap->getShadowOptions();
-        auto [layer, pos] = allocator.allocate(options->mapSize);
-        assert_invariant(layer >= 0);
-        assert_invariant(!pos.empty());
-        pShadowMap->setAllocation(layer, pos);
-        layersNeeded = std::max(uint8_t(layer + 1), layersNeeded);
+        auto allocation = allocator.allocate(options->mapSize);
+        assert_invariant(allocation.isValid());
+        assert_invariant(!allocation.viewport.empty());
+        pShadowMap->setAllocation(allocation.layer, allocation.viewport);
+        layersNeeded = std::max(uint8_t(allocation.layer + 1), layersNeeded);
     };
 
     std::function const allocateFromTextureArray =

--- a/filament/test/filament_AtlasAllocator_test.cpp
+++ b/filament/test/filament_AtlasAllocator_test.cpp
@@ -199,3 +199,180 @@ TEST(AtlasAllocator, AllocateBySizeFullLayers) {
     EXPECT_EQ(vp3.viewport, r);
 }
 
+TEST(AtlasAllocator, FreeSimple) {
+    AtlasAllocator allocator(256);
+
+    // Allocate a 256x256 block (takes the whole layer 0)
+    auto vp0 = allocator.allocate(256);
+    EXPECT_EQ(vp0.layer, 0);
+    EXPECT_FALSE(vp0.viewport.empty());
+
+    // Free it
+    allocator.free(vp0);
+
+    // Allocate it again, should get the same spot
+    auto vp1 = allocator.allocate(256);
+    EXPECT_EQ(vp1.layer, 0);
+    EXPECT_EQ(vp1.viewport, vp0.viewport);
+}
+
+TEST(AtlasAllocator, FreeAndCoalesce) {
+    AtlasAllocator allocator(256);
+
+    // Allocate 4 128x128 blocks. They should fill layer 0.
+    auto vp0 = allocator.allocate(128);
+    auto vp1 = allocator.allocate(128);
+    auto vp2 = allocator.allocate(128);
+    auto vp3 = allocator.allocate(128);
+
+    EXPECT_EQ(vp0.layer, 0);
+    EXPECT_EQ(vp1.layer, 0);
+    EXPECT_EQ(vp2.layer, 0);
+    EXPECT_EQ(vp3.layer, 0);
+
+    // Free them all
+    allocator.free(vp0);
+    allocator.free(vp1);
+    allocator.free(vp2);
+    allocator.free(vp3);
+
+    // Now allocate a 256x256 block. It should fit in layer 0 because the 4 128s were coalesced.
+    auto vpBig = allocator.allocate(256);
+    EXPECT_EQ(vpBig.layer, 0);
+    EXPECT_FALSE(vpBig.viewport.empty());
+}
+
+TEST(AtlasAllocator, FreePartialCoalesce) {
+    AtlasAllocator allocator(256);
+
+    // Allocate 4 128x128 blocks.
+    auto vp0 = allocator.allocate(128);
+    auto vp1 = allocator.allocate(128);
+    auto vp2 = allocator.allocate(128);
+    auto vp3 = allocator.allocate(128);
+
+    // Free 3 of them
+    allocator.free(vp0);
+    allocator.free(vp1);
+    allocator.free(vp2);
+
+    // Try to allocate 256. Should fail (go to next layer) because vp3 is still there.
+    auto vpBig = allocator.allocate(256);
+    EXPECT_NE(vpBig.layer, 0);
+
+    // Free the last one
+    allocator.free(vp3);
+
+    // Now allocate 256. Should succeed in layer 0.
+    // Note: vpBig took layer 1, so layer 0 is now free.
+    auto vpBig2 = allocator.allocate(256);
+    EXPECT_EQ(vpBig2.layer, 0);
+}
+
+TEST(AtlasAllocator, FreeDeepHierarchy) {
+    AtlasAllocator allocator(512);
+
+    // Allocate a small block deep in the tree
+    // 512 -> 256 -> 128 -> 64. 32 is too small for QUAD_TREE_DEPTH=4
+    auto vpSmall = allocator.allocate(64);
+    EXPECT_EQ(vpSmall.layer, 0);
+
+    // Free it
+    allocator.free(vpSmall);
+
+    // Allocate a huge block. Should fit in layer 0 if the small block was properly coalesced up to the root.
+    auto vpHuge = allocator.allocate(512);
+    EXPECT_EQ(vpHuge.layer, 0);
+}
+
+TEST(AtlasAllocator, FreeInvalid) {
+    AtlasAllocator allocator(256);
+    AtlasAllocator::Allocation invalid;
+    EXPECT_FALSE(invalid.isValid());
+    // Should not crash
+    allocator.free(invalid);
+}
+
+TEST(AtlasAllocator, Checkerboard) {
+    AtlasAllocator allocator(256);
+
+    // Allocate 4 128x128 blocks (indices 0, 1, 2, 3 in Morton order)
+    auto vp0 = allocator.allocate(128);
+    auto vp1 = allocator.allocate(128);
+    auto vp2 = allocator.allocate(128);
+    auto vp3 = allocator.allocate(128);
+
+    // Free diagonals (0 and 3)
+    allocator.free(vp0);
+    allocator.free(vp3);
+
+    // Try to allocate 256. Should fail (layer 0 is fragmented).
+    auto vpBig = allocator.allocate(256);
+    EXPECT_NE(vpBig.layer, 0);
+
+    // Free remaining
+    allocator.free(vp1);
+    allocator.free(vp2);
+
+    // Now allocate 256. Should succeed in layer 0.
+    auto vpBig2 = allocator.allocate(256);
+    EXPECT_EQ(vpBig2.layer, 0);
+}
+
+TEST(AtlasAllocator, LayerIndependence) {
+    AtlasAllocator allocator(256);
+
+    // Fill Layer 0 with a big block
+    auto l0 = allocator.allocate(256);
+    EXPECT_EQ(l0.layer, 0);
+
+    // Fill Layer 1 with a big block
+    auto l1 = allocator.allocate(256);
+    EXPECT_EQ(l1.layer, 1);
+
+    // Free Layer 0
+    allocator.free(l0);
+
+    // Allocate big block again. Should go to Layer 0.
+    auto l0_new = allocator.allocate(256);
+    EXPECT_EQ(l0_new.layer, 0);
+
+    // Layer 1 should still be occupied.
+    // If we try to allocate another big block, it should go to Layer 2.
+    auto l2 = allocator.allocate(256);
+    EXPECT_EQ(l2.layer, 2);
+}
+
+TEST(AtlasAllocator, ReuseHole) {
+    AtlasAllocator allocator(256);
+
+    // Allocate 4 128x128 blocks.
+    auto vp0 = allocator.allocate(128);
+    auto vp1 = allocator.allocate(128);
+    auto vp2 = allocator.allocate(128);
+    auto vp3 = allocator.allocate(128);
+
+    // Free the second one (vp1)
+    allocator.free(vp1);
+
+    // Allocate a new 128 block. It should fit in the hole we just made in Layer 0.
+    auto vpNew = allocator.allocate(128);
+    EXPECT_EQ(vpNew.layer, 0);
+    EXPECT_EQ(vpNew.viewport, vp1.viewport);
+}
+
+TEST(AtlasAllocator, NonPowerOfTwo) {
+    AtlasAllocator allocator(512);
+
+    // Request 100. Should round down to 64.
+    auto vp = allocator.allocate(100);
+    EXPECT_EQ(vp.viewport.width, 64);
+    EXPECT_EQ(vp.viewport.height, 64);
+    EXPECT_TRUE(vp.isValid());
+
+    // Request 500. Should round down to 256.
+    auto vp2 = allocator.allocate(500);
+    EXPECT_EQ(vp2.viewport.width, 256);
+    EXPECT_EQ(vp2.viewport.height, 256);
+    EXPECT_TRUE(vp2.isValid());
+}


### PR DESCRIPTION
This change upgrades AtlasAllocator from a simple linear allocator  (reset-only) to a full Buddy Allocator capable of both allocation and  deallocation. This enables persistent shadow map management where  individual shadow maps can be updated or resized without rebuilding the  entire atlas every frame.

Key changes:
- Implemented AtlasAllocator::free():
	- Uses the existing QuadTree structure to track allocations.
	- Automatically coalesces empty sibling nodes back into larger  parent blocks (standard Buddy Allocator behavior).
	- Optimized to be allocation-free and recursion-free, using direct  array indexing.

- Added comprehensive unit tests

Updated documentation.

The QuadTreeArray implementation remains unchanged but is now fully  utilized for bidirectional tree traversal (down for alloc, up for free).

This change will later allow us to cache shadow-maps. The AtlasAlocator is currently disabled by a feature flag.