### PR TITLE
vk: fix SSR crash on Windows AMD

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1706,6 +1706,8 @@ enum class Workaround : uint16_t {
     DISABLE_DEPTH_PRECACHE_FOR_DEFAULT_MATERIAL,
     // Emulate an sRGB swapchain in shader code.
     EMULATE_SRGB_SWAPCHAIN,
+    // Workaround for AMD Vulkan drivers on Windows crashing when SSR history is detached.
+    BLIT_SSR_HISTORY,
 };
 
 using StereoscopicType = Platform::StereoscopicType;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -121,6 +121,10 @@ public:
         return mPhysicalDeviceProperties.properties.vendorID;
     }
 
+    inline char const* getDriverName() const noexcept {
+        return mDriverProperties.driverName;
+    }
+
     /**
      * Fetches a list of pre-registered external formats for prewarming the Vulkan
      * pipeline cache.
@@ -216,6 +220,9 @@ private:
     VkPhysicalDeviceMemoryProperties mMemoryProperties = {};
     VkPhysicalDeviceProperties2 mPhysicalDeviceProperties = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
+    };
+    VkPhysicalDeviceDriverProperties mDriverProperties = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
     };
     VkPhysicalDeviceVulkan11Features mPhysicalDeviceVk11Features = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -49,6 +49,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <string_view>
 
 using namespace bluevk;
 
@@ -1656,6 +1657,17 @@ bool VulkanDriver::isWorkaroundNeeded(Workaround workaround) {
             return false;
         case Workaround::DISABLE_BLIT_INTO_TEXTURE_ARRAY:
             return false;
+        case Workaround::BLIT_SSR_HISTORY: {
+#if defined(WIN32)
+            // AMD GPU on windows crashes when SSR is enabled. It's root-caused to be writing to the
+            // SSR  history texture. We blit the history instead of using the linear output of the
+            // color pass. See Issue #9680.
+            std::string_view deviceName{ mContext.getDriverName() };
+            return deviceName.find("AMD proprietary driver") != std::string_view::npos;
+#else
+            return false;
+#endif
+        }
         default:
             return false;
     }

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -952,6 +952,9 @@ void VulkanPlatform::queryAndSetDeviceFeatures(Platform::DriverConfig const& dri
         chainStruct(&context.mPhysicalDeviceFeatures, &globalPriorityFeatures);
     }
 
+    // Obtain and store driver info
+    chainStruct(&context.mPhysicalDeviceProperties, &context.mDriverProperties);
+
     // Initialize the following fields: physicalDeviceProperties, memoryProperties,
     // physicalDeviceFeatures.
     vkGetPhysicalDeviceProperties2(mImpl->mPhysicalDevice, &context.mPhysicalDeviceProperties);

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -219,6 +219,7 @@ private:
     bool mIsFrameBufferFetchSupported : 1;
     bool mIsFrameBufferFetchMultiSampleSupported : 1;
     bool mIsAutoDepthResolveSupported : 1;
+    bool const mWorkaroundBlitSsrHistory : 1;
     Epoch mUserEpoch;
     math::float4 mShaderUserTime{};
     DisplayInfo mDisplayInfo;


### PR DESCRIPTION
Crash is due to the color output being used as the SSR history. Here we blit the color output to another texture and use the copy as the history.

Fixes #9680