### PR TITLE
repair matdbg shader editing

### DIFF
--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -273,8 +273,7 @@ bool DebugServer::handleEditCommand(const MaterialKey& key, backend::Backend api
     }
 
     const ShaderInfo info = infos[shaderIndex];
-    if (!editor.replaceShaderSource(info.shaderModel, info.variant, info.pipelineStage, source,
-            size)) {
+    if (!editor.replaceShaderSource(info.shaderModel, info.variant, info.pipelineStage, source, size)) {
         return error(__LINE__);
     }
 

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -373,6 +373,7 @@ void ShaderIndex::writeChunks(ostream& stream) {
     for (const auto& record : mShaderRecords) {
         lines.addText(record.stage, record.shader);
     }
+    lines.resolve();
     sortRecords(mShaderRecords);
 
     filamat::ChunkContainer cc;


### PR DESCRIPTION
The new LineDictionary API requires to call resolve().