### PR TITLE
Relocate the read-only property to OpenGLContext

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -222,6 +222,22 @@ OpenGLContext::OpenGLContext(OpenGLPlatform& platform,
 #endif
 #endif
 
+#if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
+    if (ext.EXT_disjoint_timer_query) {
+        // timer queries are available
+        if (bugs.dont_use_timer_query && platform.canCreateFence()) {
+            mGpuTimerType = TimerQueryFactory::Type::Fence;
+        } else {
+            mGpuTimerType = TimerQueryFactory::Type::Native;
+        }
+    } else
+#endif
+    if (platform.canCreateFence()) {
+        mGpuTimerType = TimerQueryFactory::Type::Fence;
+    } else {
+        mGpuTimerType = TimerQueryFactory::Type::Fallback;
+    }
+
     // in practice KHR_Debug has never been useful, and actually is confusing. We keep this
     // only for our own debugging, in case we need it some day.
 #if false && !defined(NDEBUG) && defined(GL_KHR_debug)

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -159,6 +159,12 @@ public:
 
     ShaderModel getShaderModel() const noexcept { return mShaderModel; }
 
+    TimerQueryFactory::Type getGpuTimerType() const noexcept { return mGpuTimerType; }
+
+    bool isGpuTimeSupported() const noexcept {
+        return getGpuTimerType() != TimerQueryFactory::Type::Fallback;
+    }
+
     void resetState() noexcept;
 
     inline void useProgram(GLuint program) noexcept;
@@ -541,6 +547,8 @@ private:
             SamplerParams::Hasher, SamplerParams::EqualTo> mSamplerMap;
 
     Platform::DriverConfig const mDriverConfig;
+
+    TimerQueryFactory::Type mGpuTimerType{ TimerQueryFactory::Type::Fallback };
 
     void bindFramebufferResolved(GLenum target, GLuint buffer) noexcept;
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2859,7 +2859,7 @@ bool OpenGLDriver::isFrameBufferFetchMultiSampleSupported() {
 }
 
 bool OpenGLDriver::isFrameTimeSupported() {
-    return TimerQueryFactory::isGpuTimeSupported();
+    return mContext.isGpuTimeSupported();
 }
 
 bool OpenGLDriver::isAutoDepthResolveSupported() {

--- a/filament/backend/src/opengl/OpenGLTimerQuery.cpp
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.cpp
@@ -48,34 +48,25 @@ class OpenGLDriver;
 
 // ------------------------------------------------------------------------------------------------
 
-bool TimerQueryFactory::mGpuTimeSupported = false;
-
 TimerQueryFactoryInterface* TimerQueryFactory::init(
         OpenGLPlatform& platform, OpenGLContext& context) {
     (void)context;
 
     TimerQueryFactoryInterface* impl = nullptr;
 
-#if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
-    if (context.ext.EXT_disjoint_timer_query) {
-        // timer queries are available
-        if (context.bugs.dont_use_timer_query && platform.canCreateFence()) {
-            // however, they don't work well, revert to using fences if we can.
-            impl = new(std::nothrow) TimerQueryFenceFactory(platform);
-        } else {
-            impl = new(std::nothrow) TimerQueryNativeFactory(context);
+    switch (context.getGpuTimerType()) {
+        case Type::Fallback: {
+            impl = new(std::nothrow) TimerQueryFallbackFactory();
+            break;
         }
-        mGpuTimeSupported = true;
-    } else
-#endif
-    if (platform.canCreateFence()) {
-        // no timer queries, but we can use fences
-        impl = new(std::nothrow) TimerQueryFenceFactory(platform);
-        mGpuTimeSupported = true;
-    } else {
-        // no queries, no fences -- that's a problem
-        impl = new(std::nothrow) TimerQueryFallbackFactory();
-        mGpuTimeSupported = false;
+        case Type::Native: {
+            impl = new(std::nothrow) TimerQueryNativeFactory(context);
+            break;
+        }
+        case Type::Fence: {
+            impl = new(std::nothrow) TimerQueryFenceFactory(platform);
+            break;
+        }
     }
     assert_invariant(impl);
     return impl;
@@ -99,8 +90,6 @@ TimerQueryResult TimerQueryFactoryInterface::getTimerQueryValue(
 }
 
 // ------------------------------------------------------------------------------------------------
-
-#if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
 
 TimerQueryNativeFactory::TimerQueryNativeFactory(OpenGLContext& context)
         : mContext(context) {
@@ -164,8 +153,6 @@ void TimerQueryNativeFactory::endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQ
         return true;
     });
 }
-
-#endif
 
 // ------------------------------------------------------------------------------------------------
 

--- a/filament/backend/src/opengl/OpenGLTimerQuery.h
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.h
@@ -61,14 +61,15 @@ struct GLTimerQuery : public HwTimerQuery {
  */
 
 class TimerQueryFactory {
-    static bool mGpuTimeSupported;
 public:
+    enum class Type {
+        Fallback = 0,
+        Native,
+        Fence,
+    };
+
     static TimerQueryFactoryInterface* init(
             OpenGLPlatform& platform, OpenGLContext& context);
-
-    static bool isGpuTimeSupported() noexcept {
-        return mGpuTimeSupported;
-    }
 };
 
 class TimerQueryFactoryInterface {
@@ -86,8 +87,6 @@ public:
     static TimerQueryResult getTimerQueryValue(GLTimerQuery* tq, uint64_t* elapsedTime) noexcept;
 };
 
-#if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
-
 class TimerQueryNativeFactory final : public TimerQueryFactoryInterface {
 public:
     explicit TimerQueryNativeFactory(OpenGLContext& context);
@@ -99,8 +98,6 @@ private:
     void endTimeElapsedQuery(OpenGLDriver& driver, GLTimerQuery* query) override;
     OpenGLContext& mContext;
 };
-
-#endif
 
 class TimerQueryFenceFactory final : public TimerQueryFactoryInterface {
 public:


### PR DESCRIPTION
This is a preparatory cleanup step to resolve a TSan warning ahead of a planned refactor of the OpenGLContext class.

BUGS=[491522442]