### PR TITLE
Add build testing checks for all the tests

### DIFF
--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -54,45 +54,47 @@ list(APPEND RESGEN_SOURCE ${DUMMY_SRC})
 # Unit tests
 # ==================================================================================================
 
-# The following tests rely on private APIs that are stripped
-# away in Release builds
-if (TNT_DEV)
-    add_executable(test_${TARGET}
-            MockDriver.h
-            filament_AtlasAllocator_test.cpp
-            test_BufferAllocator.cpp
-            test_BufferAllocatorStress.cpp
-            test_CircularQueue.cpp
-            test_compact.cpp
-            test_FenceManager.cpp
-            test_UboManager.cpp
-            filament_test_exposure.cpp
-            filament_rendering_test.cpp
-            filament_bimap_test.cpp
-            filament_framegraph_test.cpp
-            filament_test.cpp
-            filament_test_material.cpp
-            ${RESGEN_SOURCE})
+if (BUILD_TESTING)
+    # The following tests rely on private APIs that are stripped
+    # away in Release builds
+    if (TNT_DEV)
+        add_executable(test_${TARGET}
+                MockDriver.h
+                filament_AtlasAllocator_test.cpp
+                test_BufferAllocator.cpp
+                test_BufferAllocatorStress.cpp
+                test_CircularQueue.cpp
+                test_compact.cpp
+                test_FenceManager.cpp
+                test_UboManager.cpp
+                filament_test_exposure.cpp
+                filament_rendering_test.cpp
+                filament_bimap_test.cpp
+                filament_framegraph_test.cpp
+                filament_test.cpp
+                filament_test_material.cpp
+                ${RESGEN_SOURCE})
 
-    target_link_libraries(test_${TARGET} PRIVATE filamat filament gtest)
-    target_compile_options(test_${TARGET} PRIVATE ${COMPILER_FLAGS})
-    target_include_directories(test_${TARGET} PRIVATE ${RESOURCE_DIR})
-    set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
+        target_link_libraries(test_${TARGET} PRIVATE filamat filament gtest)
+        target_compile_options(test_${TARGET} PRIVATE ${COMPILER_FLAGS})
+        target_include_directories(test_${TARGET} PRIVATE ${RESOURCE_DIR})
+        set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 
-    add_executable(test_depth depth_test.cpp)
-    target_link_libraries(test_depth PRIVATE utils)
-endif()
+        add_executable(test_depth depth_test.cpp)
+        target_link_libraries(test_depth PRIVATE utils)
+    endif()
 
-add_executable(test_material_parser
-        filament_test_material_parser.cpp
-        ${RESGEN_SOURCE}
-)
-target_link_libraries(test_material_parser PRIVATE filamat filament gtest)
-target_compile_options(test_material_parser PRIVATE ${COMPILER_FLAGS})
-target_include_directories(test_material_parser PRIVATE ${RESOURCE_DIR})
-set_target_properties(test_material_parser PROPERTIES FOLDER Tests)
+    add_executable(test_material_parser
+            filament_test_material_parser.cpp
+            ${RESGEN_SOURCE}
+    )
+    target_link_libraries(test_material_parser PRIVATE filamat filament gtest)
+    target_compile_options(test_material_parser PRIVATE ${COMPILER_FLAGS})
+    target_include_directories(test_material_parser PRIVATE ${RESOURCE_DIR})
+    set_target_properties(test_material_parser PROPERTIES FOLDER Tests)
 
-if (ANDROID)
-    add_executable(test_compiler compiler_test.cpp)
-    target_link_libraries(test_compiler PRIVATE gtest utils EGL GLESv3)
+    if (ANDROID)
+        add_executable(test_compiler compiler_test.cpp)
+        target_link_libraries(test_compiler PRIVATE gtest utils EGL GLESv3)
+    endif()
 endif()

--- a/libs/bluegl/CMakeLists.txt
+++ b/libs/bluegl/CMakeLists.txt
@@ -74,17 +74,19 @@ endif()
 
 install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
 
-# Build the tests...
-add_executable(test_${TARGET}
-    tests/OpenGLSupport.cpp
-    tests/OpenGLSupport.hpp
-    tests/test_bluegl.cpp)
+if (BUILD_TESTING)
+    # Build the tests...
+    add_executable(test_${TARGET}
+        tests/OpenGLSupport.cpp
+        tests/OpenGLSupport.hpp
+        tests/test_bluegl.cpp)
 
-if (LINUX)
-    target_link_libraries(test_${TARGET} PUBLIC dl)
+    if (LINUX)
+        target_link_libraries(test_${TARGET} PUBLIC dl)
+    endif()
+
+    # and we're linking against the libraries below, importing their public headers
+    target_link_libraries(test_${TARGET} LINK_PUBLIC ${TARGET})
+    target_link_libraries(test_${TARGET} LINK_PUBLIC gtest)
+    set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 endif()
-
-# and we're linking against the libraries below, importing their public headers
-target_link_libraries(test_${TARGET} LINK_PUBLIC ${TARGET})
-target_link_libraries(test_${TARGET} LINK_PUBLIC gtest)
-set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)

--- a/libs/camutils/CMakeLists.txt
+++ b/libs/camutils/CMakeLists.txt
@@ -50,7 +50,7 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/camutils DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (BUILD_TESTING AND NOT ANDROID AND NOT WEBGL AND NOT IOS)
     add_executable(test_${TARGET} tests/test_camutils.cpp)
     target_link_libraries(test_${TARGET} PRIVATE camutils gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (IS_HOST_PLATFORM)
+if (BUILD_TESTING AND IS_HOST_PLATFORM)
     project(test_filamat)
     set(TARGET test_filamat)
     set(SRCS

--- a/libs/filament-matp/CMakeLists.txt
+++ b/libs/filament-matp/CMakeLists.txt
@@ -55,20 +55,22 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/ DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-project(test_matp)
-set(TARGET test_matp)
-set(SRCS
-    tests/test_includes.cpp
-    tests/test_includer.cpp
-    tests/test_matp.cpp
-    tests/TestMaterialParser.h
-    tests/test_compute_material.cpp
-)
+if (BUILD_TESTING)
+    project(test_matp)
+    set(TARGET test_matp)
+    set(SRCS
+        tests/test_includes.cpp
+        tests/test_includer.cpp
+        tests/test_matp.cpp
+        tests/TestMaterialParser.h
+        tests/test_compute_material.cpp
+    )
 
-add_executable(${TARGET} ${SRCS})
+    add_executable(${TARGET} ${SRCS})
 
-target_link_libraries(${TARGET} matp gtest)
+    target_link_libraries(${TARGET} matp gtest)
 
-target_include_directories(${TARGET} PRIVATE ${matp_SOURCE_DIR}/src)
+    target_include_directories(${TARGET} PRIVATE ${matp_SOURCE_DIR}/src)
 
-set_target_properties(test_matp PROPERTIES FOLDER Tests)
+    set_target_properties(test_matp PROPERTIES FOLDER Tests)
+endif()

--- a/libs/filameshio/CMakeLists.txt
+++ b/libs/filameshio/CMakeLists.txt
@@ -37,7 +37,7 @@ install(FILES ${DIST_HDRS} DESTINATION include/${TARGET})
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT IOS AND NOT WEBGL AND NOT ANDROID)
+if (BUILD_TESTING AND NOT IOS AND NOT WEBGL AND NOT ANDROID)
     add_executable(test_${TARGET} tests/test_filamesh.cpp )
     target_link_libraries(test_${TARGET} PRIVATE filameshio gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)

--- a/libs/geometry/CMakeLists.txt
+++ b/libs/geometry/CMakeLists.txt
@@ -73,7 +73,7 @@ install(FILES "${GEOMETRY_COMBINED_OUTPUT}" DESTINATION lib/${DIST_DIR} RENAME $
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (BUILD_TESTING AND NOT ANDROID AND NOT WEBGL AND NOT IOS)
     set(TARGET test_transcoder)
     add_executable(${TARGET} tests/test_transcoder.cpp)
     target_link_libraries(${TARGET} PRIVATE geometry gtest)

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -225,38 +225,40 @@ endif()
 # Tests
 # ==================================================================================================
 
-set(GLTF_TEST_FILES)
-function(add_test_gltf SOURCE TARGET)
-    set(source_path "${ROOT_DIR}/${SOURCE}")
-    set(target_path "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}")
-    add_custom_command(
-        OUTPUT ${target_path}
-        DEPENDS ${source_path}
-        COMMAND ${CMAKE_COMMAND} -E copy ${source_path} ${target_path}
-    )
-    list(APPEND GLTF_TEST_FILES "${target_path}")
-    set(GLTF_TEST_FILES ${GLTF_TEST_FILES} PARENT_SCOPE)
-endfunction()
+if (BUILD_TESTING)
+    set(GLTF_TEST_FILES)
+    function(add_test_gltf SOURCE TARGET)
+        set(source_path "${ROOT_DIR}/${SOURCE}")
+        set(target_path "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}")
+        add_custom_command(
+            OUTPUT ${target_path}
+            DEPENDS ${source_path}
+            COMMAND ${CMAKE_COMMAND} -E copy ${source_path} ${target_path}
+        )
+        list(APPEND GLTF_TEST_FILES "${target_path}")
+        set(GLTF_TEST_FILES ${GLTF_TEST_FILES} PARENT_SCOPE)
+    endfunction()
 
-add_test_gltf("third_party/models/AnimatedMorphCube/AnimatedMorphCube.glb" "AnimatedMorphCube.glb")
-add_test_gltf("third_party/models/DamagedHelmet/DamagedHelmetWebp.glb" "DamagedHelmetWebp.glb")
+    add_test_gltf("third_party/models/AnimatedMorphCube/AnimatedMorphCube.glb" "AnimatedMorphCube.glb")
+    add_test_gltf("third_party/models/DamagedHelmet/DamagedHelmetWebp.glb" "DamagedHelmetWebp.glb")
 
-add_custom_target(test_gltfio_files DEPENDS ${GLTF_TEST_FILES})
+    add_custom_target(test_gltfio_files DEPENDS ${GLTF_TEST_FILES})
 
-# The following tests rely on private APIs that are stripped
-# away in Release builds
-if (TNT_DEV AND NOT WEBGL AND NOT ANDROID AND NOT IOS)
-    set(TEST_TARGET test_gltfio)
+    # The following tests rely on private APIs that are stripped
+    # away in Release builds
+    if (TNT_DEV AND NOT WEBGL AND NOT ANDROID AND NOT IOS)
+        set(TEST_TARGET test_gltfio)
 
-    add_executable(${TEST_TARGET} test/gltfio_test.cpp)
-    add_dependencies(${TEST_TARGET} test_gltfio_files)
-    set_property(TARGET test_gltfio PROPERTY LINK_LIBRARIES)
+        add_executable(${TEST_TARGET} test/gltfio_test.cpp)
+        add_dependencies(${TEST_TARGET} test_gltfio_files)
+        set_property(TARGET test_gltfio PROPERTY LINK_LIBRARIES)
 
-    target_link_libraries(${TEST_TARGET} PRIVATE ${TARGET} gtest uberarchive)
-    if (NOT MSVC)
-        target_compile_options(${TEST_TARGET} PRIVATE ${GLTFIO_WARNINGS})
+        target_link_libraries(${TEST_TARGET} PRIVATE ${TARGET} gtest uberarchive)
+        if (NOT MSVC)
+            target_compile_options(${TEST_TARGET} PRIVATE ${GLTFIO_WARNINGS})
+        endif()
+        set_target_properties(${TEST_TARGET} PROPERTIES FOLDER Tests)
     endif()
-    set_target_properties(${TEST_TARGET} PROPERTIES FOLDER Tests)
 endif()
 
 # ==================================================================================================

--- a/libs/image/CMakeLists.txt
+++ b/libs/image/CMakeLists.txt
@@ -53,7 +53,7 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/image DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS AND NOT FILAMENT_SKIP_SDL2)
+if (BUILD_TESTING AND NOT ANDROID AND NOT WEBGL AND NOT IOS AND NOT FILAMENT_SKIP_SDL2)
     add_executable(test_${TARGET} tests/test_image.cpp)
     target_link_libraries(test_${TARGET} PRIVATE imageio gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)

--- a/libs/ktxreader/CMakeLists.txt
+++ b/libs/ktxreader/CMakeLists.txt
@@ -60,7 +60,7 @@ endfunction()
 add_testfile(color_grid_uastc_zstd.ktx2)
 add_testfile(lightroom_ibl.ktx)
 
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (BUILD_TESTING AND NOT ANDROID AND NOT WEBGL AND NOT IOS)
     add_executable(test_ktxreader tests/test_ktxreader.cpp ${TESTFILES})
     target_link_libraries(test_ktxreader PRIVATE ${TARGET} gtest)
     set_target_properties(test_ktxreader PROPERTIES FOLDER Tests)

--- a/libs/math/CMakeLists.txt
+++ b/libs/math/CMakeLists.txt
@@ -52,27 +52,29 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/math DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-add_executable(test_${TARGET}
-        tests/test_fast.cpp
-        tests/test_half.cpp
-        tests/test_mat.cpp
-        tests/test_vec.cpp
-        tests/test_quat.cpp
-)
-target_link_libraries(test_${TARGET} PRIVATE math gtest)
-set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
+if (BUILD_TESTING)
+    add_executable(test_${TARGET}
+            tests/test_fast.cpp
+            tests/test_half.cpp
+            tests/test_mat.cpp
+            tests/test_vec.cpp
+            tests/test_quat.cpp
+    )
+    target_link_libraries(test_${TARGET} PRIVATE math gtest)
+    set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 
-# ==================================================================================================
-# Benchmarks
-# ==================================================================================================
+    # ==================================================================================================
+    # Benchmarks
+    # ==================================================================================================
 
-set(BENCHMARK_SRCS
-        benchmarks/benchmark_fast.cpp include/math/mathfwd.h)
+    set(BENCHMARK_SRCS
+            benchmarks/benchmark_fast.cpp include/math/mathfwd.h)
 
-add_executable(benchmark_${TARGET} ${BENCHMARK_SRCS})
+    add_executable(benchmark_${TARGET} ${BENCHMARK_SRCS})
 
-target_compile_options(benchmark_${TARGET} PRIVATE ${OPTIMIZATION_FLAGS})
+    target_compile_options(benchmark_${TARGET} PRIVATE ${OPTIMIZATION_FLAGS})
 
-target_link_libraries(benchmark_${TARGET} PRIVATE benchmark_main utils math)
+    target_link_libraries(benchmark_${TARGET} PRIVATE benchmark_main utils math)
 
-set_target_properties(benchmark_${TARGET} PROPERTIES FOLDER Benchmarks)
+    set_target_properties(benchmark_${TARGET} PROPERTIES FOLDER Benchmarks)
+endif()

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -167,57 +167,59 @@ endif()
 # Test executables
 # ==================================================================================================
 
-set(TEST_SRCS
-        test/test_algorithm.cpp
-        test/test_Allocators.cpp
-        test/test_bitset.cpp
-        test/test_CountDownLatch.cpp
-        test/test_CString.cpp
-        test/test_ImmutableCString.cpp
-        test/test_CyclicBarrier.cpp
-        test/test_Entity.cpp
-        test/test_FixedCapacityVector.cpp
-        test/test_FixedCircularBuffer.cpp
-        test/test_Hash.cpp
-        test/test_InternPool.cpp
-        test/test_JobSystem.cpp
-        test/test_MonotonicRingMap.cpp
-        test/test_QuadTreeArray.cpp
-        test/test_RangeMap.cpp
-        test/test_RefCountedMap.cpp
-        test/test_Slice.cpp
-        test/test_StructureOfArrays.cpp
-        test/test_sstream.cpp
-        test/test_string.cpp
-        test/test_utils_main.cpp
-        test/test_Zip2Iterator.cpp
-        test/test_BinaryTreeArray.cpp
-        test/test_Status.cpp
-)
+if (BUILD_TESTING)
+    set(TEST_SRCS
+            test/test_algorithm.cpp
+            test/test_Allocators.cpp
+            test/test_bitset.cpp
+            test/test_CountDownLatch.cpp
+            test/test_CString.cpp
+            test/test_ImmutableCString.cpp
+            test/test_CyclicBarrier.cpp
+            test/test_Entity.cpp
+            test/test_FixedCapacityVector.cpp
+            test/test_FixedCircularBuffer.cpp
+            test/test_Hash.cpp
+            test/test_InternPool.cpp
+            test/test_JobSystem.cpp
+            test/test_MonotonicRingMap.cpp
+            test/test_QuadTreeArray.cpp
+            test/test_RangeMap.cpp
+            test/test_RefCountedMap.cpp
+            test/test_Slice.cpp
+            test/test_StructureOfArrays.cpp
+            test/test_sstream.cpp
+            test/test_string.cpp
+            test/test_utils_main.cpp
+            test/test_Zip2Iterator.cpp
+            test/test_BinaryTreeArray.cpp
+            test/test_Status.cpp
+    )
 
-if (WEBGL_PTHREADS)
-    target_compile_definitions(${TARGET} PUBLIC -DFILAMENT_WASM_THREADS)
-endif()
-
-# The Path tests are platform-specific
-if (NOT WEBGL)
-    if (WIN32)
-        list(APPEND TEST_SRCS test/test_WinPath.cpp)
-    else()
-        list(APPEND TEST_SRCS test/test_Path.cpp)
+    if (WEBGL_PTHREADS)
+        target_compile_definitions(${TARGET} PUBLIC -DFILAMENT_WASM_THREADS)
     endif()
+
+    # The Path tests are platform-specific
+    if (NOT WEBGL)
+        if (WIN32)
+            list(APPEND TEST_SRCS test/test_WinPath.cpp)
+        else()
+            list(APPEND TEST_SRCS test/test_Path.cpp)
+        endif()
+    endif()
+
+    add_executable(test_${TARGET} ${TEST_SRCS})
+
+    target_link_libraries(test_${TARGET} PRIVATE gtest utils tsl math)
+    set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 endif()
-
-add_executable(test_${TARGET} ${TEST_SRCS})
-
-target_link_libraries(test_${TARGET} PRIVATE gtest utils tsl math)
-set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 
 # ==================================================================================================
 # Benchmarks
 # ==================================================================================================
 
-if (NOT WEBGL)
+if (BUILD_TESTING AND NOT WEBGL)
 
     add_library(benchmark_${TARGET}_callee SHARED benchmark/benchmark_callee.cpp)
     set_target_properties(benchmark_${TARGET}_callee PROPERTIES FOLDER Benchmarks)

--- a/libs/viewer/CMakeLists.txt
+++ b/libs/viewer/CMakeLists.txt
@@ -57,7 +57,7 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/viewer DESTINATION include)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (BUILD_TESTING AND NOT ANDROID AND NOT WEBGL AND NOT IOS)
     add_executable(test_settings tests/test_settings.cpp)
     target_link_libraries(test_settings PRIVATE ${TARGET} gtest)
     set_target_properties(test_settings PROPERTIES FOLDER Tests)

--- a/tools/cmgen/CMakeLists.txt
+++ b/tools/cmgen/CMakeLists.txt
@@ -52,7 +52,7 @@ install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID)
+if (BUILD_TESTING AND NOT ANDROID)
     add_executable(test_${TARGET} tests/test_cmgen.cpp)
     target_link_libraries(test_${TARGET} PRIVATE imageio gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)

--- a/tools/glslminifier/CMakeLists.txt
+++ b/tools/glslminifier/CMakeLists.txt
@@ -31,7 +31,7 @@ install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
 # ==================================================================================================
 # Tests
 # ==================================================================================================
-if (NOT ANDROID)
+if (BUILD_TESTING AND NOT ANDROID)
     add_executable(test_${TARGET}
             src/GlslMinify.cpp
             tests/test_glslminifier.cpp


### PR DESCRIPTION
We're incorporating filament into our system. We build the leanest version of filament. There are many tests that are built regardless.

Many ways to do it but I just went with wrapping BUILD_TESTING (an existing flag) around each test. It defaults on.