### PR TITLE
Fix potential memory corruption issue in UboManager

### DIFF
--- a/filament/src/details/UboManager.cpp
+++ b/filament/src/details/UboManager.cpp
@@ -163,13 +163,20 @@ void UboManager::finishBeginFrame(DriverApi& driver) {
 
 void UboManager::endFrame(DriverApi& driver) {
     auto allocationIds =
-            FenceManager::AllocationIdContainer::with_capacity(mManagedInstances.size());
+            FenceManager::AllocationIdContainer::with_capacity(
+                    mManagedInstances.size() + mFreedAllocations.size());
     for (const auto* mi: mManagedInstances) {
         const AllocationId id = mi->getAllocationId();
         if (UTILS_UNLIKELY(!BufferAllocator::isValid(id))) {
             continue;
         }
 
+        mAllocator.acquireGpu(id);
+        allocationIds.push_back(id);
+    }
+
+    // Also track MIs that were freed during this frame.
+    for (const AllocationId id: mFreedAllocations) {
         mAllocator.acquireGpu(id);
         allocationIds.push_back(id);
     }


### PR DESCRIPTION
Currently, the `UboManager`'s `FenceManager` only tracks active instances in `mManagedInstances`. If an MI is freed after `renderer->render()` but before `renderer->endFrame()`, it is removed from this list and loses its fence tracking. This creates a window where the GPU may still be reading from the UBO slot while the CPU considers it free. If a new MaterialInstance is immediately allocated to that same slot within the same frame, the GPU may read the new (incorrect) data, leading to memory corruption.

To solve this, we include `mFreedAllocations` in the `FenceManager` tracking list in `UboManager::endFrame()`.