### PR TITLE
Move `eyeFromViewMatrix` to FL1 by default

### DIFF
--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -100,7 +100,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "eyeFromViewMatrix",      CONFIG_MAX_STEREOSCOPIC_EYES,
-                                           Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+                                           Type::MAT4,   Precision::HIGH },
             { "clipFromWorldMatrix",    CONFIG_MAX_STEREOSCOPIC_EYES,
                                            Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -46,6 +46,7 @@ highp mat4 getViewFromClipMatrix() {
     return frameUniforms.viewFromClipMatrix;
 }
 
+#if FILAMENT_EFFECTIVE_VERSION > 100
 /** @public-api */
 highp mat4 getEyeFromViewMatrix() {
     return frameUniforms.eyeFromViewMatrix[getEyeIndex()];
@@ -55,6 +56,7 @@ highp mat4 getEyeFromViewMatrix() {
 highp mat4 getEyeFromViewMatrix(int eyeIndex) {
     return frameUniforms.eyeFromViewMatrix[eyeIndex];
 }
+#endif // MATERIAL_FEATURE_LEVEL > 0
 
 /** @public-api */
 highp mat4 getClipFromWorldMatrix() {


### PR DESCRIPTION
Seems to save ~30 ms on Firefox startup at FL0.