### PR TITLE
Bump macOS minimum supported version to 11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.22.1)
 # On iOS, the deployment target is set inside third_party/clang/ios.cmake
 if (APPLE AND NOT IOS)
     # This must be set before project() is called
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "")
 endif()
 
 # ==================================================================================================

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -114,9 +114,7 @@ void logMTLCommandBufferError(MTLCommandBufferError error) {
     MTL_COMMAND_ERROR_CASE(MTLCommandBufferErrorOutOfMemory)
     MTL_COMMAND_ERROR_CASE(MTLCommandBufferErrorInvalidResource)
 
-    if (@available(macOS 11.0, *)) {
-        MTL_COMMAND_ERROR_CASE(MTLCommandBufferErrorMemoryless)
-    }
+    MTL_COMMAND_ERROR_CASE(MTLCommandBufferErrorMemoryless)
 
     if (@available(iOS 15.0, macOS 12.0, *)) {
         MTL_COMMAND_ERROR_CASE(MTLCommandBufferErrorStackOverflow)
@@ -143,12 +141,10 @@ id<MTLCommandBuffer> getPendingCommandBuffer(MetalContext* context) {
         context->latestCompletedCommandBufferId = thisCommandBufferId;
 
         auto errorCode = (MTLCommandBufferError)buffer.error.code;
-        if (@available(macOS 11.0, *)) {
-            if (errorCode == MTLCommandBufferErrorMemoryless) {
-                LOG(WARNING) << "Metal: memoryless geometry limit reached. Continuing with private "
-                                "storage mode.";
-                context->memorylessLimitsReached = true;
-            }
+        if (errorCode == MTLCommandBufferErrorMemoryless) {
+            LOG(WARNING) << "Metal: memoryless geometry limit reached. Continuing with private "
+                            "storage mode.";
+            context->memorylessLimitsReached = true;
         }
 
         if (UTILS_UNLIKELY(errorCode != MTLCommandBufferErrorNone)) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1284,11 +1284,8 @@ bool MetalDriver::isFrameBufferFetchSupported() {
     // FrameBuffer fetch is achievable via "programmable blending" in Metal, and only supported on
     // Apple GPUs with readWriteTextureSupport.
     // On macOS, framebuffer fetch requires MSL 2.3, which is only available with macOS 11.0.
-    if (@available(macOS 11.0, *)) {
-        return mContext->highestSupportedGpuFamily.apple >= 1 &&
-               mContext->device.readWriteTextureSupport;
-    }
-    return false;
+    return mContext->highestSupportedGpuFamily.apple >= 1 &&
+           mContext->device.readWriteTextureSupport;
 }
 
 bool MetalDriver::isFrameBufferFetchMultiSampleSupported() {

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -148,9 +148,7 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
 inline MTLPixelFormat getMetalFormat(PixelDataFormat format, PixelDataType type) {
     if (type == PixelDataType::UINT_2_10_10_10_REV) return MTLPixelFormatRGB10A2Unorm;
     if (type == PixelDataType::UINT_10F_11F_11F_REV) return MTLPixelFormatRG11B10Float;
-    if (@available(macOS 11, *)) {
-        if (type == PixelDataType::USHORT_565) return MTLPixelFormatB5G6R5Unorm;
-    }
+    if (type == PixelDataType::USHORT_565) return MTLPixelFormatB5G6R5Unorm;
 
     #define CONVERT(FORMAT, TYPE, MTL) \
     if (PixelDataFormat::FORMAT == format && PixelDataType::TYPE == type)  return MTLPixelFormat ## MTL;
@@ -205,33 +203,31 @@ inline MTLPixelFormat getMetalFormatLinear(MTLPixelFormat format) {
 #endif
         default: break;
     }
-    if (@available(macOS 11, *)) {
-        switch (format) {
-            case MTLPixelFormatASTC_4x4_sRGB: return MTLPixelFormatASTC_4x4_LDR;
-            case MTLPixelFormatASTC_5x4_sRGB: return MTLPixelFormatASTC_5x4_LDR;
-            case MTLPixelFormatASTC_5x5_sRGB: return MTLPixelFormatASTC_5x5_LDR;
-            case MTLPixelFormatASTC_6x5_sRGB: return MTLPixelFormatASTC_6x5_LDR;
-            case MTLPixelFormatASTC_6x6_sRGB: return MTLPixelFormatASTC_6x6_LDR;
-            case MTLPixelFormatASTC_8x5_sRGB: return MTLPixelFormatASTC_8x5_LDR;
-            case MTLPixelFormatASTC_8x6_sRGB: return MTLPixelFormatASTC_8x6_LDR;
-            case MTLPixelFormatASTC_8x8_sRGB: return MTLPixelFormatASTC_8x8_LDR;
-            case MTLPixelFormatASTC_10x5_sRGB: return MTLPixelFormatASTC_10x5_LDR;
-            case MTLPixelFormatASTC_10x6_sRGB: return MTLPixelFormatASTC_10x6_LDR;
-            case MTLPixelFormatASTC_10x8_sRGB: return MTLPixelFormatASTC_10x8_LDR;
-            case MTLPixelFormatASTC_10x10_sRGB: return MTLPixelFormatASTC_10x10_LDR;
-            case MTLPixelFormatASTC_12x10_sRGB: return MTLPixelFormatASTC_12x10_LDR;
-            case MTLPixelFormatASTC_12x12_sRGB: return MTLPixelFormatASTC_12x12_LDR;
-            case MTLPixelFormatPVRTC_RGB_2BPP_sRGB: return MTLPixelFormatPVRTC_RGB_2BPP;
-            case MTLPixelFormatPVRTC_RGB_4BPP_sRGB: return MTLPixelFormatPVRTC_RGB_4BPP;
-            case MTLPixelFormatPVRTC_RGBA_2BPP_sRGB: return MTLPixelFormatPVRTC_RGBA_2BPP;
-            case MTLPixelFormatPVRTC_RGBA_4BPP_sRGB: return MTLPixelFormatPVRTC_RGBA_4BPP;
-            case MTLPixelFormatEAC_RGBA8_sRGB: return MTLPixelFormatEAC_RGBA8;
-            case MTLPixelFormatETC2_RGB8_sRGB: return MTLPixelFormatETC2_RGB8;
-            case MTLPixelFormatETC2_RGB8A1_sRGB: return MTLPixelFormatETC2_RGB8A1;
-            case MTLPixelFormatBGR10_XR_sRGB: return MTLPixelFormatBGR10_XR;
-            case MTLPixelFormatBGRA10_XR_sRGB: return MTLPixelFormatBGRA10_XR;
-            default: break;
-        }
+    switch (format) {
+        case MTLPixelFormatASTC_4x4_sRGB: return MTLPixelFormatASTC_4x4_LDR;
+        case MTLPixelFormatASTC_5x4_sRGB: return MTLPixelFormatASTC_5x4_LDR;
+        case MTLPixelFormatASTC_5x5_sRGB: return MTLPixelFormatASTC_5x5_LDR;
+        case MTLPixelFormatASTC_6x5_sRGB: return MTLPixelFormatASTC_6x5_LDR;
+        case MTLPixelFormatASTC_6x6_sRGB: return MTLPixelFormatASTC_6x6_LDR;
+        case MTLPixelFormatASTC_8x5_sRGB: return MTLPixelFormatASTC_8x5_LDR;
+        case MTLPixelFormatASTC_8x6_sRGB: return MTLPixelFormatASTC_8x6_LDR;
+        case MTLPixelFormatASTC_8x8_sRGB: return MTLPixelFormatASTC_8x8_LDR;
+        case MTLPixelFormatASTC_10x5_sRGB: return MTLPixelFormatASTC_10x5_LDR;
+        case MTLPixelFormatASTC_10x6_sRGB: return MTLPixelFormatASTC_10x6_LDR;
+        case MTLPixelFormatASTC_10x8_sRGB: return MTLPixelFormatASTC_10x8_LDR;
+        case MTLPixelFormatASTC_10x10_sRGB: return MTLPixelFormatASTC_10x10_LDR;
+        case MTLPixelFormatASTC_12x10_sRGB: return MTLPixelFormatASTC_12x10_LDR;
+        case MTLPixelFormatASTC_12x12_sRGB: return MTLPixelFormatASTC_12x12_LDR;
+        case MTLPixelFormatPVRTC_RGB_2BPP_sRGB: return MTLPixelFormatPVRTC_RGB_2BPP;
+        case MTLPixelFormatPVRTC_RGB_4BPP_sRGB: return MTLPixelFormatPVRTC_RGB_4BPP;
+        case MTLPixelFormatPVRTC_RGBA_2BPP_sRGB: return MTLPixelFormatPVRTC_RGBA_2BPP;
+        case MTLPixelFormatPVRTC_RGBA_4BPP_sRGB: return MTLPixelFormatPVRTC_RGBA_4BPP;
+        case MTLPixelFormatEAC_RGBA8_sRGB: return MTLPixelFormatEAC_RGBA8;
+        case MTLPixelFormatETC2_RGB8_sRGB: return MTLPixelFormatETC2_RGB8;
+        case MTLPixelFormatETC2_RGB8A1_sRGB: return MTLPixelFormatETC2_RGB8A1;
+        case MTLPixelFormatBGR10_XR_sRGB: return MTLPixelFormatBGR10_XR;
+        case MTLPixelFormatBGRA10_XR_sRGB: return MTLPixelFormatBGRA10_XR;
+        default: break;
     }
     return format;
 }

--- a/filament/backend/src/metal/MetalEnums.mm
+++ b/filament/backend/src/metal/MetalEnums.mm
@@ -98,14 +98,12 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
 
     // Packed 16 bit formats are only available on Apple GPUs.
     if (context->highestSupportedGpuFamily.apple >= 1) {
-        if (@available(macOS 11.0, *)) {
             switch (format) {
                 case TextureFormat::RGB565: return MTLPixelFormatB5G6R5Unorm;
                 case TextureFormat::RGB5_A1: return MTLPixelFormatA1BGR5Unorm;
                 case TextureFormat::RGBA4: return MTLPixelFormatABGR4Unorm;
                 default: break;
             }
-        }
     }
 
     if (@available(iOS 13.0, *)) {
@@ -115,18 +113,16 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
 #if TARGET_OS_OSX
     if (context->highestSupportedGpuFamily.mac >= 1 &&
             context->device.depth24Stencil8PixelFormatSupported) {
-        if (@available(macOS 11.0, *)) {
             if (format == TextureFormat::DEPTH24_STENCIL8) {
                 return MTLPixelFormatDepth24Unorm_Stencil8;
             }
-        }
     }
 #endif
 
     // Only iOS 13.0 and Apple Silicon support the ASTC HDR profile. Older OS versions fallback to
     // LDR. The HDR profile is a superset of the LDR profile.
     if (context->highestSupportedGpuFamily.apple >= 2) {
-        if (@available(iOS 13, macOS 11.0, *)) {
+        if (@available(iOS 13, *)) {
             switch (format) {
                 case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_HDR;
                 case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_HDR;
@@ -144,7 +140,7 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
                 case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_HDR;
                 default: break;
             }
-        } else if (@available(macOS 11.0, *)) {
+        } else {
             switch (format) {
                 case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_LDR;
                 case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_LDR;
@@ -167,7 +163,6 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
 
     // EAC / ETC2 formats are only available on Apple GPUs.
     if (context->highestSupportedGpuFamily.apple >= 1) {
-        if (@available(macOS 11.0, *)) {
             switch (format) {
                 case TextureFormat::EAC_R11: return MTLPixelFormatEAC_R11Unorm;
                 case TextureFormat::EAC_R11_SIGNED: return MTLPixelFormatEAC_R11Snorm;
@@ -181,7 +176,6 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
                 case TextureFormat::ETC2_EAC_SRGBA8: return MTLPixelFormatEAC_RGBA8_sRGB;
                 default: break;
             }
-        }
     }
 
     // DXT (BC) formats are only available on macOS desktop.

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -183,9 +183,7 @@ id<MTLTexture> MetalSwapChain::createMultisampledTexture(MetalContext const& con
     descriptor.resourceOptions = MTLResourceStorageModePrivate;
 
     if (context.supportsMemorylessRenderTargets) {
-        if (@available(macOS 11.0, *)) {
-            descriptor.resourceOptions = MTLResourceStorageModeMemoryless;
-        }
+        descriptor.resourceOptions = MTLResourceStorageModeMemoryless;
     }
 
     return [context.device newTextureWithDescriptor:descriptor];
@@ -1375,9 +1373,7 @@ id<MTLTexture> MetalRenderTarget::createMultisampledTexture(MTLPixelFormat forma
     descriptor.resourceOptions = MTLResourceStorageModePrivate;
 
     if (context->supportsMemorylessRenderTargets) {
-        if (@available(macOS 11.0, *)) {
-            descriptor.resourceOptions = MTLResourceStorageModeMemoryless;
-        }
+        descriptor.resourceOptions = MTLResourceStorageModeMemoryless;
     }
 
     return [context->device newTextureWithDescriptor:descriptor];


### PR DESCRIPTION
This bumps our minimum macOS target to 11.0. 

You may need to `rm -rf out` your build folder in order to build successfully.