### PR TITLE
wip: fog for opaques in applied as a post-process effect

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SRCS
         src/materials/colorGrading/colorGrading.cpp
         src/materials/dof/dof.cpp
         src/materials/flare/flare.cpp
+        src/materials/fog/fog.cpp
         src/materials/fsr/fsr.cpp
         src/materials/sgsr/sgsr.cpp
         src/materials/ssao/ssao.cpp
@@ -283,6 +284,7 @@ set(MATERIAL_SRCS
         src/materials/dof/dofTiles.mat
         src/materials/dof/dofTilesSwizzle.mat
         src/materials/flare/flare.mat
+        src/materials/fog/fog.mat
         src/materials/fsr/fsr_easu.mat
         src/materials/fsr/fsr_easu_mobile.mat
         src/materials/fsr/fsr_easu_mobileF.mat
@@ -522,6 +524,14 @@ add_custom_command(
 add_custom_command(
         OUTPUT "${MATERIAL_DIR}/dofCombine.filamat"
         DEPENDS src/materials/dof/dofUtils.fs
+        APPEND
+)
+
+add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/fog.filamat"
+        DEPENDS ../shaders/src/surface_fog.fs
+        DEPENDS src/materials/utils/depthUtils.fs
+        DEPENDS src/materials/utils/geometry.fs
         APPEND
 )
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -37,6 +37,7 @@
 #include <filament/Viewport.h>
 
 #include <private/filament/EngineEnums.h>
+#include <private/filament/Variant.h>
 
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
@@ -219,6 +220,10 @@ public:
     void clearAncillaryBuffers(backend::DriverApi& driver,
             backend::TargetBufferFlags attachments) const noexcept;
 
+    // postfx fog
+    void fogPrepare(backend::DriverApi& driver) noexcept;
+    void fog(backend::DriverApi& driver) noexcept;
+
     // Anti-aliasing
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, Viewport const& vp,
@@ -351,7 +356,12 @@ public:
         void terminate(FEngine& engine) noexcept;
 
         FMaterial* getMaterial(FEngine& engine, backend::DriverApi& driver,
-                PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept;
+                Variant::type_t variant) const noexcept;
+
+        FMaterial* getMaterial(FEngine& engine, backend::DriverApi& driver,
+                PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept {
+                return getMaterial(engine, driver, Variant::type_t(variant));
+        }
 
     private:
         void loadMaterial(FEngine& engine) const noexcept;
@@ -376,9 +386,12 @@ public:
 
     void bindPostProcessDescriptorSet(backend::DriverApi& driver) const noexcept;
 
-    backend::PipelineState getPipelineState(
-            FMaterial const* ma,
-            PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept;
+    backend::PipelineState getPipelineState(FMaterial const* ma, Variant::type_t variant) const noexcept;
+
+    backend::PipelineState getPipelineState(FMaterial const* ma,
+                    PostProcessVariant variant = PostProcessVariant::OPAQUE) const noexcept {
+            return getPipelineState(ma, Variant::type_t(variant));
+    }
 
     void renderFullScreenQuad(FrameGraphResources::RenderPassInfo const& out,
             backend::PipelineState const& pipeline,

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -479,7 +479,7 @@ void RenderPass::generateCommands(CommandTypeFlags commandTypeFlags, Command* co
     const size_t offsetBegin = FScene::getPrimitiveCount(soa, range.first) * commandsPerPrimitive;
     const size_t offsetEnd   = FScene::getPrimitiveCount(soa, range.last) * commandsPerPrimitive;
     Command* curr = commands + offsetBegin;
-    Command* const last = commands + offsetEnd;
+    Command const* const last = commands + offsetEnd;
 
     /*
      * The switch {} below is to coerce the compiler into generating different versions of

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -75,6 +75,8 @@ public:
         backend::FeatureLevel featureLevel;
         // Auto depth resolve supported
         bool isAutoDepthResolveSupported;
+        // Use post-process fog
+        bool fogAsPostProcess;
     };
 
     struct ColorPassInput {

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -26,6 +26,8 @@
 
 #include "details/Engine.h"
 #include "details/Fence.h"
+#include "details/Material.h"
+#include "details/MaterialInstance.h"
 #include "details/Scene.h"
 #include "details/SwapChain.h"
 #include "details/View.h"
@@ -1062,7 +1064,8 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
             .hasScreenSpaceReflectionsOrRefractions = ssReflectionsOptions.enabled,
             .enabledStencilBuffer = view.isStencilBufferEnabled(),
             .featureLevel = mFeatureLevel,
-            .isAutoDepthResolveSupported = mIsAutoDepthResolveSupported
+            .isAutoDepthResolveSupported = mIsAutoDepthResolveSupported,
+            .fogAsPostProcess = view.hasFog() && engine.features.material.enable_fog_as_postprocess,
     };
 
     /*
@@ -1222,6 +1225,21 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
     // color-grading as subpass is done either by the color pass or the TAA pass if any
     auto colorGradingConfigForColor = colorGradingConfig;
     colorGradingConfigForColor.asSubpass = colorGradingConfigForColor.asSubpass && !taaOptions.enabled;
+
+    if (config.fogAsPostProcess) {
+        // append for command at the end of the opaque pass
+
+        passBuilder.customCommand(CONFIG_RENDERPASS_CHANNEL_COUNT - 1, // should be user defined
+                RenderPass::Pass::COLOR,
+                RenderPass::CustomCommand::EPILOGUE,
+                0, [&ppm, &driver, &view]() {
+                    // set the per-view descriptor set (always unlit, no ssr, no fog, no vsm)
+                    auto const& ds = view.getColorPassDescriptorSet(ShadowType::PCF)[
+                            ColorPassDescriptorSet::getIndex(false, false, false)];
+                    ds.bind(driver, DescriptorSetBindingPoints::PER_VIEW);
+                    ppm.fog(driver);
+                });
+    }
 
     if (colorGradingConfigForColor.asSubpass) {
         // append color grading subpass after all other passes

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -457,8 +457,12 @@ public:
     static void cullRenderables(utils::JobSystem& js, FScene::RenderableSoa& renderableData,
             Frustum const& frustum, size_t bit) noexcept;
 
+    ColorPassDescriptorSet& getColorPassDescriptorSet(ShadowType type) const noexcept {
+        return mColorPassDescriptorSet[type == ShadowType::PCF ? 0 : 1];
+    }
+
     ColorPassDescriptorSet& getColorPassDescriptorSet() const noexcept {
-            return mColorPassDescriptorSet[mShadowType == ShadowType::PCF ? 0 : 1];
+        return getColorPassDescriptorSet(mShadowType);
     }
 
     // Returns the frame history FIFO. This is typically used by the FrameGraph to access

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -139,6 +139,10 @@ public:
         mDescriptorSet[index].bind(driver, DescriptorSetBindingPoints::PER_VIEW);
     }
 
+    DescriptorSet const& operator[](size_t const index) const {
+        return mDescriptorSet[index];
+    }
+
     bool isVSM() const noexcept { return mIsVsm; }
 
 private:

--- a/filament/src/materials/fog/fog.cpp
+++ b/filament/src/materials/fog/fog.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fog.h"
+
+#include "generated/resources/fog.h"
+
+#include <materials/StaticMaterialInfo.h>
+
+#include <utils/Slice.h>
+
+#include <iterator>
+
+#include <stddef.h>
+
+namespace filament {
+
+static const StaticMaterialInfo sMaterialList[] = {
+        { "fog",                        MATERIAL(FOG, FOG) },
+};
+
+utils::Slice<const StaticMaterialInfo> getFogMaterialList() noexcept {
+    return { std::begin(sMaterialList), std::end(sMaterialList) };
+}
+
+} // namespace filament

--- a/filament/src/materials/fog/fog.h
+++ b/filament/src/materials/fog/fog.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <materials/StaticMaterialInfo.h>
+
+#include <utils/Slice.h>
+
+namespace filament {
+
+utils::Slice<const StaticMaterialInfo> getFogMaterialList() noexcept;
+
+} // namespace filament

--- a/filament/src/materials/fog/fog.mat
+++ b/filament/src/materials/fog/fog.mat
@@ -1,0 +1,59 @@
+material {
+    name : fog,
+    vertexDomain : device,
+    shadingModel : unlit,
+    variantFilter : [ skinning, shadowReceiver, vsm, fog ],
+    culling: none,
+    blending : transparent,
+    depthWrite : false,
+    depthCulling : false,
+    parameters : [
+        {
+            type : samplerCubemap,
+            name : fogColorTexture,
+        }
+    ],
+    variables : [
+        vertex
+    ]
+}
+
+vertex {
+    void materialVertex(inout MaterialVertexInputs material) {
+        material.vertex.xy = mesh_position.xy * 0.5 + 0.5;
+    }
+}
+
+fragment {
+
+#include "../../../../shaders/src/surface_fog.fs"
+#include "../utils/geometry.fs"
+
+void dummy(){}
+
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+
+        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
+
+        highp mat4 m = getViewFromClipMatrix();
+        highp vec2 p = vec2(m[0][0], m[1][1]);
+
+        highp float depth = sampleDepth(sampler0_structure, uv, 0.0);
+        highp float z = linearizeDepth(depth);
+        highp vec3 v = computeViewSpacePositionFromDepth(uv, z, p);
+
+        highp vec3 view = mulMat3x3Float3(getWorldFromViewMatrix(), v) - getWorldCameraPosition();
+
+        view = frameUniforms.fogFromWorldMatrix * view;
+
+        material.baseColor = fog(view
+#if MATERIAL_FEATURE_LEVEL > 0
+            , materialParams_fogColorTexture
+#endif
+            );
+
+        // TODO: fog linear mode
+        // TODO: actually set the fogColorTexture
+    }
+}

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -99,6 +99,8 @@ struct Variant {
     static constexpr type_t VSM   = 0x40; // variance shadow maps / sampler type
     static constexpr type_t STE   = 0x80; // instanced stereo
 
+    static constexpr type_t NO_VARIANT         = 0u;
+
     // special variants (variants that use the reserved space)
     static constexpr type_t SPECIAL_SSR   = VSM | SRE; // screen-space reflections variant
 

--- a/libs/utils/include/private/utils/FeatureFlagManager.h
+++ b/libs/utils/include/private/utils/FeatureFlagManager.h
@@ -95,6 +95,7 @@ public:
         struct {
             bool check_crc32_after_loading = false;
             bool enable_material_instance_uniform_batching = false;
+            bool enable_fog_as_postprocess = false;
         } material;
     } features;
 

--- a/libs/utils/src/FeatureFlagManager.cpp
+++ b/libs/utils/src/FeatureFlagManager.cpp
@@ -142,6 +142,9 @@ FeatureFlagManager::FeatureFlagManager() : mFeatures{{
         { "engine.skip_frame_when_cpu_ahead_of_display",
           "Automatically skip frames when the CPU gets ahead of the display.",
           &features.engine.skip_frame_when_cpu_ahead_of_display },
+        { "material.enable_fog_as_postprocess",
+          "Fog is applied as a separate pass for opaque objects.",
+          &features.material.enable_fog_as_postprocess },
 }} {
     overrideFeatureDefaults({ mFeatures.data(), mFeatures.size() });
 }

--- a/shaders/src/surface_fog.fs
+++ b/shaders/src/surface_fog.fs
@@ -3,18 +3,23 @@
 // see: Real-time Atmospheric Effects in Games (Carsten Wenzel)
 //------------------------------------------------------------------------------
 
-vec4 fog(vec4 color, highp vec3 view) {
+vec4 fog(highp vec3 view
+#if MATERIAL_FEATURE_LEVEL > 0
+    , const mediump samplerCube fogColorTexture
+#endif
+)
+{
     // note: d can be +inf with the skybox
     highp float d = length(view);
 
     // early exit for object "in front" of the fog
     if (d < frameUniforms.fogStart) {
-        return color;
+        return vec4(0);
     }
 
     // fogCutOffDistance is set to +inf to disable the cutoff distance
     if (d > frameUniforms.fogCutOffDistance) {
-        return color;
+        return vec4(0);
     }
 
     // .x = density
@@ -55,7 +60,7 @@ vec4 fog(vec4 color, highp vec3 view) {
         // a rigid transform, so we can take the transpose instead of the inverse, and for the
         // same reason we can use it directly instead of taking the cof() to transform a vector.
         highp mat3 worldFromUserWorldMatrix = transpose(mat3(frameUniforms.userWorldFromWorldMatrix));
-        fogColor *= textureLod(sampler0_fog, worldFromUserWorldMatrix * view, lod).rgb;
+        fogColor *= textureLod(fogColorTexture, worldFromUserWorldMatrix * view, lod).rgb;
     }
 #endif
 
@@ -78,38 +83,27 @@ vec4 fog(vec4 color, highp vec3 view) {
         fogColor += sunColor * (sunInscattering * (1.0 - sunTransmittance));
     }
 
-#if   defined(BLEND_MODE_OPAQUE)
-    // nothing to do here
-#elif defined(BLEND_MODE_TRANSPARENT)
-    fogColor *= color.a;
-#elif defined(BLEND_MODE_ADD)
-    fogColor = vec3(0.0);
-#elif defined(BLEND_MODE_MASKED)
-    // nothing to do here
-#elif defined(BLEND_MODE_MULTIPLY)
-    // FIXME: unclear what to do here
-#elif defined(BLEND_MODE_SCREEN)
-    // FIXME: unclear what to do here
-#endif
-
-    color.rgb = color.rgb * (1.0 - fogOpacity) + fogColor;
-
-    return color;
+    return vec4(fogColor, fogOpacity);
 }
 
 // A linear approximation of the fog function
-vec4 fogLinear(vec4 color, highp vec3 view) {
+vec4 fogLinear(highp vec3 view
+#if MATERIAL_FEATURE_LEVEL > 0
+    , const mediump samplerCube fogColorTexture
+#endif
+)
+{
     // note: d can be +inf with the skybox
     highp float d = length(view);
 
     // early exit for object "in front" of the fog
     if (d < frameUniforms.fogStart) {
-        return color;
+        return vec4(0);
     }
 
     // fogCutOffDistance is set to +inf to disable the cutoff distance
     if (d > frameUniforms.fogCutOffDistance) {
-        return color;
+        return vec4(0);
     }
 
     // compute fog color
@@ -126,27 +120,11 @@ vec4 fogLinear(vec4 color, highp vec3 view) {
         // a rigid transform, so we can take the transpose instead of the inverse, and for the
         // same reason we can use it directly instead of taking the cof() to transform a vector.
         highp mat3 worldFromUserWorldMatrix = transpose(mat3(frameUniforms.userWorldFromWorldMatrix));
-        fogColor *= textureLod(sampler0_fog, worldFromUserWorldMatrix * view, minMaxMip.x).rgb;
+        fogColor *= textureLod(fogColorTexture, worldFromUserWorldMatrix * view, minMaxMip.x).rgb;
     }
 #endif
 
     fogColor *= frameUniforms.iblLuminance * fogOpacity;
 
-#if   defined(BLEND_MODE_OPAQUE)
-    // nothing to do here
-#elif defined(BLEND_MODE_TRANSPARENT)
-    fogColor *= color.a;
-#elif defined(BLEND_MODE_ADD)
-    fogColor = vec3(0.0);
-#elif defined(BLEND_MODE_MASKED)
-    // nothing to do here
-#elif defined(BLEND_MODE_MULTIPLY)
-    // FIXME: unclear what to do here
-#elif defined(BLEND_MODE_SCREEN)
-    // FIXME: unclear what to do here
-#endif
-
-    color.rgb = color.rgb * (1.0 - fogOpacity) + fogColor;
-
-    return color;
+    return vec4(fogColor, fogOpacity);
 }

--- a/shaders/src/surface_main.fs
+++ b/shaders/src/surface_main.fs
@@ -66,12 +66,34 @@ void main() {
     highp vec3 view = getWorldPosition() - getWorldCameraPosition();
     view = frameUniforms.fogFromWorldMatrix * view;
 
-#if defined (FILAMENT_LINEAR_FOG)
-    fragColor = fogLinear(fragColor, view);
+#if MATERIAL_FEATURE_LEVEL > 0
+#   if defined (FILAMENT_LINEAR_FOG)
+    vec4 fogColor = fogLinear(view, sampler0_fog);
+#   else
+    vec4 fogColor = fog(view, sampler0_fog);
+#   endif
 #else
-    fragColor = fog(fragColor, view);
+#   if defined (FILAMENT_LINEAR_FOG)
+    vec4 fogColor = fogLinear(view);
+#   else
+    vec4 fogColor = fog(view);
+#   endif
 #endif
 
+#   if   defined(BLEND_MODE_OPAQUE)
+    // nothing to do here
+#   elif defined(BLEND_MODE_TRANSPARENT)
+    fogColor.rgb *= fragColor.a;
+#   elif defined(BLEND_MODE_ADD)
+    fogColor.rgb = vec3(0.0);
+#   elif defined(BLEND_MODE_MASKED)
+    // nothing to do here
+#   elif defined(BLEND_MODE_MULTIPLY)
+    // FIXME: unclear what to do here
+#   elif defined(BLEND_MODE_SCREEN)
+    // FIXME: unclear what to do here
+#endif
+    fragColor.rgb = fragColor.rgb * (1.0 - fogColor.a) + fogColor.rgb;
 #endif
 
 #if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)


### PR DESCRIPTION
Instead of computing the fog "inline", in the forward pass, we can instead compute it as post-process pass that is applied with a simple fullscreen quad blending.  On tilers, the operation entirely stays in the tile, on desktop GPU it is a blending operation.

This works only for opaque materials.

The benefit is that fog will become immune to overdraw, and the forward pass shader will be simplified, hopefully leading to less register  pressure. Overall performance should be improved.

Another benefit is that it will allow us to free the "fog" texture slot from all opaque materials.

Transparent materials are unchanged.

This feature is currently DISABLED, and still work in progress; but it should be mostly functional.

To test it:

```
env material.enable_fog_as_postprocess=true ./out/samples/gltf_viewer
```


This change refactor the fog code, but shouldn't have any impact on the current behavior.