### PR TITLE
VK: add back the removed vmaFlush for staging

### DIFF
--- a/filament/backend/src/vulkan/VulkanBufferProxy.cpp
+++ b/filament/backend/src/vulkan/VulkanBufferProxy.cpp
@@ -76,6 +76,7 @@ void VulkanBufferProxy::loadFromCpu(VulkanCommandBuffer& commands, const void* c
     assert_invariant(stage->memory());
     commands.acquire(stage);
     memcpy(stage->mapping(), cpuData, numBytes);
+    vmaFlushAllocation(mAllocator, stage->memory(), stage->offset(), numBytes);
 
     // This means that we're recording a write into a command buffer with a previous read, so it
     // needs to add a barrier (to protect the write from writing over a read).


### PR DESCRIPTION
This line was removed by accident in the staging bypass fix PR.