### PR TITLE
Revert "Swap logic of how the EGL display is initialized. (#9634)"

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -120,31 +120,25 @@ bool PlatformEGL::isOpenGL() const noexcept {
 PlatformEGL::ExternalImageEGL::~ExternalImageEGL() = default;
 
 Driver* PlatformEGL::createDriver(void* sharedContext, const DriverConfig& driverConfig) {
-    static constexpr int kMaxNumEGLDevices = 32;
+    mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
 
     EGLint major, minor;
-    EGLBoolean initialized = false;
+    EGLBoolean initialized = eglInitialize(mEGLDisplay, &major, &minor);
 
-    PFNEGLQUERYDEVICESEXTPROC const eglQueryDevicesEXT =
-        PFNEGLQUERYDEVICESEXTPROC(eglGetProcAddress("eglQueryDevicesEXT"));
-    PFNEGLGETPLATFORMDISPLAYEXTPROC const getPlatformDisplay =
-        PFNEGLGETPLATFORMDISPLAYEXTPROC(eglGetProcAddress("eglGetPlatformDisplay"));
-
-    if (eglQueryDevicesEXT != nullptr && getPlatformDisplay != nullptr) {
-        EGLint numDevices = 0;
-        EGLDeviceEXT eglDevices[kMaxNumEGLDevices];
-        if (eglQueryDevicesEXT(kMaxNumEGLDevices, eglDevices, &numDevices)) {
-            for (int i = 0; i < numDevices && !initialized; ++i) {
-                mEGLDisplay = getPlatformDisplay(EGL_PLATFORM_DEVICE_EXT, eglDevices[i], nullptr);
+    if (!initialized) {
+        EGLDeviceEXT eglDevice;
+        EGLint numDevices;
+        PFNEGLQUERYDEVICESEXTPROC const eglQueryDevicesEXT =
+                PFNEGLQUERYDEVICESEXTPROC(eglGetProcAddress("eglQueryDevicesEXT"));
+        if (eglQueryDevicesEXT != nullptr) {
+            eglQueryDevicesEXT(1, &eglDevice, &numDevices);
+            if(auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+                    eglGetProcAddress("eglGetPlatformDisplay"))) {
+                mEGLDisplay = getPlatformDisplay(EGL_PLATFORM_DEVICE_EXT, eglDevice, nullptr);
                 initialized = eglInitialize(mEGLDisplay, &major, &minor);
             }
         }
-    }
-
-    if (!initialized) {
-        mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-        assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
-        initialized = eglInitialize(mEGLDisplay, &major, &minor);
     }
 
     if (UTILS_UNLIKELY(!initialized)) {


### PR DESCRIPTION
This reverts commit c35ae6571fcc8f0fca4fc8ad16e22a10d908a473.

BUGS=[481534922, 478925865]