### PR TITLE
Debug Shadow Cascades: remove dependency on frameUniforms

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -49,6 +49,7 @@
 #include "fsr.h"
 #include "FrameHistory.h"
 #include "RenderPass.h"
+#include "ShadowMapManager.h"
 
 #include "details/Camera.h"
 #include "details/ColorGrading.h"
@@ -3830,6 +3831,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::debugShadowCascades(FrameGraph& fg,
+        ShadowMapManager const& smm,
         FrameGraphId<FrameGraphTexture> const input,
         FrameGraphId<FrameGraphTexture> const depth) noexcept {
 
@@ -3847,17 +3849,31 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::debugShadowCascades(FrameGra
                 data.output = builder.createTexture("Shadow Cascade Debug", desc);
                 builder.declareRenderPass(data.output);
             },
-            [=, this](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
+            [=, &smm, this](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
                 bindPostProcessDescriptorSet(driver);
                 bindPerRenderableDescriptorSet(driver);
                 auto color = resources.getTexture(data.color);
                 auto depth = resources.getTexture(data.depth);
                 auto const out = resources.getRenderPassInfo();
+
+                auto const& smu = smm.getShadowMappingUniforms();
+                mat4f lightFromWorldMatrix[4] = {};
+                float4 scissorNormalized[4] = {};
+                for (size_t i = 0, c = std::max(4u, (smu.cascades & 0xF)) ; i < c; i++) {
+                    auto const& csp = smm.getCascadeShaderParameters(i);
+                    lightFromWorldMatrix[i] = csp.lightSpace;
+                    scissorNormalized[i] = csp.scissorNormalized;
+                }
+
                 auto const& material = getPostProcessMaterial("debugShadowCascades");
-                FMaterialInstance* const mi =
-                        getMaterialInstance(mEngine, driver, material);
+                FMaterialInstance* const mi = getMaterialInstance(mEngine, driver, material);
                 mi->setParameter("color",  color, SamplerParams{});  // nearest
                 mi->setParameter("depth",  depth, SamplerParams{});  // nearest
+                mi->setParameter("cascadeSplits",  smu.cascadeSplits);
+                mi->setParameter("cascadeCount",  smu.cascades & 0xF);
+                mi->setParameter("shadowAtlasResolution",  smu.atlasResolution);
+                mi->setParameter("lightFromWorldMatrix",  lightFromWorldMatrix, 4);
+                mi->setParameter("scissorNormalized",  scissorNormalized, 4);
                 commitAndRenderFullScreenQuad(driver, out, mi);
                 unbindAllDescriptorSets(driver);
             });

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -66,6 +66,7 @@ class FMaterialInstance;
 class FrameGraph;
 class RenderPass;
 class RenderPassBuilder;
+class ShadowMapManager;
 class UboManager;
 struct CameraInfo;
 
@@ -322,6 +323,7 @@ public:
             bool reinhard, size_t kernelWidth, float sigma) noexcept;
 
     FrameGraphId<FrameGraphTexture> debugShadowCascades(FrameGraph& fg,
+            ShadowMapManager const& smm,
             FrameGraphId<FrameGraphTexture> input,
             FrameGraphId<FrameGraphTexture> depth) noexcept;
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -681,6 +681,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     ShadowTechnique shadowTechnique{};
     uint32_t directionalShadowsMask = 0;
     uint32_t cascadeHasVisibleShadows = 0;
+    float4 wsSplitPositionUniform = { -std::numeric_limits<float>::infinity() };
 
     if (hasVisibleShadows) {
         uint32_t const cascadeCount = cascadedShadowMaps.size();
@@ -704,10 +705,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         // (which is the near plane, and doesn't need to be communicated to the shaders).
         static_assert(CONFIG_MAX_SHADOW_CASCADES <= 5,
                 "At most, a float4 can fit 4 split positions for 5 shadow cascades");
-        float4 wsSplitPositionUniform{ -std::numeric_limits<float>::infinity() };
         std::copy(splits.begin() + 1, splits.end(), &wsSplitPositionUniform[0]);
-
-        mShadowMappingUniforms.cascadeSplits = wsSplitPositionUniform;
 
         // When computing the required bias we need a half-texel size, so we multiply by 0.5 here.
         // note: normalBias is set to zero for VSM
@@ -732,6 +730,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             auto shaderParameters = shadowMap.updateDirectional(engine,
                     lightData, 0, cameraInfo, shadowMapInfo, sceneInfo,
                     canUseDepthClamp);
+
+            mCascadesShaderParameters[i] = shaderParameters;
 
             if (shadowMap.hasVisibleShadows()) {
                 const size_t shadowIndex = shadowMap.getShadowIndex();
@@ -775,10 +775,14 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     cascades |= uint32_t(cascadedShadowMaps.size());
     cascades |= cascadeHasVisibleShadows << 8u;
 
-    mShadowMappingUniforms.directionalShadows = directionalShadowsMask;
-    mShadowMappingUniforms.ssContactShadowDistance = screenSpaceShadowDistance;
-    mShadowMappingUniforms.cascades = cascades;
-
+    mShadowMappingUniforms = {
+        .cascadeSplits = wsSplitPositionUniform,
+        .ssContactShadowDistance = screenSpaceShadowDistance,
+        .directionalShadows = directionalShadowsMask,
+        .cascades = cascades,
+        .atlasResolution = { mTextureAtlasRequirements.size, 1.0f / float(mTextureAtlasRequirements.size) }
+    };
+    
     return shadowTechnique;
 }
 

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -48,6 +48,7 @@
 
 #include <math/mat4.h>
 #include <math/half.h>
+#include <math/vec2.h>
 #include <math/vec4.h>
 
 #include <algorithm>
@@ -75,6 +76,7 @@ struct ShadowMappingUniforms {
     float ssContactShadowDistance;
     uint32_t directionalShadows;
     uint32_t cascades;
+    math::float2 atlasResolution;
 };
 
 class ShadowMapManager {
@@ -170,6 +172,10 @@ public:
         return std::min(targetExponent, filterCeiling);
     }
 
+    ShadowMap::ShaderParameters const& getCascadeShaderParameters(size_t index) const noexcept {
+        return mCascadesShaderParameters[index];
+    }
+
 private:
     explicit ShadowMapManager(FEngine& engine);
 
@@ -252,6 +258,8 @@ private:
     ShadowMappingUniforms mShadowMappingUniforms = {};
 
     ShadowMap::SceneInfo mSceneInfo;
+
+    ShadowMap::ShaderParameters mCascadesShaderParameters[4]{};
 
     // Inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
     // Because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1362,7 +1362,7 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
     // Debug: CSM visualisation
     if (UTILS_UNLIKELY(engine.debug.shadowmap.visualize_cascades &&
                        view.hasShadowing() && view.hasDirectionalLighting())) {
-        input = ppm.debugShadowCascades(fg, input, depth);
+        input = ppm.debugShadowCascades(fg, view.getShadowMapManager(), input, depth);
     }
 
     // TODO: DoF should be applied here, before TAA -- but if we do this it'll result in a lot of

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -506,6 +506,8 @@ public:
 
     MaterialGlobals getMaterialGlobals() const { return mMaterialGlobals; }
 
+    ShadowMapManager const& getShadowMapManager() const noexcept { return *mShadowMapManager; }
+
 private:
     struct FPickingQuery : public PickingQuery {
     private:

--- a/filament/src/materials/debugShadowCascades.mat
+++ b/filament/src/materials/debugShadowCascades.mat
@@ -18,8 +18,23 @@ material {
             precision: high
         },
         {
-            type : uint,
+            type : int,
             name : cascadeCount,
+            precision: high
+        },
+        {
+            type : float2,
+            name : shadowAtlasResolution,
+            precision: high
+        },
+        {
+            type : mat4[4],
+            name : lightFromWorldMatrix,
+            precision: high
+        },
+        {
+            type : float4[4],
+            name : scissorNormalized,
             precision: high
         }
     ],
@@ -59,9 +74,10 @@ fragment {
         return vec3(0.0, 0.0, 0.0);
     }
 
-    int getShadowCascade(highp float z) {
-        ivec4 greaterZ = ivec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
-        int cascadeCount = frameUniforms.cascades & 0xF;
+    int getShadowCascade(highp vec4 position) {
+        highp float z = position.z / position.w;
+        ivec4 greaterZ = ivec4(greaterThan(materialParams.cascadeSplits, vec4(z)));
+        int cascadeCount = materialParams.cascadeCount;
         return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0, cascadeCount - 1);
     }
 
@@ -70,11 +86,13 @@ fragment {
 
         // depth from the depth buffer
         highp float depth = textureLod(materialParams_depth, variable_vertex.xy, 0.0).r;
-        // convert to view-space (linear z).
-        highp vec4 p = mulMat4x4Float3(getViewFromClipMatrix(), vec3(0, 0, depth));
-        highp float z = p.z / p.w;
 
-        color.rgb *= uintToColorDebug(getShadowCascade(z));
+        highp vec2 clip = variable_vertex.xy * 2.0 - vec2(1.0);
+
+        // convert to view-space (linear z).
+        highp vec4 p = mulMat4x4Float3(getViewFromClipMatrix(), vec3(clip, depth));
+
+        color.rgb *= uintToColorDebug(getShadowCascade(p));
         postProcess.color = color;
     }
 }


### PR DESCRIPTION
The DebugShadowCasacade material was dependent on frameUniforms, instead we use material parameters. We also pass all the informations relative to cascades (it's not used yet, but will be in the future).