### PR TITLE
Try to fix verify-notes breakage

### DIFF
--- a/.github/actions/verify-release-notes/Dockerfile
+++ b/.github/actions/verify-release-notes/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4
+FROM python:3.12.13
 
 RUN pip3 install pygithub==1.55
 

--- a/.github/workflows/verify-release-notes.yml
+++ b/.github/workflows/verify-release-notes.yml
@@ -11,14 +11,11 @@ jobs:
     name: Verify Release Notes
     runs-on: ubuntu-latest
     steps:
-      # We *only* need to check out the .github/ directory.
-      # The verify RELEASE_NOTES script uses the GitHub API to verify that RELEASE_NOTES was
-      # modified.
-      - name: Check out action
-        uses: Bhacaz/checkout-files@73e17cfbe8d7e0c6b2672b20cb05a718e20d18d4
+      - uses: actions/checkout@v6
         with:
-          files: .github
-          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          sparse-checkout: |
+            .github
       - name: Verify release notes
         uses: ./.github/actions/verify-release-notes
         with:


### PR DESCRIPTION
    Try to fix verify-notes breakage
    
     - Update python3 version to 3.12.13
     - Use action/checkout instead of Bhacaz/checkout-files because action/checkout can
       use the action/files of the current PR, where as checkout-files is checking out
       a file on the main branch
     - action/checkout seems to run in less than a minute, so acceptable performance
       difference.
    
    --------------------------------------------------------------------
    
    Breakage is:
    
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/site-packages/jwt/algorithms.py", line 36, in <module>
        from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
    ModuleNotFoundError: No module named 'cryptography'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/verify_release_notes.py", line 17, in <module>
        from github import Github
      File "/usr/local/lib/python3.10/site-packages/github/__init__.py", line 56, in <module>
        from github.MainClass import Github, GithubIntegration
      File "/usr/local/lib/python3.10/site-packages/github/MainClass.py", line 54, in <module>
        import jwt
      File "/usr/local/lib/python3.10/site-packages/jwt/__init__.py", line 1, in <module>
        from .api_jwk import PyJWK, PyJWKSet
      File "/usr/local/lib/python3.10/site-packages/jwt/api_jwk.py", line 8, in <module>
        from .algorithms import get_default_algorithms, has_crypto, requires_cryptography
      File "/usr/local/lib/python3.10/site-packages/jwt/algorithms.py", line 113, in <module>
        from typing_extensions import Never
    ModuleNotFoundError: No module named 'typing_extensions'