### PR TITLE
EVSM improvements

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -2121,7 +2121,7 @@ public class View {
          */
         public boolean highPrecision = false;
         /**
-         * VSM minimum variance scale, must be positive.
+         * @deprecated has no effect.
          */
         public float minVarianceScale = 0.5f;
         /**

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -372,7 +372,7 @@ public:
         } vsm;
 
         /**
-         * Light bulb radius used for soft shadows. Currently this is only used when DPCF or PCSS is
+         * Light bulb radius used for soft shadows. Currently, this is only used when DPCF or PCSS is
          * enabled. (2cm by default).
          */
         float shadowBulbRadius = 0.02f;

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -735,7 +735,7 @@ struct VsmShadowOptions {
     bool highPrecision = false;
 
     /**
-     * VSM minimum variance scale, must be positive.
+     * @deprecated has no effect.
      */
     float minVarianceScale = 0.5f;
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -3823,15 +3823,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
                 auto const& inDesc = resources.getDescriptor(data.in);
                 auto width = inDesc.width;
                 assert_invariant(width == inDesc.height);
-                int const dim = width >> (level + 1);
+                uint32_t const dim = std::max(1u, width >> (level + 1));
 
                 auto& material = getPostProcessMaterial("vsmMipmap");
                 FMaterial const* const ma = material.getMaterial(mEngine, driver);
 
-                // When generating shadow map mip levels, we want to preserve the 1 texel border.
-                // (note clearing never respects the scissor in Filament)
                 auto const pipeline = getPipelineState(ma);
-                backend::Viewport const scissor = { 1u, 1u, dim - 2u, dim - 2u };
+                backend::Viewport const scissor = { 0, 0, dim, dim };
 
                 FMaterialInstance* const mi = getMaterialInstance(ma);
                 mi->setParameter("color", in, SamplerParams{

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -93,6 +93,10 @@ public:
         mHasScissor = true;
     }
 
+    void setScissor(backend::Viewport const& viewport) noexcept {
+        setScissor(viewport.left, viewport.bottom, viewport.width, viewport.height);
+    }
+
     void unsetScissor() noexcept {
         constexpr uint32_t maxvalu = std::numeric_limits<int32_t>::max();
         mScissorRect = { 0, 0, maxvalu, maxvalu };

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -76,6 +76,7 @@
 #include <cmath>
 #include <chrono>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <new>
 #include <ratio>
@@ -1131,8 +1132,6 @@ void FView::prepareShadowMapping() const noexcept {
         uniforms = mShadowMapManager->getShadowMappingUniforms();
     }
 
-    constexpr float low  = 5.54f; // ~ std::log(std::numeric_limits<math::half>::max()) * 0.5f;
-    constexpr float high = 42.0f; // ~ std::log(std::numeric_limits<float>::max()) * 0.5f;
     constexpr uint32_t SHADOW_SAMPLING_RUNTIME_PCF = 0u;
     constexpr uint32_t SHADOW_SAMPLING_RUNTIME_EVSM = 1u;
     constexpr uint32_t SHADOW_SAMPLING_RUNTIME_DPCF = 2u;
@@ -1148,8 +1147,8 @@ void FView::prepareShadowMapping() const noexcept {
             break;
         case ShadowType::VSM:
             s.shadowSamplingType = SHADOW_SAMPLING_RUNTIME_EVSM;
-            s.vsmExponent = mVsmShadowOptions.highPrecision ? high : low;
-            s.vsmDepthScale = mVsmShadowOptions.minVarianceScale * 0.01f * s.vsmExponent;
+            s.vsmExponent = 0; // this is only used when rendering the shadowmap, not when using it
+            s.vsmMaxMoment = ShadowMapManager::getMaxMomentEVSM(mVsmShadowOptions);
             s.vsmLightBleedReduction = mVsmShadowOptions.lightBleedReduction;
             break;
         case ShadowType::DPCF:

--- a/filament/src/ds/ShadowMapDescriptorSet.cpp
+++ b/filament/src/ds/ShadowMapDescriptorSet.cpp
@@ -28,9 +28,11 @@
 
 #include <utils/debug.h>
 
+#include <math/half.h>
 #include <math/vec4.h>
 
 #include <array>
+#include <limits>
 
 namespace filament {
 
@@ -74,8 +76,8 @@ void ShadowMapDescriptorSet::prepareLodBias(Transaction const& transaction, floa
 }
 
 void ShadowMapDescriptorSet::prepareViewport(Transaction const& transaction,
-        backend::Viewport const& viewport) noexcept {
-    PerViewDescriptorSetUtils::prepareViewport(edit(transaction), viewport, viewport);
+        backend::Viewport const& physicalViewport, backend::Viewport const& logicalViewport) noexcept {
+    PerViewDescriptorSetUtils::prepareViewport(edit(transaction), physicalViewport, logicalViewport);
     // TODO: offset calculation is now different
 }
 
@@ -90,11 +92,10 @@ void ShadowMapDescriptorSet::prepareMaterialGlobals(Transaction const& transacti
 }
 
 void ShadowMapDescriptorSet::prepareShadowMapping(Transaction const& transaction,
-        bool const highPrecision) noexcept {
+        float const vsmExponent, float const vsmMaxMoment) noexcept {
     auto& s = edit(transaction);
-    constexpr float low  = 5.54f; // ~ std::log(std::numeric_limits<math::half>::max()) * 0.5f;
-    constexpr float high = 42.0f; // ~ std::log(std::numeric_limits<float>::max()) * 0.5f;
-    s.vsmExponent = highPrecision ? high : low;
+    s.vsmExponent = vsmExponent;
+    s.vsmMaxMoment = vsmMaxMoment;
 }
 
 ShadowMapDescriptorSet::Transaction ShadowMapDescriptorSet::open(DriverApi& driver) noexcept {

--- a/filament/src/ds/ShadowMapDescriptorSet.h
+++ b/filament/src/ds/ShadowMapDescriptorSet.h
@@ -66,7 +66,7 @@ public:
             float bias) noexcept;
 
     static void prepareViewport(Transaction const& transaction,
-            backend::Viewport const& viewport) noexcept;
+            backend::Viewport const& physicalViewport, backend::Viewport const& logicalViewport) noexcept;
 
     static void prepareTime(Transaction const& transaction,
             FEngine const& engine, math::float4 const& userTime) noexcept;
@@ -75,7 +75,7 @@ public:
             std::array<math::float4, 4> const& materialGlobals) noexcept;
 
     static void prepareShadowMapping(Transaction const& transaction,
-            bool highPrecision) noexcept;
+            float vsmExponent, float vsmMaxMoment) noexcept;
 
     static Transaction open(backend::DriverApi& driver) noexcept;
 

--- a/filament/src/materials/vsmMipmap.mat
+++ b/filament/src/materials/vsmMipmap.mat
@@ -19,7 +19,8 @@ material {
         {
             name : color,
             target : color,
-            type : float4
+            type : float4,
+            precision : high
         }
     ],
     domain : postprocess,
@@ -30,8 +31,29 @@ material {
 
 fragment {
     void postProcess(inout PostProcessInputs postProcess) {
-        highp vec2 uv = gl_FragCoord.xy * materialParams.uvscale;
-        postProcess.color = textureLod(materialParams_color,
-                vec3(uv, materialParams.layer), 0.0);
+        // For EVSM mipmapping, we use a custom box filter (instead of the GPU's bilinear filter), because GPUs often
+        // use a lower precision for texture interpolation and EVSM moments are very sensitive to that.
+
+        highp ivec2 destCoord = ivec2(gl_FragCoord.xy);
+        highp ivec3 srcCoord = ivec3(destCoord * 2, materialParams.layer);
+
+#if defined(TARGET_WEBGPU_ENVIRONMENT)
+        // it looks like WebGPU doesn't support texelFetchOffset
+        highp vec4 m0 = texelFetch(materialParams_color, ivec3(srcCoord.xy + ivec2(0, 0), srcCoord.z), 0);
+        highp vec4 m1 = texelFetch(materialParams_color, ivec3(srcCoord.xy + ivec2(1, 0), srcCoord.z), 0);
+        highp vec4 m2 = texelFetch(materialParams_color, ivec3(srcCoord.xy + ivec2(0, 1), srcCoord.z), 0);
+        highp vec4 m3 = texelFetch(materialParams_color, ivec3(srcCoord.xy + ivec2(1, 1), srcCoord.z), 0);
+#else
+        highp vec4 m0 = texelFetchOffset(materialParams_color, srcCoord, 0, ivec2(0, 0));
+        highp vec4 m1 = texelFetchOffset(materialParams_color, srcCoord, 0, ivec2(1, 0));
+        highp vec4 m2 = texelFetchOffset(materialParams_color, srcCoord, 0, ivec2(0, 1));
+        highp vec4 m3 = texelFetchOffset(materialParams_color, srcCoord, 0, ivec2(1, 1));
+#endif
+
+        // Make sure to not overflow the moments when averaging them
+        postProcess.color = (m0 * 0.25) +
+                            (m1 * 0.25) +
+                            (m2 * 0.25) +
+                            (m3 * 0.25);
     }
 }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -166,7 +166,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // VSM shadows [variant: VSM]
     // --------------------------------------------------------------------------------------------
     float vsmExponent;
-    float vsmDepthScale;
+    float vsmMaxMoment;
     float vsmLightBleedReduction;
     uint32_t shadowSamplingType;                // 0: vsm, 1: dpcf
 
@@ -302,9 +302,9 @@ struct ShadowUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
         float bulbRadiusLs;                     //  4
         float nearOverFarMinusNear;             //  4
         math::float2 normalBias;                //  4
-        bool elvsm;                             //  4
-        uint32_t layer;                         //  4
-        uint32_t reserved1;                     //  4
+        bool elvsm;                             //  4   // could be 1 bit
+        uint32_t layer;                         //  4   // could be 8 bits
+        float vsmExponent;                      //  4   // could be fp16
         uint32_t reserved2;                     //  4
     };
     ShadowData shadows[CONFIG_MAX_SHADOWMAPS];

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -175,7 +175,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // VSM shadows [variant: VSM]
             // ------------------------------------------------------------------------------------
             { "vsmExponent",             0, Type::FLOAT                  },
-            { "vsmDepthScale",           0, Type::FLOAT                  },
+            { "vsmMaxMoment",            0, Type::FLOAT, Precision::HIGH },
             { "vsmLightBleedReduction",  0, Type::FLOAT                  },
             { "shadowSamplingType",      0, Type::UINT                   },
 

--- a/shaders/src/surface_types.glsl
+++ b/shaders/src/surface_types.glsl
@@ -10,7 +10,7 @@ struct ShadowData {
     highp vec2 normalBias;
     bool elvsm;
     mediump uint layer;
-    mediump uint reserved1;
+    mediump float vsmExponent;
     mediump uint reserved2;
 };
 #endif

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1747,7 +1747,7 @@ export interface View$VsmShadowOptions {
      */
     highPrecision?: boolean;
     /**
-     * VSM minimum variance scale, must be positive.
+     * @deprecated has no effect.
      */
     minVarianceScale?: number;
     /**


### PR DESCRIPTION
- refactoring/clecanup to make some changes easier
- VSM mipmap generation was mistakenly disable when blur radius was 0
- analytic variance was disabled because the math only worked for VSM. Fixed the math.
- better handling of large blurs when using fp32
- implement EVSM equivalent of receiver plane normal bias
- use correct EVSM clearing color
- mipmapping with point lights works much better (no seams)
- min variance is computed automatically
- custom high precision mipmaping shader for VSM

There are a lot of changes in the PR, but they should all only affect EVSM, which is  generally not used.