### PR TITLE
Fix a race when garbage-collecting components

### DIFF
--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -54,7 +54,7 @@ RenderableManager::getInstance(Entity const e) const noexcept {
 }
 
 void RenderableManager::destroy(Entity const e) noexcept {
-    return downcast(this)->destroy(e);
+    return downcast(this)->clientDestroy(e);
 }
 
 void RenderableManager::setAxisAlignedBoundingBox(Instance const instance, const Box& aabb) {

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -85,7 +85,6 @@ void FCameraManager::destroy(FEngine& engine, Entity const e) noexcept {
         { // scope for camera -- it's invalid after this scope.
             FCamera* const camera = manager.elementAt<CAMERA>(i);
             assert_invariant(camera);
-            camera->terminate(engine);
             engine.getHeapAllocator().destroy(camera);
 
             // Remove the camera component

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -577,7 +577,7 @@ void FRenderableManager::create(
     FEngine::DriverApi& driver = engine.getDriverApi();
 
     if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
-        destroy(entity);
+        destroy(entity, driver);
     }
     Instance const ci = manager.addComponent(entity);
     assert_invariant(ci);
@@ -733,41 +733,42 @@ void FRenderableManager::create(
 }
 
 // this destroys a single component from an entity
-void FRenderableManager::destroy(Entity const e) noexcept {
+void FRenderableManager::destroy(Entity const e, DriverApi& driver) noexcept {
     Instance const ci = getInstance(e);
     if (ci) {
-        destroyComponent(ci);
+        destroyComponent(ci, driver);
         mManager.removeComponent(e);
     }
 }
 
+void FRenderableManager::clientDestroy(utils::Entity e) noexcept {
+    destroy(e, mEngine.getDriverApi());
+}
+
 // this destroys all components in this manager
-void FRenderableManager::terminate() noexcept {
+void FRenderableManager::terminate(DriverApi& driver) noexcept {
     auto& manager = mManager;
     if (!manager.empty()) {
         DLOG(INFO) << "cleaning up " << manager.getComponentCount()
                    << " leaked Renderable components";
         while (!manager.empty()) {
             Instance const ci = manager.end() - 1;
-            destroyComponent(ci);
+            destroyComponent(ci, driver);
             manager.removeComponent(manager.getEntity(ci));
         }
     }
-    mHwRenderPrimitiveFactory.terminate(mEngine.getDriverApi());
+    mHwRenderPrimitiveFactory.terminate(driver);
 }
 
-void FRenderableManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity const e) {
-        destroy(e);
+void FRenderableManager::gc(EntityManager& em, DriverApi& driver) noexcept {
+    mManager.gc(em, [this, &driver](Entity const e) {
+        destroy(e, driver);
     });
 }
 
 // This is basically a Renderable's destructor.
-void FRenderableManager::destroyComponent(Instance const ci) noexcept {
+void FRenderableManager::destroyComponent(Instance const ci, DriverApi& driver) noexcept {
     auto& manager = mManager;
-    FEngine& engine = mEngine;
-
-    FEngine::DriverApi& driver = engine.getDriverApi();
 
     // See create(RenderableManager::Builder&, Entity)
     destroyComponentPrimitives(mHwRenderPrimitiveFactory, driver, manager[ci].primitives);

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -91,9 +91,9 @@ public:
     ~FRenderableManager();
 
     // free-up all resources
-    void terminate() noexcept;
+    void terminate(backend::DriverApi& driver) noexcept;
 
-    void gc(utils::EntityManager& em) noexcept;
+    void gc(utils::EntityManager& em, backend::DriverApi& driver) noexcept;
 
     /*
      * Component Manager APIs
@@ -125,7 +125,11 @@ public:
 
     void create(const Builder& builder, utils::Entity entity);
 
-    void destroy(utils::Entity e) noexcept;
+    void destroy(utils::Entity e, backend::DriverApi& driver) noexcept;
+
+    // The client API should have taken an Engine&, but it doesn't, so that's a workaround
+    // so we can keep the API as it is.
+    void clientDestroy(utils::Entity e) noexcept;
 
     inline void setAxisAlignedBoundingBox(Instance instance, const Box& aabb);
 
@@ -239,7 +243,7 @@ public:
     };
 
 private:
-    void destroyComponent(Instance ci) noexcept;
+    void destroyComponent(Instance ci, backend::DriverApi& driver) noexcept;
     static void destroyComponentPrimitives(
             HwRenderPrimitiveFactory& factory, backend::DriverApi& driver,
             utils::Slice<FRenderPrimitive> primitives) noexcept;

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -46,9 +46,6 @@ public:
 
     FCamera(FEngine& engine, utils::Entity e);
 
-    void terminate(FEngine&) noexcept { }
-
-
     // Sets the projection matrices (viewing and culling). The viewing matrice has infinite far.
     void setProjection(Projection projection,
                        double left, double right, double bottom, double top,

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -20,6 +20,11 @@
 #include "TextureCache.h"
 #include "RenderPrimitive.h"
 
+#include "components/CameraManager.h"
+#include "components/LightManager.h"
+#include "components/RenderableManager.h"
+#include "components/TransformManager.h"
+
 #include "details/BufferObject.h"
 #include "details/Camera.h"
 #include "details/Fence.h"
@@ -58,6 +63,7 @@
 #include <utils/CallStack.h>
 #include <utils/CString.h>
 #include <utils/Invocable.h>
+#include <utils/JobSystem.h>
 #include <utils/Logger.h>
 #include <utils/Panic.h>
 #include <utils/PrivateImplementation-impl.h>
@@ -600,7 +606,7 @@ void FEngine::shutdown() {
     mResourceAllocatorDisposer->terminate();
     mResourceAllocatorDisposer.reset();
     mDFG.terminate(*this);                  // free-up the DFG
-    mRenderableManager.terminate();         // free-up all renderables
+    mRenderableManager.terminate(driver);   // free-up all renderables
     mLightManager.terminate();              // free-up all lights
     mCameraManager.terminate(*this);        // free-up all cameras
 
@@ -764,13 +770,30 @@ void FEngine::prepare(DriverApi& driver) {
     });
 }
 
-void FEngine::gcManagers() {
-    // Note: this runs in a Job
-    auto& em = mEntityManager;
-    mRenderableManager.gc(em);
-    mLightManager.gc(em);
-    mTransformManager.gc(em);
-    mCameraManager.gc(*this, em);
+void FEngine::gc() {
+    JobSystem& js = getJobSystem();
+    auto *rootJob = js.createJob();
+
+    js.run(
+            jobs::createJob(js, rootJob, [this] {
+                // These are safe to GC *sequentially* from a worker thread.
+                // The JobSystem acts as a release/acquire operation.
+                mLightManager.gc(mEntityManager);
+                mTransformManager.gc(mEntityManager);
+                mCameraManager.gc(*this, mEntityManager);
+            }));
+
+    if (isAsynchronousModeEnabled()) {
+        // gcDeferredAsyncObjectDestruction() is thread-safe in this context because
+        // 1. JobSystem provides the release/acquire operation
+        // 2. it's only used from the main thread, which we are blocking during the gc
+        js.run(jobs::createJob(js, rootJob, &FEngine::gcDeferredAsyncObjectDestruction, this));
+    }
+
+    // RenderableManager cannot be gc'ed from a different thread, because it needs the DriverAPI
+    mRenderableManager.gc(mEntityManager, getDriverApi());
+
+    js.runAndWait(rootJob);
 }
 
 void FEngine::gcDeferredAsyncObjectDestruction() {
@@ -1399,7 +1422,7 @@ bool FEngine::destroy(const FMaterialInstance* p) {
 
 UTILS_NOINLINE
 void FEngine::destroy(Entity const e) {
-    mRenderableManager.destroy(e);
+    mRenderableManager.destroy(e, getDriverApi());
     mLightManager.destroy(e);
     mTransformManager.destroy(e);
     mCameraManager.destroy(*this, e);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -456,8 +456,7 @@ public:
     }
 
     void prepare(backend::DriverApi& driver);
-    void gcManagers();
-    void gcDeferredAsyncObjectDestruction();
+    void gc();
     void submitFrame();
 
     using ShaderContent = utils::FixedCapacityVector<uint8_t>;
@@ -582,6 +581,8 @@ private:
 
     int loop();
     void flushCommandBuffer(backend::CommandBufferQueue& commandBufferQueue) const;
+
+    void gcDeferredAsyncObjectDestruction();
 
     template<typename T>
     bool isValid(const T* ptr, ResourceList<T> const& list) const;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -310,13 +310,7 @@ void FRenderer::skipFrame(uint64_t vsyncSteadyClockTimeNano) {
     engine.flush();     // flush command stream
 
     // Run GC
-    JobSystem& js = engine.getJobSystem();
-    auto *rootJob = js.createJob();
-    js.run(jobs::createJob(js, rootJob, &FEngine::gcManagers, &engine)); // gc all component managers
-    if (engine.isAsynchronousModeEnabled()) {
-        js.run(jobs::createJob(js, rootJob, &FEngine::gcDeferredAsyncObjectDestruction, &engine));
-    }
-    js.runAndWait(rootJob);
+    engine.gc();
 
     mFrameSkipper.frameSkipped();
 }
@@ -518,13 +512,7 @@ void FRenderer::endFrame() {
     engine.flush();     // flush command stream
 
     // Run GC
-    JobSystem& js = engine.getJobSystem();
-    auto *rootJob = js.createJob();
-    js.run(jobs::createJob(js, rootJob, &FEngine::gcManagers, &engine)); // gc all component managers
-    if (engine.isAsynchronousModeEnabled()) {
-        js.run(jobs::createJob(js, rootJob, &FEngine::gcDeferredAsyncObjectDestruction, &engine));
-    }
-    js.runAndWait(rootJob);
+    engine.gc();
 }
 
 void FRenderer::readPixels(


### PR DESCRIPTION
Not all component managers are thread-safe for garbage-collection. In particular, some need to access the DriverAPI which is never thread-safe.

We refactor the garbage-collection code into FEngine, so it's not duplicated in FRenderer. We make it more explicit that  FRenderableManager::destroyComponent() needs the DriverAPI, and we don't call its gc() from a job.

Besides the refactoring, the only change in this CL is that  FRenderableManager::gc() is no longer called from a job.


FIXES=[489134910]