### PR TITLE
Print command stream histogram before crashing

### DIFF
--- a/filament/backend/include/private/backend/CommandBufferQueue.h
+++ b/filament/backend/include/private/backend/CommandBufferQueue.h
@@ -27,6 +27,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <functional>
+
 namespace filament::backend {
 
 /*
@@ -64,7 +66,7 @@ public:
 
     // all commands buffers (Slices) written to this point are returned by waitForCommand(). This
     // call blocks until the CircularBuffer has at least mRequiredSize bytes available.
-    void flush();
+    void flush(std::function<void(void*, void*)> const& debugPrintHistogram = nullptr);
 
     // returns from waitForCommands() immediately.
     void requestExit();

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -225,26 +225,28 @@ public:
     struct CommandInfo {
         size_t size;
         const char* name;
+        int index;
     };
     std::unordered_map<Execute, CommandInfo> mCommands;
 
     void initializeLookup() {
+        int currentIndex = 0;
 #define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params)
 #define DECL_DRIVER_API(methodName, paramsDecl, params)                                            \
     mCommands[mDispatcher.methodName##_] = { CommandBase::align(sizeof(COMMAND_TYPE(methodName))), \
-        #methodName };
+        #methodName, currentIndex++ };
 #define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params)                            \
     mCommands[mDispatcher.methodName##_] = {                                                       \
-        CommandBase::align(sizeof(COMMAND_TYPE(methodName##R))), #methodName                       \
+        CommandBase::align(sizeof(COMMAND_TYPE(methodName##R))), #methodName, currentIndex++       \
     };
 
 #include "private/backend/DriverAPI.inc"
 
         mCommands[CustomCommand::execute] = { CommandBase::align(sizeof(CustomCommand)),
-            "CustomCommand" };
+            "CustomCommand", currentIndex++ };
 
         // NoopCommands have variable size. We will handle them specially using their mNext pointer.
-        mCommands[NoopCommand::execute] = { 0, "NoopCommand" };
+        mCommands[NoopCommand::execute] = { 0, "NoopCommand", currentIndex++ };
     }
 
 public:

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -221,6 +221,7 @@ public:
 
     CircularBuffer const& getCircularBuffer() const noexcept { return mCurrentBuffer; }
 
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
     using Execute = Dispatcher::Execute;
     struct CommandInfo {
         size_t size;
@@ -248,6 +249,7 @@ public:
         // NoopCommands have variable size. We will handle them specially using their mNext pointer.
         mCommands[NoopCommand::execute] = { 0, "NoopCommand", currentIndex++ };
     }
+#endif
 
 public:
 #define DECL_DRIVER_API(methodName, paramsDecl, params)                                         \
@@ -293,10 +295,12 @@ public:
 
     void execute(void* buffer);
 
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
     void debugIterateCommands(void* head, void* tail,
             std::function<void(CommandInfo const& info)> const& callback);
 
     void debugPrintHistogram(void* head, void* tail);
+#endif
 
     /*
      * queueCommand() allows to queue a lambda function as a command.

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -48,6 +48,11 @@
 
 #define FILAMENT_DEBUG_COMMANDS              FILAMENT_DEBUG_COMMANDS_NONE
 
+// Upon command stream overflow, print a histogram of commands
+#ifndef FILAMENT_DEBUG_COMMANDS_HISTOGRAM
+#define FILAMENT_DEBUG_COMMANDS_HISTOGRAM 0
+#endif
+
 namespace filament::backend {
 
 class BufferDescriptor;

--- a/filament/backend/src/CommandBufferQueue.cpp
+++ b/filament/backend/src/CommandBufferQueue.cpp
@@ -106,11 +106,13 @@ void CommandBufferQueue::flush(std::function<void(void*, void*)> const& debugPri
     std::unique_lock lock(mLock);
 
     // circular buffer is too small, we corrupted the stream
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
     if (UTILS_VERY_UNLIKELY(used > mFreeSpace)) {
         if (debugPrintHistogram) {
             debugPrintHistogram(begin, end);
         }
     }
+#endif
     FILAMENT_CHECK_POSTCONDITION(used <= mFreeSpace) <<
             "Backend CommandStream overflow. Commands are corrupted and unrecoverable.\n"
             "Please increase minCommandBufferSizeMB inside the Config passed to Engine::create.\n"

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -30,12 +30,15 @@
 #include <utils/ostream.h>
 #include <utils/sstream.h>
 
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
 #include <algorithm>
+#include <vector>
+#endif
+
 #include <cstddef>
 #include <functional>
 #include <string>
 #include <utility>
-#include <vector>
 
 #ifdef __ANDROID__
 #include <sys/system_properties.h>
@@ -86,7 +89,9 @@ CommandStream::CommandStream(Driver& driver, CircularBuffer& buffer) noexcept
     mUsePerformanceCounter = bool(atoi(property));
 #endif
 
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
     initializeLookup();
+#endif
 }
 
 void CommandStream::execute(void* buffer) {
@@ -130,6 +135,7 @@ void CommandStream::execute(void* buffer) {
     }
 }
 
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
 void CommandStream::debugIterateCommands(void* head, void* tail,
         std::function<void(CommandInfo const& info)> const& callback) {
     CommandBase* UTILS_RESTRICT base = static_cast<CommandBase*>(head);
@@ -192,6 +198,7 @@ void CommandStream::debugPrintHistogram(void* head, void* tail) {
     LOG(INFO) << "CS hist: " << short_histogram;
     LOG(INFO) << "";
 }
+#endif
 
 void CommandStream::queueCommand(std::function<void()> command) {
     new(allocateCommand(CustomCommand::align(sizeof(CustomCommand)))) CustomCommand(std::move(command));

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -143,7 +143,8 @@ void CommandStream::debugIterateCommands(void* head, void* tail,
         if (e == NoopCommand::execute) {
             NoopCommand* noop = static_cast<NoopCommand*>(p);
             size_t size = noop->mNext;
-            callback({ size, "NoopCommand" });
+            int noopIndex = mCommands[NoopCommand::execute].index;
+            callback({ size, "NoopCommand", noopIndex });
             p = reinterpret_cast<CommandBase*>(reinterpret_cast<char*>(p) + size);
             continue;
         }
@@ -161,8 +162,11 @@ void CommandStream::debugIterateCommands(void* head, void* tail,
 
 void CommandStream::debugPrintHistogram(void* head, void* tail) {
     std::unordered_map<std::string_view, int> histogram;
-    debugIterateCommands(head, tail,
-            [&](CommandInfo const& info) { histogram[std::string_view(info.name)]++; });
+    std::unordered_map<int, int> index_histogram;
+    debugIterateCommands(head, tail, [&](CommandInfo const& info) {
+        histogram[std::string_view(info.name)]++;
+        index_histogram[info.index]++;
+    });
 
     std::vector<std::pair<std::string_view, int>> sorted_histogram(histogram.begin(),
             histogram.end());
@@ -173,6 +177,19 @@ void CommandStream::debugPrintHistogram(void* head, void* tail) {
     for (auto const& [name, count]: sorted_histogram) {
         LOG(INFO) << name << ": " << count;
     }
+
+    std::vector<std::pair<int, int>> sorted_index_histogram(index_histogram.begin(),
+            index_histogram.end());
+    std::sort(sorted_index_histogram.begin(), sorted_index_histogram.end(),
+            [](auto const& a, auto const& b) { return a.second > b.second; });
+
+    std::string short_histogram = "";
+    for (size_t i = 0, n = sorted_index_histogram.size(); i < n; ++i) {
+        short_histogram += std::to_string(sorted_index_histogram[i].first) + ":" +
+                           std::to_string(sorted_index_histogram[i].second);
+        short_histogram += (i < n - 1) ? ";" : ".";
+    }
+    LOG(INFO) << "CS hist: " << short_histogram;
     LOG(INFO) << "";
 }
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -921,7 +921,10 @@ int FEngine::loop() {
 void FEngine::flushCommandBuffer(CommandBufferQueue& commandBufferQueue) const {
     getDriver().purge();
     commandBufferQueue.flush([this](void* begin, void* end) {
-        const_cast<FEngine*>(this)->getDriverApi().debugPrintHistogram(begin, end);
+        UTILS_UNUSED FEngine* engine = const_cast<FEngine*>(this);
+#if FILAMENT_DEBUG_COMMANDS_HISTOGRAM
+        engine->getDriverApi().debugPrintHistogram(begin, end);
+#endif
     });
 }
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -920,7 +920,9 @@ int FEngine::loop() {
 
 void FEngine::flushCommandBuffer(CommandBufferQueue& commandBufferQueue) const {
     getDriver().purge();
-    commandBufferQueue.flush();
+    commandBufferQueue.flush([this](void* begin, void* end) {
+        const_cast<FEngine*>(this)->getDriverApi().debugPrintHistogram(begin, end);
+    });
 }
 
 const FMaterial* FEngine::getSkyboxMaterial() const noexcept {


### PR DESCRIPTION
Adds a command stream histogram that is printed immediately before the engine crashes due to a command buffer overflow. To do this without increasing the size of the command stream buffer, we track each command's `mExecute` pointer and map it to a `CommandInfo` struct. This enables iterating through the buffer after the fact to tally and log command statistics.