### PR TITLE
github: fix bad conditional in presubmit

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -13,15 +13,49 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# The conditional "verification.verified == false" is meant to skip doing presubmit jobs when the
-#   commit is to main, and the commit is "verified".  Typically, a verified commit will have passed
-#   through presubmit already.
+# The conditional 'if' on each job is meant to skip presubmit jobs when a commit is pushed to main
+# and that commit is cryptographically "verified". Typically, a verified commit (like a GitHub UI
+# squash-and-merge) has already passed through presubmit during the Pull Request phase.
+# The conditional explicitly checks:
+# 1. always() && !cancelled(): Ensures the job runs even if 'check-verification' is skipped, but
+#    aborts if the workflow was manually cancelled.
+# 2. github.event_name == 'pull_request': Presubmits should always run normally on PRs.
+# 3. github.event_name == 'push' && ...: If it's a push to main, it only runs if the
+#    'check-verification' job confirmed the commit is NOT verified.
 
 jobs:
+  check-verification:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      verified: ${{ steps.check.outputs.verified }}
+    steps:
+      - name: Check commit verification
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha
+            });
+            core.setOutput('verified', data.commit.verification.verified);
+
   build-desktop-mac:
     name: build-mac
     runs-on: 'macos-14-xlarge'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -37,7 +71,17 @@ jobs:
   build-desktop-linux:
     name: build-linux
     runs-on: 'ubuntu-24.04-4core'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -53,7 +97,17 @@ jobs:
   build-windows:
     name: build-windows
     runs-on: 'windows-2022'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -66,7 +120,17 @@ jobs:
   build-android:
     name: build-android
     runs-on: 'ubuntu-24.04-4core'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -94,7 +158,17 @@ jobs:
   build-ios:
     name: build-iOS
     runs-on: 'macos-14-xlarge'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -110,7 +184,17 @@ jobs:
   build-web:
     name: build-web
     runs-on: 'ubuntu-24.04-4core'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -124,7 +208,17 @@ jobs:
   validate-docs:
     name: validate-docs
     runs-on: 'ubuntu-24.04'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -138,7 +232,17 @@ jobs:
   test-renderdiff:
     name: test-renderdiff
     runs-on: 'macos-14-xlarge'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -208,7 +312,17 @@ jobs:
   validate-wgsl-webgpu:
     name: validate-wgsl-webgpu
     runs-on: 'ubuntu-24.04-4core'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -222,7 +336,17 @@ jobs:
   test-code-correctness:
     name: test-code-correctness
     runs-on: 'macos-14-xlarge'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -244,7 +368,17 @@ jobs:
   test-backend:
     name: test-backend
     runs-on: 'macos-14-xlarge'
-    if: github.event_name == 'pull_request' || github.event.head_commit.verification.verified == false
+    needs: [check-verification]
+    if: >
+      always() && !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          needs.check-verification.result == 'success' &&
+          needs.check-verification.outputs.verified == 'false'
+        )
+      )
     steps:
       - uses: actions/checkout@v4.1.6
         with:


### PR DESCRIPTION
The previous conditional used
github.event.head_commit.verification.verified, which is not a real field. Hence, the attempt to reduce presubmit runs did not actually succeed.  Here we replace it with a more correct verification step.