### PR TITLE
VK: More refactor of the external sampler flow

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -55,12 +55,7 @@ public:
             VkDeviceSize size) noexcept;
 
     void updateSampler(fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t binding,
-            fvkmemory::resource_ptr<VulkanTexture> texture, VkSampler sampler,
-            VkDescriptorSetLayout externalSamplerLayout = VK_NULL_HANDLE) noexcept;
-
-    void updateSamplerForExternalSamplerSet(fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t binding,
-            fvkmemory::resource_ptr<VulkanTexture> texture) noexcept;
-
+            fvkmemory::resource_ptr<VulkanTexture> texture, VkSampler sampler) noexcept;
 
     void updateInputAttachment(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
             VulkanAttachment const& attachment) noexcept;
@@ -75,6 +70,9 @@ public:
 
     fvkmemory::resource_ptr<VulkanDescriptorSet> createSet(Handle<HwDescriptorSet> handle,
             fvkmemory::resource_ptr<VulkanDescriptorSetLayout> layout);
+
+    void cloneSet(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
+            fvkutils::SamplerBitmask samplerMask) noexcept;
 
     // This method is meant to be used with external samplers
     VkDescriptorSet getVkSet(DescriptorCount const& count, VkDescriptorSetLayout vklayout);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -507,7 +507,7 @@ void VulkanDriver::updateDescriptorSetTexture(
     auto set = resource_ptr<VulkanDescriptorSet>::cast(&mResourceManager, dsh);
     auto texture = resource_ptr<VulkanTexture>::cast(&mResourceManager, th);
 
-    if (UTILS_UNLIKELY(mExternalImageManager.isExternallySampledTexture(texture))) {
+    if (UTILS_UNLIKELY(texture->isExternallySampled())) {
         mExternalImageManager.bindExternallySampledTexture(set, binding, texture, params);
         mAppState.hasBoundExternalImages = true;
         set->isAnExternalSamplerBound = true;
@@ -523,8 +523,6 @@ void VulkanDriver::updateDescriptorSetTexture(
         };
         VkSampler const vksampler = mSamplerCache.getSampler(cacheParams);
         mDescriptorSetCache.updateSampler(set, binding, texture, vksampler);
-        mExternalImageManager.clearTextureBinding(set, binding);
-        mStreamedImageManager.unbindStreamedTexture(set, binding);
     }
 }
 
@@ -767,10 +765,6 @@ void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::S
     // texture into the read layout.
     texture->transitionLayout(&commands, texture->getPrimaryViewRange(), VulkanLayout::FRAG_READ);
 
-    if (imgData.external.valid()) {
-        mExternalImageManager.addExternallySampledTexture(texture, conversion);
-    }
-
     texture.inc();
     mResourceManager.associateHandle(th.getId(), std::move(tag));
 }
@@ -814,8 +808,6 @@ void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
     }
     auto texture = resource_ptr<VulkanTexture>::cast(&mResourceManager, th);
     texture.dec();
-
-    mExternalImageManager.removeExternallySampledTexture(texture);
 }
 
 void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program, utils::ImmutableCString&& tag) {
@@ -1429,8 +1421,6 @@ void VulkanDriver::updateStreams(CommandStream* driver) {
                             VulkanLayout::FRAG_READ);
 
                     if (imgData.external.valid()) {
-                        mExternalImageManager.addExternallySampledTexture(newTexture,
-                                conversion);
                         // Cache the AHB backed image. Acquires the image here.
                         s->pushImage(image, newTexture);
                     }
@@ -2409,7 +2399,6 @@ void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
         if (std::any_of(layoutHandles.begin(), layoutHandles.end(), haveExternalSamplers)) {
             BindInDrawBundle bundle = {
                 .pipelineState = pipelineState,
-                .dsLayoutHandles = layoutHandles,
                 .descriptorSetMask = descriptorSetMask,
             };
             mPipelineState.bindInDraw = { true, bundle };
@@ -2555,7 +2544,6 @@ void VulkanDriver::draw2(uint32_t indexOffset, uint32_t indexCount, uint32_t ins
     VkCommandBuffer cmdbuffer = mCurrentRenderPass.commandBuffer->buffer();
     auto const& [doBindInDraw, bundle] = mPipelineState.bindInDraw;
 
-    fvkutils::DescriptorSetMask setsWithExternalSamplers = {};
     if (doBindInDraw) {
         // Create the new pipeline layout from the current bounded descriptor sets.
         // The layout of the descriptor sets at this point should have the final one taking into account

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -177,7 +177,6 @@ private:
 
     struct BindInDrawBundle {
         PipelineState pipelineState = {};
-        DescriptorSetLayoutHandleList dsLayoutHandles = {};
         fvkutils::DescriptorSetMask descriptorSetMask = {};
         resource_ptr<VulkanProgram> program = {};
     };

--- a/filament/backend/src/vulkan/VulkanExternalImageManager.h
+++ b/filament/backend/src/vulkan/VulkanExternalImageManager.h
@@ -62,20 +62,8 @@ public:
     void clearTextureBinding(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
                              uint8_t bindingPoint);
 
-    void addExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> external,
-            VkSamplerYcbcrConversion const conversion);
-
-    void removeExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> image);
-
-    bool isExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> image) const;
-
     VkSamplerYcbcrConversion getVkSamplerYcbcrConversion(
             VulkanPlatform::ExternalImageMetadata const& metadata);
-
-    struct ImageData {
-        fvkmemory::resource_ptr<VulkanTexture> image;
-        VkSamplerYcbcrConversion conversion = VK_NULL_HANDLE;
-    };
 
     // - Update the descriptor set layout with the external samplers. This layout will be assign the
     // respective immutable samplers to the layout.
@@ -104,7 +92,6 @@ private:
 
     // Use vectors instead of hash maps because we only expect small number of entries.
     std::vector<SetBindingInfo> mSetBindings;
-    std::vector<ImageData> mImages;
 };
 
 } // filament::backend

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -840,19 +840,6 @@ void VulkanTexture::setLayout(VkImageSubresourceRange const& range, VulkanLayout
     }
 }
 
-void VulkanTexture::setYcbcrConversion(VkSamplerYcbcrConversion conversion) {
-    // Note that this comparison is valid because we only ever create VkSamplerYcbcrConversion from
-    // a cache.  So for each set of parameters, there is exactly one conversion (similar to
-    // samplers).
-    VulkanTextureState::Ycbcr ycbcr = {
-        .conversion = conversion,
-    };
-    if (mState->mYcbcr != ycbcr) {
-        mState->mYcbcr = ycbcr;
-        mState->clearCachedImageViews();
-    }
-}
-
 VulkanLayout VulkanTexture::getLayout(uint32_t layer, uint32_t level) const {
     assert_invariant(level <= 0xffff && layer <= 0xffff);
     const uint32_t key = (layer << 16) | level;

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -242,6 +242,8 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
         return mState->mIsProtected;
     }
 
+    bool isExternallySampled() const { return mState->mYcbcr.conversion != VK_NULL_HANDLE; }
+
     bool transitionLayout(VulkanCommandBuffer* commands, VkImageSubresourceRange const& range,
             VulkanLayout newLayout);
 
@@ -262,10 +264,7 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     // manually (outside of calls to transitionLayout).
     void setLayout(VkImageSubresourceRange const& range, VulkanLayout newLayout);
 
-    // This is used in the case of external images and external samplers. AHB might update the
-    // conversion per-frame. This implies that we need to invalidate the view cache when that
-    // happens.
-    void setYcbcrConversion(VkSamplerYcbcrConversion conversion);
+    VkSamplerYcbcrConversion getYcbcrConversion() const { return mState->mYcbcr.conversion; }
 
 #if FVK_ENABLED(FVK_DEBUG_TEXTURE)
     void print() const;


### PR DESCRIPTION
Query the texture directly to know if it uses an external sampler or not. This is already known when the texture is created.

Remove dead code related to the external sampler flow.

Simplify the code of the VulkanExternalImageManager class.