### PR TITLE
fix uberz offset to pointer out of bounds write

### DIFF
--- a/libs/gltfio/src/ArchiveCache.cpp
+++ b/libs/gltfio/src/ArchiveCache.cpp
@@ -67,7 +67,7 @@ void ArchiveCache::load(const void* archiveData, uint64_t archiveByteCount) {
     uint64_t* basePointer = (uint64_t*) utils::aligned_alloc(decompSize, 8);
     ZSTD_decompress(basePointer, decompSize, archiveData, archiveByteCount);
     mArchive = (ReadableArchive*) basePointer;
-    convertOffsetsToPointers(mArchive);
+    convertOffsetsToPointers(mArchive, decompSize);
     mMaterials = FixedCapacityVector<Material*>(mArchive->specsCount, nullptr);
 }
 

--- a/libs/uberz/CMakeLists.txt
+++ b/libs/uberz/CMakeLists.txt
@@ -45,3 +45,12 @@ endif()
 # ==================================================================================================
 install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
 install(DIRECTORY ${PUBLIC_HDR_DIR}/uberz DESTINATION include)
+
+# ==================================================================================================
+# Tests
+# ==================================================================================================
+if (FILAMENT_BUILD_TESTING)
+    add_executable(test_${TARGET} tests/test_ReadableArchive.cpp)
+    target_link_libraries(test_${TARGET} PRIVATE ${TARGET} gtest)
+    set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
+endif()

--- a/libs/uberz/include/uberz/ReadableArchive.h
+++ b/libs/uberz/include/uberz/ReadableArchive.h
@@ -17,6 +17,7 @@
 #ifndef UBERZ_READABLE_ARCHIVE_H
 #define UBERZ_READABLE_ARCHIVE_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <uberz/ArchiveEnums.h>
@@ -28,7 +29,7 @@ namespace filament::uberz {
 // ArchiveSpec is a parse-free binary format. The client simply casts a word-aligned content blob
 // into a ReadableArchive struct pointer, then calls the following function to convert all the
 // offset fields into pointers.
-void convertOffsetsToPointers(struct ReadableArchive* archive);
+void convertOffsetsToPointers(struct ReadableArchive* archive, size_t archiveSize);
 
 UTILS_WARNING_PUSH
 UTILS_WARNING_ENABLE_PADDED

--- a/libs/uberz/src/ReadableArchive.cpp
+++ b/libs/uberz/src/ReadableArchive.cpp
@@ -16,7 +16,10 @@
 
 #include <uberz/ReadableArchive.h>
 
-#include <utils/debug.h>
+#include <utils/Panic.h>
+
+#include <cstring>
+#include <limits>
 
 using namespace filament;
 using namespace utils;
@@ -27,19 +30,65 @@ static_assert(sizeof(ReadableArchive) == 4 + 4 + 8 + 8);
 static_assert(sizeof(ArchiveSpec) == 1 + 1 + 2 + 4 + 8 + 8);
 static_assert(sizeof(ArchiveFlag) == 8 + 8);
 
-void convertOffsetsToPointers(ReadableArchive* archive) {
-    constexpr size_t wordSize = sizeof(uint64_t);
-    assert_invariant(archive->specsOffset % wordSize == 0);
-    uint64_t* basePointer = (uint64_t*) archive;
-    archive->specs = (ArchiveSpec*) (basePointer + archive->specsOffset / wordSize);
+namespace {
+
+constexpr uint32_t READABLE_ARCHIVE_MAGIC = 'UBER';
+constexpr uint32_t READABLE_ARCHIVE_VERSION = 0;
+constexpr size_t WORD_SIZE = sizeof(uint64_t);
+
+size_t checkedMultiply(uint64_t count, size_t itemSize, const char* reason) {
+    FILAMENT_CHECK_PRECONDITION(count <= std::numeric_limits<size_t>::max() / itemSize)
+            << reason;
+    return size_t(count) * itemSize;
+}
+
+uint8_t* checkedOffset(ReadableArchive* archive, size_t archiveSize,
+        uint64_t offset, size_t length, const char* reason) {
+    FILAMENT_CHECK_PRECONDITION(offset <= archiveSize && length <= archiveSize - size_t(offset))
+            << reason;
+    return reinterpret_cast<uint8_t*>(archive) + size_t(offset);
+}
+
+const char* checkedCString(ReadableArchive* archive, size_t archiveSize,
+        uint64_t offset, const char* reason) {
+    FILAMENT_CHECK_PRECONDITION(offset < archiveSize) << reason;
+    const char* string = reinterpret_cast<const char*>(archive) + size_t(offset);
+    FILAMENT_CHECK_PRECONDITION(memchr(string, 0, archiveSize - size_t(offset)) != nullptr)
+            << reason;
+    return string;
+}
+
+} // namespace
+
+void convertOffsetsToPointers(ReadableArchive* archive, size_t archiveSize) {
+    FILAMENT_CHECK_PRECONDITION(archiveSize >= sizeof(ReadableArchive))
+            << "Uberz archive header is truncated";
+    FILAMENT_CHECK_PRECONDITION(archive->magic == READABLE_ARCHIVE_MAGIC)
+            << "Uberz archive has invalid magic";
+    FILAMENT_CHECK_PRECONDITION(archive->version == READABLE_ARCHIVE_VERSION)
+            << "Uberz archive has unsupported version";
+    FILAMENT_CHECK_PRECONDITION(archive->specsOffset % WORD_SIZE == 0)
+            << "Uberz specs offset is misaligned";
+
+    const size_t specsSize = checkedMultiply(archive->specsCount, sizeof(ArchiveSpec),
+            "Uberz specs array size overflows");
+    archive->specs = reinterpret_cast<ArchiveSpec*>(checkedOffset(archive, archiveSize,
+            archive->specsOffset, specsSize, "Uberz specs array exceeds buffer"));
+
     for (uint64_t i = 0; i < archive->specsCount; ++i) {
         ArchiveSpec& spec = archive->specs[i];
-        assert_invariant(spec.flagsOffset % wordSize == 0);
-        spec.flags = (ArchiveFlag*) (basePointer + (spec.flagsOffset / wordSize));
-        spec.package = ((uint8_t*) basePointer) + spec.packageOffset;
+        FILAMENT_CHECK_PRECONDITION(spec.flagsOffset % WORD_SIZE == 0)
+                << "Uberz flags offset is misaligned";
+        const size_t flagsSize = checkedMultiply(spec.flagsCount, sizeof(ArchiveFlag),
+                "Uberz flags array size overflows");
+        spec.flags = reinterpret_cast<ArchiveFlag*>(checkedOffset(archive, archiveSize,
+                spec.flagsOffset, flagsSize, "Uberz flags array exceeds buffer"));
+        spec.package = checkedOffset(archive, archiveSize, spec.packageOffset,
+                spec.packageByteCount, "Uberz package exceeds buffer");
         for (uint64_t j = 0; j < spec.flagsCount; ++j) {
             ArchiveFlag& flag = spec.flags[j];
-            flag.name = ((const char*) basePointer) + flag.nameOffset;
+            flag.name = checkedCString(archive, archiveSize, flag.nameOffset,
+                    "Uberz flag name exceeds buffer");
         }
     }
 }

--- a/libs/uberz/tests/test_ReadableArchive.cpp
+++ b/libs/uberz/tests/test_ReadableArchive.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <uberz/ReadableArchive.h>
+
+#include <gtest/gtest.h>
+
+#include <utils/Panic.h>
+
+#include <array>
+#include <string>
+
+using filament::uberz::ArchiveFeature;
+using filament::uberz::ArchiveFlag;
+using filament::uberz::ArchiveSpec;
+using filament::uberz::ReadableArchive;
+using filament::uberz::convertOffsetsToPointers;
+
+namespace {
+
+TEST(ReadableArchiveTest, RejectsSpecsOffsetOutsideBuffer) {
+    alignas(8) std::array<uint8_t, 64> storage {};
+    auto* archive = reinterpret_cast<ReadableArchive*>(storage.data());
+    archive->magic = 'UBER';
+    archive->version = 0;
+    archive->specsCount = 1;
+    archive->specsOffset = storage.size();
+
+#if UTILS_EXCEPTIONS
+    try {
+        convertOffsetsToPointers(archive, storage.size());
+        FAIL() << "Expected malformed specs offset to be rejected.";
+    } catch (const utils::PreconditionPanic& exception) {
+        EXPECT_NE(std::string(exception.what()).find("spec"), std::string::npos);
+    } catch (const std::exception& exception) {
+        FAIL() << "Unexpected exception: " << exception.what();
+    }
+#else
+    EXPECT_DEATH({ convertOffsetsToPointers(archive, storage.size()); }, "spec");
+#endif
+}
+
+TEST(ReadableArchiveTest, RejectsFlagNamesOutsideBuffer) {
+    alignas(8) std::array<uint8_t, 96> storage {};
+    auto* archive = reinterpret_cast<ReadableArchive*>(storage.data());
+    archive->magic = 'UBER';
+    archive->version = 0;
+    archive->specsCount = 1;
+    archive->specsOffset = sizeof(ReadableArchive);
+
+    auto* spec = reinterpret_cast<ArchiveSpec*>(storage.data() + archive->specsOffset);
+    *spec = {};
+    spec->flagsCount = 1;
+    spec->flagsOffset = archive->specsOffset + sizeof(ArchiveSpec);
+    spec->packageOffset = storage.size() - 1;
+
+    auto* flag = reinterpret_cast<ArchiveFlag*>(storage.data() + spec->flagsOffset);
+    flag->nameOffset = storage.size();
+    flag->value = ArchiveFeature::OPTIONAL;
+
+#if UTILS_EXCEPTIONS
+    try {
+        convertOffsetsToPointers(archive, storage.size());
+        FAIL() << "Expected malformed flag name offset to be rejected.";
+    } catch (const utils::PreconditionPanic& exception) {
+        EXPECT_NE(std::string(exception.what()).find("name"), std::string::npos);
+    } catch (const std::exception& exception) {
+        FAIL() << "Unexpected exception: " << exception.what();
+    }
+#else
+    EXPECT_DEATH({ convertOffsetsToPointers(archive, storage.size()); }, "name");
+#endif
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tools/uberz/src/main.cpp
+++ b/tools/uberz/src/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[]) {
         uint64_t* basePointer = (uint64_t*) utils::aligned_alloc(decompSize, 8);
         ZSTD_decompress(basePointer, decompSize, archiveData, archiveSize);
         existingArchive = (ReadableArchive*) basePointer;
-        convertOffsetsToPointers(existingArchive);
+        convertOffsetsToPointers(existingArchive, decompSize);
         existingMaterialsCount = existingArchive->specsCount;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes out-of-bounds reads and writes in `uberz::convertOffsetsToPointers` by making archive pointer conversion size-aware.

## Vulnerability

`convertOffsetsToPointers` rewrote attacker-controlled offsets from a decompressed uberz archive into live pointers without validating that the offsets remained inside the archive buffer. In release builds the existing `assert_invariant` checks compile away, so malformed values such as `specsOffset`, `flagsOffset`, `packageOffset`, or `nameOffset` could force the converter to write invalid pointers into the archive structure and then continue traversing those invalid addresses.

Real call sites include:

- `gltfio::ArchiveCache::load`
- the append path in `tools/uberz`

Any application or service that loads untrusted `.uberz` content could therefore crash or hit broader memory corruption.

## Fix

The patch changes the conversion API to accept the decompressed archive size and validates all offset-derived regions before any pointer rewriting happens:

- validate archive header size, magic, version, and alignment requirements;
- validate the `specs` array range before converting `specsOffset`;
- validate each `flags` array, package range, and NUL-terminated flag name string;
- keep these checks active in release builds;
- update both `gltfio` and `tools/uberz` to pass the decompressed archive size into the validator.

## Tests

Added `libs/uberz/tests/test_ReadableArchive.cpp` with regression coverage for:

- a top-level `specsOffset` that points outside the archive buffer;
- a nested `flag.nameOffset` that points outside the archive buffer.

## Why this PR is scoped separately

This change only addresses uberz archive validation and call-site propagation. It is intentionally separate from the two independent KTX deserialization fixes.
