### PR TITLE
github: fix broken header check

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -77,9 +77,6 @@ jobs:
         with:
           name: filament-mac
           path: out/filament-release-darwin.tgz
-      - name: Check public headers
-        run: |
-          test/check-headers/test.sh out/release/filament/include
 
   build-web:
     name: build-web

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -64,9 +64,15 @@ jobs:
       - name: Run build script
         run: |
           cd build/mac && printf "y" | ./build.sh presubmit-with-test
-      - name: Test material parser
+      - name: Test - material parser
         run: |
           out/cmake-release/filament/test/test_material_parser
+      - name: Test - public headers
+        run: |
+          # out/cmake-release should have the artifacts ready for installation. Here we install it
+          #   to test the public headers
+          ninja -C out/cmake-release install
+          test/check-headers/test.sh out/release/filament/include
 
   build-desktop-linux:
     name: build-linux

--- a/test/check-headers/test.sh
+++ b/test/check-headers/test.sh
@@ -53,6 +53,12 @@ for f in $(find . -name '*.h'); do
 done
 popd >/dev/null
 
+# Check if the system has getopt
+HAS_SYSTEM_GETOPT=0
+if echo "#include <getopt.h>" | clang -x c++ -std=c++17 -E - > /dev/null 2>&1; then
+    HAS_SYSTEM_GETOPT=1
+fi
+
 rm -rf out/check-headers
 mkdir -p out/check-headers
 
@@ -61,10 +67,17 @@ echo "Checking that public headers compile independently..."
 for include in "${includes[@]}"; do
     rm -f ${TMP_FILE}
     echo "Checking ${include}"
-    if [[ "${include}" == "utils/Systrace.h" ]]; then
-        # A necessary define before we can include utils/Systrace.h
-        echo "#define SYSTRACE_TAG SYSTRACE_TAG_DISABLED" >> ${TMP_FILE}
-    fi
+    case "${include}" in
+        "utils/Systrace.h")
+            # A necessary define before we can include utils/Systrace.h
+            echo "#define SYSTRACE_TAG SYSTRACE_TAG_DISABLED" >> ${TMP_FILE}
+            ;;
+        "utils/getopt.h")
+            if [[ $HAS_SYSTEM_GETOPT -eq 1 ]]; then
+                echo "#define HAS_SYSTEM_GETOPT 1" >> ${TMP_FILE}
+            fi
+            ;;
+    esac
     echo "#include <${include}>" >> ${TMP_FILE}
     # Filament is built internally with C++20, but we maintain C++17 compatibility (for the time
     # being) in our public headers to support projects on older toolchains.

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -22,3 +22,9 @@ include_directories(${PUBLIC_HDR_DIR})
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 target_include_directories (${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 set_target_properties(${TARGET} PROPERTIES FOLDER ThirdParty)
+
+# ==================================================================================================
+# Installation
+# ==================================================================================================
+install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
+install(DIRECTORY ${PUBLIC_HDR_DIR}/getopt DESTINATION include)


### PR DESCRIPTION
 - Move header check from postsubmit to presubmit
 - Install third_party/getop if needed
 - Modify check-headers test to use system getopt when it's available.