### PR TITLE
Remove instanced stereoscopic type

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -206,10 +206,6 @@ public:
          */
         NONE,
         /**
-         * Stereoscopic rendering is performed using instanced rendering technique.
-         */
-        INSTANCED,
-        /**
          * Stereoscopic rendering is performed using the multiview feature from the graphics
          * backend.
          */

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1267,8 +1267,6 @@ bool MetalDriver::isProtectedContentSupported() {
 
 bool MetalDriver::isStereoSupported() {
     switch (mStereoscopicType) {
-        case backend::StereoscopicType::INSTANCED:
-            return true;
         case backend::StereoscopicType::MULTIVIEW:
             // TODO: implement multiview feature in Metal.
             return false;

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -363,12 +363,6 @@ void OpenGLContext::setDefaultState() noexcept {
 #endif
     }
 #endif
-
-    if (ext.EXT_clip_cull_distance
-            && mDriverConfig.stereoscopicType == StereoscopicType::INSTANCED) {
-        glEnable(GL_CLIP_DISTANCE0);
-        glEnable(GL_CLIP_DISTANCE1);
-    }
 }
 
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2872,8 +2872,6 @@ bool OpenGLDriver::isStereoSupported() {
         return false;
     }
     switch (getDriverConfig().stereoscopicType) {
-        case StereoscopicType::INSTANCED:
-            return mContext.ext.EXT_clip_cull_distance;
         case StereoscopicType::MULTIVIEW:
             return mContext.ext.OVR_multiview2;
         case StereoscopicType::NONE:

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1588,8 +1588,6 @@ bool VulkanDriver::isProtectedContentSupported() {
 
 bool VulkanDriver::isStereoSupported() {
     switch (mStereoscopicType) {
-        case backend::StereoscopicType::INSTANCED:
-            return mContext.isClipDistanceSupported();
         case backend::StereoscopicType::MULTIVIEW:
             return mContext.isMultiviewEnabled();
         case backend::StereoscopicType::NONE:

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -984,10 +984,7 @@ void VulkanPlatform::queryAndSetDeviceFeatures(Platform::DriverConfig const& dri
     context.mProtectedMemorySupported =
             static_cast<bool>(queryProtectedMemoryFeatures.protectedMemory);
 
-    // Only enable shaderClipDistance if we are doing instanced stereoscopic rendering.
-    if (driverConfig.stereoscopicType != StereoscopicType::INSTANCED) {
-        context.mPhysicalDeviceFeatures.features.shaderClipDistance = VK_FALSE;
-    }
+    context.mPhysicalDeviceFeatures.features.shaderClipDistance = VK_FALSE;
 
     // Check the availability of lazily allocated memory
     context.mLazilyAllocatedMemorySupported = false;

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -464,7 +464,6 @@ void FEngine::init() {
         FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
         switch (mConfig.stereoscopicType) {
             case StereoscopicType::NONE:
-            case StereoscopicType::INSTANCED:
                 defaultMaterialBuilder.package(
                         MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
                 break;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1243,14 +1243,6 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
 
     passBuilder.commandTypeFlags(RenderPass::CommandTypeFlags::COLOR);
 
-
-    // RenderPass::IS_INSTANCED_STEREOSCOPIC only applies to the color pass
-    if (view.hasStereo() &&
-        engine.getConfig().stereoscopicType == StereoscopicType::INSTANCED) {
-        renderFlags |= RenderPass::IS_INSTANCED_STEREOSCOPIC;
-        passBuilder.renderFlags(renderFlags);
-    }
-
     // create the pass, which generates all its commands (this is a heavy operation)
     RenderPass const pass{ passBuilder.build(engine, driver) };
 

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -140,7 +140,6 @@ FMaterial const* FSkybox::createMaterial(FEngine& engine) {
     {
         switch (engine.getConfig().stereoscopicType) {
             case Engine::StereoscopicType::NONE:
-            case Engine::StereoscopicType::INSTANCED:
                 builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
                 break;
             case Engine::StereoscopicType::MULTIVIEW:

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -939,7 +939,7 @@ private:
     Interpolation mInterpolation = Interpolation::SMOOTH;
     VertexDomain mVertexDomain = VertexDomain::OBJECT;
     TransparencyMode mTransparencyMode = TransparencyMode::DEFAULT;
-    StereoscopicType mStereoscopicType = StereoscopicType::INSTANCED;
+    StereoscopicType mStereoscopicType = StereoscopicType::MULTIVIEW;
     uint8_t mStereoscopicEyeCount = 2;
 
     filament::AttributeBitset mRequiredAttributes;

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -912,7 +912,6 @@ bool GLSLPostProcessor::fullOptimization(const TShader& tShader,
                 //   layout(num_views = 2) in;
                 glslOptions.ovr_multiview_view_count = config.materialInfo->stereoscopicEyeCount;
                 break;
-            case StereoscopicType::INSTANCED:
             case StereoscopicType::NONE:
                 // Nothing to generate
                 break;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1033,7 +1033,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .domain = mMaterialDomain,
                         .materialInfo = &info,
                         .hasFramebufferFetch = mEnableFramebufferFetch,
-                        .usesClipDistance = v.variant.hasStereo() && info.stereoscopicType == StereoscopicType::INSTANCED,
+                        .usesClipDistance = false,
                         .glsl = {},
                 };
 

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -68,15 +68,6 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
             }
             if (v.hasStereo() && stage == ShaderStage::VERTEX) {
                 switch (material.stereoscopicType) {
-                case StereoscopicType::INSTANCED:
-                    // If we're not processing the shader through glslang (in the case of unoptimized
-                    // OpenGL shaders), then we need to add the #extension string ourselves.
-                    // If we ARE running the shader through glslang, then we must not include it,
-                    // otherwise glslang will complain.
-                    out << "#ifndef FILAMENT_GLSLANG\n";
-                    out << "#extension GL_EXT_clip_cull_distance : require\n";
-                    out << "#endif\n\n";
-                    break;
                 case StereoscopicType::MULTIVIEW:
                     if (mTargetApi == TargetApi::VULKAN) {
                         out << "#extension GL_EXT_multiview : enable\n";
@@ -101,9 +92,6 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
             }
             if (v.hasStereo() && stage == ShaderStage::VERTEX) {
                 switch (material.stereoscopicType) {
-                case StereoscopicType::INSTANCED:
-                    // Nothing to generate
-                    break;
                 case StereoscopicType::MULTIVIEW:
                     if (mTargetApi == TargetApi::VULKAN) {
                         out << "#extension GL_EXT_multiview : enable\n";
@@ -128,9 +116,6 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
 
     if (v.hasStereo() && stage == ShaderStage::VERTEX) {
         switch (material.stereoscopicType) {
-        case StereoscopicType::INSTANCED:
-            // Nothing to generate
-            break;
         case StereoscopicType::MULTIVIEW:
             if (mTargetApi != TargetApi::VULKAN) {
                 out << "layout(num_views = " << material.stereoscopicEyeCount << ") in;\n";
@@ -233,9 +218,6 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
     generateDefine(out, "FILAMENT_EFFECTIVE_VERSION", effective_version);
 
     switch (material.stereoscopicType) {
-    case StereoscopicType::INSTANCED:
-        generateDefine(out, "FILAMENT_STEREO_INSTANCED", true);
-        break;
     case StereoscopicType::MULTIVIEW:
         generateDefine(out, "FILAMENT_STEREO_MULTIVIEW", true);
         break;

--- a/libs/filament-matp/src/ParametersProcessor.cpp
+++ b/libs/filament-matp/src/ParametersProcessor.cpp
@@ -961,7 +961,6 @@ static utils::Status processGroupSizes(MaterialBuilder& builder, const JsonishVa
 
 static utils::Status processStereoscopicType(MaterialBuilder& builder, const JsonishValue& value) {
     static const std::unordered_map<std::string, MaterialBuilder::StereoscopicType> strToEnum{
-            { "instanced", MaterialBuilder::StereoscopicType::INSTANCED },
             { "multiview",  MaterialBuilder::StereoscopicType::MULTIVIEW },
     };
     auto jsonString = value.toJsonString();

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -741,9 +741,7 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
 
         Engine::Config engineConfig = {};
         engineConfig.stereoscopicEyeCount = config.stereoscopicEyeCount;
-#if defined(FILAMENT_SAMPLES_STEREO_TYPE_INSTANCED)
-        engineConfig.stereoscopicType = Engine::StereoscopicType::INSTANCED;
-#elif defined (FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
+#if defined (FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
         engineConfig.stereoscopicType = Engine::StereoscopicType::MULTIVIEW;
 #else
         engineConfig.stereoscopicType = Engine::StereoscopicType::NONE;

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -7,9 +7,7 @@
  * @public-api
  */
 int getEyeIndex() {
-#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
-    return instance_index % CONFIG_STEREO_EYE_COUNT;
-#elif defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
+#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_MULTIVIEW)
 
 #   if defined(TARGET_VULKAN_ENVIRONMENT)
     return int(gl_ViewIndex);

--- a/shaders/src/surface_varyings.glsl
+++ b/shaders/src/surface_varyings.glsl
@@ -33,17 +33,3 @@ LAYOUT_LOCATION(11) VARYING highp vec4 vertex_lightSpacePosition;
 #endif
 
 // Note that fragColor is an output and is not declared here; see surface_main.fs and surface_depth_main.fs
-
-#if defined(VARIANT_HAS_STEREO) && defined(FILAMENT_STEREO_INSTANCED)
-#if defined(GL_ES) && defined(FILAMENT_GLSLANG)
-// On ES, gl_ClipDistance is not a built-in, so we have to rely on EXT_clip_cull_distance
-// However, this extension is not supported by glslang, so we instead write to
-// filament_gl_ClipDistance, which will get decorated at the SPIR-V stage to refer to the built-in.
-// The location here does not matter, so long as it doesn't conflict with others.
-LAYOUT_LOCATION(100) out float filament_gl_ClipDistance[2];
-#define FILAMENT_CLIPDISTANCE filament_gl_ClipDistance
-#else
-// If we're on Desktop GL (or not running shaders through glslang), we're free to use gl_ClipDistance
-#define FILAMENT_CLIPDISTANCE gl_ClipDistance
-#endif // GL_ES && FILAMENT_GLSLANG
-#endif // VARIANT_HAS_STEREO


### PR DESCRIPTION
an option to remove the instanced stereoscopic type was brought up in the conversation whether we can have multiview as the default value for the stereo rendering.