### PR TITLE
Fix possible buffer overflow in CommandStream

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -969,7 +969,7 @@ void RenderPass::Executor::execute(FEngine const& engine, DriverApi& driver,
 
             // check we have enough capacity to write these commandCount commands, if not,
             // request a new CircularBuffer allocation of `capacity` bytes.
-            if (UTILS_UNLIKELY(circularBuffer.getUsed() > capacity - commandSizeInBytes)) {
+            if (UTILS_UNLIKELY(circularBuffer.getUsed() + commandSizeInBytes > capacity)) {
                 // FIXME: eventually we can't flush here because this will be a secondary
                 //        command buffer. We will need another solution for overflows.
                 const_cast<FEngine&>(engine).flush();


### PR DESCRIPTION
Because of an improper boundary check caused a possible unsigned integer overflow, it was possible to overrun the command stream buffer in RenderPass::execute().

It would happen when the batch size was larger than the buffer capacity (usually a few MB). 

FIXES=[474264976]