### PR TITLE
External sampler bind index bug

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.cpp
@@ -62,7 +62,7 @@ uint32_t appendBindings(VkDescriptorSetLayoutBinding* toBind, VkDescriptorType t
 
 uint32_t appendSamplerBindings(VkDescriptorSetLayoutBinding* toBind,
         fvkutils::SamplerBitmask const& mask, fvkutils::SamplerBitmask const& external,
-        utils::FixedCapacityVector<std::pair<uint32_t, VkSampler>> const& immutableSamplers) {
+        utils::FixedCapacityVector<std::pair<uint64_t, VkSampler>> const& immutableSamplers) {
     using Bitmask = fvkutils::SamplerBitmask;
     uint32_t count = 0;
     Bitmask alreadySeen;
@@ -101,13 +101,13 @@ uint32_t appendSamplerBindings(VkDescriptorSetLayoutBinding* toBind,
 }
 
 uint64_t computeImmutableSamplerHash(
-        utils::FixedCapacityVector<std::pair<uint32_t, VkSampler>> const& samplers) {
+        utils::FixedCapacityVector<std::pair<uint64_t, VkSampler>> const& samplers) {
     size_t const size = samplers.size();
     if (size == 0) {
         return 0;
     }
-    //32bit + 64bit per element = 3 words
-    return utils::hash::murmur3((uint32_t*) samplers.data(), samplers.size() * 3, 0);
+    //64bit + 64bit per element = 4 words
+    return utils::hash::murmur3((uint32_t*) samplers.data(), samplers.size() * 4, 0);
 }
 
 } // anonymous namespace
@@ -128,7 +128,7 @@ void VulkanDescriptorSetLayoutCache::terminate() noexcept {
 VkDescriptorSetLayout VulkanDescriptorSetLayoutCache::getVkLayout(
         VulkanDescriptorSetLayout::Bitmask const& bitmasks,
         fvkutils::SamplerBitmask externalSamplers,
-        utils::FixedCapacityVector<std::pair<uint32_t, VkSampler>> immutableSamplers) {
+        utils::FixedCapacityVector<std::pair<uint64_t, VkSampler>> immutableSamplers) {
     LayoutKey key = {
         .bitmask = bitmasks,
         .immutableSamplerHash = computeImmutableSamplerHash(immutableSamplers),

--- a/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetLayoutCache.h
@@ -47,7 +47,7 @@ public:
     // This method is meant to be used with external samplers
     VkDescriptorSetLayout getVkLayout(VulkanDescriptorSetLayout::Bitmask const& bitmasks,
             fvkutils::SamplerBitmask externalSamplers,
-            utils::FixedCapacityVector<std::pair<uint32_t, VkSampler>> immutableSamplers = {});
+            utils::FixedCapacityVector<std::pair<uint64_t, VkSampler>> immutableSamplers = {});
 
 private:
     VkDevice mDevice;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -882,7 +882,7 @@ void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils
             // formats. It seems to be enough, in practicce, to simply run through a list of the types of
             // samplers that *might* appear. As long as the real pipeline is close enough to something that
             // the driver has seen before, we are able to get a cache hit.
-            utils::FixedCapacityVector<std::pair<uint32_t, VkSampler>> externalSamplers(
+            utils::FixedCapacityVector<std::pair<uint64_t, VkSampler>> externalSamplers(
                     layouts[i]->bitmask.externalSampler.count(), { 0, externalSampler });
             vkLayouts[i] = mDescriptorSetLayoutCache.getVkLayout(
                 layouts[i]->bitmask, layouts[i]->bitmask.externalSampler, externalSamplers);

--- a/filament/backend/src/vulkan/VulkanExternalImageManager.cpp
+++ b/filament/backend/src/vulkan/VulkanExternalImageManager.cpp
@@ -142,10 +142,10 @@ void VulkanExternalImageManager::updateSetAndLayout(
         return std::get<0>(a) < std::get<0>(b);
     });
 
-    utils::FixedCapacityVector<std::pair<uint32_t,VkSampler>> outSamplers;
+    utils::FixedCapacityVector<std::pair<uint64_t,VkSampler>> outSamplers;
     outSamplers.reserve(MAX_SAMPLER_COUNT);
     std::for_each(samplerAndBindings.begin(), samplerAndBindings.end(),
-            [&](auto const& b) { outSamplers.push_back({ static_cast<uint32_t>(std::get<0>(b)), std::get<1>(b) }); });
+            [&](auto const& b) { outSamplers.push_back({ static_cast<uint64_t>(std::get<0>(b)), std::get<1>(b) }); });
 
     VkDescriptorSetLayout const newLayout = mDescriptorSetLayoutCache->getVkLayout(layout->bitmask,
             actualExternalSamplers, outSamplers);


### PR DESCRIPTION
On some video use cases when the same vkSampler is retreived from the cache, we still need to ensure it is bound to the same index, otherwise VK considers it as two separate layouts for immutable samplers (bind index and sampler object need to match). As it stands we fail to differenciate when the same sampler is bound to two different bind points. We needs two separate layouts.