### PR TITLE
Fix memory safety vulnerabilities in filaflat parsing components

### DIFF
--- a/libs/filaflat/CMakeLists.txt
+++ b/libs/filaflat/CMakeLists.txt
@@ -36,3 +36,18 @@ endif()
 # We do not need filaflat headers in the install directory
 # install(DIRECTORY ${PUBLIC_HDR_DIR}/filaflat DESTINATION include)
 install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
+
+# ==================================================================================================
+# Tests
+# ==================================================================================================
+if (FILAMENT_BUILD_TESTING AND IS_HOST_PLATFORM)
+    project(test_filaflat)
+    set(TARGET test_filaflat)
+    set(SRCS
+            tests/test_filaflat.cpp)
+
+    add_executable(${TARGET} ${SRCS})
+    target_include_directories(${TARGET} PRIVATE src)
+    target_link_libraries(${TARGET} filaflat gtest)
+    set_target_properties(${TARGET} PROPERTIES FOLDER Tests)
+endif()

--- a/libs/filaflat/include/filaflat/Unflattener.h
+++ b/libs/filaflat/include/filaflat/Unflattener.h
@@ -49,14 +49,20 @@ public:
         return mCursor < mEnd;
     }
 
-    bool willOverflow(size_t size) const noexcept {
-        return (mCursor + size) > mEnd;
+    bool willOverflow(size_t const size) const noexcept {
+        // Evaluate the remaining valid buffer size instead of using pointer arithmetic,
+        // preventing arbitrary integer size overflows from pointer wrapping.
+        return size > size_t(mEnd - mCursor);
     }
 
     void skipAlignmentPadding() {
         const uint8_t padSize = (8 - (intptr_t(mCursor) % 8)) % 8;
-        mCursor += padSize;
-        assert_invariant(0 == (intptr_t(mCursor) % 8));
+        if (UTILS_UNLIKELY(willOverflow(padSize))) {
+            mCursor = mEnd;
+        } else {
+            mCursor += padSize;
+            assert_invariant(0 == (intptr_t(mCursor) % 8));
+        }
     }
 
     template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>

--- a/libs/filaflat/src/ChunkContainer.cpp
+++ b/libs/filaflat/src/ChunkContainer.cpp
@@ -15,20 +15,25 @@
  */
 
 #include <filaflat/ChunkContainer.h>
-
 #include <filaflat/Unflattener.h>
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+
+#include <cstddef>
+#include <cstdint>
 
 namespace filaflat {
 
 ChunkContainer::~ChunkContainer() noexcept = default;
 
-bool ChunkContainer::hasChunk(Type type) const noexcept {
+bool ChunkContainer::hasChunk(Type const type) const noexcept {
     auto const& chunks = mChunks;
     auto pos = chunks.find(type);
     return pos != chunks.end();
 }
 
-bool ChunkContainer::hasChunk(Type type, ChunkDesc* pChunkDesc) const noexcept {
+bool ChunkContainer::hasChunk(Type const type, ChunkDesc* pChunkDesc) const noexcept {
     assert_invariant(pChunkDesc);
     auto const& chunks = mChunks;
     auto pos = chunks.find(type);
@@ -53,8 +58,11 @@ bool ChunkContainer::parseChunk(Unflattener& unflattener) {
     // If size goes beyond the boundaries of the package, this is an invalid chunk. Discard it.
     // All remaining chunks cannot be accessed and will not be mapped.
     auto cursor = unflattener.getCursor();
-    if (!(cursor + size >= (uint8_t *)mData &&
-          cursor + size <= (uint8_t *)mData + mSize)) {
+    const uint8_t* start = static_cast<const uint8_t*>(mData);
+    const uint8_t* end = start + mSize;
+
+    // Secure boundary check bypassing hardware pointer-overflow undefined behavior 
+    if (size > size_t(end - cursor)) {
         return false;
     }
 

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -17,27 +17,38 @@
 #include <filaflat/MaterialChunk.h>
 #include <filaflat/ChunkContainer.h>
 
+#include <filament/MaterialChunkType.h>
+
+#include <private/filament/Variant.h>
+
 #include <backend/DriverEnums.h>
 
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Invocable.h>
 #include <utils/Log.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 namespace filaflat {
 
-static inline uint32_t makeKey(
+static uint32_t makeKey(
         MaterialChunk::ShaderModel shaderModel,
-        MaterialChunk::Variant variant,
+        MaterialChunk::Variant const variant,
         MaterialChunk::ShaderStage stage) noexcept {
     static_assert(sizeof(variant.key) * 8 <= 8);
     return (uint32_t(shaderModel) << 16) | (uint32_t(stage) << 8) | variant.key;
 }
 
-void MaterialChunk::decodeKey(uint32_t key,
-        MaterialChunk::ShaderModel* model,
-        MaterialChunk::Variant* variant,
-        MaterialChunk::ShaderStage* stage) {
-    variant->key = key & 0xff;
-    *model = MaterialChunk::ShaderModel((key >> 16) & 0xff);
-    *stage = MaterialChunk::ShaderStage((key >> 8) & 0xff);
+void MaterialChunk::decodeKey(uint32_t const key,
+        ShaderModel* outModel,
+        Variant* outVariant,
+        ShaderStage* outStage) {
+    outVariant->key = key & 0xff;
+    *outModel = ShaderModel((key >> 16) & 0xff);
+    *outStage = ShaderStage((key >> 8) & 0xff);
 }
 
 MaterialChunk::MaterialChunk(ChunkContainer const& container)
@@ -46,7 +57,7 @@ MaterialChunk::MaterialChunk(ChunkContainer const& container)
 
 MaterialChunk::~MaterialChunk() noexcept = default;
 
-bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
+bool MaterialChunk::initialize(filamat::ChunkType const materialTag) {
 
     if (mBase != nullptr) {
         // initialize() should be called only once.
@@ -93,7 +104,7 @@ bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
             return false;
         }
 
-        uint32_t key = makeKey(ShaderModel(model), variant, ShaderStage(stage));
+        uint32_t const key = makeKey(ShaderModel(model), variant, ShaderStage(stage));
         mOffsets[key] = offsetValue;
     }
     return true;
@@ -101,19 +112,19 @@ bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
 
 bool MaterialChunk::getTextShader(Unflattener unflattener,
         BlobDictionary const& dictionary, ShaderContent& shaderContent,
-        ShaderModel shaderModel, Variant variant, ShaderStage shaderStage) const {
+        ShaderModel const shaderModel, Variant const variant, ShaderStage const shaderStage) const {
     if (mBase == nullptr) {
         return false;
     }
 
     // Jump and read
-    uint32_t key = makeKey(shaderModel, variant, shaderStage);
-    auto pos = mOffsets.find(key);
+    uint32_t const key = makeKey(shaderModel, variant, shaderStage);
+    auto const pos = mOffsets.find(key);
     if (pos == mOffsets.end()) {
         return false;
     }
 
-    size_t offset = pos->second;
+    size_t const offset = pos->second;
     if (offset == 0) {
         // This shader was not found.
         return false;
@@ -142,7 +153,17 @@ bool MaterialChunk::getTextShader(Unflattener unflattener,
         if (!unflattener.read(&lineIndex)) {
             return false;
         }
+
+        if (UTILS_UNLIKELY(lineIndex >= dictionary.size())) {
+            return false;
+        }
+
         const auto& content = dictionary[lineIndex];
+
+        // Ensure string is correctly formed and doesn't exceed reserved shader space.
+        if (UTILS_UNLIKELY(content.size() == 0 || cursor + content.size() - 1 > shaderSize)) {
+            return false;
+        }
 
         // remove the terminating null character.
         memcpy(&shaderContent[cursor], content.data(), content.size() - 1);
@@ -157,15 +178,19 @@ bool MaterialChunk::getTextShader(Unflattener unflattener,
 }
 
 bool MaterialChunk::getBinaryShader(BlobDictionary const& dictionary,
-        ShaderContent& shaderContent, ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage) const {
+        ShaderContent& shaderContent, ShaderModel const shaderModel, filament::Variant const variant, ShaderStage const shaderStage) const {
 
     if (mBase == nullptr) {
         return false;
     }
 
-    uint32_t key = makeKey(shaderModel, variant, shaderStage);
-    auto pos = mOffsets.find(key);
+    uint32_t const key = makeKey(shaderModel, variant, shaderStage);
+    auto const pos = mOffsets.find(key);
     if (pos == mOffsets.end()) {
+        return false;
+    }
+
+    if (UTILS_UNLIKELY(pos->second >= dictionary.size())) {
         return false;
     }
 
@@ -173,16 +198,16 @@ bool MaterialChunk::getBinaryShader(BlobDictionary const& dictionary,
     return true;
 }
 
-bool MaterialChunk::hasShader(ShaderModel model, Variant variant, ShaderStage stage) const noexcept {
+bool MaterialChunk::hasShader(ShaderModel const model, Variant const variant, ShaderStage const stage) const noexcept {
     if (mBase == nullptr) {
         return false;
     }
-    auto pos = mOffsets.find(makeKey(model, variant, stage));
+    auto const pos = mOffsets.find(makeKey(model, variant, stage));
     return pos != mOffsets.end();
 }
 
 bool MaterialChunk::getShader(ShaderContent& shaderContent, BlobDictionary const& dictionary,
-        ShaderModel shaderModel, filament::Variant variant, ShaderStage stage) const {
+        ShaderModel const shaderModel, filament::Variant const variant, ShaderStage const stage) const {
     switch (mMaterialTag) {
         case filamat::ChunkType::MaterialGlsl:
         case filamat::ChunkType::MaterialEssl1:

--- a/libs/filaflat/src/Unflattener.cpp
+++ b/libs/filaflat/src/Unflattener.cpp
@@ -16,35 +16,52 @@
 
 #include <filaflat/Unflattener.h>
 
+#include <utils/compiler.h>
+#include <utils/CString.h>
+
+#include <cstddef>
+#include <cstdint>
+
 namespace filaflat {
+
+using namespace utils;
 
 bool Unflattener::read(const char** blob, size_t* size) noexcept {
     uint64_t nbytes;
     if (!read(&nbytes)) {
         return false;
     }
+
+    // Prevent integer/pointer wrap-around by verifying boundaries
+    if (willOverflow(nbytes)) {
+        return false;
+    }
+
     const uint8_t* start = mCursor;
     mCursor += nbytes;
-    bool const overflowed = mCursor > mEnd;
-    if (!overflowed) {
-        *blob = (const char*)start;
-        *size = nbytes;
-    }
-    return !overflowed;
+
+    *blob = reinterpret_cast<const char*>(start);
+    *size = nbytes;
+    
+    return true;
 }
 
-bool Unflattener::read(utils::CString* const s) noexcept {
+bool Unflattener::read(CString* const s) noexcept {
     const uint8_t* const start = mCursor;
     const uint8_t* const last = mEnd;
     const uint8_t* curr = start;
+
     while (curr < last && *curr != '\0') {
         curr++;
     }
-    bool const overflowed = start >= last;
+
+    // A securely read CString must be explicitly null-terminated inside the chunk.
+    bool const overflowed = curr == last;
     if (UTILS_LIKELY(!overflowed)) {
-        *s = utils::CString{ (const char*)start, utils::CString::size_type(curr - start) };
+        *s = CString{ reinterpret_cast<const char*>(start), CString::size_type(curr - start) };
         curr++;
     }
+
     mCursor = curr;
     return !overflowed;
 }
@@ -53,14 +70,18 @@ bool Unflattener::read(const char** const s) noexcept {
     const uint8_t* const start = mCursor;
     const uint8_t* const last = mEnd;
     const uint8_t* curr = start;
+
     while (curr < last && *curr != '\0') {
         curr++;
     }
-    bool const overflowed = start >= last;
+
+    // Explicitly reject strings that terminate abruptly at chunk boundaries without '\0'
+    bool const overflowed = curr == last;
     if (UTILS_LIKELY(!overflowed)) {
-        *s = (char const*)start;
+        *s = reinterpret_cast<char const*>(start);
         curr++;
     }
+
     mCursor = curr;
     return !overflowed;
 }

--- a/libs/filaflat/tests/test_filaflat.cpp
+++ b/libs/filaflat/tests/test_filaflat.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filaflat/ChunkContainer.h>
+#include <filaflat/DictionaryReader.h>
+#include <filaflat/MaterialChunk.h>
+#include <filaflat/Unflattener.h>
+#include <filament/MaterialChunkType.h>
+
+#include <vector>
+#include <cstdint>
+
+using namespace filaflat;
+
+class FilaflatSecurityTest : public ::testing::Test {
+protected:
+    void write64(std::vector<uint8_t>& vec, uint64_t val) {
+        for (int i = 0; i < 8; i++) vec.push_back((val >> (8 * i)) & 0xFF);
+    }
+    void write32(std::vector<uint8_t>& vec, uint32_t val) {
+        for (int i = 0; i < 4; i++) vec.push_back((val >> (8 * i)) & 0xFF);
+    }
+    void write16(std::vector<uint8_t>& vec, uint16_t val) {
+        for (int i = 0; i < 2; i++) vec.push_back((val >> (8 * i)) & 0xFF);
+    }
+};
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+// 1. OOB Read during dictionary text flat buffer parsing 
+// By definition, strlen() will read far out of bounds since we provide no null terminator.
+TEST_F(FilaflatSecurityTest, DictionaryTextOOBRead) {
+    std::vector<uint8_t> payload;
+    write32(payload, 1); // stringCount = 1
+    // Maliciously omitting the null terminator here
+    payload.push_back('v'); payload.push_back('u'); payload.push_back('l'); payload.push_back('n');
+
+    std::vector<uint8_t> fileData;
+    write64(fileData, (uint64_t)filamat::ChunkType::DictionaryText);
+    write32(fileData, payload.size());
+    fileData.insert(fileData.end(), payload.begin(), payload.end());
+
+#ifndef _WIN32
+    // To reliably trigger a crash (segfault) without ASAN when strlen tries to read OOB,
+    // we allocate exactly up to a protected page boundary.
+    size_t pageSize = getpagesize();
+    uint8_t* memory = (uint8_t*)mmap(NULL, pageSize * 2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    ASSERT_NE(memory, MAP_FAILED);
+    // Protect the second page so any read into it causes an immediate SIGSEGV.
+    mprotect(memory + pageSize, pageSize, PROT_NONE);
+
+    // Place our fileData at the very end of the first page.
+    uint8_t* exactData = memory + pageSize - fileData.size();
+    memcpy(exactData, fileData.data(), fileData.size());
+
+    ChunkContainer container(exactData, fileData.size());
+    ASSERT_TRUE(container.parse());
+
+    BlobDictionary dictionary;
+    // THIS LINE EXPLOITS THE VULNERABILITY (Will violently Segmentation Fault due to page access violation)
+    DictionaryReader::unflatten(container, filamat::ChunkType::DictionaryText, dictionary);
+    
+    munmap(memory, pageSize * 2);
+#else
+    ChunkContainer container(fileData.data(), fileData.size());
+    ASSERT_TRUE(container.parse());
+    BlobDictionary dictionary;
+    DictionaryReader::unflatten(container, filamat::ChunkType::DictionaryText, dictionary);
+#endif
+}
+
+// 2. Heap Buffer Overflow writing dictionary arrays to undersized output buffers
+TEST_F(FilaflatSecurityTest, MaterialChunkHeapOverflow) {
+    std::vector<uint8_t> payload;
+    write64(payload, 1); // numShaders
+    payload.push_back(1); // model
+    payload.push_back(0); // variant
+    payload.push_back(0); // stage
+    write32(payload, 15); // offset (8 + 1 + 1 + 1 + 4 = 15)
+    
+    // Shader content layout
+    write32(payload, 4);  // shaderSize (vulnerable tiny size)
+    write32(payload, 1);  // lineCount = 1
+    write16(payload, 0);  // lineIndex = 0
+
+    std::vector<uint8_t> fileData;
+    write64(fileData, (uint64_t)filamat::ChunkType::MaterialGlsl);
+    write32(fileData, payload.size());
+    fileData.insert(fileData.end(), payload.begin(), payload.end());
+
+    ChunkContainer container(fileData.data(), fileData.size());
+    ASSERT_TRUE(container.parse());
+
+    MaterialChunk chunk(container);
+    ASSERT_TRUE(chunk.initialize(filamat::ChunkType::MaterialGlsl));
+
+    BlobDictionary dict;
+    dict.reserve(1); // FixedCapacityVector must be explicitly reserved before push_back
+    ShaderContent content;
+    // Pre-populate dictionary with an enormous string
+    // This is vastly larger than shaderSize=4 above
+    content.reserve(1024);
+    content.resize(1024);
+    content[0] = 'H'; content[1023] = '\0';
+    dict.push_back(content);
+
+    ShaderContent output;
+    // THIS LINE EXPLOITS THE VULNERABILITY (Heap buffer overflow, memcpy overwrite)
+    // The patched `getShader` routine securely rejects it by evaluating `content.size() > shaderSize` returning false.
+    bool valid = chunk.getShader(output, dict, MaterialChunk::ShaderModel(1), filament::Variant{0}, MaterialChunk::ShaderStage(0));
+    EXPECT_FALSE(valid) << "VULNERABILITY: Heap overflow validation bypassed!";
+}
+
+// 3. Out of Bounds Read via index mapping evasion (Text mode)
+TEST_F(FilaflatSecurityTest, MaterialChunkOOBReadText) {
+    std::vector<uint8_t> payload;
+    write64(payload, 1); // numShaders
+    payload.push_back(1); // model
+    payload.push_back(0); // variant
+    payload.push_back(0); // stage
+    write32(payload, 15); // offset (8 + 1 + 1 + 1 + 4 = 15)
+    write32(payload, 100);  // shaderSize 
+    write32(payload, 1);  // lineCount = 1
+    write16(payload, 9999);  // lineIndex = 9999 (VULNERABLE ACCESS)
+
+    std::vector<uint8_t> fileData;
+    write64(fileData, (uint64_t)filamat::ChunkType::MaterialGlsl);
+    write32(fileData, payload.size());
+    fileData.insert(fileData.end(), payload.begin(), payload.end());
+
+    ChunkContainer container(fileData.data(), fileData.size());
+    ASSERT_TRUE(container.parse());
+
+    MaterialChunk chunk(container);
+    ASSERT_TRUE(chunk.initialize(filamat::ChunkType::MaterialGlsl));
+
+    BlobDictionary dict; // Empty dictionary
+    ShaderContent output;
+    // THIS LINE EXPLOITS THE VULNERABILITY (OOB Memory Access dict[9999])
+    chunk.getShader(output, dict, MaterialChunk::ShaderModel(1), filament::Variant{0}, MaterialChunk::ShaderStage(0));
+}
+
+// 4. Out of Bounds Read via index mapping evasion (Binary mode)
+TEST_F(FilaflatSecurityTest, MaterialChunkOOBReadBinary) {
+    std::vector<uint8_t> payload;
+    write64(payload, 1); // numShaders
+    payload.push_back(1); // model
+    payload.push_back(0); // variant
+    payload.push_back(0); // stage
+    
+    // For binary mode, the offset field serves as the dictionary index
+    write32(payload, 9999); // offset = 9999 (VULNERABLE ACCESS)
+
+    std::vector<uint8_t> fileData;
+    // Utilizing MaterialSpirv triggers getBinaryShader
+    write64(fileData, (uint64_t)filamat::ChunkType::MaterialSpirv);
+    write32(fileData, payload.size());
+    fileData.insert(fileData.end(), payload.begin(), payload.end());
+
+    ChunkContainer container(fileData.data(), fileData.size());
+    ASSERT_TRUE(container.parse());
+
+    MaterialChunk chunk(container);
+    ASSERT_TRUE(chunk.initialize(filamat::ChunkType::MaterialSpirv));
+
+    BlobDictionary dict; // Empty dictionary
+    ShaderContent output;
+    // THIS LINE EXPLOITS THE VULNERABILITY (OOB Memory Access dict[9999])
+    chunk.getShader(output, dict, MaterialChunk::ShaderModel(1), filament::Variant{0}, MaterialChunk::ShaderStage(0));
+}
+
+// 5. Integer overflow / Pointer wrap-around evasion 
+TEST_F(FilaflatSecurityTest, UnflattenerIntegerWrapBypass) {
+    std::vector<uint8_t> payload;
+    // An artificially huge size likely to wrap around mCursor + nbytes 
+    write64(payload, 0xFFFFFFFFFFFFFFF0); 
+
+    Unflattener unflattener(payload.data(), payload.data() + payload.size());
+    const char* blob;
+    size_t size;
+    
+    // Attempt the Out-Of-Bounds wrap read
+    bool bypassed = unflattener.read(&blob, &size);
+
+    // THIS LINE EXPLOITS THE VULNERABILITY (Will securely trigger Test Failure)
+    // A secure implementation should evaluate the impossible wrapper size and explicitly return false.
+    // The vulnerability forces it to return true, defying the integer boundaries and bypassing checks.
+    EXPECT_FALSE(bypassed) << "VULNERABILITY: Integer wrap successfully bypassed Unflattener boundaries!";
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    const int rv = RUN_ALL_TESTS();
+    if (testing::UnitTest::GetInstance()->test_to_run_count() == 0) {
+        //If you run a test filter that contains 0 tests that was likely not intentional. Fail in that scenario.
+        return 1;
+    }
+    return rv;
+}


### PR DESCRIPTION
* Fix out-of-bounds string read by verifying null-terminator existence during extraction.
* Fix heap buffer overflow by validating dictionary string lengths  against target shader buffers before copying.
* Fix out-of-bounds array reads by validating chunk-provided lookup  indices against parsed dictionary sizes.
* Fix integer wrapping exploits by replacing pointer addition with  offset subtraction during chunk size verifications.

Add unit tests for these vulerabilities.