### PR TITLE
Fix a bug in update_state

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -639,8 +639,8 @@ private:
     template <typename T, typename F>
     static inline void update_state(T& state, T const& expected, F functor, bool force = false) noexcept {
         if (UTILS_UNLIKELY(force || state != expected)) {
-            state = expected;
             functor();
+            state = expected;
         }
     }
 


### PR DESCRIPTION
In OpenGLContext.h, the `bindTexture` method attempts to unbind the previous texture target when the target changes for a specific unit. However, due to the behavior of update_state, it ends up unbinding the new target instead.

Fix this by storing the state after functor execution, which is a more natural logical flow.