### PR TITLE
remove the remaining instances of std::string

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -31,7 +31,6 @@
 #include <cstring>
 #include <cstddef>
 #include <functional>
-#include <string>
 #include <tuple>
 #include <unordered_set>
 
@@ -69,7 +68,7 @@ public:
 
     struct ExtensionHashFn {
         std::size_t operator()(utils::CString const& s) const noexcept {
-            return std::hash<std::string>{}(s.data());
+            return std::hash<utils::CString>{}(s.data());
         }
     };
     // Note: utils::CString::operator== has an edge case that breaks for the extension set.

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -32,7 +32,7 @@
 
 #include <cstddef>
 #include <functional>
-#include <string>
+#include <string_view>
 #include <utility>
 
 #ifdef __ANDROID__

--- a/filament/src/LocalProgramCache.cpp
+++ b/filament/src/LocalProgramCache.cpp
@@ -182,7 +182,7 @@ Program::SpecializationConstant LocalProgramCache::getConstantImpl(
         return getConstantImpl(it->second + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
     }
 
-    std::string name_cstring(name);
+    CString name_cstring(name);
     PANIC_PRECONDITION("No such constant exists: %s", name_cstring.c_str());
     return {};
 }

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -27,8 +27,6 @@
 #include <utils/debug.h>
 #include <utils/CString.h>
 
-#include <string>
-
 using namespace filament::backend;
 
 namespace filament {

--- a/libs/filamat/include/filamat/Enums.h
+++ b/libs/filamat/include/filamat/Enums.h
@@ -18,7 +18,7 @@
 #define TNT_ENUMMANAGER_H
 
 #include <algorithm>
-#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include <filamat/MaterialBuilder.h>
@@ -37,55 +37,55 @@ using OutputType = MaterialBuilder::OutputType;
 using ConstantType = MaterialBuilder::ConstantType;
 using ShaderStageType = MaterialBuilder::ShaderStageFlags;
 
-// Convenience methods to convert std::string to Enum and also iterate over Enum values.
+// Convenience methods to convert std::string_view to Enum and also iterate over Enum values.
 class Enums {
 public:
 
     // Returns true if string "s" is a valid string representation of an element of enum T.
     template<typename T>
-    static bool isValid(const std::string& s) noexcept {
-        std::unordered_map<std::string, T>& map = getMap<T>();
+    static bool isValid(const std::string_view& s) noexcept {
+        std::unordered_map<std::string_view, T>& map = getMap<T>();
         return map.find(s) != map.end();
     }
 
     // Return enum matching its string representation. Returns undefined if s is not a valid enum T
     // value. You should always call isValid() first to validate a string before calling toEnum().
     template<typename T>
-    static T toEnum(const std::string& s) noexcept {
-        std::unordered_map<std::string, T>& map = getMap<T>();
+    static T toEnum(const std::string_view& s) noexcept {
+        std::unordered_map<std::string_view, T>& map = getMap<T>();
         return map.at(s);
     }
 
     template<typename T>
-    static std::string toString(T t) noexcept;
+    static std::string_view toString(T t) noexcept;
 
     // Return a map of all values in an enum with their string representation.
     template<typename T>
-    static std::unordered_map<std::string, T>& map() noexcept {
-        std::unordered_map<std::string, T>& map = getMap<T>();
+    static std::unordered_map<std::string_view, T>& map() noexcept {
+        auto& map = getMap<T>();
         return map;
     };
 
 private:
     template<typename T>
-    static std::unordered_map<std::string, T>& getMap() noexcept;
+    static std::unordered_map<std::string_view, T>& getMap() noexcept;
 
-    static std::unordered_map<std::string, Property> mStringToProperty;
-    static std::unordered_map<std::string, UniformType> mStringToUniformType;
-    static std::unordered_map<std::string, SamplerType> mStringToSamplerType;
-    static std::unordered_map<std::string, SubpassType> mStringToSubpassType;
-    static std::unordered_map<std::string, SamplerFormat> mStringToSamplerFormat;
-    static std::unordered_map<std::string, ParameterPrecision> mStringToSamplerPrecision;
-    static std::unordered_map<std::string, OutputTarget> mStringToOutputTarget;
-    static std::unordered_map<std::string, OutputQualifier> mStringToOutputQualifier;
-    static std::unordered_map<std::string, OutputType> mStringToOutputType;
-    static std::unordered_map<std::string, ConstantType> mStringToConstantType;
-    static std::unordered_map<std::string, ShaderStageType> mStringToShaderStageType;
+    static std::unordered_map<std::string_view, Property> mStringToProperty;
+    static std::unordered_map<std::string_view, UniformType> mStringToUniformType;
+    static std::unordered_map<std::string_view, SamplerType> mStringToSamplerType;
+    static std::unordered_map<std::string_view, SubpassType> mStringToSubpassType;
+    static std::unordered_map<std::string_view, SamplerFormat> mStringToSamplerFormat;
+    static std::unordered_map<std::string_view, ParameterPrecision> mStringToSamplerPrecision;
+    static std::unordered_map<std::string_view, OutputTarget> mStringToOutputTarget;
+    static std::unordered_map<std::string_view, OutputQualifier> mStringToOutputQualifier;
+    static std::unordered_map<std::string_view, OutputType> mStringToOutputType;
+    static std::unordered_map<std::string_view, ConstantType> mStringToConstantType;
+    static std::unordered_map<std::string_view, ShaderStageType> mStringToShaderStageType;
 };
 
 template<typename T>
-std::string Enums::toString(T t) noexcept {
-    std::unordered_map<std::string, T>& map = getMap<T>();
+std::string_view Enums::toString(T t) noexcept {
+    auto& map = getMap<T>();
     auto result = std::find_if(map.begin(), map.end(), [t](auto& pair) {
         return pair.second == t;
     });

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -18,9 +18,11 @@
 
 #include "filamat/MaterialBuilder.h"
 
+#include <string_view>
+
 namespace filamat {
 
-std::unordered_map<std::string, Property> Enums::mStringToProperty = {
+std::unordered_map<std::string_view, Property> Enums::mStringToProperty = {
         { "baseColor",           Property::BASE_COLOR },
         { "roughness",           Property::ROUGHNESS },
         { "metallic",            Property::METALLIC },
@@ -55,11 +57,11 @@ std::unordered_map<std::string, Property> Enums::mStringToProperty = {
 };
 
 template <>
-std::unordered_map<std::string, Property>& Enums::getMap<Property>() noexcept {
+std::unordered_map<std::string_view, Property>& Enums::getMap<Property>() noexcept {
     return mStringToProperty;
 };
 
-std::unordered_map<std::string, UniformType> Enums::mStringToUniformType = {
+std::unordered_map<std::string_view, UniformType> Enums::mStringToUniformType = {
         { "bool",     UniformType::BOOL },
         { "bool2",    UniformType::BOOL2 },
         { "bool3",    UniformType::BOOL3 },
@@ -83,11 +85,11 @@ std::unordered_map<std::string, UniformType> Enums::mStringToUniformType = {
 };
 
 template <>
-std::unordered_map<std::string, UniformType>& Enums::getMap<UniformType>() noexcept {
+std::unordered_map<std::string_view, UniformType>& Enums::getMap<UniformType>() noexcept {
     return mStringToUniformType;
 };
 
-std::unordered_map<std::string, SamplerType> Enums::mStringToSamplerType = {
+std::unordered_map<std::string_view, SamplerType> Enums::mStringToSamplerType = {
         { "sampler2d",           SamplerType::SAMPLER_2D },
         { "sampler2dArray",      SamplerType::SAMPLER_2D_ARRAY },
         { "sampler3d",           SamplerType::SAMPLER_3D },
@@ -97,20 +99,20 @@ std::unordered_map<std::string, SamplerType> Enums::mStringToSamplerType = {
 };
 
 template <>
-std::unordered_map<std::string, SamplerType>& Enums::getMap<SamplerType>() noexcept {
+std::unordered_map<std::string_view, SamplerType>& Enums::getMap<SamplerType>() noexcept {
     return mStringToSamplerType;
 };
 
-std::unordered_map<std::string, SubpassType> Enums::mStringToSubpassType = {
+std::unordered_map<std::string_view, SubpassType> Enums::mStringToSubpassType = {
         { "subpassInput",       SubpassType::SUBPASS_INPUT },
 };
 
 template <>
-std::unordered_map<std::string, SubpassType>& Enums::getMap<SubpassType>() noexcept {
+std::unordered_map<std::string_view, SubpassType>& Enums::getMap<SubpassType>() noexcept {
     return mStringToSubpassType;
 };
 
-std::unordered_map<std::string, ParameterPrecision> Enums::mStringToSamplerPrecision = {
+std::unordered_map<std::string_view, ParameterPrecision> Enums::mStringToSamplerPrecision = {
         { "default", ParameterPrecision::DEFAULT },
         { "low",     ParameterPrecision::LOW },
         { "medium",  ParameterPrecision::MEDIUM },
@@ -118,30 +120,30 @@ std::unordered_map<std::string, ParameterPrecision> Enums::mStringToSamplerPreci
 };
 
 template <>
-std::unordered_map<std::string, ParameterPrecision>& Enums::getMap<ParameterPrecision>() noexcept {
+std::unordered_map<std::string_view, ParameterPrecision>& Enums::getMap<ParameterPrecision>() noexcept {
     return mStringToSamplerPrecision;
 };
 
-std::unordered_map<std::string, OutputTarget> Enums::mStringToOutputTarget = {
+std::unordered_map<std::string_view, OutputTarget> Enums::mStringToOutputTarget = {
         { "color",   OutputTarget::COLOR },
         { "depth",   OutputTarget::DEPTH }
 };
 
 template <>
-std::unordered_map<std::string, OutputTarget>& Enums::getMap<OutputTarget>() noexcept {
+std::unordered_map<std::string_view, OutputTarget>& Enums::getMap<OutputTarget>() noexcept {
     return mStringToOutputTarget;
 };
 
-std::unordered_map<std::string, OutputQualifier> Enums::mStringToOutputQualifier = {
+std::unordered_map<std::string_view, OutputQualifier> Enums::mStringToOutputQualifier = {
         { "out",     OutputQualifier::OUT }
 };
 
 template <>
-std::unordered_map<std::string, OutputQualifier>& Enums::getMap<OutputQualifier>() noexcept {
+std::unordered_map<std::string_view, OutputQualifier>& Enums::getMap<OutputQualifier>() noexcept {
     return mStringToOutputQualifier;
 };
 
-std::unordered_map<std::string, OutputType> Enums::mStringToOutputType = {
+std::unordered_map<std::string_view, OutputType> Enums::mStringToOutputType = {
         { "float",   OutputType::FLOAT },
         { "float2",  OutputType::FLOAT2 },
         { "float3",  OutputType::FLOAT3 },
@@ -149,11 +151,11 @@ std::unordered_map<std::string, OutputType> Enums::mStringToOutputType = {
 };
 
 template <>
-std::unordered_map<std::string, OutputType>& Enums::getMap<OutputType>() noexcept {
+std::unordered_map<std::string_view, OutputType>& Enums::getMap<OutputType>() noexcept {
     return mStringToOutputType;
 };
 
-std::unordered_map<std::string, SamplerFormat> Enums::mStringToSamplerFormat = {
+std::unordered_map<std::string_view, SamplerFormat> Enums::mStringToSamplerFormat = {
         { "int",    SamplerFormat::INT },
         { "uint",   SamplerFormat::UINT },
         { "float",  SamplerFormat::FLOAT },
@@ -161,29 +163,29 @@ std::unordered_map<std::string, SamplerFormat> Enums::mStringToSamplerFormat = {
 };
 
 template <>
-std::unordered_map<std::string, SamplerFormat>& Enums::getMap<SamplerFormat>() noexcept {
+std::unordered_map<std::string_view, SamplerFormat>& Enums::getMap<SamplerFormat>() noexcept {
     return mStringToSamplerFormat;
 };
 
-std::unordered_map<std::string, ConstantType > Enums::mStringToConstantType = {
+std::unordered_map<std::string_view, ConstantType > Enums::mStringToConstantType = {
         { "int",   ConstantType::INT },
         { "float", ConstantType::FLOAT },
         { "bool",  ConstantType::BOOL },
 };
 
 template <>
-std::unordered_map<std::string, ConstantType>& Enums::getMap<ConstantType>() noexcept {
+std::unordered_map<std::string_view, ConstantType>& Enums::getMap<ConstantType>() noexcept {
     return mStringToConstantType;
 };
 
-std::unordered_map<std::string, ShaderStageType> Enums::mStringToShaderStageType = {
+std::unordered_map<std::string_view, ShaderStageType> Enums::mStringToShaderStageType = {
         { "fragment", ShaderStageType::FRAGMENT },
         { "vertex",   ShaderStageType::VERTEX },
         { "compute",  ShaderStageType::COMPUTE },
 };
 
 template <>
-std::unordered_map<std::string, ShaderStageType>& Enums::getMap<ShaderStageType>() noexcept {
+std::unordered_map<std::string_view, ShaderStageType>& Enums::getMap<ShaderStageType>() noexcept {
     return mStringToShaderStageType;
 };
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1417,7 +1417,7 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
         auto const* stage = to_string(sib.getStageFlags());
         for (auto const& sampler: samplers) {
             LOG(ERROR) << "\"" << sampler.name.c_str() << "\" "
-                   << Enums::toString(sampler.type).c_str() << " " << stage << '\n';
+                   << Enums::toString(sampler.type) << " " << stage << '\n';
         }
     };
 

--- a/libs/filament-matp/src/DirIncluder.cpp
+++ b/libs/filament-matp/src/DirIncluder.cpp
@@ -41,13 +41,13 @@ bool DirIncluder::operator()(const utils::CString& includedBy, IncludeResult& re
     const utils::Path headerPath = getHeaderPath();
 
     if (!headerPath.isFile()) {
-        utils::slog.e << "File " << headerPath << " does not exist." << utils::io::endl;
+        utils::slog.e << "File " << headerPath.c_str() << " does not exist." << utils::io::endl;
         return false;
     }
 
     std::ifstream stream(headerPath.getPath(), std::ios::binary);
     if (!stream) {
-        utils::slog.e << "Unable to open " << headerPath << "." << utils::io::endl;
+        utils::slog.e << "Unable to open " << headerPath.c_str() << "." << utils::io::endl;
         return false;
     }
 

--- a/libs/filament-matp/src/ParametersProcessor.cpp
+++ b/libs/filament-matp/src/ParametersProcessor.cpp
@@ -39,27 +39,24 @@ using namespace utils;
 namespace matp {
 
 template <class T>
-static utils::Status logEnumIssue(const std::string& key, const JsonishString& value,
-        const std::unordered_map<std::string, T>& map) noexcept {
-    utils::io::sstream errorMessage;
-    errorMessage << "Error while processing key '" << key << "' value." << utils::io::endl;
-    errorMessage << "Value '" << value.getString() << "' is invalid. Valid values are:"
-            << utils::io::endl;
+static Status logEnumIssue(const std::string_view& key, const JsonishString& value,
+        const std::unordered_map<std::string_view, T>& map) noexcept {
+    io::sstream errorMessage;
+    errorMessage << "Error while processing key '" << key << "' value." << io::endl;
+    errorMessage << "Value '" << value.getString() << "' is invalid. Valid values are:" << io::endl;
     for (const auto& entries : map) {
-        errorMessage << "    " << entries.first  << utils::io::endl;
+        errorMessage << "    " << entries.first  << io::endl;
     }
-    return utils::Status::invalidArgument(errorMessage.c_str());
+    return Status::invalidArgument(errorMessage.c_str());
 }
 
 template <class T>
-static bool isStringValidEnum(const std::unordered_map<std::string, T>& map,
-        const std::string& s) noexcept {
+static bool isStringValidEnum(const std::unordered_map<std::string_view, T>& map, const std::string_view& s) noexcept {
     return map.find(s) != map.end();
 }
 
 template <class T>
-static T stringToEnum(const std::unordered_map<std::string, T>& map,
-        const std::string& s) noexcept {
+static T stringToEnum(const std::unordered_map<std::string_view, T>& map, const std::string_view& s) noexcept {
     return map.at(s);
 }
 
@@ -74,18 +71,18 @@ static MaterialBuilder::Variable intToVariable(size_t i) noexcept {
     }
 }
 
-static utils::Status processName(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processName(MaterialBuilder& builder, const JsonishValue& value) {
     builder.name(value.toJsonString()->getString().c_str());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processApiLevel(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processApiLevel(MaterialBuilder& builder, const JsonishValue& value) {
     builder.setApiLevel(value.toJsonNumber()->getFloat());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processInterpolation(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::Interpolation> strToEnum {
+static Status processInterpolation(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::Interpolation> strToEnum {
         { "smooth", MaterialBuilder::Interpolation::SMOOTH },
         { "flat", MaterialBuilder::Interpolation::FLAT },
     };
@@ -94,7 +91,7 @@ static utils::Status processInterpolation(MaterialBuilder& builder, const Jsonis
         return logEnumIssue("interpolation", *interpolationString, strToEnum);
     }
     builder.interpolation(stringToEnum(strToEnum, interpolationString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
 /**
@@ -141,34 +138,34 @@ static ssize_t extractArraySize(std::string& type) {
     return (ssize_t)std::stoul(type.c_str() + start + 1, nullptr);
 }
 
-static utils::Status processParameter(MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
+static Status processParameter(MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
 
     const JsonishValue* typeValue = jsonObject.getValue("type");
     if (!typeValue) {
-        return utils::Status::invalidArgument("parameters: entry without key 'type'.");
+        return Status::invalidArgument("parameters: entry without key 'type'.");
     }
     if (typeValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("parameters: type value must be STRING.");
+        return Status::invalidArgument("parameters: type value must be STRING.");
     }
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("parameters: entry without 'name' key.");
+        return Status::invalidArgument("parameters: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("parameters: name value must be STRING.");
+        return Status::invalidArgument("parameters: name value must be STRING.");
     }
 
     const JsonishValue* transformNameValue = jsonObject.getValue("transformName");
     if (transformNameValue && transformNameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument(
+        return Status::invalidArgument(
                 "parameters: transformName value must be STRING.");
     }
 
     const JsonishValue* precisionValue = jsonObject.getValue("precision");
     if (precisionValue) {
         if (precisionValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("parameters: precision must be a STRING.");
+            return Status::invalidArgument("parameters: precision must be a STRING.");
         }
         auto precisionString = precisionValue->toJsonString();
         if (!Enums::isValid<ParameterPrecision>(precisionString->getString())){
@@ -179,7 +176,7 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
     const JsonishValue* formatValue = jsonObject.getValue("format");
     if (formatValue) {
         if (formatValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("parameters: format must be a STRING.");
+            return Status::invalidArgument("parameters: format must be a STRING.");
         }
         auto formatString = formatValue->toJsonString();
         if (!Enums::isValid<SamplerFormat>(formatString->getString())){
@@ -190,13 +187,13 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
     const JsonishValue* filterableValue = jsonObject.getValue("filterable");
     if (filterableValue) {
         if (filterableValue->getType() != JsonishValue::BOOL) {
-            return utils::Status::invalidArgument("parameters: filterable must be a BOOL.");
+            return Status::invalidArgument("parameters: filterable must be a BOOL.");
         }
     }
     const JsonishValue* multiSampleValue = jsonObject.getValue("multisample");
     if (multiSampleValue) {
         if (multiSampleValue->getType() != JsonishValue::BOOL) {
-            return utils::Status::invalidArgument("parameters: multisample must be a BOOL.");
+            return Status::invalidArgument("parameters: multisample must be a BOOL.");
         }
     }
 
@@ -209,7 +206,7 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
     if (stagesValue) {
         ShaderStageFlags parsedStages = ShaderStageFlags::NONE;
         if (stagesValue->getType() != JsonishValue::ARRAY) {
-            return utils::Status::invalidArgument("parameters: stages must be an ARRAY.");
+            return Status::invalidArgument("parameters: stages must be an ARRAY.");
         }
         for (auto value: stagesValue->toJsonArray()->getElements()) {
             if (value->getType() == JsonishValue::Type::STRING) {
@@ -219,15 +216,15 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
                 if (Enums::isValid<ShaderStageType>(stageString)) {
                     parsedStages |= Enums::toEnum<ShaderStageType>(stageString);
                 } else {
-                    utils::io::sstream errorMessage;
+                    io::sstream errorMessage;
                     errorMessage << "stages: the stage '" << stageString <<
                                        "' for parameter with name '" << nameString <<
                                        "' is not a valid shader stage.";
-                    return utils::Status::invalidArgument(errorMessage.c_str());
+                    return Status::invalidArgument(errorMessage.c_str());
                 }
                 continue;
             }
-            return utils::Status::invalidArgument(
+            return Status::invalidArgument(
                     "parameters: stages must be an array of STRINGs.");
         }
         stages = parsedStages;
@@ -237,11 +234,11 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
 
     if (Enums::isValid<UniformType>(typeString)) {
         if (stages.has_value()) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "parameters: the uniform parameter with name '" << nameString << "'"
                       << " has shader stages specified. Shader stages are only supported for"
                       << " samplers.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
         MaterialBuilder::UniformType const type = Enums::toEnum<UniformType>(typeString);
         ParameterPrecision precision = ParameterPrecision::DEFAULT;
@@ -256,11 +253,11 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
         }
     } else if (Enums::isValid<SamplerType>(typeString)) {
         if (arraySize > 0) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "parameters: the parameter with name '" << nameString << "'"
                     << " is an array of samplers of size " << arraySize << ". Arrays of samplers"
                     << " are currently not supported.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         MaterialBuilder::SamplerType const type = Enums::toEnum<SamplerType>(typeString);
@@ -272,15 +269,15 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
                 precisionValue->toJsonString()->getString()) : ParameterPrecision::DEFAULT;
 
         if (format == SamplerFormat::SHADOW) {
-            return utils::Status::invalidArgument(
+            return Status::invalidArgument(
                     "Materials should not be able to define a shadow sampler");
         }
 
         if (format == SamplerFormat::INT && filterableValue) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "parameters: the parameter with name '" << nameString << "'"
                       << " is an integer sampler. The `filterable` attribute must not be defined.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         // For samplers without `filterable` defined, we use the following logic
@@ -294,11 +291,11 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
 
         if (transformNameValue) {
             if (type != MaterialBuilder::SamplerType::SAMPLER_EXTERNAL) {
-                utils::io::sstream errorMessage;
+                io::sstream errorMessage;
                 errorMessage << "parameters: the parameter with name '" << nameString << "'"
                     << " is a sampler of type " << typeString << " and has a transformName."
                     << " Transform names are only supported for external samplers.";
-                return utils::Status::invalidArgument(errorMessage.c_str());
+                return Status::invalidArgument(errorMessage.c_str());
             }
             auto transformName = transformNameValue->toJsonString()->getString();
             builder.parameter(nameString.c_str(), type, format, precision, filterable,
@@ -309,49 +306,49 @@ static utils::Status processParameter(MaterialBuilder& builder, const JsonishObj
         }
 
     } else {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "parameters: the type '" << typeString
                << "' for parameter with name '" << nameString << "' is neither a valid uniform "
                << "type nor a valid sampler type.";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
 
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processParameters(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processParameters(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
 
-    utils::Status status;
+    Status status;
     for (auto value : jsonArray->getElements()) {
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processParameter(builder, *value->toJsonObject());
+            Status s = processParameter(builder, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("parameters must be an array of OBJECTs.");
+        return Status::invalidArgument("parameters must be an array of OBJECTs.");
     }
     return status;
 }
 
-static utils::Status processConstant(MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
+static Status processConstant(MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
     const JsonishValue* typeValue = jsonObject.getValue("type");
     if (!typeValue) {
-        return utils::Status::invalidArgument("constants: entry without key 'type'.");
+        return Status::invalidArgument("constants: entry without key 'type'.");
     }
     if (typeValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("constants: type value must be STRING.");
+        return Status::invalidArgument("constants: type value must be STRING.");
     }
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("constants: entry without 'name' key.");
+        return Status::invalidArgument("constants: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("constants: name value must be STRING.");
+        return Status::invalidArgument("constants: name value must be STRING.");
     }
 
     auto typeString = typeValue->toJsonString()->getString();
@@ -365,7 +362,7 @@ static utils::Status processConstant(MaterialBuilder& builder, const JsonishObje
                 int32_t intDefault = 0;
                 if (defaultValue) {
                     if (defaultValue->getType() != JsonishValue::NUMBER) {
-                        return utils::Status::invalidArgument(
+                        return Status::invalidArgument(
                                 "constants: INT constants must have NUMBER default value");
                     }
                     // FIXME: Jsonish doesn't distinguish between integers and floats.
@@ -378,7 +375,7 @@ static utils::Status processConstant(MaterialBuilder& builder, const JsonishObje
                 float floatDefault = 0.0f;
                 if (defaultValue) {
                     if (defaultValue->getType() != JsonishValue::NUMBER) {
-                        return utils::Status::invalidArgument(
+                        return Status::invalidArgument(
                                 "constants: FLOAT constants must have NUMBER default value");
                     }
                     floatDefault = defaultValue->toJsonNumber()->getFloat();
@@ -390,7 +387,7 @@ static utils::Status processConstant(MaterialBuilder& builder, const JsonishObje
                 bool boolDefault = false;
                 if (defaultValue) {
                     if (defaultValue->getType() != JsonishValue::BOOL) {
-                        return utils::Status::invalidArgument(
+                        return Status::invalidArgument(
                                 "constants: BOOL constants must have BOOL default value");
                     }
                     boolDefault = defaultValue->toJsonBool()->getBool();
@@ -399,56 +396,56 @@ static utils::Status processConstant(MaterialBuilder& builder, const JsonishObje
                 break;
         }
     } else {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "constants: the type '" << typeString
                   << "' for constant with name '" << nameString << "' is not a valid constant "
                   << "parameter type.";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processConstants(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processConstants(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
 
-    utils::Status status;
+    Status status;
     for (auto value : jsonArray->getElements()) {
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processConstant(builder, *value->toJsonObject());
+            Status s = processConstant(builder, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("constants must be an array of OBJECTs.");
+        return Status::invalidArgument("constants must be an array of OBJECTs.");
     }
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processBufferField(filament::BufferInterfaceBlock::Builder& builder,
+static Status processBufferField(filament::BufferInterfaceBlock::Builder& builder,
         const JsonishObject& jsonObject) noexcept {
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("buffers: entry without 'name' key.");
+        return Status::invalidArgument("buffers: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("buffers: name value must be STRING.");
+        return Status::invalidArgument("buffers: name value must be STRING.");
     }
 
     const JsonishValue* typeValue = jsonObject.getValue("type");
     if (!typeValue) {
-        return utils::Status::invalidArgument("buffers: entry without key 'type'.");
+        return Status::invalidArgument("buffers: entry without key 'type'.");
     }
     if (typeValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("buffers: type value must be STRING.");
+        return Status::invalidArgument("buffers: type value must be STRING.");
     }
 
     const JsonishValue* precisionValue = jsonObject.getValue("precision");
     if (precisionValue) {
         if (precisionValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("buffers: precision must be a STRING.");
+            return Status::invalidArgument("buffers: precision must be a STRING.");
         }
 
         auto precisionString = precisionValue->toJsonString();
@@ -477,16 +474,16 @@ static utils::Status processBufferField(filament::BufferInterfaceBlock::Builder&
                 { nameString.data(), nameString.size() }, uint32_t(arraySize), type, precision } });
         }
     } else {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "buffers: the type '" << typeString << "' for parameter with name '"
                   << nameString << "' is not a valid buffer field type.";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processBuffer(MaterialBuilder& builder,
+static Status processBuffer(MaterialBuilder& builder,
         const JsonishObject& jsonObject) noexcept {
 
     filament::BufferInterfaceBlock::Builder bibb;
@@ -496,26 +493,26 @@ static utils::Status processBuffer(MaterialBuilder& builder,
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("buffers: entry without 'name' key.");
+        return Status::invalidArgument("buffers: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("buffers: name value must be STRING.");
+        return Status::invalidArgument("buffers: name value must be STRING.");
     }
 
     const JsonishValue* qualifiersValue = jsonObject.getValue("qualifiers");
     if (!qualifiersValue) {
-        return utils::Status::invalidArgument("buffers: entry without key 'qualifiers'.");
+        return Status::invalidArgument("buffers: entry without key 'qualifiers'.");
     }
     if (qualifiersValue->getType() != JsonishValue::ARRAY) {
-        return utils::Status::invalidArgument("buffers: qualifiers value must be an ARRAY.");
+        return Status::invalidArgument("buffers: qualifiers value must be an ARRAY.");
     }
 
     const JsonishValue* fieldsValue = jsonObject.getValue("fields");
     if (!fieldsValue) {
-        return utils::Status::invalidArgument("buffers: entry without key 'fields'.");
+        return Status::invalidArgument("buffers: entry without key 'fields'.");
     }
     if (fieldsValue->getType() != JsonishValue::ARRAY) {
-        return utils::Status::invalidArgument("buffers: fields value must be an ARRAY.");
+        return Status::invalidArgument("buffers: fields value must be an ARRAY.");
     }
 
     auto nameString = nameValue->toJsonString()->getString();
@@ -539,71 +536,71 @@ static utils::Status processBuffer(MaterialBuilder& builder,
             }
             continue;
         }
-        return utils::Status::invalidArgument("buffers: qualifiers must be an array of STRINGs.");
+        return Status::invalidArgument("buffers: qualifiers must be an array of STRINGs.");
     }
 
-    utils::Status status;
+    Status status;
     for (auto value : fieldsValue->toJsonArray()->getElements()) {
 
         if (bibb.hasVariableSizeArray()) {
-            return utils::Status::invalidArgument(
+            return Status::invalidArgument(
                     "buffers: a variable size array must be the only and last field.");
         }
 
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processBufferField(bibb, *value->toJsonObject());
+            Status s = processBufferField(bibb, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("buffers: fields must be an array of OBJECTs.");
+        return Status::invalidArgument("buffers: fields must be an array of OBJECTs.");
     }
 
     builder.buffer(bibb.build());
     return status;
 }
 
-static utils::Status processBuffers(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processBuffers(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
-    utils::Status status;
+    Status status;
     for (auto value : jsonArray->getElements()) {
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processBuffer(builder, *value->toJsonObject());
+            Status s = processBuffer(builder, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("buffers must be an array of OBJECTs.");
+        return Status::invalidArgument("buffers must be an array of OBJECTs.");
     }
     return status;
 }
 
 
-static utils::Status processSubpass(
+static Status processSubpass(
         MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
 
     const JsonishValue* typeValue = jsonObject.getValue("type");
     if (!typeValue) {
-        return utils::Status::invalidArgument("subpasses: entry without key 'type'.");
+        return Status::invalidArgument("subpasses: entry without key 'type'.");
     }
     if (typeValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("subpasses: type value must be STRING.");
+        return Status::invalidArgument("subpasses: type value must be STRING.");
     }
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("subpasses: entry without 'name' key.");
+        return Status::invalidArgument("subpasses: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("subpasses: name value must be STRING.");
+        return Status::invalidArgument("subpasses: name value must be STRING.");
     }
 
     const JsonishValue* precisionValue = jsonObject.getValue("precision");
     if (precisionValue) {
         if (precisionValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("subpasses: precision must be a STRING.");
+            return Status::invalidArgument("subpasses: precision must be a STRING.");
         }
 
         auto precisionString = precisionValue->toJsonString();
@@ -615,7 +612,7 @@ static utils::Status processSubpass(
     const JsonishValue* formatValue = jsonObject.getValue("format");
     if (formatValue) {
         if (formatValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("subpasses: format must be a STRING.");
+            return Status::invalidArgument("subpasses: format must be a STRING.");
         }
 
         auto formatString = formatValue->toJsonString();
@@ -631,11 +628,11 @@ static utils::Status processSubpass(
 
     if (Enums::isValid<SubpassType>(typeString)) {
         if (arraySize > 0) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "subpasses: the parameter with name '" << nameString << "'"
                       << " is an array of subpasses of size " << arraySize << ". Arrays of subpasses"
                       << " are currently not supported.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         MaterialBuilder::SubpassType type = Enums::toEnum<SubpassType>(typeString);
@@ -655,42 +652,42 @@ static utils::Status processSubpass(
             builder.subpass(type, nameString.c_str());
         }
     } else {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "subpasses: the type '" << typeString
                   << "' for parameter with name '" << nameString << "' is neither a valid uniform "
                   << "type nor a valid sampler type.";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processSubpasses(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processSubpasses(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
 
-    utils::Status status;
+    Status status;
     for (auto value : jsonArray->getElements()) {
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processSubpass(builder, *value->toJsonObject());
+            Status s = processSubpass(builder, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("subpasses must be an array of OBJECTs.");
+        return Status::invalidArgument("subpasses must be an array of OBJECTs.");
     }
     return status;
 }
 
-static utils::Status processVariables(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processVariables(MaterialBuilder& builder, const JsonishValue& value) {
     const JsonishArray* jsonArray = value.toJsonArray();
     const auto& elements = jsonArray->getElements();
 
     if (elements.size() > MaterialBuilder::MATERIAL_VARIABLES_COUNT) {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "variables: Max array size is "
                      << MaterialBuilder::MATERIAL_VARIABLES_COUNT << ".";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
 
     for (size_t i = 0; i < elements.size(); i++) {
@@ -705,16 +702,16 @@ static utils::Status processVariables(MaterialBuilder& builder, const JsonishVal
 
             const JsonishValue* nameValue = jsonObject.getValue("name");
             if (!nameValue) {
-                return utils::Status::invalidArgument("variables: entry without 'name' key.");
+                return Status::invalidArgument("variables: entry without 'name' key.");
             }
             if (nameValue->getType() != JsonishValue::STRING) {
-                return utils::Status::invalidArgument("variables: name value must be STRING.");
+                return Status::invalidArgument("variables: name value must be STRING.");
             }
 
             const JsonishValue* precisionValue = jsonObject.getValue("precision");
             if (precisionValue) {
                 if (precisionValue->getType() != JsonishValue::STRING) {
-                    return utils::Status::invalidArgument("variables: precision must be a STRING.");
+                    return Status::invalidArgument("variables: precision must be a STRING.");
                 }
                 auto precisionString = precisionValue->toJsonString();
                 if (!Enums::isValid<ParameterPrecision>(precisionString->getString())){
@@ -732,19 +729,19 @@ static utils::Status processVariables(MaterialBuilder& builder, const JsonishVal
             nameString = elementValue->toJsonString()->getString();
             builder.variable(v, nameString.c_str());
         } else {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "variables: array index " << i << " is not a STRING. found:" <<
                     JsonishValue::typeToString(elementValue->getType());
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processRequires(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processRequires(MaterialBuilder& builder, const JsonishValue& value) {
     using Attribute = filament::VertexAttribute;
-    static const std::unordered_map<std::string, Attribute> strToEnum {
+    static const std::unordered_map<std::string_view, Attribute> strToEnum {
         { "color", Attribute::COLOR },
         { "position", Attribute::POSITION },
         { "tangents", Attribute::TANGENTS },
@@ -761,7 +758,7 @@ static utils::Status processRequires(MaterialBuilder& builder, const JsonishValu
     };
     for (auto v : value.toJsonArray()->getElements()) {
         if (v->getType() != JsonishValue::Type::STRING) {
-            return utils::Status::invalidArgument("requires: entries must be STRINGs.");
+            return Status::invalidArgument("requires: entries must be STRINGs.");
         }
 
         auto jsonString = v->toJsonString();
@@ -772,11 +769,11 @@ static utils::Status processRequires(MaterialBuilder& builder, const JsonishValu
         builder.require(stringToEnum(strToEnum, jsonString->getString()));
     }
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processBlending(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::BlendingMode> strToEnum {
+static Status processBlending(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::BlendingMode> strToEnum {
         { "add", MaterialBuilder::BlendingMode::ADD },
         { "masked", MaterialBuilder::BlendingMode::MASKED },
         { "opaque", MaterialBuilder::BlendingMode::OPAQUE },
@@ -792,11 +789,11 @@ static utils::Status processBlending(MaterialBuilder& builder, const JsonishValu
     }
 
     builder.blending(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processBlendFunction(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::BlendFunction> strToEnum{
+static Status processBlendFunction(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::BlendFunction> strToEnum{
             { "zero",             MaterialBuilder::BlendFunction::ZERO },
             { "one",              MaterialBuilder::BlendFunction::ONE },
             { "srcColor",         MaterialBuilder::BlendFunction::SRC_COLOR },
@@ -811,7 +808,7 @@ static utils::Status processBlendFunction(MaterialBuilder& builder, const Jsonis
     };
 
     if (value.getType() != JsonishValue::Type::OBJECT) {
-        return utils::Status::invalidArgument("blendFunction must be an OBJECT.");
+        return Status::invalidArgument("blendFunction must be an OBJECT.");
     }
 
     JsonishObject const* const jsonObject = value.toJsonObject();
@@ -828,24 +825,24 @@ static utils::Status processBlendFunction(MaterialBuilder& builder, const Jsonis
         const char* key = entry.first;
         const JsonishValue* v = jsonObject->getValue(key);
         if (!v) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "blendFunction: entry without '" << key << "' key.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
         if (v->getType() != JsonishValue::STRING) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "blendFunction: '" << key << "' value must be STRING.";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
         *entry.second = stringToEnum(strToEnum, v->toJsonString()->getString());
     }
     builder.customBlendFunctions(srcRGB, srcA, dstRGB, dstA);
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processPostLightingBlending(
+static Status processPostLightingBlending(
         MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::BlendingMode> strToEnum {
+    static const std::unordered_map<std::string_view, MaterialBuilder::BlendingMode> strToEnum {
         { "add", MaterialBuilder::BlendingMode::ADD },
         { "opaque", MaterialBuilder::BlendingMode::OPAQUE },
         { "transparent", MaterialBuilder::BlendingMode::TRANSPARENT },
@@ -858,11 +855,11 @@ static utils::Status processPostLightingBlending(
     }
 
     builder.postLightingBlending(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processVertexDomain(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::VertexDomain> strToEnum {
+static Status processVertexDomain(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::VertexDomain> strToEnum {
         { "device", MaterialBuilder::VertexDomain::DEVICE},
         { "object", MaterialBuilder::VertexDomain::OBJECT},
         { "world", MaterialBuilder::VertexDomain::WORLD},
@@ -874,11 +871,11 @@ static utils::Status processVertexDomain(MaterialBuilder& builder, const Jsonish
     }
 
     builder.vertexDomain(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processCulling(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::CullingMode> strToEnum {
+static Status processCulling(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::CullingMode> strToEnum {
         { "back", MaterialBuilder::CullingMode::BACK },
         { "front", MaterialBuilder::CullingMode::FRONT },
         { "frontAndBack", MaterialBuilder::CullingMode::FRONT_AND_BACK },
@@ -890,11 +887,11 @@ static utils::Status processCulling(MaterialBuilder& builder, const JsonishValue
     }
 
     builder.culling(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processQuality(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::ShaderQuality> strToEnum {
+static Status processQuality(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::ShaderQuality> strToEnum {
         { "low", MaterialBuilder::ShaderQuality::LOW },
         { "normal", MaterialBuilder::ShaderQuality::NORMAL },
         { "high", MaterialBuilder::ShaderQuality::HIGH },
@@ -906,10 +903,10 @@ static utils::Status processQuality(MaterialBuilder& builder, const JsonishValue
     }
 
     builder.quality(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processFeatureLevel(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processFeatureLevel(MaterialBuilder& builder, const JsonishValue& value) {
     using filament::backend::FeatureLevel;
     JsonishNumber const* const number = value.toJsonNumber();
     FeatureLevel featureLevel;
@@ -922,15 +919,15 @@ static utils::Status processFeatureLevel(MaterialBuilder& builder, const Jsonish
     } else if (number->getFloat() == 3.0f) {
         featureLevel = FeatureLevel::FEATURE_LEVEL_3;
     } else {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "featureLevel: invalid value " << number->getFloat();
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
     builder.featureLevel(featureLevel);
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processGroupSizes(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processGroupSizes(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
 
     filament::math::uint3 groupSize{ 1, 1, 1 };
@@ -938,7 +935,7 @@ static utils::Status processGroupSizes(MaterialBuilder& builder, const JsonishVa
 
     for (auto value : jsonArray->getElements()) {
         if (index >= 3) {
-            return utils::Status::invalidArgument("groupSize: must be an array no larger than 3");
+            return Status::invalidArgument("groupSize: must be an array no larger than 3");
         }
         if (value->getType() == JsonishValue::Type::NUMBER) {
             JsonishNumber const* const number = value->toJsonNumber();
@@ -946,21 +943,21 @@ static utils::Status processGroupSizes(MaterialBuilder& builder, const JsonishVa
             if (aFloat > 0 && floor(aFloat) == aFloat) {
                 groupSize[index] = uint32_t(floor(aFloat));
             } else {
-                utils::io::sstream errorMessage;
+                io::sstream errorMessage;
                 errorMessage<< "groupSize: invalid value " << aFloat;
-                return utils::Status::invalidArgument(errorMessage.c_str());
+                return Status::invalidArgument(errorMessage.c_str());
             }
             index++;
             continue;
         }
-        return utils::Status::invalidArgument("groupSize must be an array of NUMBERs.");
+        return Status::invalidArgument("groupSize must be an array of NUMBERs.");
     }
     builder.groupSize(groupSize);
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processStereoscopicType(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::StereoscopicType> strToEnum{
+static Status processStereoscopicType(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::StereoscopicType> strToEnum{
             { "instanced", MaterialBuilder::StereoscopicType::INSTANCED },
             { "multiview",  MaterialBuilder::StereoscopicType::MULTIVIEW },
     };
@@ -970,24 +967,24 @@ static utils::Status processStereoscopicType(MaterialBuilder& builder, const Jso
     }
 
     builder.stereoscopicType(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processOutput(
+static Status processOutput(
         MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {
 
     const JsonishValue* nameValue = jsonObject.getValue("name");
     if (!nameValue) {
-        return utils::Status::invalidArgument("outputs: entry without 'name' key.");
+        return Status::invalidArgument("outputs: entry without 'name' key.");
     }
     if (nameValue->getType() != JsonishValue::STRING) {
-        return utils::Status::invalidArgument("outputs: name value must be STRING.");
+        return Status::invalidArgument("outputs: name value must be STRING.");
     }
 
     const JsonishValue* targetValue = jsonObject.getValue("target");
     if (targetValue) {
         if (targetValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("outputs: target must be a STRING.");
+            return Status::invalidArgument("outputs: target must be a STRING.");
         }
 
         auto targetString = targetValue->toJsonString();
@@ -999,7 +996,7 @@ static utils::Status processOutput(
     const JsonishValue* precisionValue = jsonObject.getValue("precision");
     if (precisionValue) {
         if (precisionValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("parameters: precision must be a STRING.");
+            return Status::invalidArgument("parameters: precision must be a STRING.");
         }
 
         auto precisionString = precisionValue->toJsonString();
@@ -1011,7 +1008,7 @@ static utils::Status processOutput(
     const JsonishValue* typeValue = jsonObject.getValue("type");
     if (typeValue) {
         if (typeValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("outputs: type must be a STRING.");
+            return Status::invalidArgument("outputs: type must be a STRING.");
         }
 
         auto typeString = typeValue->toJsonString();
@@ -1023,7 +1020,7 @@ static utils::Status processOutput(
     const JsonishValue* qualifierValue = jsonObject.getValue("qualifier");
     if (qualifierValue) {
         if (qualifierValue->getType() != JsonishValue::STRING) {
-            return utils::Status::invalidArgument("outputs: qualifier must be a STRING.");
+            return Status::invalidArgument("outputs: qualifier must be a STRING.");
         }
 
         auto qualifierString = qualifierValue->toJsonString();
@@ -1035,7 +1032,7 @@ static utils::Status processOutput(
     const JsonishValue* locationValue = jsonObject.getValue("location");
     if (locationValue) {
         if (locationValue->getType() != JsonishValue::NUMBER) {
-            return utils::Status::invalidArgument("outputs: location must be a NUMBER.");
+            return Status::invalidArgument("outputs: location must be a NUMBER.");
         }
     }
 
@@ -1072,53 +1069,53 @@ static utils::Status processOutput(
 
     builder.output(qualifier, target, precision, type, name, location);
 
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processOutputs(MaterialBuilder& builder, const JsonishValue& v) {
+static Status processOutputs(MaterialBuilder& builder, const JsonishValue& v) {
     auto jsonArray = v.toJsonArray();
 
-    utils::Status status;
+    Status status;
     for (auto value : jsonArray->getElements()) {
         if (value->getType() == JsonishValue::Type::OBJECT) {
-            utils::Status s = processOutput(builder, *value->toJsonObject());
+            Status s = processOutput(builder, *value->toJsonObject());
             if (!s.isOk()) {
                 status = s;
             }
             continue;
         }
-        return utils::Status::invalidArgument("outputs must be an array of OBJECTs.");
+        return Status::invalidArgument("outputs must be an array of OBJECTs.");
     }
     return status;
 }
 
-static utils::Status processColorWrite(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processColorWrite(MaterialBuilder& builder, const JsonishValue& value) {
     builder.colorWrite(value.toJsonBool()->getBool());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processDepthWrite(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processDepthWrite(MaterialBuilder& builder, const JsonishValue& value) {
     builder.depthWrite(value.toJsonBool()->getBool());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processInstanced(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processInstanced(MaterialBuilder& builder, const JsonishValue& value) {
     builder.instanced(value.toJsonBool()->getBool());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processDepthCull(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processDepthCull(MaterialBuilder& builder, const JsonishValue& value) {
     builder.depthCulling(value.toJsonBool()->getBool());
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processDoubleSided(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processDoubleSided(MaterialBuilder& builder, const JsonishValue& value) {
     builder.doubleSided(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processTransparencyMode(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::TransparencyMode> strToEnum {
+static Status processTransparencyMode(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::TransparencyMode> strToEnum {
         { "default", MaterialBuilder::TransparencyMode::DEFAULT },
         { "twoPassesOneSide", MaterialBuilder::TransparencyMode::TWO_PASSES_ONE_SIDE },
         { "twoPassesTwoSides", MaterialBuilder::TransparencyMode::TWO_PASSES_TWO_SIDES },
@@ -1129,95 +1126,95 @@ static utils::Status processTransparencyMode(MaterialBuilder& builder, const Jso
     }
 
     builder.transparencyMode(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processMaskThreshold(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processMaskThreshold(MaterialBuilder& builder, const JsonishValue& value) {
     builder.maskThreshold(value.toJsonNumber()->getFloat());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processAlphaToCoverage(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processAlphaToCoverage(MaterialBuilder& builder, const JsonishValue& value) {
     builder.alphaToCoverage(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processShadowMultiplier(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processShadowMultiplier(MaterialBuilder& builder, const JsonishValue& value) {
     builder.shadowMultiplier(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processTransparentShadow(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processTransparentShadow(MaterialBuilder& builder, const JsonishValue& value) {
     builder.transparentShadow(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processSpecularAntiAliasing(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processSpecularAntiAliasing(MaterialBuilder& builder, const JsonishValue& value) {
     builder.specularAntiAliasing(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processSpecularAntiAliasingVariance(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processSpecularAntiAliasingVariance(MaterialBuilder& builder, const JsonishValue& value) {
     builder.specularAntiAliasingVariance(value.toJsonNumber()->getFloat());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processSpecularAntiAliasingThreshold(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processSpecularAntiAliasingThreshold(MaterialBuilder& builder, const JsonishValue& value) {
     builder.specularAntiAliasingThreshold(value.toJsonNumber()->getFloat());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processClearCoatIorChange(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processClearCoatIorChange(MaterialBuilder& builder, const JsonishValue& value) {
     builder.clearCoatIorChange(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processFlipUV(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processFlipUV(MaterialBuilder& builder, const JsonishValue& value) {
     builder.flipUV(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processLinearFog(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processLinearFog(MaterialBuilder& builder, const JsonishValue& value) {
     builder.linearFog(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processShadowFarAttenuation(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processShadowFarAttenuation(MaterialBuilder& builder, const JsonishValue& value) {
     builder.shadowFarAttenuation(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processMultiBounceAO(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processMultiBounceAO(MaterialBuilder& builder, const JsonishValue& value) {
     builder.multiBounceAmbientOcclusion(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processFramebufferFetch(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processFramebufferFetch(MaterialBuilder& builder, const JsonishValue& value) {
     if (value.toJsonBool()->getBool()) {
         builder.enableFramebufferFetch();
     }
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processVertexDomainDeviceJittered(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processVertexDomainDeviceJittered(MaterialBuilder& builder, const JsonishValue& value) {
     builder.vertexDomainDeviceJittered(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processLegacyMorphing(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processLegacyMorphing(MaterialBuilder& builder, const JsonishValue& value) {
     if (value.toJsonBool()->getBool()) {
         builder.useLegacyMorphing();
     }
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processCustomSurfaceShading(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processCustomSurfaceShading(MaterialBuilder& builder, const JsonishValue& value) {
     builder.customSurfaceShading(value.toJsonBool()->getBool());
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processSpecularAmbientOcclusion(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::SpecularAmbientOcclusion> strToEnum {
+static Status processSpecularAmbientOcclusion(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::SpecularAmbientOcclusion> strToEnum {
             { "none",        MaterialBuilder::SpecularAmbientOcclusion::NONE },
             { "simple",      MaterialBuilder::SpecularAmbientOcclusion::SIMPLE },
             { "bentNormals", MaterialBuilder::SpecularAmbientOcclusion::BENT_NORMALS },
@@ -1231,11 +1228,11 @@ static utils::Status processSpecularAmbientOcclusion(MaterialBuilder& builder, c
     }
 
     builder.specularAmbientOcclusion(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processShading(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::Shading> strToEnum {
+static Status processShading(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::Shading> strToEnum {
         { "cloth",              MaterialBuilder::Shading::CLOTH },
         { "lit",                MaterialBuilder::Shading::LIT },
         { "subsurface",         MaterialBuilder::Shading::SUBSURFACE },
@@ -1248,11 +1245,11 @@ static utils::Status processShading(MaterialBuilder& builder, const JsonishValue
     }
 
     builder.shading(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processDomain(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::MaterialDomain> strToEnum {
+static Status processDomain(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::MaterialDomain> strToEnum {
         { "surface",            MaterialBuilder::MaterialDomain::SURFACE },
         { "postprocess",        MaterialBuilder::MaterialDomain::POST_PROCESS },
         { "compute",            MaterialBuilder::MaterialDomain::COMPUTE },
@@ -1263,11 +1260,11 @@ static utils::Status processDomain(MaterialBuilder& builder, const JsonishValue&
     }
 
     builder.materialDomain(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processRefractionMode(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::RefractionMode> strToEnum{
+static Status processRefractionMode(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::RefractionMode> strToEnum{
             { "none",        MaterialBuilder::RefractionMode::NONE },
             { "cubemap",     MaterialBuilder::RefractionMode::CUBEMAP },
             { "screenspace", MaterialBuilder::RefractionMode::SCREEN_SPACE },
@@ -1278,11 +1275,11 @@ static utils::Status processRefractionMode(MaterialBuilder& builder, const Jsoni
     }
 
     builder.refractionMode(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processReflectionMode(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::ReflectionMode> strToEnum {
+static Status processReflectionMode(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::ReflectionMode> strToEnum {
             { "default", MaterialBuilder::ReflectionMode ::DEFAULT },
             { "screenspace", MaterialBuilder::ReflectionMode::SCREEN_SPACE },
     };
@@ -1292,11 +1289,11 @@ static utils::Status processReflectionMode(MaterialBuilder& builder, const Jsoni
     }
 
     builder.reflectionMode(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processRefractionType(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, MaterialBuilder::RefractionType> strToEnum {
+static Status processRefractionType(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string_view, MaterialBuilder::RefractionType> strToEnum {
             { "solid", MaterialBuilder::RefractionType::SOLID },
             { "thin",  MaterialBuilder::RefractionType::THIN },
     };
@@ -1306,15 +1303,15 @@ static utils::Status processRefractionType(MaterialBuilder& builder, const Jsoni
     }
 
     builder.refractionType(stringToEnum(strToEnum, jsonString->getString()));
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-static utils::Status processVariantFilter(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processVariantFilter(MaterialBuilder& builder, const JsonishValue& value) {
     // We avoid using an initializer list for this particular map to avoid build errors that are
     // due to static initialization ordering.
     using filament::Variant;
-    static const std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum  = [] {
-        std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum;
+    static const std::unordered_map<std::string_view, filament::UserVariantFilterBit> strToEnum  = [] {
+        std::unordered_map<std::string_view, filament::UserVariantFilterBit> strToEnum;
         strToEnum["directionalLighting"]    = filament::UserVariantFilterBit::DIRECTIONAL_LIGHTING;
         strToEnum["dynamicLighting"]        = filament::UserVariantFilterBit::DYNAMIC_LIGHTING;
         strToEnum["shadowReceiver"]         = filament::UserVariantFilterBit::SHADOW_RECEIVER;
@@ -1333,32 +1330,32 @@ static utils::Status processVariantFilter(MaterialBuilder& builder, const Jsonis
     for (size_t i = 0; i < elements.size(); i++) {
         auto elementValue = elements[i];
         if (elementValue->getType() != JsonishValue::Type::STRING) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "variant_filter: array index " << i <<
                       " is not a STRING. found:" <<
                       JsonishValue::typeToString(elementValue->getType());
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         const std::string& s = elementValue->toJsonString()->getString();
         if (!isStringValidEnum(strToEnum, s)) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "variant_filter: variant " << s << " is not a valid variant";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         variantFilter |= (uint32_t)strToEnum.at(s);
     }
 
     builder.variantFilter(variantFilter);
-    return utils::Status::ok();
+    return Status::ok();
 }
 
-static utils::Status processUseDefaultDepthVariant(MaterialBuilder& builder, const JsonishValue& value) {
+static Status processUseDefaultDepthVariant(MaterialBuilder& builder, const JsonishValue& value) {
     if (value.toJsonBool()->getBool()) {
         builder.useDefaultDepthVariant();
     }
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
 ParametersProcessor::ParametersProcessor() {
@@ -1414,7 +1411,7 @@ ParametersProcessor::ParametersProcessor() {
     mParameters["apiLevel"]                      = { &processApiLevel, Type::NUMBER };
 }
 
-utils::Status ParametersProcessor::process(MaterialBuilder& builder, const JsonishObject& jsonObject) {
+Status ParametersProcessor::process(MaterialBuilder& builder, const JsonishObject& jsonObject) {
     for(const auto& entry : jsonObject.getEntries()) {
         const std::string& key = entry.first;
         const JsonishValue* field = entry.second;
@@ -1425,36 +1422,36 @@ utils::Status ParametersProcessor::process(MaterialBuilder& builder, const Jsoni
 
         // Verify type is what was expected.
         if (mParameters.at(key).rootAssert != field->getType()) {
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "Value for key:\"" << key << "\" is not what was expected."
-                         << utils::io::endl;
+                         << io::endl;
             errorMessage << "Got :\"" << JsonishValue::typeToString(field->getType())
                          << "\" but expected '"
                    << JsonishValue::typeToString(mParameters.at(key).rootAssert) << "'";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
         }
 
         auto fPointer = mParameters[key].callback;
-        if (utils::Status status = fPointer(builder, *field); !status.isOk()) {
+        if (Status status = fPointer(builder, *field); !status.isOk()) {
             std::cerr << "Error while processing material json, key:\"" << key << "\"" << std::endl;
             return status;
         }
     }
-    return utils::Status::ok();;
+    return Status::ok();;
 }
 
-utils::Status ParametersProcessor::process(filamat::MaterialBuilder& builder, const std::string& key, const std::string& value) {
+Status ParametersProcessor::process(MaterialBuilder& builder, const std::string& key, const std::string& value) {
     if (mParameters.find(key) == mParameters.end()) {
-        utils::io::sstream errorMessage;
+        io::sstream errorMessage;
         errorMessage << "Ignoring config entry (unknown key): \"" << key << "\"";
-        return utils::Status::invalidArgument(errorMessage.c_str());
+        return Status::invalidArgument(errorMessage.c_str());
     }
 
     std::unique_ptr<JsonishValue> var;
     switch (mParameters.at(key).rootAssert) {
         case JsonishValue::Type::BOOL: {
             std::string lower;
-            std::transform(value.begin(), value.end(), std::back_inserter(lower), ::tolower);
+            std::transform(value.begin(), value.end(), std::back_inserter(lower), tolower);
             if (lower.empty() || lower == "false" || lower == "f" || lower == "0") {
                 var = std::make_unique<JsonishBool>(false);
             }
@@ -1470,18 +1467,18 @@ utils::Status ParametersProcessor::process(filamat::MaterialBuilder& builder, co
             var = std::make_unique<JsonishString>(value);
             break;
         default:
-            utils::io::sstream errorMessage;
+            io::sstream errorMessage;
             errorMessage << "Unsupported type: \""
                       << JsonishValue::typeToString(mParameters.at(key).rootAssert) << "\"";
-            return utils::Status::invalidArgument(errorMessage.c_str());
+            return Status::invalidArgument(errorMessage.c_str());
     }
 
     auto fPointer = mParameters[key].callback;
-    if (utils::Status status = fPointer(builder, *var); !status.isOk()) {
+    if (Status status = fPointer(builder, *var); !status.isOk()) {
         std::cerr << "Error while processing material param, key:\"" << key << "\"" << std::endl;
         return status;
     }
-    return utils::Status::ok();
+    return Status::ok();
 }
 
 } // namespace matp

--- a/libs/utils/include/utils/Panic.h
+++ b/libs/utils/include/utils/Panic.h
@@ -28,9 +28,9 @@
 
 #include <utils/CallStack.h>
 #include <utils/compiler.h>
+#include <utils/CString.h>
 #include <utils/sstream.h>
 
-#include <string>
 #include <string_view>
 
 #ifdef __EXCEPTIONS
@@ -394,14 +394,14 @@ public:
      * @param file the file where the above function in implemented
      * @param line the line in the above file where the error was detected
      * @param literal a literal version of the error message
-     * @param reason std::string describing the error
+     * @param reason CString describing the error
      * @see ASSERT_PRECONDITION, ASSERT_POSTCONDITION, ASSERT_ARITHMETIC
      * @see PANIC_PRECONDITION, PANIC_POSTCONDITION, PANIC_ARITHMETIC
      * @see setMode()
      */
     static void panic(
             char const* function, char const* file, int line, char const* literal,
-            std::string reason) UTILS_NORETURN;
+            CString reason) UTILS_NORETURN;
 
 private:
     /**
@@ -413,7 +413,7 @@ private:
      * @param reason a description of the cause of the error
      */
     TPanic(char const* function, char const* file, int line, char const* literal,
-            std::string reason);
+            CString reason);
 
     friend class PreconditionPanic;
     friend class PostconditionPanic;
@@ -426,9 +426,9 @@ private:
     char const* const mFile = nullptr;      // file where the panic happened
     char const* const mFunction = nullptr;  // function where the panic happened
     int const mLine = -1;                   // line where the panic happened
-    std::string mLiteral;                   // reason for the panic, built only from literals
-    std::string mReason;                    // reason for the panic
-    mutable std::string mWhat;              // fully formatted reason
+    CString mLiteral;                       // reason for the panic, built only from literals
+    CString mReason;                        // reason for the panic
+    mutable CString mWhat;                  // fully formatted reason
     CallStack mCallstack;
 };
 
@@ -525,7 +525,7 @@ public:
     PanicStream& operator<<(const char* value) noexcept;
     PanicStream& operator<<(const unsigned char* value) noexcept;
 
-    PanicStream& operator<<(std::string const& value) noexcept;
+    PanicStream& operator<<(CString const& value) noexcept;
     PanicStream& operator<<(std::string_view const& value) noexcept;
 
 protected:

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -24,7 +24,11 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
+
+#include <stddef.h>
+#include <stdint.h>
 
 namespace utils::io {
 
@@ -62,7 +66,6 @@ public:
     ostream& operator<<(const char* string) noexcept;
     ostream& operator<<(const unsigned char* string) noexcept;
 
-    ostream& operator<<(std::string const& s) noexcept;
     ostream& operator<<(std::string_view const& s) noexcept;
 
     ostream& operator<<(ostream& (* f)(ostream&)) noexcept { return f(*this); }
@@ -149,11 +152,17 @@ class ostream;
 }
 
 inline std::ostream& operator<<(std::ostream& o, bitset32 const& s) noexcept {
-    return o << (void*) uintptr_t(s.getValue());
+    return o << reinterpret_cast<void*>(uintptr_t(s.getValue()));
 }
+
 inline io::ostream& operator<<(io::ostream& o, bitset32 const& s) noexcept {
-    return o << (void*) uintptr_t(s.getValue());
+    return o << reinterpret_cast<void*>(uintptr_t(s.getValue()));
 }
+
+inline io::ostream& operator<<(io::ostream& o, std::string const& s) noexcept {
+    return o << static_cast<std::string_view>(s);
+}
+
 }// namespace utils
 
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -56,7 +56,6 @@
 #if defined(WIN32)
 #    define NOMINMAX
 #    include <windows.h>
-#    include <string>
 # else
 #    include <pthread.h>
 #endif
@@ -210,14 +209,22 @@ JobSystem::JobSystem(const size_t userThreadCount, const size_t adoptableThreads
     static_assert(std::atomic<bool>::is_always_lock_free);
     static_assert(std::atomic<uint16_t>::is_always_lock_free);
 
-    std::random_device rd;
     const size_t hardwareThreadCount = mThreadCount;
     auto& states = mThreadStates;
 
     #pragma nounroll
     for (size_t i = 0, n = states.size(); i < n; i++) {
+        // don't use std::random_device because it forces the use of std::string
+        constexpr uint32_t base_seed = 1337;
+        uint32_t seed = base_seed + static_cast<uint32_t>(i);
+        seed = (seed ^ 61) ^ (seed >> 16);
+        seed = seed + (seed << 3);
+        seed = seed ^ (seed >> 4);
+        seed = seed * 0x27d4eb2d;
+        seed = seed ^ (seed >> 15);
+
         auto& state = states[i];
-        state.rndGen = default_random_engine(rd());
+        state.rndGen = default_random_engine(seed);
         state.js = this;
         if (i < hardwareThreadCount) {
             // don't start a thread of adoptable thread slots

--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -20,6 +20,7 @@
 
 #include <utils/CallStack.h>
 #include <utils/compiler.h>
+#include <utils/CString.h>
 #include <utils/Log.h>
 #include <utils/Logger.h>
 #include <utils/ostream.h>
@@ -33,7 +34,6 @@
 #include <cstring>
 #include <mutex>
 #include <new>
-#include <string>
 #include <string_view>
 #include <utility>
 
@@ -79,8 +79,8 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 UTILS_NOINLINE
-static std::string sprintfToString(const char* format, va_list args) noexcept {
-    std::string s;
+static CString sprintfToString(const char* format, va_list args) noexcept {
+    CString s;
     va_list tmp;
     va_copy(tmp, args);
     int n = vsnprintf(nullptr, 0, format, tmp);
@@ -91,22 +91,22 @@ static std::string sprintfToString(const char* format, va_list args) noexcept {
         char* const buf = new(std::nothrow) char[n];
         if (buf) {
             vsnprintf(buf, size_t(n), format, args);
-            s.assign(buf);
+            s = CString(buf);
             delete [] buf;
         }
     }
     return s;
 }
 
-static std::string sprintfToString(const char* format, ...) noexcept {
+static CString sprintfToString(const char* format, ...) noexcept {
     va_list args;
     va_start(args, format);
-    std::string const s{ sprintfToString(format, args) };
+    CString const s{ sprintfToString(format, args) };
     va_end(args);
     return s;
 }
 
-static std::string buildPanicString(
+static CString buildPanicString(
         std::string_view const& msg, const char* function, int line,
         const char* file, const char* reason) {
 #ifndef NDEBUG
@@ -130,7 +130,7 @@ void Panic::setPanicHandler(PanicHandlerCallback const handler, void* user) noex
 
 template<typename T>
 TPanic<T>::TPanic(const char* function, const char* file, int const line, char const* literal,
-        std::string reason)
+        CString reason)
         : mFile(file),
           mFunction(function),
           mLine(line),
@@ -200,7 +200,7 @@ void TPanic<T>::panic(char const* function, char const* file, int const line, ch
         const char* format, ...) {
     va_list args;
     va_start(args, format);
-    std::string reason{ sprintfToString(format, args) };
+    CString reason{ sprintfToString(format, args) };
     va_end(args);
 
     panic(function, file, line, literal, std::move(reason));
@@ -208,10 +208,10 @@ void TPanic<T>::panic(char const* function, char const* file, int const line, ch
 
 template<typename T>
 void TPanic<T>::panic(char const* function, char const* file, int line, char const* literal,
-        std::string reason) {
+        CString reason) {
 
     if (reason.empty()) {
-        reason = literal;
+        reason = CString(literal);
     }
 
     T e(function, formatFile(file), line, literal, std::move(reason));
@@ -238,10 +238,10 @@ namespace details {
 void panicLog(char const* function, char const* file, int const line, const char* format, ...) noexcept {
     va_list args;
     va_start(args, format);
-    std::string const reason{ sprintfToString(format, args) };
+    CString const reason{ sprintfToString(format, args) };
     va_end(args);
 
-    std::string const msg = buildPanicString("PanicLog",
+    CString const msg = buildPanicString("PanicLog",
             function, line, file, reason.c_str());
 
     slog.e << msg << io::endl;
@@ -343,7 +343,7 @@ PanicStream& PanicStream::operator<<(unsigned char const* value) noexcept {
     return *this;
 }
 
-PanicStream& PanicStream::operator<<(std::string const& value) noexcept {
+PanicStream& PanicStream::operator<<(CString const& value) noexcept {
     mStream << value;
     return *this;
 }

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <mutex>
-#include <string>
 #include <string_view>
 #include <utility>
 
@@ -204,10 +203,6 @@ ostream& ostream::operator<<(const unsigned char* string) noexcept {
 
 ostream& ostream::operator<<(const void* value) noexcept {
     return print("%p", value);
-}
-
-ostream& ostream::operator<<(std::string const& s) noexcept {
-    return print("%s", s.c_str());
 }
 
 ostream& ostream::operator<<(std::string_view const& s) noexcept {


### PR DESCRIPTION
libfilament (including libutils and libmath) are 100% std::string free.

std::string is pulled in the .so (on android) through libc++ for  exception handling, even if we're not using them. There is not much we can do here, but at least, it's not because of us!

utils::ostream still references it but only as an inline function, so if the inline is not called, std::string won't be pulled in.

It's also referenced from Path.cpp, but that's not included in libfilament.