### PR TITLE
VK: Fix AHB import validation error

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -72,6 +72,10 @@ VkFormat transformVkFormat(VkFormat format, bool sRGB) {
     return format;
 }
 
+bool isFormatSrgb(VkFormat format) {
+  return format == VK_FORMAT_R8G8B8A8_SRGB || format == VK_FORMAT_R8G8B8_SRGB;
+}
+
 bool isProtectedFromUsage(uint64_t usage) {
     return usage & AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT;
 }
@@ -367,7 +371,7 @@ VulkanPlatform::ImageData VulkanPlatformAndroid::createVkImageFromExternal(
             .pViewFormats = formats,
         };
 
-        if (fvkExternalImage->sRGB) {
+        if (isFormatSrgb(metadata.format)) {
             formats[0] = metadata.format;
             formats[1] = transformVkFormat(metadata.format, /*sRGB=*/false);
             imageFormatListInfo.pNext = externalCreateInfo.pNext;
@@ -377,7 +381,7 @@ VulkanPlatform::ImageData VulkanPlatformAndroid::createVkImageFromExternal(
         VkImageCreateInfo const imageInfo = {
             .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
             .pNext = &externalCreateInfo,
-            .flags = fvkExternalImage->sRGB ? VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT : 0u,
+            .flags = isFormatSrgb(metadata.format) ? VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT : 0u,
             .imageType = VK_IMAGE_TYPE_2D,
             // For non external images, use the same format as the AHB, which isn't in SRGB
             // Fix VUID-VkMemoryAllocateInfo-pNext-02387


### PR DESCRIPTION
In some cases the external image to be imported is flagged as using a sRGB dataspace but when the AHB is imported its actual format is UNDEFINED and requires an external sampler.

In these cases, its not valid to set the VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT flag.

See VUID-VkImageCreateInfo-pNext-02396

FIXES=[483456747]