### PR TITLE
Simplify the API of MaterialInstanceManager

### DIFF
--- a/filament/src/MaterialInstanceManager.cpp
+++ b/filament/src/MaterialInstanceManager.cpp
@@ -19,90 +19,61 @@
 
 #include "details/Engine.h"
 #include "details/Material.h"
-#include "details/MaterialInstance.h"
 
-#include <utils/debug.h>
-
-#include <iterator>
-#include <utility>
-
-#include <stdint.h>
+#include <cstdint>
 
 namespace filament {
 
-using Record = MaterialInstanceManager::Record;
+using namespace utils;
 
-std::pair<FMaterialInstance*, int32_t> Record::getInstance() {
-    if (mAvailable < mInstances.size()) {
-        auto index = mAvailable++;
-        return { mInstances[index], index };
-    }
-    assert_invariant(mAvailable == mInstances.size());
-    auto& name = mMaterial->getName();
-    FMaterialInstance* inst = mMaterial->createInstance(name.c_str_safe());
-    mInstances.push_back(inst);
-    return { inst, mAvailable++ };
-}
+MaterialInstanceManager::MaterialInstanceManager() noexcept = default;
 
-FMaterialInstance* Record::getInstance(int32_t const fixedInstanceindex) const {
-    assert_invariant(fixedInstanceindex >= 0 &&  fixedInstanceindex < int32_t(mInstances.size()));
-    return mInstances[fixedInstanceindex];
-}
-
-// Defined in cpp to avoid inlining
-Record::Record(Record const& rhs) noexcept = default;
-Record& Record::operator=(Record const& rhs) noexcept = default;
-Record::Record(Record&& rhs) noexcept = default;
-Record& Record::operator=(Record&& rhs) noexcept = default;
-
-void Record::terminate(FEngine& engine) {
-    std::for_each(mInstances.begin(), mInstances.end(),
-            [&engine](auto instance) { engine.destroy(instance); });
-}
-
-MaterialInstanceManager::MaterialInstanceManager() noexcept {}
-
-MaterialInstanceManager::MaterialInstanceManager(
-        MaterialInstanceManager const& rhs) noexcept = default;
 MaterialInstanceManager::MaterialInstanceManager(MaterialInstanceManager&& rhs) noexcept = default;
-MaterialInstanceManager& MaterialInstanceManager::operator=(
-        MaterialInstanceManager const& rhs) noexcept = default;
-MaterialInstanceManager& MaterialInstanceManager::operator=(
-        MaterialInstanceManager&& rhs) noexcept = default;
-
+MaterialInstanceManager& MaterialInstanceManager::operator=(MaterialInstanceManager&& rhs) noexcept = default;
 MaterialInstanceManager::~MaterialInstanceManager() = default;
 
 void MaterialInstanceManager::terminate(FEngine& engine) {
-    std::for_each(mMaterials.begin(), mMaterials.end(), [&engine](auto& record) {
-        record.terminate(engine);
-    });
+    for (auto const& [key, instance] : mMaterialInstances) {
+        engine.destroy(instance);
+    }
+    mMaterialInstances.clear();
+
+    for (auto const& [material, pool] : mAnonymousMaterialInstances) {
+        for (auto instance : pool.instances) {
+            engine.destroy(instance);
+        }
+    }
+    mAnonymousMaterialInstances.clear();
 }
 
-Record& MaterialInstanceManager::getRecord(FMaterial const* const ma) const {
-    auto itr = std::find_if(mMaterials.begin(), mMaterials.end(), [ma](auto& record) {
-        return ma == record.mMaterial;
-    });
-    if (itr == mMaterials.end()) {
-        mMaterials.emplace_back(ma);
-        itr = std::prev(mMaterials.end());
+void MaterialInstanceManager::reset() {
+    for (auto& [material, pool] : mAnonymousMaterialInstances) {
+        pool.highWaterMark = 0;
     }
-    return *itr;
+}
+
+FMaterialInstance* MaterialInstanceManager::getMaterialInstance(FMaterial const* ma, uint32_t tag) const {
+    Key const key{ma, tag};
+    auto it = mMaterialInstances.find(key);
+    if (it != mMaterialInstances.end()) {
+        return it->second;
+    }
+
+    FMaterialInstance* const instance = ma->createInstance(ma->getName().c_str_safe());
+    mMaterialInstances.emplace(key, instance);
+    return instance;
 }
 
 FMaterialInstance* MaterialInstanceManager::getMaterialInstance(FMaterial const* ma) const {
-    auto [inst, index] = getRecord(ma).getInstance();
-    return inst;
-}
+    AnonymousPool& pool = mAnonymousMaterialInstances[ma];
+    if (pool.highWaterMark < pool.instances.size()) {
+        return pool.instances[pool.highWaterMark++];
+    }
 
-FMaterialInstance* MaterialInstanceManager::getMaterialInstance(FMaterial const* ma,
-        int32_t const fixedIndex) const {
-    return getRecord(ma).getInstance(fixedIndex);
+    FMaterialInstance* const instance = ma->createInstance(ma->getName().c_str_safe());
+    pool.instances.push_back(instance);
+    pool.highWaterMark++;
+    return instance;
 }
-
-std::pair<FMaterialInstance*, int32_t> MaterialInstanceManager::getFixedMaterialInstance(
-        FMaterial const* ma) {
-    return getRecord(ma).getInstance();
-}
-
 
 } // namespace filament

--- a/filament/src/MaterialInstanceManager.h
+++ b/filament/src/MaterialInstanceManager.h
@@ -16,9 +16,12 @@
 
 #pragma once
 
-#include <utils/bitset.h>
-
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
 #include <vector>
+
+#include <utils/Hash.h>
 
 namespace filament {
 
@@ -30,37 +33,10 @@ class FEngine;
 // re-use instances across frames.
 class MaterialInstanceManager {
 public:
-    class Record {
-    public:
-        Record(FMaterial const* material)
-            : mMaterial(material),
-              mAvailable(0) {}
-        ~Record() = default;
-
-        Record(Record const& rhs) noexcept;
-        Record& operator=(Record const& rhs) noexcept;
-        Record(Record&& rhs) noexcept;
-        Record& operator=(Record&& rhs) noexcept;
-
-        void terminate(FEngine& engine);
-        void reset() { mAvailable = 0; }
-        std::pair<FMaterialInstance*, int32_t> getInstance();
-        FMaterialInstance* getInstance(int32_t fixedInstanceindex) const;
-
-    private:
-        FMaterial const* mMaterial = nullptr;
-        std::vector<FMaterialInstance*> mInstances;
-        uint32_t mAvailable;
-
-        friend class MaterialInstanceManager;
-    };
-
-    constexpr static int32_t INVALID_FIXED_INDEX = -1;
-
     MaterialInstanceManager() noexcept;
-    MaterialInstanceManager(MaterialInstanceManager const& rhs) noexcept;
+    MaterialInstanceManager(MaterialInstanceManager const& rhs) = delete;
     MaterialInstanceManager(MaterialInstanceManager&& rhs) noexcept;
-    MaterialInstanceManager& operator=(MaterialInstanceManager const& rhs) noexcept;
+    MaterialInstanceManager& operator=(MaterialInstanceManager const& rhs) = delete;
     MaterialInstanceManager& operator=(MaterialInstanceManager&& rhs) noexcept;
 
     ~MaterialInstanceManager();
@@ -71,40 +47,60 @@ public:
      */
     void terminate(FEngine& engine);
 
-    /*
-     * This returns a material instance given a material. The implementation will try to find an
-     * available instance in the cache. If one is not found, then a new instance will be created and
-     * added to the cache.
+    /**
+     * Resets the anonymous material instances cache.
+     */
+    void reset();
+
+    /**
+     * This returns a material instance given a material and a tag.
+     *
+     * If the material instance doesn't exist in the cache, it is created and cached.
+     *
+     * @param ma    FMaterial to get a MaterialInstance for
+     * @param tag   A unique tag identifying the MaterialInstance
+     * @return      A FMaterialInstance pointer
+     */
+    FMaterialInstance* getMaterialInstance(FMaterial const* ma, uint32_t tag) const;
+
+    /**
+     * This returns a material instance given a material from a cache.
+     *
+     * If the material instance doesn't exist in the cache, it is created and cached.
+     *
+     * It is permissible to call the method several times, in which case a different MaterialInstance will be returned.
+     * It is guaranteed to be different from MaterialInstances returned with a tag.
+     *
+     * @param ma    FMaterial to get a MaterialInstance for
+     * @return      A FMaterialInstance pointer
      */
     FMaterialInstance* getMaterialInstance(FMaterial const* ma) const;
 
-    /*
-     * This returns a material instance given a material and an index. The `fixedIndex` should be
-     * a value returned by getiFixedMaterialInstance.
-     */
-    FMaterialInstance* getMaterialInstance(FMaterial const* ma, int32_t const fixedIndex) const;
-
-    /*
-     * This returns a material instance and an index given a material. This is needed for the
-     * case when two framegraph passes need to refer to the same material instance.
-     * The returned index can be used with `getFixedMaterialInstance` to get a specific instance
-     * of a material (and not a random entry in the record cache).
-     */
-    std::pair<FMaterialInstance*, int32_t> getFixedMaterialInstance(FMaterial const* ma);
-
-
-    /*
-     * Marks all of the material instances as unused. Typically, you'd call this at the beginning of
-     * a frame.
-     */
-    void reset() {
-        std::for_each(mMaterials.begin(), mMaterials.end(), [](auto& record) { record.reset(); });
-    }
-
 private:
-    Record& getRecord(FMaterial const* material) const;
+    struct Key {
+        FMaterial const* material;
+        uint32_t tag;
+        bool operator==(Key const& rhs) const noexcept {
+            return material == rhs.material && tag == rhs.tag;
+        }
+    };
 
-    mutable std::vector<Record> mMaterials;
+    struct Hasher {
+        std::size_t operator()(Key const& key) const noexcept {
+            std::size_t seed = 0;
+            utils::hash::combine(seed, key.material);
+            utils::hash::combine(seed, key.tag);
+            return seed;
+        }
+    };
+
+    struct AnonymousPool {
+        std::vector<FMaterialInstance*> instances;
+        uint32_t highWaterMark = 0;
+    };
+
+    mutable std::unordered_map<Key, FMaterialInstance*, Hasher> mMaterialInstances;
+    mutable std::unordered_map<FMaterial const*, AnonymousPool> mAnonymousMaterialInstances;
 };
 
 } // namespace filament

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -486,13 +486,6 @@ private:
 
     MaterialInstanceManager mMaterialInstanceManager;
 
-    struct {
-        int32_t colorGradingTranslucent = MaterialInstanceManager::INVALID_FIXED_INDEX;
-        int32_t colorGradingOpaque = MaterialInstanceManager::INVALID_FIXED_INDEX;
-        int32_t customResolve = MaterialInstanceManager::INVALID_FIXED_INDEX;
-        int32_t clearDepth = MaterialInstanceManager::INVALID_FIXED_INDEX;
-    } mFixedMaterialInstanceIndex;
-
     backend::Handle<backend::HwTexture> mStarburstTexture;
 
     std::uniform_real_distribution<float> mUniformDistribution{0.0f, 1.0f};


### PR DESCRIPTION
It's no longer necessary to preallocate a "tag" to reuse a material instance. Instead, we can simply pass a unique tag when getting the instance from the pool.