### PR TITLE
Harden filamesh parser and LinearImage against malformed inputs

### DIFF
--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -100,18 +100,42 @@ public:
      * file cannot be matched to a material in the registry, a default material is
      * used instead. The default material can be overridden by adding a material
      * named "DefaultMaterial" to the registry.
+     *
+     * This overload does NOT validate reads against the buffer size. Prefer the
+     * overload that accepts dataSize when loading data from an untrusted source.
      */
     static Mesh loadMeshFromBuffer(filament::Engine* engine,
             void const* data, Callback destructor, void* user,
             MaterialRegistry& materials);
 
     /**
+     * Loads a filamesh renderable from an in-memory buffer, validating that all
+     * reads stay within dataSize bytes of data. Returns an empty Mesh on any
+     * malformed header field or truncated payload.
+     */
+    static Mesh loadMeshFromBuffer(filament::Engine* engine,
+            void const* data, size_t dataSize, Callback destructor, void* user,
+            MaterialRegistry& materials);
+
+    /**
      * Loads a filamesh renderable from an in-memory buffer. The material registry
      * can be used to provide named materials. All the primitives of the decoded
      * renderable are assigned the specified default material.
+     *
+     * This overload does NOT validate reads against the buffer size. Prefer the
+     * overload that accepts dataSize when loading data from an untrusted source.
      */
     static Mesh loadMeshFromBuffer(filament::Engine* engine,
             void const* data, Callback destructor, void* user,
+            filament::MaterialInstance* defaultMaterial);
+
+    /**
+     * Loads a filamesh renderable from an in-memory buffer, validating that all
+     * reads stay within dataSize bytes of data. All the primitives of the decoded
+     * renderable are assigned the specified default material.
+     */
+    static Mesh loadMeshFromBuffer(filament::Engine* engine,
+            void const* data, size_t dataSize, Callback destructor, void* user,
             filament::MaterialInstance* defaultMaterial);
 };
 

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -32,11 +32,11 @@
 #include <utils/Log.h>
 #include <utils/Path.h>
 
-#include <string>
-#include <vector>
+#include <cstdint>
+#include <cstring>
 #include <map>
 #include <string>
-#include <climits>
+#include <vector>
 
 #include <fcntl.h>
 #if !defined(WIN32)
@@ -79,7 +79,7 @@ MeshReader::MaterialRegistry::~MaterialRegistry() {
 }
 
 // Default move construction
-MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&& rhs) 
+MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&& rhs)
     : mImpl(nullptr) {
     std::swap(mImpl, rhs.mImpl);
 }
@@ -181,7 +181,7 @@ MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const ut
         p += sizeof(MAGICID);
 
         if (!strncmp(MAGICID, magic, 8)) {
-            mesh = loadMeshFromBuffer(engine, data, nullptr, nullptr, materials);
+            mesh = loadMeshFromBuffer(engine, data, size, nullptr, nullptr, materials);
         }
 
         Fence::waitAndDestroy(engine->createFence());
@@ -192,101 +192,146 @@ MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const ut
     return mesh;
 }
 
+// Backward-compatible overload: no buffer-size information is provided, so no
+// buffer-end bounds checking is performed. Callers with untrusted data should
+// use the overload that accepts dataSize.
 MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         void const* data, Callback destructor, void* user,
         MaterialInstance* defaultMaterial) {
-    MaterialRegistry reg;
-    reg.registerMaterialInstance(utils::CString(DEFAULT_MATERIAL), defaultMaterial);
-    return loadMeshFromBuffer(engine, data, destructor, user, reg);
+    return loadMeshFromBuffer(engine, data, SIZE_MAX, destructor, user, defaultMaterial);
 }
 
 MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         void const* data, Callback destructor, void* user,
         MaterialRegistry& materials) {
-    const uint8_t* p = (const uint8_t*) data;
-    if (strncmp(MAGICID, (const char *) p, 8)) {
+    return loadMeshFromBuffer(engine, data, SIZE_MAX, destructor, user, materials);
+}
+
+MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
+        void const* data, size_t dataSize, Callback destructor, void* user,
+        MaterialInstance* defaultMaterial) {
+    MaterialRegistry reg;
+    reg.registerMaterialInstance(utils::CString(DEFAULT_MATERIAL), defaultMaterial);
+    return loadMeshFromBuffer(engine, data, dataSize, destructor, user, reg);
+}
+
+MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
+        void const* data, size_t dataSize, Callback destructor, void* user,
+        MaterialRegistry& materials) {
+    const uint8_t* const base = (const uint8_t*) data;
+    size_t consumed = 0;
+
+    // Magic.
+    if (dataSize < sizeof(MAGICID) || strncmp(MAGICID, (const char*) base, sizeof(MAGICID))) {
         utils::slog.e << "Magic string not found." << utils::io::endl;
         return {};
     }
-    p += 8;
+    consumed = sizeof(MAGICID);
 
-    Header* header = (Header*) p;
-    p += sizeof(Header);
+    // Header: copy into a local to avoid strict-aliasing and alignment UB when
+    // the caller-supplied buffer is not naturally aligned for uint32_t fields.
+    if (dataSize - consumed < sizeof(Header)) {
+        utils::slog.e << "Buffer too small for header." << utils::io::endl;
+        return {};
+    }
+    Header header;
+    memcpy(&header, base + consumed, sizeof(Header));
+    consumed += sizeof(Header);
 
-    // Validate that parts count does not cause overflow when multiplied by sizeof(Part).
-    if (header->parts > SIZE_MAX / sizeof(Part)) {
-        utils::slog.e << "Mesh part count is too large." << utils::io::endl;
+    if (header.version != VERSION) {
+        utils::slog.e << "Unsupported filamesh version: " << header.version << utils::io::endl;
         return {};
     }
 
-    // Sanity-check vertex and index sizes to catch obviously corrupt headers.
-    // vertexSize and indexSize are uint32_t, so they individually fit in size_t,
-    // but verify the sum with parts doesn't wrap.
-    uint64_t totalPayload = (uint64_t)header->vertexSize + (uint64_t)header->indexSize
-            + (uint64_t)header->parts * sizeof(Part);
-    if (totalPayload > SIZE_MAX) {
-        utils::slog.e << "Mesh payload sizes overflow." << utils::io::endl;
+    // Vertex data.
+    if (header.vertexSize > dataSize - consumed) {
+        utils::slog.e << "Invalid vertexSize." << utils::io::endl;
         return {};
     }
+    const uint8_t* vertexData = base + consumed;
+    consumed += header.vertexSize;
 
-    uint8_t const* vertexData = p;
-    p += header->vertexSize;
-
-    uint8_t const* indices = p;
-    p += header->indexSize;
-
-    Part* parts = (Part*) p;
-    p += header->parts * sizeof(Part);
-
-    uint32_t materialCount = (uint32_t) *p;
-    p += sizeof(uint32_t);
-
-    // Cap material count to a reasonable limit to prevent excessive allocation.
-    if (materialCount > header->parts + 1) {
-        utils::slog.e << "Material count (" << materialCount
-                << ") exceeds part count." << utils::io::endl;
+    // Index data.
+    if (header.indexSize > dataSize - consumed) {
+        utils::slog.e << "Invalid indexSize." << utils::io::endl;
         return {};
     }
+    const uint8_t* indices = base + consumed;
+    consumed += header.indexSize;
+
+    // Parts.
+    if (header.parts > SIZE_MAX / sizeof(Part)) {
+        utils::slog.e << "Mesh part count overflows." << utils::io::endl;
+        return {};
+    }
+    const size_t partsBytes = size_t(header.parts) * sizeof(Part);
+    if (partsBytes > dataSize - consumed) {
+        utils::slog.e << "Invalid parts count." << utils::io::endl;
+        return {};
+    }
+    const uint8_t* const partsBase = base + consumed;
+    consumed += partsBytes;
+
+    // Material count. The writer emits a 4-byte uint32_t; read it as such
+    // instead of dereferencing a single byte.
+    if (dataSize - consumed < sizeof(uint32_t)) {
+        utils::slog.e << "Buffer too small for material count." << utils::io::endl;
+        return {};
+    }
+    uint32_t materialCount;
+    memcpy(&materialCount, base + consumed, sizeof(uint32_t));
+    consumed += sizeof(uint32_t);
 
     std::vector<std::string> partsMaterial(materialCount);
     for (size_t i = 0; i < materialCount; i++) {
-        uint32_t nameLength = (uint32_t) *p;
-        p += sizeof(uint32_t);
-
-        // Validate nameLength to prevent reading beyond the material name data.
-        if (nameLength > 0xFFFF) {
-            utils::slog.e << "Material name length is unreasonable." << utils::io::endl;
+        if (dataSize - consumed < sizeof(uint32_t)) {
+            utils::slog.e << "Buffer too small for material name length." << utils::io::endl;
             return {};
         }
+        uint32_t nameLength;
+        memcpy(&nameLength, base + consumed, sizeof(uint32_t));
+        consumed += sizeof(uint32_t);
 
-        partsMaterial[i] = (const char*) p;
-        p += nameLength + 1; // null terminated
+        // Promote to size_t before adding 1 so that nameLength == UINT32_MAX
+        // cannot wrap to 0 and bypass the bounds check.
+        const size_t nameSpan = size_t(nameLength) + 1;
+        if (nameSpan > dataSize - consumed) {
+            utils::slog.e << "Invalid material name length." << utils::io::endl;
+            return {};
+        }
+        partsMaterial[i] = (const char*) (base + consumed);
+        consumed += nameSpan;
     }
 
     Mesh mesh;
 
     mesh.indexBuffer = IndexBuffer::Builder()
-            .indexCount(header->indexCount)
-            .bufferType(header->indexType == UI16 ? IndexBuffer::IndexType::USHORT
+            .indexCount(header.indexCount)
+            .bufferType(header.indexType == UI16 ? IndexBuffer::IndexType::USHORT
                     : IndexBuffer::IndexType::UINT)
             .build(*engine);
 
     // If the index buffer is compressed, then decode the indices into a temporary buffer.
     // The user callback can be called immediately afterwards because the source data does not get
     // passed to the GPU.
-    const size_t indicesSize = header->indexSize;
-    if (header->flags & COMPRESSION) {
-        size_t indexSize = header->indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
-        size_t indexCount = header->indexCount;
+    const size_t indicesSize = header.indexSize;
+    if (header.flags & COMPRESSION) {
+        size_t indexSize = header.indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
+        size_t indexCount = header.indexCount;
         if (indexCount > 0 && indexSize > SIZE_MAX / indexCount) {
             utils::slog.e << "Index buffer size overflow." << utils::io::endl;
             return {};
         }
         size_t uncompressedSize = indexSize * indexCount;
         void* uncompressed = malloc(uncompressedSize);
+        if (!uncompressed) {
+            utils::slog.e << "Failed to allocate index buffer." << utils::io::endl;
+            return {};
+        }
         int err = meshopt_decodeIndexBuffer(uncompressed, indexCount, indexSize, indices,
                 indicesSize);
         if (err) {
+            free(uncompressed);
             utils::slog.e << "Unable to decode index buffer." << utils::io::endl;
             return {};
         }
@@ -302,32 +347,32 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     }
 
     VertexBuffer::Builder vbb;
-    vbb.vertexCount(header->vertexCount)
+    vbb.vertexCount(header.vertexCount)
             .bufferCount(1)
             .normalized(VertexAttribute::COLOR)
             .normalized(VertexAttribute::TANGENTS);
 
-    VertexBuffer::AttributeType uvtype = (header->flags & TEXCOORD_SNORM16) ?
+    VertexBuffer::AttributeType uvtype = (header.flags & TEXCOORD_SNORM16) ?
             VertexBuffer::AttributeType::SHORT2 : VertexBuffer::AttributeType::HALF2;
 
     vbb
             .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::HALF4,
-                        header->offsetPosition, uint8_t(header->stridePosition))
+                        header.offsetPosition, uint8_t(header.stridePosition))
             .attribute(VertexAttribute::TANGENTS, 0, VertexBuffer::AttributeType::SHORT4,
-                        header->offsetTangents, uint8_t(header->strideTangents))
+                        header.offsetTangents, uint8_t(header.strideTangents))
             .attribute(VertexAttribute::COLOR, 0, VertexBuffer::AttributeType::UBYTE4,
-                        header->offsetColor, uint8_t(header->strideColor))
+                        header.offsetColor, uint8_t(header.strideColor))
             .attribute(VertexAttribute::UV0, 0, uvtype,
-                        header->offsetUV0, uint8_t(header->strideUV0))
-            .normalized(VertexAttribute::UV0, header->flags & TEXCOORD_SNORM16);
+                        header.offsetUV0, uint8_t(header.strideUV0))
+            .normalized(VertexAttribute::UV0, header.flags & TEXCOORD_SNORM16);
 
     constexpr uint32_t uintmax = std::numeric_limits<uint32_t>::max();
-    const bool hasUV1 = header->offsetUV1 != uintmax && header->strideUV1 != uintmax;
+    const bool hasUV1 = header.offsetUV1 != uintmax && header.strideUV1 != uintmax;
 
     if (hasUV1) {
         vbb
             .attribute(VertexAttribute::UV1, 0, VertexBuffer::AttributeType::HALF2,
-                    header->offsetUV1, uint8_t(header->strideUV1))
+                    header.offsetUV1, uint8_t(header.strideUV1))
             .normalized(VertexAttribute::UV1);
     }
 
@@ -336,48 +381,54 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     // If the vertex buffer is compressed, then decode the vertices into a temporary buffer.
     // The user callback can be called immediately afterwards because the source data does not get
     // passed to the GPU.
-    const size_t verticesSize = header->vertexSize;
-    if (header->flags & COMPRESSION) {
+    const size_t verticesSize = header.vertexSize;
+    if (header.flags & COMPRESSION) {
         size_t vertexSize = sizeof(half4) + sizeof(short4) + sizeof(ubyte4) + sizeof(ushort2) +
                 (hasUV1 ? sizeof(ushort2) : 0);
-        size_t vertexCount = header->vertexCount;
+        size_t vertexCount = header.vertexCount;
         if (vertexCount > 0 && vertexSize > SIZE_MAX / vertexCount) {
             utils::slog.e << "Vertex buffer size overflow." << utils::io::endl;
             return {};
         }
         size_t uncompressedSize = vertexSize * vertexCount;
         void* uncompressed = malloc(uncompressedSize);
+        if (!uncompressed) {
+            utils::slog.e << "Failed to allocate vertex buffer." << utils::io::endl;
+            return {};
+        }
         const uint8_t* srcdata = vertexData + sizeof(CompressionHeader);
         int err = 0;
-        if (header->flags & INTERLEAVED) {
+        if (header.flags & INTERLEAVED) {
             err |= meshopt_decodeVertexBuffer(uncompressed, vertexCount, vertexSize, srcdata,
                     vertexSize);
         } else {
-            const CompressionHeader* sizes = (CompressionHeader*) vertexData;
+            CompressionHeader sizes;
+            memcpy(&sizes, vertexData, sizeof(CompressionHeader));
             uint8_t* dstdata = (uint8_t*) uncompressed;
             auto decode = meshopt_decodeVertexBuffer;
 
-            err |= decode(dstdata, vertexCount, sizeof(half4), srcdata, sizes->positions);
-            srcdata += sizes->positions;
+            err |= decode(dstdata, vertexCount, sizeof(half4), srcdata, sizes.positions);
+            srcdata += sizes.positions;
             dstdata += sizeof(half4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(short4), srcdata, sizes->tangents);
-            srcdata += sizes->tangents;
+            err |= decode(dstdata, vertexCount, sizeof(short4), srcdata, sizes.tangents);
+            srcdata += sizes.tangents;
             dstdata += sizeof(short4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(ubyte4), srcdata, sizes->colors);
-            srcdata += sizes->colors;
+            err |= decode(dstdata, vertexCount, sizeof(ubyte4), srcdata, sizes.colors);
+            srcdata += sizes.colors;
             dstdata += sizeof(ubyte4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes->uv0);
+            err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes.uv0);
 
-            if (sizes->uv1) {
-                srcdata += sizes->uv0;
+            if (sizes.uv1) {
+                srcdata += sizes.uv0;
                 dstdata += sizeof(ushort2) * vertexCount;
-                err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes->uv1);
+                err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes.uv1);
             }
         }
         if (err) {
+            free(uncompressed);
             utils::slog.e << "Unable to decode vertex buffer." << utils::io::endl;
             return {};
         }
@@ -394,18 +445,21 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
     mesh.renderable = utils::EntityManager::get().create();
 
-    RenderableManager::Builder builder(header->parts);
-    builder.boundingBox(header->aabb);
+    RenderableManager::Builder builder(header.parts);
+    builder.boundingBox(header.aabb);
 
     const auto defaultmi = materials.getMaterialInstance(utils::CString(DEFAULT_MATERIAL));
-    for (size_t i = 0; i < header->parts; i++) {
+    for (size_t i = 0; i < header.parts; i++) {
+        Part part;
+        memcpy(&part, partsBase + i * sizeof(Part), sizeof(Part));
+
         builder.geometry(i, RenderableManager::PrimitiveType::TRIANGLES,
-                mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
-                parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
+                mesh.vertexBuffer, mesh.indexBuffer, part.offset,
+                part.minIndex, part.maxIndex, part.indexCount);
 
         // It may happen that there are more parts than materials
         // therefore we have to use Part::material instead of i.
-        uint32_t materialIndex = parts[i].material;
+        uint32_t materialIndex = part.material;
         if (materialIndex >= partsMaterial.size()) {
             utils::slog.e << "Material index (" << materialIndex << ") of mesh part ("
                     << i << ") is out of bounds (" << partsMaterial.size() << ")" << utils::io::endl;

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -292,18 +292,39 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         memcpy(&nameLength, base + consumed, sizeof(uint32_t));
         consumed += sizeof(uint32_t);
 
-        // Promote to size_t before adding 1 so that nameLength == UINT32_MAX
-        // cannot wrap to 0 and bypass the bounds check.
-        const size_t nameSpan = size_t(nameLength) + 1;
-        if (nameSpan > dataSize - consumed) {
+        // Bound nameLength against the remaining buffer before adding 1 so
+        // the add cannot wrap on 32-bit targets where size_t is 32-bit.
+        if (nameLength >= dataSize - consumed) {
             utils::slog.e << "Invalid material name length." << utils::io::endl;
             return {};
         }
-        partsMaterial[i] = (const char*) (base + consumed);
-        consumed += nameSpan;
+        // Copy exactly nameLength bytes. Assigning from a bare C-string
+        // pointer would fall back to strlen and could read past the declared
+        // span if the buffer is not NUL-terminated at the expected offset.
+        partsMaterial[i].assign((const char*) (base + consumed), nameLength);
+        consumed += size_t(nameLength) + 1;
     }
 
     Mesh mesh;
+
+    // Pre-compute compressed-buffer sizing so we can reject malformed headers
+    // before allocating any engine-owned resources (which would otherwise
+    // leak on early return).
+    constexpr uint32_t uintmax = std::numeric_limits<uint32_t>::max();
+    const bool hasUV1 = header.offsetUV1 != uintmax && header.strideUV1 != uintmax;
+    const size_t indexStride = header.indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
+    const size_t vertexStride = sizeof(half4) + sizeof(short4) + sizeof(ubyte4) + sizeof(ushort2) +
+            (hasUV1 ? sizeof(ushort2) : 0);
+    if (header.flags & COMPRESSION) {
+        if (header.indexCount > 0 && indexStride > SIZE_MAX / header.indexCount) {
+            utils::slog.e << "Index buffer size overflow." << utils::io::endl;
+            return {};
+        }
+        if (header.vertexCount > 0 && vertexStride > SIZE_MAX / header.vertexCount) {
+            utils::slog.e << "Vertex buffer size overflow." << utils::io::endl;
+            return {};
+        }
+    }
 
     mesh.indexBuffer = IndexBuffer::Builder()
             .indexCount(header.indexCount)
@@ -316,23 +337,20 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     // passed to the GPU.
     const size_t indicesSize = header.indexSize;
     if (header.flags & COMPRESSION) {
-        size_t indexSize = header.indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
-        size_t indexCount = header.indexCount;
-        if (indexCount > 0 && indexSize > SIZE_MAX / indexCount) {
-            utils::slog.e << "Index buffer size overflow." << utils::io::endl;
-            return {};
-        }
-        size_t uncompressedSize = indexSize * indexCount;
+        const size_t indexCount = header.indexCount;
+        const size_t uncompressedSize = indexStride * indexCount;
         void* uncompressed = malloc(uncompressedSize);
         if (!uncompressed) {
             utils::slog.e << "Failed to allocate index buffer." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
-        int err = meshopt_decodeIndexBuffer(uncompressed, indexCount, indexSize, indices,
+        int err = meshopt_decodeIndexBuffer(uncompressed, indexCount, indexStride, indices,
                 indicesSize);
         if (err) {
             free(uncompressed);
             utils::slog.e << "Unable to decode index buffer." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
         if (destructor) {
@@ -366,9 +384,6 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
                         header.offsetUV0, uint8_t(header.strideUV0))
             .normalized(VertexAttribute::UV0, header.flags & TEXCOORD_SNORM16);
 
-    constexpr uint32_t uintmax = std::numeric_limits<uint32_t>::max();
-    const bool hasUV1 = header.offsetUV1 != uintmax && header.strideUV1 != uintmax;
-
     if (hasUV1) {
         vbb
             .attribute(VertexAttribute::UV1, 0, VertexBuffer::AttributeType::HALF2,
@@ -383,24 +398,20 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     // passed to the GPU.
     const size_t verticesSize = header.vertexSize;
     if (header.flags & COMPRESSION) {
-        size_t vertexSize = sizeof(half4) + sizeof(short4) + sizeof(ubyte4) + sizeof(ushort2) +
-                (hasUV1 ? sizeof(ushort2) : 0);
-        size_t vertexCount = header.vertexCount;
-        if (vertexCount > 0 && vertexSize > SIZE_MAX / vertexCount) {
-            utils::slog.e << "Vertex buffer size overflow." << utils::io::endl;
-            return {};
-        }
-        size_t uncompressedSize = vertexSize * vertexCount;
+        const size_t vertexCount = header.vertexCount;
+        const size_t uncompressedSize = vertexStride * vertexCount;
         void* uncompressed = malloc(uncompressedSize);
         if (!uncompressed) {
             utils::slog.e << "Failed to allocate vertex buffer." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
+            engine->destroy(mesh.vertexBuffer);
             return {};
         }
         const uint8_t* srcdata = vertexData + sizeof(CompressionHeader);
         int err = 0;
         if (header.flags & INTERLEAVED) {
-            err |= meshopt_decodeVertexBuffer(uncompressed, vertexCount, vertexSize, srcdata,
-                    vertexSize);
+            err |= meshopt_decodeVertexBuffer(uncompressed, vertexCount, vertexStride, srcdata,
+                    vertexStride);
         } else {
             CompressionHeader sizes;
             memcpy(&sizes, vertexData, sizeof(CompressionHeader));
@@ -430,6 +441,8 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         if (err) {
             free(uncompressed);
             utils::slog.e << "Unable to decode vertex buffer." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
+            engine->destroy(mesh.vertexBuffer);
             return {};
         }
         if (destructor) {

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <climits>
 
 #include <fcntl.h>
 #if !defined(WIN32)
@@ -165,6 +166,10 @@ MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const ut
     Mesh mesh;
 
     int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        utils::slog.e << "Unable to open mesh file." << utils::io::endl;
+        return mesh;
+    }
 
     size_t size = fileSize(fd);
     char* data = (char*) malloc(size);
@@ -208,6 +213,22 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     Header* header = (Header*) p;
     p += sizeof(Header);
 
+    // Validate that parts count does not cause overflow when multiplied by sizeof(Part).
+    if (header->parts > SIZE_MAX / sizeof(Part)) {
+        utils::slog.e << "Mesh part count is too large." << utils::io::endl;
+        return {};
+    }
+
+    // Sanity-check vertex and index sizes to catch obviously corrupt headers.
+    // vertexSize and indexSize are uint32_t, so they individually fit in size_t,
+    // but verify the sum with parts doesn't wrap.
+    uint64_t totalPayload = (uint64_t)header->vertexSize + (uint64_t)header->indexSize
+            + (uint64_t)header->parts * sizeof(Part);
+    if (totalPayload > SIZE_MAX) {
+        utils::slog.e << "Mesh payload sizes overflow." << utils::io::endl;
+        return {};
+    }
+
     uint8_t const* vertexData = p;
     p += header->vertexSize;
 
@@ -220,10 +241,24 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     uint32_t materialCount = (uint32_t) *p;
     p += sizeof(uint32_t);
 
+    // Cap material count to a reasonable limit to prevent excessive allocation.
+    if (materialCount > header->parts + 1) {
+        utils::slog.e << "Material count (" << materialCount
+                << ") exceeds part count." << utils::io::endl;
+        return {};
+    }
+
     std::vector<std::string> partsMaterial(materialCount);
     for (size_t i = 0; i < materialCount; i++) {
         uint32_t nameLength = (uint32_t) *p;
         p += sizeof(uint32_t);
+
+        // Validate nameLength to prevent reading beyond the material name data.
+        if (nameLength > 0xFFFF) {
+            utils::slog.e << "Material name length is unreasonable." << utils::io::endl;
+            return {};
+        }
+
         partsMaterial[i] = (const char*) p;
         p += nameLength + 1; // null terminated
     }
@@ -243,6 +278,10 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     if (header->flags & COMPRESSION) {
         size_t indexSize = header->indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
         size_t indexCount = header->indexCount;
+        if (indexCount > 0 && indexSize > SIZE_MAX / indexCount) {
+            utils::slog.e << "Index buffer size overflow." << utils::io::endl;
+            return {};
+        }
         size_t uncompressedSize = indexSize * indexCount;
         void* uncompressed = malloc(uncompressedSize);
         int err = meshopt_decodeIndexBuffer(uncompressed, indexCount, indexSize, indices,
@@ -302,6 +341,10 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         size_t vertexSize = sizeof(half4) + sizeof(short4) + sizeof(ubyte4) + sizeof(ushort2) +
                 (hasUV1 ? sizeof(ushort2) : 0);
         size_t vertexCount = header->vertexCount;
+        if (vertexCount > 0 && vertexSize > SIZE_MAX / vertexCount) {
+            utils::slog.e << "Vertex buffer size overflow." << utils::io::endl;
+            return {};
+        }
         size_t uncompressedSize = vertexSize * vertexCount;
         void* uncompressed = malloc(uncompressedSize);
         const uint8_t* srcdata = vertexData + sizeof(CompressionHeader);

--- a/libs/filameshio/tests/test_filamesh.cpp
+++ b/libs/filameshio/tests/test_filamesh.cpp
@@ -157,7 +157,8 @@ TEST_F(FilameshTest, NonInterleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), stream.str().size(),
+            nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);
@@ -206,7 +207,8 @@ TEST_F(FilameshTest, Interleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), stream.str().size(),
+            nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);

--- a/libs/image/src/LinearImage.cpp
+++ b/libs/image/src/LinearImage.cpp
@@ -16,21 +16,28 @@
 
 #include <image/LinearImage.h>
 
+#include <cstdint>
 #include <cstring> // for memset
 #include <memory>
-#include <climits>
 #include <stdexcept>
 
 namespace image  {
 
 struct LinearImage::SharedReference {
     SharedReference(uint32_t width, uint32_t height, uint32_t channels) {
-        const uint64_t nfloats = (uint64_t)width * height * channels;
-        if (nfloats > SIZE_MAX / sizeof(float)) {
-            throw std::overflow_error("LinearImage dimensions too large");
+        // width * height fits in uint64_t; the subsequent multiplication by
+        // channels can still overflow uint64_t, so saturate in two stages.
+        const uint64_t wh = uint64_t(width) * height;
+        if (channels != 0 && wh > UINT64_MAX / channels) {
+            throw std::runtime_error("LinearImage dimensions too large");
         }
-        float* floats = new float[static_cast<size_t>(nfloats)];
-        memset(floats, 0, sizeof(float) * static_cast<size_t>(nfloats));
+        const uint64_t nfloats = wh * channels;
+        if (nfloats > SIZE_MAX / sizeof(float)) {
+            throw std::runtime_error("LinearImage dimensions too large");
+        }
+        const size_t n = static_cast<size_t>(nfloats);
+        float* floats = new float[n];
+        memset(floats, 0, sizeof(float) * n);
         pixels = std::shared_ptr<float>(floats, std::default_delete<float[]>());
     }
     std::shared_ptr<float> pixels;

--- a/libs/image/src/LinearImage.cpp
+++ b/libs/image/src/LinearImage.cpp
@@ -18,14 +18,19 @@
 
 #include <cstring> // for memset
 #include <memory>
+#include <climits>
+#include <stdexcept>
 
 namespace image  {
 
 struct LinearImage::SharedReference {
     SharedReference(uint32_t width, uint32_t height, uint32_t channels) {
-        const uint32_t nfloats = width * height * channels;
-        float* floats = new float[nfloats];
-        memset(floats, 0, sizeof(float) * nfloats);
+        const uint64_t nfloats = (uint64_t)width * height * channels;
+        if (nfloats > SIZE_MAX / sizeof(float)) {
+            throw std::overflow_error("LinearImage dimensions too large");
+        }
+        float* floats = new float[static_cast<size_t>(nfloats)];
+        memset(floats, 0, sizeof(float) * static_cast<size_t>(nfloats));
         pixels = std::shared_ptr<float>(floats, std::default_delete<float[]>());
     }
     std::shared_ptr<float> pixels;


### PR DESCRIPTION
## Summary

Hardens two attacker-reachable parsers against malformed input while fixing three latent correctness bugs that exist in `main` today.

### `libs/filameshio` — MeshReader

- **New `loadMeshFromBuffer` overload that accepts `dataSize`** and bounds-checks every read against the buffer end (magic, header, vertexSize, indexSize, parts array, materialCount, each material nameLength). The existing overloads are kept as thin wrappers forwarding with `dataSize = SIZE_MAX`, so external callers compile unchanged.
- **`loadMeshFromFile`** forwards the known file size through the new bounds-validated path (plus the pre-existing `fd < 0` guard).
- **Alignment / strict-aliasing fix**: `Header`, `CompressionHeader`, and each `Part` are now read via `memcpy` into a local instead of cast through the caller-supplied buffer, which may not be naturally aligned for `uint32_t`.
- **`materialCount` / `nameLength` read fix**: the original code wrote `uint32_t x = (uint32_t) *p;` — this dereferences a single byte and then advances by `sizeof(uint32_t)`, silently truncating any value ≥ 256 and breaking on big-endian hosts. Replaced with `memcpy` so all four bytes emitted by the writer (`tools/filamesh/src/MeshWriter.cpp:253-255`) are read.
- **`nameLength + 1` overflow fix**: promote to `size_t` before `+ 1`, otherwise `nameLength == UINT32_MAX` wraps to zero and the bounds check is bypassed.
- **Header `version` check**: reject unknown versions before interpreting fields whose layout could differ.
- **Integer-overflow checks on compressed buffer sizing** (`indexSize * indexCount`, `vertexSize * vertexCount`) and on `header.parts * sizeof(Part)` before pointer arithmetic.
- **`malloc` return checks** on the two compressed-decode paths; the scratch buffer is `free`'d if decoding fails instead of leaking.

### `libs/image` — LinearImage

- `LinearImage(width, height, channels)` previously computed `uint32_t nfloats = width * height * channels;` — silently truncating on values like 65536 × 65536 × 3 and producing an undersized allocation followed by out-of-bounds `memset` / pixel writes.
- Now saturates in two stages (`width * height` fits in `uint64_t`; the multiply by `channels` is checked against `UINT64_MAX / channels`), then validates against `SIZE_MAX / sizeof(float)` before allocation. Throws `std::runtime_error` on overflow, matching the convention already used in `libs/imageio` (`ImageDecoder.cpp`, `ImageEncoder.cpp`).

## Test plan

- [ ] `test_filamesh` (`NonInterleaved`, `Interleaved`) — updated to call the bounds-validated overload; should continue to pass.
- [ ] Craft a filamesh buffer with `parts = 0xFFFFFFFF` and verify the overflow check rejects it.
- [ ] Craft a filamesh buffer that claims `materialCount = 300` to confirm that, with the `memcpy` fix, all 300 material entries are parsed (old code would silently read 300 as 0x2C = 44 on little-endian).
- [ ] Craft a filamesh buffer with `nameLength = 0xFFFFFFFF` and verify the `size_t`-promoted bounds check rejects it.
- [ ] Truncated buffer (every payload field one byte short of the file) — each should return an empty `Mesh` instead of reading past the end.
- [ ] `LinearImage(65536, 65536, 3)` throws `std::runtime_error`.
- [ ] Existing `.filamesh` samples load unchanged via the backward-compat overload.
