### PR TITLE
Add shared context support to PlatformOSMesa

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformOSMesa.h
+++ b/filament/backend/include/backend/platforms/PlatformOSMesa.h
@@ -31,6 +31,11 @@
 #include <backend/platforms/OpenGLPlatform.h>
 #include <backend/DriverEnums.h>
 
+#include <unordered_map>
+#include <thread>
+#include <shared_mutex>
+#include <memory>
+
 namespace filament::backend {
 
 /**
@@ -58,10 +63,20 @@ protected:
     bool makeCurrent(ContextType type, SwapChain* drawSwapChain,
             SwapChain* readSwapChain) override;
     void commit(SwapChain* swapChain) noexcept override;
+    bool isExtraContextSupported() const noexcept override;
+    void createContext(bool shared) override;
+    void releaseContext() noexcept override;
 
 private:
     OSMesaContext mContext;
     void* mOsMesaApi = nullptr;
+
+    struct ContextInfo {
+        OSMesaContext context;
+        std::unique_ptr<uint8_t[]> buffer;
+    };
+    std::unordered_map<std::thread::id, ContextInfo> mAdditionalContexts;
+    mutable std::shared_mutex mAdditionalContextsLock;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformOSMesa.cpp
@@ -16,8 +16,9 @@
 
 #include <backend/platforms/PlatformOSMesa.h>
 
-#include <utils/Log.h>
+#include <utils/Logger.h>
 #include <utils/Panic.h>
+#include <utils/ThreadUtils.h>
 
 #include <dlfcn.h>
 #include <memory>
@@ -127,9 +128,7 @@ Driver* PlatformOSMesa::createDriver(void* sharedGLContext,
         0,
     };
 
-    FILAMENT_CHECK_PRECONDITION(sharedGLContext == nullptr)
-            << "shared GL context is not supported with PlatformOSMesa";
-    mContext = api->fOSMesaCreateContextAttribs(attribs, NULL);
+    mContext = api->fOSMesaCreateContextAttribs(attribs, (OSMesaContext) sharedGLContext);
 
     // We need to do a no-op makecurrent here so that the context will be in a correct state before
     // any GL calls.
@@ -145,11 +144,85 @@ Driver* PlatformOSMesa::createDriver(void* sharedGLContext,
 
 void PlatformOSMesa::terminate() noexcept {
     OSMesaAPI* api = (OSMesaAPI*) mOsMesaApi;
+
+    for (auto& it: mAdditionalContexts) {
+        api->fOSMesaDestroyContext(it.second.context);
+    }
+    mAdditionalContexts.clear();
+
     api->fOSMesaDestroyContext(mContext);
     delete api;
     mOsMesaApi = nullptr;
 
     bluegl::unbind();
+}
+
+bool PlatformOSMesa::isExtraContextSupported() const noexcept { return true; }
+
+void PlatformOSMesa::createContext(bool shared) {
+    std::thread::id currentThreadId = utils::ThreadUtils::getThreadId();
+
+    {
+        std::shared_lock<std::shared_mutex> lock(mAdditionalContextsLock);
+        auto it = mAdditionalContexts.find(currentThreadId);
+        if (it != mAdditionalContexts.end()) {
+            LOG(WARNING) << "Shared context is already created for this thread";
+            return;
+        }
+    }
+
+    OSMesaAPI* api = (OSMesaAPI*) mOsMesaApi;
+
+    static constexpr int attribs[] = {
+        OSMESA_FORMAT, GL_RGBA,
+        OSMESA_DEPTH_BITS, 24,
+        OSMESA_STENCIL_BITS, 8,
+        OSMESA_ACCUM_BITS, 0,
+        OSMESA_PROFILE, OSMESA_CORE_PROFILE,
+        0,
+    };
+
+    OSMesaContext context = api->fOSMesaCreateContextAttribs(attribs, shared ? mContext : NULL);
+    if (!context) {
+        LOG(ERROR) << "Failed to create shared context";
+        return;
+    }
+
+    // OSMesa requires a non-null buffer to make a context current. Since we don't have a window
+    // or swapchain here, we use a dummy 1x1 buffer.
+    auto buffer = std::make_unique<uint8_t[]>(1 * 1 * 4 * sizeof(BackingType));
+
+    auto result = api->fOSMesaMakeCurrent(context, buffer.get(), BACKING_GL_TYPE, 1, 1);
+    FILAMENT_CHECK_POSTCONDITION(result == GL_TRUE)
+            << "OSMesaMakeCurrent failed for extra context!";
+
+    std::lock_guard<std::shared_mutex> lock(mAdditionalContextsLock);
+    mAdditionalContexts[currentThreadId] = { context, std::move(buffer) };
+}
+
+void PlatformOSMesa::releaseContext() noexcept {
+    std::thread::id currentThreadId = utils::ThreadUtils::getThreadId();
+    OSMesaContext context = nullptr;
+
+    {
+        std::lock_guard<std::shared_mutex> lock(mAdditionalContextsLock);
+        auto it = mAdditionalContexts.find(currentThreadId);
+        if (it == mAdditionalContexts.end()) {
+            LOG(WARNING) << "Attempted to destroy non-existing shared context";
+            return;
+        }
+        context = it->second.context;
+    }
+
+    OSMesaAPI* api = (OSMesaAPI*) mOsMesaApi;
+    // Passing NULL as the context is the standard way to unbind in OSMesa.
+    api->fOSMesaMakeCurrent(NULL, NULL, 0, 0, 0);
+    api->fOSMesaDestroyContext(context);
+
+    {
+        std::lock_guard<std::shared_mutex> lock(mAdditionalContextsLock);
+        mAdditionalContexts.erase(currentThreadId);
+    }
 }
 
 Platform::SwapChain* PlatformOSMesa::createSwapChain(void* nativeWindow, uint64_t flags) noexcept {

--- a/filament/backend/test/test_AsyncUploads.cpp
+++ b/filament/backend/test/test_AsyncUploads.cpp
@@ -53,8 +53,6 @@ static void signalCallback(void* user) {
 TEST_F(BackendTest, BasicAsyncFlow) {
     SKIP_IF(Backend::VULKAN, "Vulkan does not support asynchronous resource uploading");
     SKIP_IF(Backend::WEBGPU, "WebGPU does not support asynchronous resource uploading");
-    SKIP_IF(SkipEnvironment(OperatingSystem::CI, Backend::OPENGL),
-            "Mesa does not support shared contexts");
 
     constexpr int kRenderTargetSize = 512;
 
@@ -184,7 +182,7 @@ TEST_F(BackendTest, BasicAsyncFlow) {
             addCleanup(api.createRenderPrimitive(vbh, ibh, PrimitiveType::TRIANGLES));
 
     // Bind texture
-    SamplerParams samplerParams;
+    SamplerParams samplerParams {};
     samplerParams.filterMin = SamplerMinFilter::NEAREST;
     samplerParams.filterMag = SamplerMagFilter::NEAREST;
 


### PR DESCRIPTION
This enables testing async uploads on CI by supporting OpenGL shared contexts for Mesa.

### What changed:
- Allowed creating extra contexts in `PlatformOSMesa` (and removed the assertion blocking it).
- Added a tiny 1x1 dummy buffer for these extra contexts because OSMesa complains if you make a context current without a buffer.
- Cleaned up the extra contexts properly in `terminate`.