### PR TITLE
fix Ktx1Bundle image blob copy heap buffer overflow

### DIFF
--- a/libs/image/src/Ktx1Bundle.cpp
+++ b/libs/image/src/Ktx1Bundle.cpp
@@ -150,16 +150,23 @@ Ktx1Bundle::Ktx1Bundle(uint8_t const* bytes, uint32_t nbytes) :
     // One aspect of the KTX spec is that the semantics differ for non-array cubemaps.
     const bool isNonArrayCube = mNumCubeFaces > 1 && mArrayLength == 1;
     const uint32_t facesPerMip = mArrayLength * mNumCubeFaces;
+    const uint8_t* const fileEnd = bytes + nbytes;
 
     // Extract blobs from the serialized byte stream.
     const uint32_t totalSize = nbytes - (pdata - bytes);
     mBlobs->blobs.resize(totalSize);
     for (uint32_t mipmap = 0; mipmap < mNumMipLevels; ++mipmap) {
+        FILAMENT_CHECK_PRECONDITION(size_t(fileEnd - pdata) >= sizeof(uint32_t))
+                << "KTX image size header is truncated";
         const uint32_t imageSize = *((uint32_t const*) pdata);
-        const uint32_t faceSize = isNonArrayCube ? imageSize : (imageSize / facesPerMip);
-        const uint32_t levelSize = faceSize * mNumCubeFaces * mArrayLength;
         pdata += sizeof(uint32_t);
-        memcpy(mBlobs->get(flatten(this, {mipmap, 0, 0})), pdata, levelSize);
+        const uint32_t faceSize = isNonArrayCube ? imageSize : (imageSize / facesPerMip);
+        const uint64_t levelSize = uint64_t(faceSize) * mNumCubeFaces * mArrayLength;
+        FILAMENT_CHECK_PRECONDITION(levelSize <= size_t(fileEnd - pdata))
+                << "KTX image data exceeds buffer";
+        FILAMENT_CHECK_PRECONDITION(levelSize <= mBlobs->blobs.size())
+                << "KTX image data exceeds destination buffer";
+        memcpy(mBlobs->get(flatten(this, {mipmap, 0, 0})), pdata, size_t(levelSize));
         for (uint32_t layer = 0; layer < mArrayLength; ++layer) {
             for (uint32_t face = 0; face < mNumCubeFaces; ++face) {
                 mBlobs->sizes[flatten(this, {mipmap, layer, face})] = faceSize;

--- a/libs/image/tests/test_image.cpp
+++ b/libs/image/tests/test_image.cpp
@@ -32,6 +32,7 @@
 #include <math/vec3.h>
 #include <math/vec4.h>
 
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <sstream>
@@ -75,6 +76,38 @@ static void updateOrCompare(const LinearImage& limg, const utils::Path& fname);
 
 // Subtracts two images, does an abs(), then normalizes such that min/max transform to 0/1.
 static LinearImage diffImages(const LinearImage& a, const LinearImage& b);
+
+namespace {
+
+struct TestSerializationHeader {
+    uint8_t magic[12];
+    KtxInfo info;
+    uint32_t numberOfArrayElements;
+    uint32_t numberOfFaces;
+    uint32_t numberOfMipmapLevels;
+    uint32_t bytesOfKeyValueData;
+};
+
+static_assert(sizeof(TestSerializationHeader) == 16 * 4, "Unexpected KTX test header size.");
+
+static vector<uint8_t> createKtxWithTruncatedImageData() {
+    constexpr uint8_t kMagic[] = {
+            0xab, 0x4b, 0x54, 0x58, 0x20, 0x31, 0x31, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a};
+
+    TestSerializationHeader header = {};
+    memcpy(header.magic, kMagic, sizeof(kMagic));
+    header.numberOfFaces = 1;
+    header.numberOfMipmapLevels = 1;
+
+    vector<uint8_t> buffer(sizeof(header) + sizeof(uint32_t), 0);
+    memcpy(buffer.data(), &header, sizeof(header));
+
+    uint32_t imageSize = 256;
+    memcpy(buffer.data() + sizeof(header), &imageSize, sizeof(imageSize));
+    return buffer;
+}
+
+} // namespace
 
 TEST_F(ImageTest, LuminanceFilters) { // NOLINT
     auto tiny = createGrayFromAscii("000 010 000");
@@ -425,6 +458,25 @@ TEST_F(ImageTest, Ktx) { // NOLINT
         val = string(bundleWithMetadata.getMetadata("foo"));
         ASSERT_EQ(val, "bar");
     }
+}
+
+TEST_F(ImageTest, KtxRejectsTruncatedImageBlobs) {
+    vector<uint8_t> buffer = createKtxWithTruncatedImageData();
+
+#if UTILS_EXCEPTIONS
+    try {
+        Ktx1Bundle bundle(buffer.data(), static_cast<uint32_t>(buffer.size()));
+        (void) bundle;
+        FAIL() << "Expected truncated image data to be rejected.";
+    } catch (const utils::PreconditionPanic& exception) {
+        EXPECT_NE(string(exception.what()).find("image"), string::npos);
+    } catch (const std::exception& exception) {
+        FAIL() << "Unexpected exception: " << exception.what();
+    }
+#else
+    EXPECT_DEATH({ Ktx1Bundle bundle(buffer.data(), static_cast<uint32_t>(buffer.size())); },
+            "image");
+#endif
 }
 
 TEST_F(ImageTest, getSphericalHarmonics) {


### PR DESCRIPTION
## Summary

This PR fixes a heap buffer overflow in `image::Ktx1Bundle` image blob deserialization.

## Vulnerability

`Ktx1Bundle` sized its destination blob storage from the number of bytes remaining in the serialized input, but then trusted attacker-controlled `imageSize` metadata when calculating the number of bytes to copy with `memcpy`. A minimal KTX payload that declared a much larger image body than was actually present could therefore drive out-of-bounds reads and writes during blob extraction.

This affects any code path that deserializes untrusted `.ktx` data through `image::Ktx1Bundle`.

## Fix

The patch enforces consistency between declared blob sizes and the actual serialized buffers:

- verify that an image size header is fully present before reading it;
- compute the effective level size and verify that it fits inside the remaining source bytes;
- verify that the computed level size also fits inside the allocated destination blob buffer before calling `memcpy`.

If any of those checks fail, deserialization now aborts with a controlled precondition failure instead of corrupting memory.

## Tests

Added a regression test in `libs/image/tests/test_image.cpp` that provides a truncated KTX image body and verifies the constructor rejects it instead of accepting the malformed blob layout.

## Why this PR is scoped separately

This change only addresses the image blob copy length mismatch. It does not include the independent metadata key parsing fix or the uberz offset validation fix.
