### PR TITLE
fix android CMake so LTO can be turned on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,11 +326,13 @@ endif()
 if (FILAMENT_ENABLE_LTO)
     include(CheckIPOSupported)
 
-    check_ipo_supported(RESULT IPO_SUPPORT)
+    check_ipo_supported(RESULT IPO_SUPPORT OUTPUT IPO_ERROR)
 
     if (IPO_SUPPORT)
-        message(STATUS "LTO support is enabled")
+        message(STATUS "IPO / LTO is enabled")
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(WARNING "IPO / LTO is not supported by this architecture: ${IPO_ERROR}")
     endif()
 endif()
 

--- a/build/toolchain-aarch64-linux-android.cmake
+++ b/build/toolchain-aarch64-linux-android.cmake
@@ -46,6 +46,7 @@ list(SORT NDK_VERSIONS)
 list(GET NDK_VERSIONS -1 NDK_VERSION)
 get_filename_component(NDK_VERSION ${NDK_VERSION} NAME)
 set(TOOLCHAIN ${ANDROID_HOME_UNIX}/ndk/${NDK_VERSION}/toolchains/llvm/prebuilt/${HOST_NAME_L}-x86_64)
+set(CMAKE_ANDROID_NDK_VERSION ${NDK_VERSION})
 
 # specify the cross compiler
 set(COMPILER_SUFFIX)

--- a/build/toolchain-arm7-linux-android.cmake
+++ b/build/toolchain-arm7-linux-android.cmake
@@ -47,6 +47,7 @@ list(SORT NDK_VERSIONS)
 list(GET NDK_VERSIONS -1 NDK_VERSION)
 get_filename_component(NDK_VERSION ${NDK_VERSION} NAME)
 set(TOOLCHAIN ${ANDROID_HOME_UNIX}/ndk/${NDK_VERSION}/toolchains/llvm/prebuilt/${HOST_NAME_L}-x86_64)
+set(CMAKE_ANDROID_NDK_VERSION ${NDK_VERSION})
 
 # specify the cross compiler
 set(COMPILER_SUFFIX)

--- a/build/toolchain-x86-linux-android.cmake
+++ b/build/toolchain-x86-linux-android.cmake
@@ -46,6 +46,7 @@ list(SORT NDK_VERSIONS)
 list(GET NDK_VERSIONS -1 NDK_VERSION)
 get_filename_component(NDK_VERSION ${NDK_VERSION} NAME)
 set(TOOLCHAIN ${ANDROID_HOME_UNIX}/ndk/${NDK_VERSION}/toolchains/llvm/prebuilt/${HOST_NAME_L}-x86_64)
+set(CMAKE_ANDROID_NDK_VERSION ${NDK_VERSION})
 
 # specify the cross compiler
 set(COMPILER_SUFFIX)

--- a/build/toolchain-x86_64-linux-android.cmake
+++ b/build/toolchain-x86_64-linux-android.cmake
@@ -46,6 +46,7 @@ list(SORT NDK_VERSIONS)
 list(GET NDK_VERSIONS -1 NDK_VERSION)
 get_filename_component(NDK_VERSION ${NDK_VERSION} NAME)
 set(TOOLCHAIN ${ANDROID_HOME_UNIX}/ndk/${NDK_VERSION}/toolchains/llvm/prebuilt/${HOST_NAME_L}-x86_64)
+set(CMAKE_ANDROID_NDK_VERSION ${NDK_VERSION})
 
 # specify the cross compiler
 set(COMPILER_SUFFIX)


### PR DESCRIPTION
our custom build system didn't set CMAKE_ANDROID_NDK_VERSION which is needed for CMake's check_ipo_supported.