### PR TITLE
Small fix to allow PlatformEGL to work on non-Android targets.

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformEGLHeadless.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLHeadless.cpp
@@ -17,7 +17,6 @@
 #include <backend/platforms/PlatformEGLHeadless.h>
 
 #include <bluegl/BlueGL.h>
-#include "../gl_headers.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>


### PR DESCRIPTION
Don't assume glGetString(GL_EXTENSIONS) returns a non-null value as null is a possible return value for OpenGL (desktop).