### PR TITLE
Add support for custom outputs for unlit surface materials

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -278,7 +278,15 @@ public:
         FLOAT,
         FLOAT2,
         FLOAT3,
-        FLOAT4
+        FLOAT4,
+        INT,
+        INT2,
+        INT3,
+        INT4,
+        UINT,
+        UINT2,
+        UINT3,
+        UINT4
     };
 
     struct PreprocessorDefine {

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -148,6 +148,14 @@ std::unordered_map<std::string_view, OutputType> Enums::mStringToOutputType = {
         { "float2",  OutputType::FLOAT2 },
         { "float3",  OutputType::FLOAT3 },
         { "float4",  OutputType::FLOAT4 },
+        { "int",     OutputType::INT },
+        { "int2",    OutputType::INT2 },
+        { "int3",    OutputType::INT3 },
+        { "int4",    OutputType::INT4 },
+        { "uint",    OutputType::UINT },
+        { "uint2",   OutputType::UINT2 },
+        { "uint3",   OutputType::UINT3 },
+        { "uint4",   OutputType::UINT4 }
 };
 
 template <>

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1302,6 +1302,25 @@ error:
         mShading = Shading::UNLIT;
     }
 
+    if (mMaterialDomain == MaterialDomain::SURFACE && !mOutputs.empty()) {
+        if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+            LOG(ERROR) << "Error: feature level 0 does not support custom outputs.";
+            goto error;
+        }
+        if (mOutputs.size() > 1) {
+            LOG(ERROR) << "Error: surface materials only support a maximum of 1 custom output.";
+            goto error;
+        }
+        if (mShading != Shading::UNLIT) {
+            LOG(ERROR) << "Error: custom outputs are only supported for unlit surface materials.";
+            goto error;
+        }
+        if (mBlendingMode != BlendingMode::OPAQUE) {
+            LOG(ERROR) << "Error: surface materials with custom outputs must use opaque blending.";
+            goto error;
+        }
+    }
+
     // Add a default color output.
     if (mMaterialDomain == MaterialDomain::POST_PROCESS && mOutputs.empty()) {
         output(VariableQualifier::OUT,

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -1242,6 +1242,14 @@ char const* CodeGenerator::getOutputTypeName(MaterialBuilder::OutputType type) n
         case MaterialBuilder::OutputType::FLOAT2: return "vec2";
         case MaterialBuilder::OutputType::FLOAT3: return "vec3";
         case MaterialBuilder::OutputType::FLOAT4: return "vec4";
+        case MaterialBuilder::OutputType::INT:    return "int";
+        case MaterialBuilder::OutputType::INT2:   return "ivec2";
+        case MaterialBuilder::OutputType::INT3:   return "ivec3";
+        case MaterialBuilder::OutputType::INT4:   return "ivec4";
+        case MaterialBuilder::OutputType::UINT:   return "uint";
+        case MaterialBuilder::OutputType::UINT2:  return "uvec2";
+        case MaterialBuilder::OutputType::UINT3:  return "uvec3";
+        case MaterialBuilder::OutputType::UINT4:  return "uvec4";
     }
 }
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -607,6 +607,16 @@ std::string ShaderGenerator::createSurfaceFragmentProgram(ShaderModel const shad
             +PerMaterialBindingPoints::MATERIAL_PARAMS,
             material.uib);
 
+    if (!filament::Variant::isValidDepthVariant(variant)) {
+        if (!mOutputs.empty()) {
+            CodeGenerator::generateDefine(fs, "HAS_CUSTOM_OUTPUT", 1u);
+            for (const auto& output: mOutputs) {
+                cg.generateOutput(fs, ShaderStage::FRAGMENT, output.name, output.location,
+                        output.qualifier, output.precision, output.type);
+            }
+        }
+    }
+
     CodeGenerator::generateSeparator(fs);
 
     if (featureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
@@ -808,13 +818,16 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel const 
     CodeGenerator::generatePostProcessGetters(fs, ShaderStage::FRAGMENT);
 
     // Generate post-process outputs.
-    for (const auto& output : mOutputs) {
-        if (output.target == MaterialBuilder::OutputTarget::COLOR) {
-            cg.generateOutput(fs, ShaderStage::FRAGMENT, output.name, output.location,
-                    output.qualifier, output.precision, output.type);
-        }
-        if (output.target == MaterialBuilder::OutputTarget::DEPTH) {
-            CodeGenerator::generateDefine(fs, "FRAG_OUTPUT_DEPTH", 1u);
+    if (!mOutputs.empty()) {
+        CodeGenerator::generateDefine(fs, "HAS_CUSTOM_OUTPUT", 1u);
+        for (const auto& output: mOutputs) {
+            if (output.target == MaterialBuilder::OutputTarget::COLOR) {
+                cg.generateOutput(fs, ShaderStage::FRAGMENT, output.name, output.location,
+                        output.qualifier, output.precision, output.type);
+            }
+            if (output.target == MaterialBuilder::OutputTarget::DEPTH) {
+                CodeGenerator::generateDefine(fs, "FRAG_OUTPUT_DEPTH", 1u);
+            }
         }
     }
 

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -1061,6 +1061,85 @@ TEST_F(MaterialCompiler, ClientApiLevelReleasedUseOfUnstableApiFails) {
     EXPECT_FALSE(result.isValid());
 }
 
+TEST_F(MaterialCompiler, CustomOutputSuccess) {
+    std::string shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.customOutput = uvec4(1, 2, 3, 4);
+        }
+    )");
+
+    filamat::MaterialBuilder builder;
+    builder.material(shaderCode.c_str());
+    builder.shading(filament::Shading::UNLIT);
+    builder.blending(filament::BlendingMode::OPAQUE);
+    builder.featureLevel(FeatureLevel::FEATURE_LEVEL_1);
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput");
+
+    filamat::Package result = builder.build(*jobSystem);
+    EXPECT_TRUE(result.isValid());
+}
+
+TEST_F(MaterialCompiler, CustomOutputFeatureLevel0Fails) {
+    filamat::MaterialBuilder builder;
+    builder.featureLevel(FeatureLevel::FEATURE_LEVEL_0);
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput");
+    filamat::Package result = builder.build(*jobSystem);
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(MaterialCompiler, CustomOutputMoreThanOneFails) {
+    filamat::MaterialBuilder builder;
+    builder.featureLevel(FeatureLevel::FEATURE_LEVEL_1);
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput");
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput1");
+    filamat::Package result = builder.build(*jobSystem);
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(MaterialCompiler, CustomOutputLitFails) {
+    filamat::MaterialBuilder builder;
+    builder.featureLevel(FeatureLevel::FEATURE_LEVEL_1);
+    builder.shading(filament::Shading::LIT);
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput");
+    filamat::Package result = builder.build(*jobSystem);
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(MaterialCompiler, CustomOutputTransparentFails) {
+    filamat::MaterialBuilder builder;
+    builder.featureLevel(FeatureLevel::FEATURE_LEVEL_1);
+    builder.shading(filament::Shading::UNLIT);
+    builder.blending(filament::BlendingMode::TRANSPARENT);
+    builder.output(filamat::MaterialBuilder::VariableQualifier::OUT,
+                   filamat::MaterialBuilder::OutputTarget::COLOR,
+                   filamat::MaterialBuilder::Precision::DEFAULT,
+                   filamat::MaterialBuilder::OutputType::UINT4,
+                   "customOutput");
+    filamat::Package result = builder.build(*jobSystem);
+    EXPECT_FALSE(result.isValid());
+}
+
 #if FILAMENT_SUPPORTS_WEBGPU
 TEST_F(MaterialCompiler, WgslConversionBakedColor) {
     std::string bakedColorCodeFrag(R"(

--- a/shaders/src/surface_main.fs
+++ b/shaders/src/surface_main.fs
@@ -1,4 +1,10 @@
+#if !defined(HAS_CUSTOM_OUTPUT)
 layout(location = 0) out vec4 fragColor;
+#else
+// Define fragColor even with custom outputs enabled to satisfy usages. It will be removed
+// during dead-code elimination.
+vec4 fragColor;
+#endif
 
 #if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
 void blendPostLightingColor(const MaterialInputs material, inout vec4 color) {
@@ -116,4 +122,7 @@ void main() {
 #endif
 
 
+#if defined(HAS_CUSTOM_OUTPUT)
+    FRAG_OUTPUT_AT0 = inputs.FRAG_OUTPUT0;
+#endif
 }

--- a/shaders/src/surface_material_inputs.fs
+++ b/shaders/src/surface_material_inputs.fs
@@ -105,6 +105,10 @@ struct MaterialInputs {
     float shadowStrength;
 #endif
 
+#if defined(FRAG_OUTPUT0)
+    FRAG_OUTPUT_MATERIAL_TYPE0 FRAG_OUTPUT0;
+#endif
+
 };
 
 void initMaterial(out MaterialInputs material) {
@@ -207,6 +211,10 @@ void initMaterial(out MaterialInputs material) {
 
 #if defined(MATERIAL_HAS_SHADOW_STRENGTH)
     material.shadowStrength = 0.0;
+#endif
+
+#if defined(FRAG_OUTPUT0)
+    material.FRAG_OUTPUT0 = FRAG_OUTPUT_MATERIAL_TYPE0(0.0);
 #endif
 }
 


### PR DESCRIPTION
Unlit surface materials can now use `outputs` to define a single output that will bypass the typical color code path. This allows users to write directly `materialInputs.customOutput`.

More aggressive validation will be done in a follow-up PR.

BUGS=[490401325]