### PR TITLE
Add inferred template to View.cpp

### DIFF
--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -143,7 +143,7 @@ FView::FView(FEngine& engine)
 #ifndef NDEBUG
     // This can fail if another view has already registered this data source
     mDebugState->owner = debugRegistry.registerDataSource("d.view.frame_info",
-            [weak = std::weak_ptr(mDebugState)]() -> DebugRegistry::DataSource {
+            [weak = std::weak_ptr<DebugState>(mDebugState)]() -> DebugRegistry::DataSource {
                 // the View could have been destroyed by the time we do this
                 auto const state = weak.lock();
                 if (!state) {


### PR DESCRIPTION
In some cases, this missing template causes build issues when locally building Impress prebuilts.