### PR TITLE
Fix integer overflow in computeBindingSize for glTF accessors

### DIFF
--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -168,7 +168,20 @@ bool primitiveHasVertexColor(cgltf_primitive* inPrim) {
 // private but its implementation file is available in this cpp file.
 uint32_t computeBindingSize(cgltf_accessor const* accessor) {
     cgltf_size element_size = cgltf_calc_size(accessor->type, accessor->component_type);
-    return uint32_t(accessor->stride * (accessor->count - 1) + element_size);
+    // Validate against overflow, consistent with the check in decodeMeshoptCompression above.
+    FILAMENT_CHECK_POSTCONDITION(accessor->count > 0)
+            << "gltfio: accessor count must be > 0";
+    cgltf_size const countMinus1 = accessor->count - 1;
+    if (accessor->stride > 0) {
+        cgltf_size const maxCount = std::numeric_limits<cgltf_size>::max() / accessor->stride;
+        FILAMENT_CHECK_POSTCONDITION(countMinus1 <= maxCount)
+                << "gltfio: binding size overflow (stride=" << accessor->stride
+                << ", count=" << accessor->count << ")";
+    }
+    cgltf_size const result = accessor->stride * countMinus1 + element_size;
+    FILAMENT_CHECK_POSTCONDITION(result <= std::numeric_limits<uint32_t>::max())
+            << "gltfio: binding size exceeds uint32_t max";
+    return uint32_t(result);
 }
 
 void convertBytesToShorts(uint16_t* dst, uint8_t const* src, size_t count) {


### PR DESCRIPTION
## Summary

Add overflow validation to `computeBindingSize()`, **consistent with the existing overflow check already present in `decodeMeshoptCompression()` in the same file** (lines 100-104).

The multiplication `accessor->stride * (accessor->count - 1)` can overflow when both `stride` and `count` are large values from a glTF file. The result is truncated to `uint32_t`, producing an undersized value that is used for buffer allocation in `ResourceLoader`. This can lead to undersized buffer objects when processing crafted glTF files.

Additionally, if `accessor->count` is 0, the subtraction `count - 1` underflows to `SIZE_MAX`.

### Existing pattern (same file, line 100-104):
```cpp
size_t const theoreticalMaxCount = std::numeric_limits<size_t>::max() / compression->stride;
FILAMENT_CHECK_PRECONDITION(compression->count <= theoreticalMaxCount)
        << "gltfio: meshopt decompression exceeds maximum count...";
```

This PR applies the same overflow-prevention pattern to `computeBindingSize()`.

## Test plan

- Existing glTF loading tests continue to pass
- Crafted glTF files with overflow-inducing stride/count values now fail gracefully with a precondition error