### PR TITLE
fix Ktx1Bundle metadata key null termination out of bounds read

### DIFF
--- a/libs/image/src/Ktx1Bundle.cpp
+++ b/libs/image/src/Ktx1Bundle.cpp
@@ -19,6 +19,7 @@
 #include <utils/Panic.h>
 #include <utils/string.h>
 
+#include <cstring>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -129,16 +130,28 @@ Ktx1Bundle::Ktx1Bundle(uint8_t const* bytes, uint32_t nbytes) :
     // We use std::string to store both the key and the value. Note that the spec says the value can
     // be a binary blob that contains null characters.
     uint8_t const* pdata = bytes + sizeof(SerializationHeader);
-    uint8_t const* end = pdata + header->bytesOfKeyValueData;
+    const size_t metadataByteCount = header->bytesOfKeyValueData;
+    FILAMENT_CHECK_PRECONDITION(metadataByteCount <= size_t(nbytes - sizeof(SerializationHeader)))
+            << "KTX metadata exceeds buffer";
+    uint8_t const* end = pdata + metadataByteCount;
     while (pdata < end) {
+        FILAMENT_CHECK_PRECONDITION(size_t(end - pdata) >= sizeof(uint32_t))
+                << "KTX metadata entry is truncated";
         const uint32_t keyAndValueByteSize = *((uint32_t const*) pdata);
         pdata += sizeof(uint32_t);
-        std::string key((const char*) pdata);
-        uint8_t const* pval = pdata + key.size() + 1;
-        pdata += keyAndValueByteSize;
-        std::string val((const char*) pval, (const char*) pdata);
+        FILAMENT_CHECK_PRECONDITION(keyAndValueByteSize <= size_t(end - pdata))
+                << "KTX metadata entry exceeds metadata block";
+        uint8_t const* const kvEnd = pdata + keyAndValueByteSize;
+        const void* const nul = memchr(pdata, 0, keyAndValueByteSize);
+        FILAMENT_CHECK_PRECONDITION(nul != nullptr) << "KTX metadata key must be null-terminated";
+        uint8_t const* const pval = static_cast<uint8_t const*>(nul) + 1;
+        std::string key((const char*) pdata, (const char*) nul);
+        std::string val((const char*) pval, (const char*) kvEnd);
+        pdata = kvEnd;
         mMetadata->keyvals.insert({key, val});
         const uint32_t paddingSize = 3 - ((keyAndValueByteSize + 3) % 4);
+        FILAMENT_CHECK_PRECONDITION(paddingSize <= size_t(end - pdata))
+                << "KTX metadata padding exceeds metadata block";
         pdata += paddingSize;
     }
 

--- a/libs/image/tests/test_image.cpp
+++ b/libs/image/tests/test_image.cpp
@@ -32,6 +32,7 @@
 #include <math/vec3.h>
 #include <math/vec4.h>
 
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <sstream>
@@ -75,6 +76,41 @@ static void updateOrCompare(const LinearImage& limg, const utils::Path& fname);
 
 // Subtracts two images, does an abs(), then normalizes such that min/max transform to 0/1.
 static LinearImage diffImages(const LinearImage& a, const LinearImage& b);
+
+namespace {
+
+struct TestSerializationHeader {
+    uint8_t magic[12];
+    KtxInfo info;
+    uint32_t numberOfArrayElements;
+    uint32_t numberOfFaces;
+    uint32_t numberOfMipmapLevels;
+    uint32_t bytesOfKeyValueData;
+};
+
+static_assert(sizeof(TestSerializationHeader) == 16 * 4, "Unexpected KTX test header size.");
+
+static vector<uint8_t> createKtxWithUnterminatedMetadataKey() {
+    constexpr uint8_t kMagic[] = {
+            0xab, 0x4b, 0x54, 0x58, 0x20, 0x31, 0x31, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a};
+
+    TestSerializationHeader header = {};
+    memcpy(header.magic, kMagic, sizeof(kMagic));
+    header.numberOfMipmapLevels = 1;
+    header.bytesOfKeyValueData = 8;
+
+    vector<uint8_t> buffer(sizeof(header) + header.bytesOfKeyValueData, 0xff);
+    memcpy(buffer.data(), &header, sizeof(header));
+
+    uint8_t* metadata = buffer.data() + sizeof(header);
+    const uint32_t keyAndValueByteSize = 4;
+    memcpy(metadata, &keyAndValueByteSize, sizeof(keyAndValueByteSize));
+    metadata += sizeof(keyAndValueByteSize);
+    memcpy(metadata, "ABCD", keyAndValueByteSize);
+    return buffer;
+}
+
+} // namespace
 
 TEST_F(ImageTest, LuminanceFilters) { // NOLINT
     auto tiny = createGrayFromAscii("000 010 000");
@@ -425,6 +461,24 @@ TEST_F(ImageTest, Ktx) { // NOLINT
         val = string(bundleWithMetadata.getMetadata("foo"));
         ASSERT_EQ(val, "bar");
     }
+}
+
+TEST_F(ImageTest, KtxRejectsMetadataKeysWithoutNullTerminator) {
+    vector<uint8_t> buffer = createKtxWithUnterminatedMetadataKey();
+#if UTILS_EXCEPTIONS
+    try {
+        Ktx1Bundle bundle(buffer.data(), static_cast<uint32_t>(buffer.size()));
+        (void) bundle;
+        FAIL() << "Expected malformed metadata to be rejected.";
+    } catch (const utils::PreconditionPanic& exception) {
+        EXPECT_NE(string(exception.what()).find("null-terminated"), string::npos);
+    } catch (const std::exception& exception) {
+        FAIL() << "Unexpected exception: " << exception.what();
+    }
+#else
+    EXPECT_DEATH({ Ktx1Bundle bundle(buffer.data(), static_cast<uint32_t>(buffer.size())); },
+            "metadata key.*null");
+#endif
 }
 
 TEST_F(ImageTest, getSphericalHarmonics) {


### PR DESCRIPTION
## Summary

This PR fixes an out-of-bounds read in `image::Ktx1Bundle` metadata deserialization.

## Vulnerability

`Ktx1Bundle` parsed KTX key/value metadata by constructing the key with `std::string(const char*)` on attacker-controlled bytes. If a malformed metadata entry omitted a NUL terminator inside the current entry, the parser would continue scanning past the end of the metadata payload until it found a zero byte. In practice this allows a crafted `.ktx` file to trigger an out-of-bounds read during deserialization and crash any application or service that consumes untrusted KTX input.

The vulnerable path was in `libs/image/src/Ktx1Bundle.cpp` during metadata traversal.

## Fix

The patch makes metadata parsing range-aware before any string construction:

- verify that `bytesOfKeyValueData` stays inside the source buffer;
- verify that each metadata record header and record body are fully present;
- require a NUL terminator inside the current metadata entry before constructing the key;
- construct both key and value from explicit byte ranges instead of relying on unbounded C string scanning;
- verify that metadata padding also remains inside the metadata block.

## Tests

Added a regression test in `libs/image/tests/test_image.cpp` that feeds a malformed metadata entry without a NUL terminator and verifies the constructor rejects it with a controlled precondition failure instead of walking out of bounds.

## Why this PR is scoped separately

This change only addresses malformed metadata key parsing. It does not include the independent image blob length validation fix or the uberz archive validation fix.
