### PR TITLE
remove the now unneeded FL0 materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ option(FILAMENT_ENABLE_TSAN "Enable Thread Sanitizer" OFF)
 
 option(FILAMENT_ENABLE_COVERAGE "Enable LLVM code coverage" OFF)
 
-option(FILAMENT_ENABLE_FEATURE_LEVEL_0 "Enable Feature Level 0" ON)
-
 option(FILAMENT_ENABLE_MULTIVIEW "Enable multiview for Filament" OFF)
 
 option(FILAMENT_SUPPORTS_OSMESA "Enable OSMesa (headless GL context) for Filament" OFF)

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -313,11 +313,6 @@ if (NOT FILAMENT_DISABLE_GTAO)
     )
 endif()
 
-set(MATERIAL_FL0_SRCS
-        src/materials/defaultMaterial.mat
-        src/materials/skybox.mat
-)
-
 set(MATERIAL_MULTIVIEW_SRCS
         src/materials/clearDepth.mat
         src/materials/defaultMaterial.mat
@@ -342,11 +337,6 @@ if (NOT DFG_LUT_SIZE)
     endif()
 endif()
 message(STATUS "DFG LUT size set to ${DFG_LUT_SIZE}x${DFG_LUT_SIZE}")
-
-# Whether to include FL0 materials.
-if (FILAMENT_ENABLE_FEATURE_LEVEL_0)
-    add_definitions(-DFILAMENT_ENABLE_FEATURE_LEVEL_0)
-endif()
 
 # Whether to include MULTIVIEW materials.
 if (FILAMENT_ENABLE_MULTIVIEW)
@@ -428,21 +418,6 @@ foreach(mat_dir ${MATERIAL_DIRS})
         )
         list(APPEND FILAMAT_FILES_FOR_GROUP ${output_path})
         list(APPEND FILAMAT_TARGETS_FOR_GROUP ${output_path})
-
-        # --- Feature Level 0 variant ---
-        list(FIND MATERIAL_FL0_SRCS ${mat_src} index)
-        if (${index} GREATER -1 AND FILAMENT_ENABLE_FEATURE_LEVEL_0)
-            string(REGEX REPLACE "[.]filamat$" "_fl0.filamat" output_path_fl0 ${output_path})
-            add_custom_command(
-                    OUTPUT ${output_path_fl0}
-                    COMMAND matc ${MATC_BASE_FLAGS} -PfeatureLevel=0 -o ${output_path_fl0} ${fullname}
-                    MAIN_DEPENDENCY ${fullname}
-                    DEPENDS matc
-                    COMMENT "Compiling material ${fullname} (FL0)"
-            )
-            list(APPEND FILAMAT_FILES_FOR_GROUP ${output_path_fl0})
-            list(APPEND FILAMAT_TARGETS_FOR_GROUP ${output_path_fl0})
-        endif()
 
         # --- Multiview variant ---
         list(FIND MATERIAL_MULTIVIEW_SRCS ${mat_src} index)

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -350,10 +350,6 @@ void FEngine::init() {
 
     mActiveFeatureLevel = std::min(mActiveFeatureLevel, driverApi.getFeatureLevel());
 
-#ifndef FILAMENT_ENABLE_FEATURE_LEVEL_0
-    assert_invariant(mActiveFeatureLevel > FeatureLevel::FEATURE_LEVEL_0);
-#endif
-
     LOG(INFO) << "Backend feature level: " << int(driverApi.getFeatureLevel());
     LOG(INFO) << "FEngine feature level: " << int(mActiveFeatureLevel);
 
@@ -461,34 +457,23 @@ void FEngine::init() {
             driverApi,
             descriptor_sets::getPerRenderableLayout() };
 
-#ifdef FILAMENT_ENABLE_FEATURE_LEVEL_0
-    if (UTILS_UNLIKELY(mActiveFeatureLevel == FeatureLevel::FEATURE_LEVEL_0)) {
-        FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
-        defaultMaterialBuilder.package(
-                MATERIALS_DEFAULTMATERIAL_FL0_DATA, MATERIALS_DEFAULTMATERIAL_FL0_SIZE);
-        mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
-    } else
-#endif
-    {
-        FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
-        switch (mConfig.stereoscopicType) {
-            case StereoscopicType::NONE:
-            case StereoscopicType::INSTANCED:
-                defaultMaterialBuilder.package(
-                        MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
-                break;
-            case StereoscopicType::MULTIVIEW:
+    FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
+    switch (mConfig.stereoscopicType) {
+        case StereoscopicType::NONE:
+        case StereoscopicType::INSTANCED:
+            defaultMaterialBuilder.package(
+                    MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
+            break;
+        case StereoscopicType::MULTIVIEW:
 #ifdef FILAMENT_ENABLE_MULTIVIEW
-                defaultMaterialBuilder.package(
-                        MATERIALS_DEFAULTMATERIAL_MULTIVIEW_DATA,
-                        MATERIALS_DEFAULTMATERIAL_MULTIVIEW_SIZE);
+            defaultMaterialBuilder.package(
+                    MATERIALS_DEFAULTMATERIAL_MULTIVIEW_DATA, MATERIALS_DEFAULTMATERIAL_MULTIVIEW_SIZE);
 #else
-                assert_invariant(false);
+            assert_invariant(false);
 #endif
-                break;
-        }
-        mDefaultMaterial = downcast(defaultMaterialBuilder.build(*this));
+            break;
     }
+    mDefaultMaterial = downcast(defaultMaterialBuilder.build(*this));
 
     // We must commit the default material instance here. It may not be used in a scene, but its
     // descriptor set may still be used for shared variants.

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -132,26 +132,19 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
 
 FMaterial const* FSkybox::createMaterial(FEngine& engine) {
     Material::Builder builder;
-#ifdef FILAMENT_ENABLE_FEATURE_LEVEL_0
-    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == Engine::FeatureLevel::FEATURE_LEVEL_0)) {
-        builder.package(MATERIALS_SKYBOX_FL0_DATA, MATERIALS_SKYBOX_FL0_SIZE);
-    } else
-#endif
-    {
-        switch (engine.getConfig().stereoscopicType) {
-            case Engine::StereoscopicType::NONE:
-            case Engine::StereoscopicType::INSTANCED:
-                builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
-                break;
-            case Engine::StereoscopicType::MULTIVIEW:
+    switch (engine.getConfig().stereoscopicType) {
+        case Engine::StereoscopicType::NONE:
+        case Engine::StereoscopicType::INSTANCED:
+            builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
+            break;
+        case Engine::StereoscopicType::MULTIVIEW:
 #ifdef FILAMENT_ENABLE_MULTIVIEW
-                builder.package(MATERIALS_SKYBOX_MULTIVIEW_DATA, MATERIALS_SKYBOX_MULTIVIEW_SIZE);
+            builder.package(MATERIALS_SKYBOX_MULTIVIEW_DATA, MATERIALS_SKYBOX_MULTIVIEW_SIZE);
 #else
-                PANIC_POSTCONDITION("Multiview is enabled in the Engine, but this build has not "
-                                    "been compiled for multiview.");
+            PANIC_POSTCONDITION("Multiview is enabled in the Engine, but this build has not "
+                                "been compiled for multiview.");
 #endif
-                break;
-        }
+            break;
     }
     auto material = builder.build(engine);
     return downcast(material);

--- a/filament/src/materials/defaultMaterial.mat
+++ b/filament/src/materials/defaultMaterial.mat
@@ -1,6 +1,7 @@
 material {
     name : "Filament Default Material",
-    shadingModel : unlit
+    shadingModel : unlit,
+    featureLevel: 0
 }
 
 fragment {

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -26,7 +26,8 @@ material {
     depthWrite : false,
     shadingModel : unlit,
     variantFilter : [ skinning, shadowReceiver, vsm ],
-    culling: none
+    culling: none,
+    featureLevel: 0
 }
 
 fragment {

--- a/web/examples/CMakeLists.txt
+++ b/web/examples/CMakeLists.txt
@@ -28,24 +28,6 @@ function(build_material MAT_FILE TARGET_DIR MAT_NAME OUT_LIST)
     set(${OUT_LIST} ${${OUT_LIST}} ${output_path} PARENT_SCOPE)
 endfunction()
 
-function(build_material_fl0 MAT_FILE TARGET_DIR MAT_NAME OUT_LIST)
-    if (FILAMENT_ENABLE_FEATURE_LEVEL_0)
-        set(MATC_FLAGS -a opengl -p mobile)
-        if (NOT CMAKE_BUILD_TYPE MATCHES Release)
-            set(MATC_FLAGS -g ${MATC_FLAGS})
-        endif()
-        set(mat_src "${CMAKE_CURRENT_SOURCE_DIR}/${MAT_FILE}")
-        set(output_path "${SERVER_DIR}/${TARGET_DIR}/${MAT_NAME}_fl0.filamat")
-        add_custom_command(
-                OUTPUT ${output_path}
-                COMMAND matc ${MATC_FLAGS} -PfeatureLevel=0 -o ${output_path} ${mat_src}
-                MAIN_DEPENDENCY ${mat_src}
-                DEPENDS matc
-                COMMENT "Compiling material FL0 ${mat_src} to ${output_path}")
-        set(${OUT_LIST} ${${OUT_LIST}} ${output_path} PARENT_SCOPE)
-    endif()
-endfunction()
-
 function(add_ktxfiles SOURCE TARGET EXTRA_ARGS TARGET_DIR OUT_LIST)
     set(source_path "${ROOT_DIR}/${SOURCE}")
     set(target_path "${SERVER_DIR}/${TARGET_DIR}/${TARGET}")
@@ -148,7 +130,7 @@ add_envmap("third_party/environments/lightroom_14b.hdr" "default_env" ${TARGET_D
 
 set(TARGET_DIR "cube_fl0")
 add_localfile("cube_fl0.html" "cube_fl0.html" ${TARGET_DIR} ALL_DEMO_ASSETS)
-build_material_fl0("materials/nonlit.mat" ${TARGET_DIR} "nonlit" ALL_DEMO_ASSETS)
+build_material("materials/nonlit.mat" ${TARGET_DIR} "nonlit" ALL_DEMO_ASSETS)
 
 set(TARGET_DIR "helmet")
 add_localfile("helmet.html" "helmet.html" ${TARGET_DIR} ALL_DEMO_ASSETS)

--- a/web/examples/cube_fl0.html
+++ b/web/examples/cube_fl0.html
@@ -27,7 +27,7 @@
   <script src="../gl-matrix-min.js"></script>
   <script>
 
-    Filament.init(['nonlit_fl0.filamat'], () => {
+    Filament.init(['nonlit.filamat'], () => {
       window.VertexAttribute = Filament.VertexAttribute;
       window.AttributeType = Filament.VertexBuffer$AttributeType;
       window.Projection = Filament.Camera$Projection;
@@ -124,7 +124,7 @@
 
         this.ib.setBuffer(engine, CUBE_INDICES);
 
-        const mat = engine.createMaterial('nonlit_fl0.filamat');
+        const mat = engine.createMaterial('nonlit.filamat');
         const matinst = mat.getDefaultInstance();
         Filament.RenderableManager.Builder(1)
           .boundingBox({ center: [-1, -1, -1], halfExtent: [1, 1, 1] })


### PR DESCRIPTION
Filament needed to compile FL0 materials for both FL0 and FL1, but this is now done automatically when a material is a FL0 material.