### PR TITLE
Fix heap buffer overflow in MaterialChunk::getTextShader

### DIFF
--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -142,7 +142,18 @@ bool MaterialChunk::getTextShader(Unflattener unflattener,
         if (!unflattener.read(&lineIndex)) {
             return false;
         }
+        if (lineIndex >= dictionary.size()) {
+            return false;
+        }
         const auto& content = dictionary[lineIndex];
+        if (content.empty()) {
+            return false;
+        }
+
+        // Validate that the copy will not exceed the buffer.
+        if (cursor + content.size() - 1 > shaderSize) {
+            return false;
+        }
 
         // remove the terminating null character.
         memcpy(&shaderContent[cursor], content.data(), content.size() - 1);
@@ -150,8 +161,10 @@ bool MaterialChunk::getTextShader(Unflattener unflattener,
     }
 
     // Write the terminating null character.
+    if (cursor >= shaderSize) {
+        return false;
+    }
     shaderContent[cursor++] = 0;
-    assert_invariant(cursor == shaderSize);
 
     return true;
 }


### PR DESCRIPTION
## Summary

Add bounds checks to prevent three out-of-bounds access scenarios in the material binary parser (`MaterialChunk::getTextShader`):

1. **Out-of-bounds dictionary access**: Validate `lineIndex` against `dictionary.size()` before indexing. Without this check, a malformed `.filamat` file with `lineIndex >= dictionary.size()` causes an out-of-bounds read on the dictionary vector (the `assert` in `FixedCapacityVector::operator[]` is stripped in release builds).

2. **Unsigned integer underflow**: Check for empty dictionary entries to prevent unsigned integer underflow in `content.size() - 1` (which evaluates to `SIZE_MAX` when content is empty, causing `memcpy` to read massive memory).

3. **Heap buffer overflow via cursor overrun**: Validate that the cumulative `cursor` does not exceed the allocated `shaderSize` buffer before each `memcpy`. Previously, the only check was an `assert_invariant` at the end (debug-only), allowing heap buffer overflow in release builds when dictionary entries sum to more than `shaderSize`.

## Test plan

- Existing material parser tests continue to pass
- Malformed `.filamat` files with invalid `lineIndex` values now return `false` instead of crashing