### PR TITLE
egl: allow for ordering display init paths

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -84,6 +84,22 @@ protected:
     Driver* createDriver(void* sharedContext, const DriverConfig& driverConfig) override;
 
     /**
+     * The implementation of *createDriver*.
+     * @param sharedContext an optional shared context. This is not meaningful with all graphic
+     *                      APIs and platforms.
+     *                      For EGL platforms, this is an EGLContext.
+     *
+     * @param driverConfig  specifies driver initialization parameters
+     *
+     * @param initFirstbyquery determines the order of initialization. If true, then we'd query by
+     *                         eglQueryDevicesEXT first instead of using the default display. Useful
+     *                         for headless egl initialization.
+     * @return nullptr on failure, or a pointer to the newly created driver.
+     */
+    Driver* createDriverBase(void* sharedContext, const DriverConfig& driverConfig,
+            bool initFirstByQuery);
+
+    /**
      * This returns zero. This method can be overridden to return something more useful.
      * @return zero
      */

--- a/filament/backend/src/opengl/platforms/PlatformEGLHeadless.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLHeadless.cpp
@@ -66,7 +66,7 @@ backend::Driver* PlatformEGLHeadless::createDriver(void* sharedContext,
         return nullptr;
     }
 
-    return PlatformEGL::createDriver(sharedContext, driverConfig);
+    return PlatformEGL::createDriverBase(sharedContext, driverConfig, true /* initFirstByQuery */);
 }
 
 } // namespace filament


### PR DESCRIPTION
On certain platforms, initialization by query device is preferred. On others, initialization by default device is preferred. To accomodate for either, we use a bool to switch the ordering if needed. PlatformEGLHeadless is assumed use the query device path first, and PlatformEGL will still check the default device/display first.

FIXES=481534922