### PR TITLE
backend: Platform::getDeviceInfo for querying device and driver info

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -600,6 +600,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_CircularBuffer.cpp
             test/test_CommandBufferQueue.cpp
             test/test_Template.cpp
+            test/test_Platform.cpp
         )
         if (FILAMENT_SUPPORTS_WEBGPU)
             list(APPEND BACKEND_TEST_SRC

--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -217,6 +217,17 @@ public:
     };
 
     /**
+     * Types of device/driver information that can be queried from the platform.
+     */
+    enum class DeviceInfoType {
+        OPENGL_RENDERER,    //!< glGetString(GL_RENDERER)
+        OPENGL_VENDOR,      //!< glGetString(GL_VENDOR)
+        VULKAN_DEVICE_NAME, //!< VkPhysicalDeviceProperties::deviceName
+        VULKAN_DRIVER_NAME, //!< VkPhysicalDeviceDriverProperties::driverName
+        VULKAN_DRIVER_INFO, //!< VkPhysicalDeviceDriverProperties::driverInfo
+    };
+
+    /**
      * This controls the priority level for GPU work scheduling, which helps prioritize the
      * submitted GPU work and enables preemption.
      */
@@ -316,7 +327,7 @@ public:
          */
         StereoscopicType stereoscopicType = StereoscopicType::NONE;
 
-        /*
+        /**
          * The number of eyes to render when stereoscopic rendering is enabled. Supported values are
          * between 1 and Engine::getMaxStereoscopicEyes() (inclusive).
          */
@@ -376,6 +387,16 @@ public:
      * @return The OS version.
      */
     virtual int getOSVersion() const noexcept = 0;
+
+    /**
+     * Queries device/driver information of the graphics API.
+     * @param infoType the type of information to query.
+     * @param driver a pointer to the current driver.
+     * @return a CString containing the requested information.
+     */
+    virtual utils::CString getDeviceInfo(DeviceInfoType infoType,
+            Driver* UTILS_NULLABLE driver) const noexcept = 0;
+
 
     /**
      * Creates and initializes the low-level API (e.g. an OpenGL context or Vulkan instance),

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -52,6 +52,9 @@ protected:
 
     ~OpenGLPlatform() noexcept override;
 
+    utils::CString getDeviceInfo(DeviceInfoType infoType,
+            Driver* UTILS_NULLABLE driver) const noexcept override;
+
 public:
     struct ExternalTexture {
         unsigned int target; // GLenum target

--- a/filament/backend/include/backend/platforms/PlatformMetal.h
+++ b/filament/backend/include/backend/platforms/PlatformMetal.h
@@ -38,6 +38,7 @@ public:
 
     Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) override;
     int getOSVersion() const noexcept override { return 0; }
+    utils::CString getDeviceInfo(DeviceInfoType, Driver*) const noexcept override { return {}; }
 
     /**
      * Optionally initializes the Metal platform by acquiring resources necessary for rendering.

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -143,6 +143,8 @@ public:
         return 0;
     }
 
+    utils::CString getDeviceInfo(DeviceInfoType infoType, Driver* driver) const noexcept override;
+
     // ----------------------------------------------------
     // ---------- Platform Customization options ----------
     struct Customization {

--- a/filament/backend/include/backend/platforms/WebGPUPlatform.h
+++ b/filament/backend/include/backend/platforms/WebGPUPlatform.h
@@ -46,6 +46,9 @@ public:
     ~WebGPUPlatform() override = default;
 
     [[nodiscard]] int getOSVersion() const noexcept final { return 0; }
+    [[nodiscard]] utils::CString getDeviceInfo(DeviceInfoType, Driver*) const noexcept override {
+        return {};
+    }
 
     [[nodiscard]] wgpu::Instance& getInstance() noexcept { return mInstance; }
 

--- a/filament/backend/src/noop/PlatformNoop.h
+++ b/filament/backend/src/noop/PlatformNoop.h
@@ -26,6 +26,7 @@ class PlatformNoop final : public Platform {
 public:
 
     int getOSVersion() const noexcept final { return 0; }
+    utils::CString getDeviceInfo(DeviceInfoType, Driver*) const noexcept override { return {}; }
 
     ~PlatformNoop() noexcept override = default;
 

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -45,6 +45,19 @@ Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform,
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
 
+utils::CString OpenGLPlatform::getDeviceInfo(DeviceInfoType infoType,
+        Driver* driver) const noexcept {
+    switch (infoType) {
+        case DeviceInfoType::OPENGL_RENDERER:
+            return getRendererString(driver);
+        case DeviceInfoType::OPENGL_VENDOR:
+            return getVendorString(driver);
+        default:
+            FILAMENT_CHECK_POSTCONDITION(false) << "Unsupported DeviceInfoType for OpenGLPlatform";
+            return {};
+    }
+}
+
 utils::CString OpenGLPlatform::getVendorString(Driver const* driver) {
     auto const p = static_cast<OpenGLDriverBase const*>(driver);
 #if UTILS_HAS_RTTI

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -137,6 +137,14 @@ public:
         return mFenceExportFlags;
     }
 
+    inline const char* getPhysicalDeviceName() const noexcept {
+        return mPhysicalDeviceProperties.properties.deviceName;
+    }
+
+    inline const char* getDriverName() const noexcept { return mDriverProperties.driverName; }
+
+    inline const char* getDriverInfo() const noexcept { return mDriverProperties.driverInfo; }
+
     inline bool isImageCubeArraySupported() const noexcept {
         return mPhysicalDeviceFeatures.features.imageCubeArray == VK_TRUE;
     }
@@ -212,10 +220,15 @@ public:
         return mGlobalPrioritySupported;
     }
 
+    inline bool isDriverPropertiesSupported() const noexcept { return mDriverPropertiesSupported; }
+
 private:
     VkPhysicalDeviceMemoryProperties mMemoryProperties = {};
     VkPhysicalDeviceProperties2 mPhysicalDeviceProperties = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
+    };
+    VkPhysicalDeviceDriverProperties mDriverProperties = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
     };
     VkPhysicalDeviceVulkan11Features mPhysicalDeviceVk11Features = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,
@@ -246,6 +259,7 @@ private:
     bool mProtectedMemorySupported = false;
     bool mVertexInputDynamicStateSupported = false;
     bool mGlobalPrioritySupported = false;
+    bool mDriverPropertiesSupported = false;
 
     // These are options that can be enabled or disabled at an application level.
     bool mAsyncPipelineCachePrewarmingEnabled = false;

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -704,6 +704,30 @@ VulkanPlatform::VulkanPlatform() = default;
 
 VulkanPlatform::~VulkanPlatform() = default;
 
+utils::CString VulkanPlatform::getDeviceInfo(DeviceInfoType infoType,
+        Driver* driver) const noexcept {
+    if (mImpl->mPhysicalDevice == VK_NULL_HANDLE) {
+        return {};
+    }
+    auto& context = mImpl->mContext;
+    switch (infoType) {
+        case DeviceInfoType::VULKAN_DEVICE_NAME: {
+            return utils::CString(context.getPhysicalDeviceName());
+        }
+        case DeviceInfoType::VULKAN_DRIVER_NAME: {
+            return context.isDriverPropertiesSupported() ? utils::CString(context.getDriverName())
+                                                         : utils::CString();
+        }
+        case DeviceInfoType::VULKAN_DRIVER_INFO: {
+            return context.isDriverPropertiesSupported() ? utils::CString(context.getDriverInfo())
+                                                         : utils::CString();
+        }
+        default:
+            FILAMENT_CHECK_POSTCONDITION(false) << "Unsupported DeviceInfoType for VulkanPlatform";
+            return {};
+    }
+}
+
 VulkanPlatform::SwapChainBundle VulkanPlatform::getSwapChainBundle(SwapChainPtr handle) {
     return static_cast<VulkanPlatformSwapChainBase*>(handle)->getSwapChainBundle();
 }
@@ -950,6 +974,11 @@ void VulkanPlatform::queryAndSetDeviceFeatures(Platform::DriverConfig const& dri
     };
     if (setContains(deviceExts, VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME)) {
         chainStruct(&context.mPhysicalDeviceFeatures, &globalPriorityFeatures);
+    }
+
+    if (vkGetPhysicalDeviceProperties2) {
+        chainStruct(&context.mPhysicalDeviceProperties, &context.mDriverProperties);
+        context.mDriverPropertiesSupported = true;
     }
 
     // Initialize the following fields: physicalDeviceProperties, memoryProperties,

--- a/filament/backend/test/test_Platform.cpp
+++ b/filament/backend/test/test_Platform.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <backend/Platform.h>
+#include <gtest/gtest.h>
+#include <private/backend/PlatformFactory.h>
+
+namespace filament::backend {
+
+TEST(PlatformTest, GetDeviceInfo) {
+    Backend backend = Backend::DEFAULT;
+    Platform* platform = PlatformFactory::create(&backend);
+    ASSERT_NE(platform, nullptr);
+
+    // Test valid queries for the current platform (will be either GL, Vulkan, or Metal depending on
+    // host)
+    if (backend == Backend::OPENGL) {
+        platform->getDeviceInfo(Platform::DeviceInfoType::OPENGL_RENDERER, nullptr);
+        platform->getDeviceInfo(Platform::DeviceInfoType::OPENGL_VENDOR, nullptr);
+
+        // Death tests for Vulkan info on OpenGL platform
+        EXPECT_DEATH(platform->getDeviceInfo(Platform::DeviceInfoType::VULKAN_DEVICE_NAME, nullptr),
+                "Unsupported DeviceInfoType");
+    } else if (backend == Backend::VULKAN) {
+        platform->getDeviceInfo(Platform::DeviceInfoType::VULKAN_DEVICE_NAME, nullptr);
+        platform->getDeviceInfo(Platform::DeviceInfoType::VULKAN_DRIVER_NAME, nullptr);
+        platform->getDeviceInfo(Platform::DeviceInfoType::VULKAN_DRIVER_INFO, nullptr);
+
+        // Death tests for OpenGL info on Vulkan platform
+        EXPECT_DEATH(platform->getDeviceInfo(Platform::DeviceInfoType::OPENGL_RENDERER, nullptr),
+                "Unsupported DeviceInfoType");
+    }
+
+    PlatformFactory::destroy(&platform);
+}
+
+} // namespace filament::backend


### PR DESCRIPTION
This adds a pure virtual getDeviceInfo() method to the Platform interface to allow querying graphics API specific information like renderer, vendor, device name, and driver details.

- OpenGLPlatform: returns renderer and vendor strings.
- VulkanPlatform: returns device, driver name, and driver info (cached in VulkanContext).
- Metal/WebGPU/Noop: return empty strings.
- Added unit tests and death tests for mismatched info types.