### PR TITLE
metal: add readTexture implementation

### DIFF
--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -35,6 +35,8 @@
 #include <vector>
 #include <deque>
 
+@protocol MTLTexture;
+
 namespace filament {
 namespace backend {
 
@@ -159,6 +161,9 @@ private:
 
     void enumerateBoundBuffers(BufferObjectBinding bindingType,
             const std::function<void(const BufferState&, MetalBuffer*, uint32_t)>& f);
+
+    void readTextureCommon(id<MTLTexture> srcTexture, uint8_t level, uint16_t layer, uint32_t x,
+            uint32_t y, uint32_t width, uint32_t height, PixelBufferDescriptor&& data);
 
     backend::StereoscopicType const mStereoscopicType;
     backend::AsynchronousMode const mAsynchronousMode;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1751,12 +1751,34 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
     MetalAttachment color = srcTarget->getDrawColorAttachment(0);
     id<MTLTexture> srcTexture = color.getTexture();
     size_t miplevel = color.getLevel();
+    size_t layer = color.getLayer();
 
     // Clamp height and width to actual texture's height and width
     MTLSize srcTextureSize = MTLSizeMake(srcTexture.width >> miplevel, srcTexture.height >> miplevel, 1);
     height = std::min(static_cast<uint32_t>(srcTextureSize.height), height);
     width = std::min(static_cast<uint32_t>(srcTextureSize.width), width);
 
+    readTextureCommon(srcTexture, miplevel, layer, x, y, width, height, std::move(data));
+}
+
+void MetalDriver::readTexture(Handle<HwTexture> src, uint8_t level, uint16_t layer, uint32_t x,
+        uint32_t y, uint32_t width, uint32_t height, PixelBufferDescriptor&& p) {
+    FILAMENT_CHECK_PRECONDITION(!isInRenderPass(mContext))
+            << "readTexture must be called outside of a render pass.";
+
+    auto srcTexture = handle_cast<MetalTexture>(src);
+    id<MTLTexture> texture = srcTexture->getMtlTextureForWrite();
+
+    // Clamp height and width to actual texture's height and width
+    MTLSize srcTextureSize = MTLSizeMake(texture.width >> level, texture.height >> level, 1);
+    height = std::min(static_cast<uint32_t>(srcTextureSize.height), height);
+    width = std::min(static_cast<uint32_t>(srcTextureSize.width), width);
+
+    readTextureCommon(texture, level, layer, x, y, width, height, std::move(p));
+}
+
+void MetalDriver::readTextureCommon(id<MTLTexture> srcTexture, uint8_t level, uint16_t layer,
+        uint32_t x, uint32_t y, uint32_t width, uint32_t height, PixelBufferDescriptor&& data) {
     const MTLPixelFormat format = getMetalFormat(data.format, data.type);
     FILAMENT_CHECK_PRECONDITION(format != MTLPixelFormatInvalid)
             << "The chosen combination of PixelDataFormat (" << (int)data.format
@@ -1764,10 +1786,14 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
             << ") is not supported for "
                "readPixels.";
 
+    // Clamp height and width to actual texture's height and width
+    MTLSize levelSize = MTLSizeMake(std::max(1lu, srcTexture.width >> level),
+            std::max(1lu, srcTexture.height >> level), 1);
+
     MTLTextureDescriptor* textureDescriptor =
             [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:format
-                                                               width:srcTextureSize.width
-                                                              height:srcTextureSize.height
+                                                               width:levelSize.width
+                                                              height:levelSize.height
                                                            mipmapped:NO];
 #if defined(FILAMENT_IOS)
     textureDescriptor.storageMode = MTLStorageModeShared;
@@ -1779,14 +1805,16 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
 
     MetalBlitter::BlitArgs args{};
     args.filter = SamplerMagFilter::NEAREST;
-    args.source.level = miplevel;
-    args.source.region = MTLRegionMake2D(0, 0, srcTexture.width >> miplevel, srcTexture.height >> miplevel);
+    args.source.level = level;
+    args.source.slice = layer;
+    args.source.region = MTLRegionMake2D(0, 0, levelSize.width, levelSize.height);
     args.source.texture = srcTexture;
     args.destination.level = 0;
+    args.destination.slice = 0;
     args.destination.region = MTLRegionMake2D(0, 0, readPixelsTexture.width, readPixelsTexture.height);
     args.destination.texture = readPixelsTexture;
 
-    mContext->blitter->blit(getPendingCommandBuffer(mContext), args, "readPixels blit");
+    mContext->blitter->blit(getPendingCommandBuffer(mContext), args, "readTexture blit");
 
 #if !defined(FILAMENT_IOS)
     // Managed textures on macOS require explicit synchronization between GPU / CPU.
@@ -1812,12 +1840,6 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
         scheduleDestroy(std::move(*p));
         delete p;
     }];
-}
-
-void MetalDriver::readTexture(Handle<HwTexture> src, uint8_t level, uint16_t layer, uint32_t x,
-        uint32_t y, uint32_t width, uint32_t height, PixelBufferDescriptor&& p) {
-    // TODO: implement readTexture
-    scheduleDestroy(std::move(p));
 }
 
 void MetalDriver::readBufferSubData(backend::BufferObjectHandle boh,

--- a/filament/backend/test/test_ReadTexture.cpp
+++ b/filament/backend/test/test_ReadTexture.cpp
@@ -41,6 +41,17 @@ void main() {
 }
 )");
 
+std::string fragmentCoord(R"(#version 450 core
+layout(location = 0) out vec4 fragColor;
+void main() {
+    // gl_FragCoord.xy is in pixels. (0.5, 0.5) is the center of the bottom-left pixel.
+    // We want to map this to a color to verify orientation.
+    // Red varies with X, Green varies with Y.
+    // We assume a 64x64 texture for this test.
+    vec2 coord = gl_FragCoord.xy / 64.0;
+    fragColor = vec4(coord.x, coord.y, 0.0, 1.0);
+}
+)");
 }
 
 namespace test {
@@ -51,8 +62,6 @@ public:
 };
 
 TEST_F(ReadTextureTest, ReadTexture2D) {
-    SKIP_IF(Backend::METAL, "readTexture not implemented for Metal");
-
     DriverApi& api = getDriverApi();
     const size_t textureSize = 64;
 
@@ -146,8 +155,6 @@ TEST_F(ReadTextureTest, ReadTexture2D) {
 }
 
 TEST_F(ReadTextureTest, ReadTextureArray) {
-    SKIP_IF(Backend::METAL, "readTexture not implemented for Metal");
-
     DriverApi& api = getDriverApi();
     const size_t textureSize = 64;
     const uint16_t layers = 2;
@@ -212,6 +219,110 @@ TEST_F(ReadTextureTest, ReadTextureArray) {
         flushAndWait();
         EXPECT_TRUE(finished);
     }
+}
+
+TEST_F(ReadTextureTest, ReadTextureXCoordinates) {
+    SKIP_IF(Backend::OPENGL, "readTexture not implemented for OpenGL");
+
+    DriverApi& api = getDriverApi();
+    const size_t textureSize = 64;
+
+    Handle<HwSwapChain> swapChain =
+            addCleanup(api.createSwapChainHeadless(textureSize, textureSize, 0));
+    api.makeCurrent(swapChain, swapChain);
+
+    auto usage = TextureUsage::COLOR_ATTACHMENT | TextureUsage::SAMPLEABLE | TextureUsage::BLIT_SRC;
+    Handle<HwTexture> const texture = addCleanup(api.createTexture(SamplerType::SAMPLER_2D, 1,
+            TextureFormat::RGBA8, 1, textureSize, textureSize, 1, usage));
+
+    Handle<HwRenderTarget> renderTarget = addCleanup(api.createRenderTarget(
+            TargetBufferFlags::COLOR, textureSize, textureSize, 1, 0, { { texture, 0 } }, {}, {}));
+
+    // Draw a full-screen quad (using a large triangle)
+    TrianglePrimitive triangle(api);
+    const math::float2 fsVertices[3] = { { -1.0f, -1.0f }, { 3.0f, -1.0f }, { -1.0f, 3.0f } };
+    triangle.updateVertices(fsVertices);
+
+    std::string vertexShader =
+            SharedShaders::getVertexShaderText(VertexShaderType::Noop, ShaderUniformType::None);
+    Shader shader(api, *mCleanup,
+            ShaderConfig{
+                .vertexShader = vertexShader,
+                .fragmentShader = fragmentCoord,
+                .uniforms = {},
+            });
+
+    RenderPassParams params = getClearColorRenderPass(math::float4(0));
+    params.viewport.width = textureSize;
+    params.viewport.height = textureSize;
+
+    api.beginFrame(0, 0, 0);
+    api.beginRenderPass(renderTarget, params);
+
+    PipelineState state = getColorWritePipelineState();
+    shader.addProgramToPipelineState(state);
+    state.primitiveType = PrimitiveType::TRIANGLES;
+    state.vertexBufferInfo = triangle.getVertexBufferInfo();
+    api.bindPipeline(state);
+    api.bindRenderPrimitive(triangle.getRenderPrimitive());
+    api.draw2(0, 3, 1);
+
+    api.endRenderPass();
+
+    // Read texture back
+    size_t bufferSize = textureSize * textureSize * 4;
+    void* buffer = calloc(1, bufferSize);
+
+    struct UserData {
+        bool finished = false;
+    } userData;
+
+    PixelBufferDescriptor descriptor(
+            buffer, bufferSize, PixelDataFormat::RGBA, PixelDataType::UBYTE, 1, 0, 0, textureSize,
+            [](void* buffer, size_t size, void* user) {
+                UserData* data = (UserData*) user;
+                data->finished = true;
+
+                uint8_t* pixels = (uint8_t*) buffer;
+                const size_t width = 64;
+                const size_t height = 64;
+
+                // Check Bottom-Left (0, 0) -> Should be black (0, 0, 0)
+                // In buffer, this is at index 0
+                // Y=0, X=0
+                EXPECT_NEAR(pixels[0], 0, 5);
+                EXPECT_NEAR(pixels[1], 0, 5);
+
+                // Check Bottom-Right (1, 0) -> Should be Red (255, 0, 0)
+                // Y=0, X=63
+                size_t br_idx = (63) * 4;
+                EXPECT_NEAR(pixels[br_idx], 255, 5);
+                EXPECT_NEAR(pixels[br_idx + 1], 0, 5);
+
+                // Check Top-Left (0, 1) -> Should be Green (0, 255, 0)
+                // Y=63, X=0
+                size_t tl_idx = (63 * width) * 4;
+                EXPECT_NEAR(pixels[tl_idx], 0, 5);
+                EXPECT_NEAR(pixels[tl_idx + 1], 255, 5);
+
+                // Check Top-Right (1, 1) -> Should be Yellow (255, 255, 0)
+                // Y=63, X=63
+                size_t tr_idx = (63 * width + 63) * 4;
+                EXPECT_NEAR(pixels[tr_idx], 255, 5);
+                EXPECT_NEAR(pixels[tr_idx + 1], 255, 5);
+
+                free(buffer);
+            },
+            &userData);
+
+    api.readTexture(texture, 0, 0, 0, 0, textureSize, textureSize, std::move(descriptor));
+
+    api.commit(swapChain);
+    api.endFrame(0);
+
+    flushAndWait();
+
+    EXPECT_TRUE(userData.finished);
 }
 
 } // namespace test


### PR DESCRIPTION
 - Also added a test to verify the y-flipping mechanism of each backend produces the same rendering across backends.