### PR TITLE
utils: Implement high-performance sparse bitsets for ECS indices.

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -39,6 +39,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/Mutex.h
         ${PUBLIC_HDR_DIR}/${TARGET}/NameComponentManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/ostream.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/PagedArenaBitset.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Panic.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Path.h
         ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation.h
@@ -92,6 +93,7 @@ set(SRCS
         src/string.cpp
         src/ThreadUtils.cpp
         src/Status.cpp
+        src/PagedArenaBitset.cpp
 )
 
 if (WIN32)
@@ -181,6 +183,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_algorithm.cpp
             test/test_Allocators.cpp
             test/test_bitset.cpp
+            test/test_EntitySet.cpp
             test/test_tribool.cpp
             test/test_CountDownLatch.cpp
             test/test_CString.cpp
@@ -242,7 +245,8 @@ if (FILAMENT_BUILD_TESTING AND NOT WASM)
             benchmark/benchmark_calls.cpp
             benchmark/benchmark_JobSystem.cpp
             benchmark/benchmark_mutex.cpp
-            benchmark/benchmark_memcpy.cpp)
+            benchmark/benchmark_memcpy.cpp
+            benchmark/benchmark_EntitySet.cpp)
 
 
     add_executable(benchmark_${TARGET} ${BENCHMARK_SRCS})

--- a/libs/utils/benchmark/benchmark_EntitySet.cpp
+++ b/libs/utils/benchmark/benchmark_EntitySet.cpp
@@ -1,0 +1,811 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PerformanceCounters.h"
+
+#include <utils/compiler.h>
+#include <utils/PagedArenaBitset.h>
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+using namespace utils;
+
+// this is the batch used for in-place benchmarks. It needs to be high enough to mask the overhead of the
+// bitset copy (needed for the benchmark) and low-enough that we don't exhaust the L3 cache.
+const size_t kInPlaceBatchSize = 100;
+
+template<typename T>
+T clone_helper(const T& val) {
+    return val.clone();
+}
+
+template<typename Policy>
+void BM_bitset_Insert(benchmark::State& state) {
+    Policy set;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 100000};
+    std::uniform_int_distribution<uint32_t> ndGen{0, 0};
+    std::vector<uint32_t> bits(count);
+    size_t idx = 0;
+    while (idx < count) {
+        uint32_t const base = ndBase(gen);
+        uint32_t const g = ndGen(gen);
+        size_t const batchSize = std::min<size_t>(count - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            bits[idx++] = (g << 17) | ((base + j) & 0x1FFFF);
+        }
+    }
+
+    for (auto _ : state) {
+        for (auto b : bits) {
+            set.add(b);
+        }
+        state.PauseTiming();
+        set.clear();
+        state.ResumeTiming();
+    }
+}
+
+template<typename Policy>
+void BM_bitset_Intersect(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::intersect(set1, set2);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_Difference(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::difference(set1, set2);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectInPlace(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    std::vector<Policy> temps(kInPlaceBatchSize);
+    // Pre-allocate once outside the loop to bypass Scudo entirely
+    for (auto& t : temps) {
+        t.copyFrom(set1);
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        for (auto& t : temps) {
+            t.copyFrom(set1);
+        }
+        state.ResumeTiming();
+
+        for (auto& t : temps) {
+            benchmark::DoNotOptimize(t);
+            t.intersect(set2);
+            benchmark::ClobberMemory();
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * kInPlaceBatchSize);
+}
+
+template<typename Policy>
+void BM_bitset_IntersectFragmented(benchmark::State& state) {
+    size_t const numPages = state.range(0);
+    size_t const totalBits = 4096;
+    size_t const bitsPerPage = totalBits / numPages;
+    size_t const stride = 1U << 17;
+
+    Policy set1;
+    Policy set2;
+
+    for (size_t i = 0; i < numPages; ++i) {
+        uint32_t const regionStart = i * stride;
+        for (size_t j = 0; j < bitsPerPage; ++j) {
+            set1.add(regionStart + j);
+        }
+        set2.add(regionStart);
+    }
+
+    std::vector<Policy> temps(kInPlaceBatchSize);
+    // Pre-allocate once outside the loop to bypass Scudo entirely
+    for (auto& t : temps) {
+        t.copyFrom(set1);
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        for (auto& t : temps) {
+            t.copyFrom(set1);
+        }
+        state.ResumeTiming();
+
+        for (auto& t : temps) {
+            benchmark::DoNotOptimize(t);
+            t.intersect(set2);
+            benchmark::ClobberMemory();
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * kInPlaceBatchSize);
+}
+
+template<typename Policy>
+void BM_bitset_DifferenceInPlace(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    std::vector<Policy> temps(kInPlaceBatchSize);
+    // Pre-allocate once outside the loop to bypass Scudo entirely
+    for (auto& t : temps) {
+        t.copyFrom(set1);
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        for (auto& t : temps) {
+            t.copyFrom(set1);
+        }
+        state.ResumeTiming();
+
+        for (auto& t : temps) {
+            benchmark::DoNotOptimize(t);
+            t.difference(set2);
+            benchmark::ClobberMemory();
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * kInPlaceBatchSize);
+}
+
+template<typename Policy>
+void BM_bitset_IntersectMulti2(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    uint32_t const base = 1000;
+
+    // Overlap
+    for (size_t j = 0; j < overlapCount; ++j) {
+        set1.add(base + j);
+        set2.add(base + j);
+    }
+
+    size_t idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base1 = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base1 + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base2 = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base2 + j);
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::intersect(set1, set2);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectMulti6(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    uint32_t const base = 1000;
+
+    for (size_t i = 0; i < 6; ++i) {
+        // Overlap
+        for (size_t j = 0; j < overlapCount; ++j) {
+            sets[i].add(base + j);
+        }
+
+        // Disjoint
+        size_t idx = 0;
+        while (idx < disjointCount) {
+            uint32_t const baseI = ndBase(gen) + 50000 + i * 50000;
+            size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+            for (size_t j = 0; j < batchSize; ++j) {
+                sets[i].add(baseI + j);
+            }
+            idx += batchSize;
+        }
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::intersect(sets[0], sets[1], sets[2], sets[3], sets[4], sets[5]);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectChained6(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    uint32_t const base = 1000;
+
+    for (size_t i = 0; i < 6; ++i) {
+        // Overlap
+        for (size_t j = 0; j < overlapCount; ++j) {
+            sets[i].add(base + j);
+        }
+
+        // Disjoint
+        size_t idx = 0;
+        while (idx < disjointCount) {
+            uint32_t const baseI = ndBase(gen) + 50000 + i * 50000;
+            size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+            for (size_t j = 0; j < batchSize; ++j) {
+                sets[i].add(baseI + j);
+            }
+            idx += batchSize;
+        }
+    }
+
+    for (auto _ : state) {
+        Policy r = Policy::intersect(sets[0], sets[1]);
+        r.intersect(sets[2]);
+        r.intersect(sets[3]);
+        r.intersect(sets[4]);
+        r.intersect(sets[5]);
+        benchmark::DoNotOptimize(r);
+    }
+}
+
+template<typename Policy>
+void setupFilterBenchmark(std::array<Policy, 6>& sets) {
+    std::default_random_engine gen{123};
+
+    // 1. Sparse Filter (sets[0])
+    // 100 random bits spread across 27-bit domain
+    std::uniform_int_distribution<uint32_t> dist27{0, (1U << 27) - 1};
+    for (int i = 0; i < 100; ++i) {
+        sets[0].add(dist27(gen));
+    }
+
+    // 2. Dense Noise (sets[1] to sets[5])
+    // 70% density by filling random pages!
+    std::uniform_real_distribution<double> distProb{0.0, 1.0};
+    for (size_t i = 1; i < 6; ++i) {
+        for (uint32_t j = 0; j < (1U << 27); j += 4096) {
+            if (distProb(gen) < 0.7) {
+                for (uint32_t k = 0; k < 4096; ++k) {
+                    sets[i].add(j + k);
+                }
+            }
+        }
+    }
+
+    // Ensure they have at least some bits in common!
+    std::vector<uint32_t> filterBits;
+    sets[0].extractTo(filterBits);
+    for (size_t i = 0; i < std::min<size_t>(10, filterBits.size()); ++i) {
+        uint32_t bit = filterBits[i];
+        for (size_t j = 1; j < 6; ++j) {
+            sets[j].add(bit);
+        }
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectMulti6_Filter(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    setupFilterBenchmark(sets);
+
+    for (auto _ : state) {
+        Policy temp = Policy::intersect(sets[0], sets[1], sets[2], sets[3], sets[4], sets[5]);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectChained6_Filter_Best(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    setupFilterBenchmark(sets);
+
+    for (auto _ : state) {
+        Policy r = Policy::intersect(sets[0], sets[1]);
+        r.intersect(sets[2]);
+        r.intersect(sets[3]);
+        r.intersect(sets[4]);
+        r.intersect(sets[5]);
+        benchmark::DoNotOptimize(r);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectChained6_Filter_Worst(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    setupFilterBenchmark(sets);
+
+    for (auto _ : state) {
+        Policy r = Policy::intersect(sets[1], sets[2]);
+        r.intersect(sets[3]);
+        r.intersect(sets[4]);
+        r.intersect(sets[5]);
+        r.intersect(sets[0]);
+        benchmark::DoNotOptimize(r);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_Iteration(benchmark::State& state) {
+    Policy set;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 100000};
+    std::uniform_int_distribution<uint32_t> ndGen{0, 0};
+    size_t idx = 0;
+    while (idx < count) {
+        uint32_t const base = ndBase(gen);
+        uint32_t const g = ndGen(gen);
+        size_t const batchSize = std::min<size_t>(count - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set.add((g << 17) | ((base + j) & 0x1FFFF));
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        size_t sum = 0;
+        set.forEachSetBit([&sum](uint32_t bit) {
+            sum += bit;
+        });
+        benchmark::DoNotOptimize(sum);
+    }
+}
+
+template<>
+void BM_bitset_Iteration<PagedArenaBitset>(benchmark::State& state) {
+    PagedArenaBitset set;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 100000};
+    std::uniform_int_distribution<uint32_t> ndGen{0, 0};
+    size_t idx = 0;
+    while (idx < count) {
+        uint32_t const base = ndBase(gen);
+        uint32_t const g = ndGen(gen);
+        size_t const batchSize = std::min<size_t>(count - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set.add((g << 17) | ((base + j) & 0x1FFFF));
+        }
+        idx += batchSize;
+    }
+
+    std::vector<uint32_t> buffer;
+    for (auto _ : state) {
+        set.extractTo(buffer);
+        size_t sum = 0;
+        for (uint32_t const bit : buffer) {
+            sum += bit;
+        }
+        benchmark::DoNotOptimize(sum);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_Merge(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::merge(set1, set2);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_MergeInPlace(benchmark::State& state) {
+    Policy set1;
+    Policy set2;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    size_t idx = 0;
+    while (idx < overlapCount) {
+        uint32_t const base = ndBase(gen);
+        size_t const batchSize = std::min<size_t>(overlapCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 50000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set1.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    idx = 0;
+    while (idx < disjointCount) {
+        uint32_t const base = ndBase(gen) + 100000;
+        size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set2.add(base + j);
+        }
+        idx += batchSize;
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Policy temp = set1.clone(); // Clone to avoid accumulating!
+        state.ResumeTiming();
+        temp.merge(set2);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_Merge6(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    for (size_t i = 0; i < 6; ++i) {
+        // Overlap
+        for (size_t j = 0; j < overlapCount; ++j) {
+            sets[i].add(1000 + j);
+        }
+
+        // Disjoint
+        size_t idx = 0;
+        while (idx < disjointCount) {
+            uint32_t const baseI = ndBase(gen) + 50000 + i * 50000;
+            size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+            for (size_t j = 0; j < batchSize; ++j) {
+                sets[i].add(baseI + j);
+            }
+            idx += batchSize;
+        }
+    }
+
+    for (auto _ : state) {
+        Policy temp = Policy::merge(sets[0], sets[1], sets[2], sets[3], sets[4], sets[5]);
+        benchmark::DoNotOptimize(temp);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_IntersectSize6(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    for (size_t i = 0; i < 6; ++i) {
+        // Overlap
+        for (size_t j = 0; j < overlapCount; ++j) {
+            sets[i].add(1000 + j);
+        }
+
+        // Disjoint
+        size_t idx = 0;
+        while (idx < disjointCount) {
+            uint32_t const baseI = ndBase(gen) + 50000 + i * 50000;
+            size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+            for (size_t j = 0; j < batchSize; ++j) {
+                sets[i].add(baseI + j);
+            }
+            idx += batchSize;
+        }
+    }
+
+    for (auto _ : state) {
+        uint32_t size = Policy::intersectSize(sets[0], sets[1], sets[2], sets[3], sets[4], sets[5]);
+        benchmark::DoNotOptimize(size);
+    }
+}
+
+template<typename Policy>
+void BM_bitset_MergeSize6(benchmark::State& state) {
+    std::array<Policy, 6> sets;
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 50000};
+
+    size_t const overlapCount = std::max<size_t>(count / 100, 1);
+    size_t const disjointCount = count - overlapCount;
+
+    for (size_t i = 0; i < 6; ++i) {
+        // Overlap
+        for (size_t j = 0; j < overlapCount; ++j) {
+            sets[i].add(1000 + j);
+        }
+
+        // Disjoint
+        size_t idx = 0;
+        while (idx < disjointCount) {
+            uint32_t const baseI = ndBase(gen) + 50000 + i * 50000;
+            size_t const batchSize = std::min<size_t>(disjointCount - idx, 100);
+            for (size_t j = 0; j < batchSize; ++j) {
+                sets[i].add(baseI + j);
+            }
+            idx += batchSize;
+        }
+    }
+
+    for (auto _ : state) {
+        uint32_t size = Policy::mergeSize(sets[0], sets[1], sets[2], sets[3], sets[4], sets[5]);
+        benchmark::DoNotOptimize(size);
+    }
+}
+
+// Registrations
+#define REGISTER_BENCHMARKS(Type) \
+    BENCHMARK_TEMPLATE(BM_bitset_Insert, Type)->Range(10, 100000); \
+    BENCHMARK_TEMPLATE(BM_bitset_Intersect, Type)->Range(10, 100000); \
+    BENCHMARK_TEMPLATE(BM_bitset_Difference, Type)->Range(10, 100000); \
+    BENCHMARK_TEMPLATE(BM_bitset_IntersectInPlace, Type)->Range(10, 100000)->Iterations(10); \
+    BENCHMARK_TEMPLATE(BM_bitset_DifferenceInPlace, Type)->Range(10, 100000)->Iterations(10); \
+    BENCHMARK_TEMPLATE(BM_bitset_Iteration, Type)->Range(10, 100000);
+
+REGISTER_BENCHMARKS(PagedArenaBitset)
+
+BENCHMARK_TEMPLATE(BM_bitset_Merge, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_MergeInPlace, PagedArenaBitset)->Range(10, 100000)->Iterations(10);
+BENCHMARK_TEMPLATE(BM_bitset_Merge6, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectSize6, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_MergeSize6, PagedArenaBitset)->Range(10, 100000);
+
+BENCHMARK_TEMPLATE(BM_bitset_IntersectMulti2, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectMulti6, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectChained6, PagedArenaBitset)->Range(10, 100000);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectMulti6_Filter, PagedArenaBitset);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectChained6_Filter_Best, PagedArenaBitset);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectChained6_Filter_Worst, PagedArenaBitset);
+BENCHMARK_TEMPLATE(BM_bitset_IntersectFragmented, PagedArenaBitset)->RangeMultiplier(2)->Range(1, 64)->Iterations(10);
+;

--- a/libs/utils/include/utils/PagedArenaBitset.h
+++ b/libs/utils/include/utils/PagedArenaBitset.h
@@ -1,0 +1,540 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_PAGEARENABITSET_H
+#define TNT_UTILS_PAGEARENABITSET_H
+
+#include <utils/compiler.h>
+#include <utils/Slice.h>
+#include <utils/algorithm.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cassert>
+#include <type_traits>
+#include <vector>
+
+namespace utils {
+
+/**
+ * @class PagedArenaBitset
+ * @brief A highly optimized, cache-coherent sparse bitset tailored for Generational ECS indices.
+ *
+ * @details
+ * This structure implements a 4-level hierarchical bitset designed to handle large,
+ * sparse integer domains (e.g., 2^27) where bits are densely clustered in "islands".
+ * It is specifically optimized for Entity Component Systems where Entity IDs combine a
+ * monotonically increasing generation value with a dense, recyclable base index.
+ *
+ * ### Hierarchical Memory Architecture
+ * @code
+ * ENTITY ID [27 bits]
+ * [ Master Word | Master Bit | Summary Bit | Word Idx | Bit Index ]
+ * [   3 bits    |   6 bits   |   6 bits    |  6 bits  |   6 bits  ]
+ * |             |            |             |          |
+ * |             |            |             |          +->  [Level 3: Bit position in u64]
+ * |             |            |             +------------>  [Level 3: Word position in Page]
+ * |             |            +-------------------------->  [Level 1: Page presence in Summary]
+ * |             +--------------------------------------->  [Level 0: Summary Word presence]
+ * +------------------------------------------------------> [Level 0: Master Word selection]
+ *
+ * VISUAL TOPOLOGY:
+ * +-------------------------------------------------------+
+ * | [Level 0] MASTER MASK (8 x u64)                       | <-- High-level Skip (512 bits)
+ * | [ 11110000... ]                                       |
+ * +-----------|-------------------------------------------+
+ *             v
+ * +-------------------------------------------------------+
+ * | [Level 1] SUMMARY MASK (512 x u64)                    | <-- Mid-level Skip (4 KB)
+ * | [ ...00101100... ]                                    |
+ * +-----------|-------------------------------------------+
+ *             v
+ * +-------------------------------------------------------+
+ * | [Level 2] DIRECTORY (32,768 x u16)                    | <-- Logical -> Physical (64 KB)
+ * | [ 0 | 5 | X | 2 | X | X | 1 | ... ] (X = Gated/Dirty) |
+ * +-----------|-------------------------------------------+
+ *             v
+ * +-------------------------------------------------------+
+ * | [Level 3] ARENA (Contiguous Pages)                    | <-- Dense Storage
+ * | +---------------------------------------------------+ |
+ * | | Page N:                                           | |
+ * | | [ activeWordsMask ] (1 x u64)                     | | <-- Word-level Skip
+ * | | [ words          ] (64 x u64)                     | |
+ * | +---------------------------------------------------+ |
+ * +-------------------------------------------------------+
+ * @endcode
+ *
+ * ### Architecture (The "Trust the Mask" Design)
+ * - **Level 0 (Master Mask):** A 512-bit mask where each bit maps 1:1 to a single word of the
+ * Summary Mask. Enables ultra-fast O(1) skipping of 256k-bit empty generational gaps.
+ * - **Level 1 (Summary Mask):** A 4KB mask where each bit flags the allocation of a single page.
+ * - **Level 2 (Directory):** A 64KB array mapping logical page indices to physical arena indices.
+ * *Note:* This memory is left uninitialized/garbage. It is strictly gated by the masks.
+ * - **Level 3 (Arena):** A contiguous pool holding fixed 520-byte pages. Each page contains
+ * 4,096 bits (64 words) and a 64-bit `activeWordsMask` to skip empty words during operations.
+ *
+ * ### Performance Guarantees & Assumptions
+ * - **Zero-Cost Clear:** Because the architecture strictly "Trusts the Mask", initializing
+ * or clearing the bitset requires no massive memory allocations or 64KB memsets. It drops
+ * overhead to <20ns by only zeroing the small bitmasks.
+ * - **Strict Move Semantics:** To prevent catastrophic, silent O(N) memory allocations
+ * and L1 cache thrashing inside ECS update loops, implicit copy constructors are strictly
+ * disabled. Moves are O(1) and noexcept. If a deep snapshot is required, the explicit
+ * `clone()` method must be used.
+ * - **Ghost Pages:** Single-bit `remove()` operations intentionally leak empty pages
+ * ("ghost pages") to keep the hot-path branchless. These are automatically cleaned up
+ * during bulk `intersect`/`difference` operations or via an explicit `defragment()` call.
+ * - **Iteration:** Designed strictly for bulk processing. Random probing via `operator[]`
+ * is supported but incurs L1/L2 cache misses. For maximum performance, use `extractTo()`
+ * to materialize the bits into a flat vector using the Master Mask's hardware intrinsics.
+ */
+class UTILS_PUBLIC PagedArenaBitset {
+public:
+    // ======================================================================================
+    // PagedArenaBitset Core Configuration
+    // --------------------------------------------------------------------------------------
+    // These three constants are the absolute foundation of the bitset's geometry.
+    // Every mask size, directory size, and struct layout is derived mathematically from these.
+    // ======================================================================================
+
+    // The total addressable capacity of the bitset (2^27 = ~134.2 million bits).
+    // This defines the maximum permissible Entity Index. It directly dictates the
+    // maximum size of the L2 Directory and the span of the Mask hierarchies.
+    static constexpr uint32_t DOMAIN_BITS = 27;
+
+    // The allocation granularity of the Arena, expressed as a bit-shift (2^12 = 4096 bits).
+    // This is the "Page Size". Every active 4096-bit range allocates exactly one 512-byte
+    // Page in memory. This balances L2 Directory footprint against sparse memory overhead.
+    static constexpr uint32_t PAGE_SHIFT = 12;
+
+    // The hardware execution width, expressed as a bit-shift (2^6 = 64 bits).
+    // This binds the bitset to the CPU's native 64-bit architecture (uint64_t), ensuring
+    // that inner loops perfectly align with hardware popcount (tzcnt/blsr) intrinsics.
+    static constexpr uint32_t WORD_SHIFT = 6;
+
+    // The maximum number of bitsets that can be processed in a single multi-way operation
+    // (e.g., maximum components in an ECS query). Bounds the stack size for hot loops.
+    static constexpr size_t MAX_MULTI_WAY_INPUTS = 64;
+
+
+    PagedArenaBitset();
+    ~PagedArenaBitset();
+
+    /**
+     * @brief Move constructor. Transfers ownership of all internal heap resources.
+     * * @details This operation is O(1) and noexcept. It performs a pointer swap of the
+     * underlying directory and arena vectors.
+     * * @param rhs The bitset to move from.
+     * * @note **Moved-from State (The Zombie):** The @p other object is left in a
+     * non-functional state. While primitive members (like `mSize`) are copied and
+     * retain their values, the internal heap-allocated buffers are nullified.
+     * * @warning **Caveat:** This object is **unrecoverable**. Because there is no
+     * resurrection logic, calling `clear()` will not re-allocate the storage
+     * required for use. `empty()` may return a false negative if the source was
+     * not empty. The only safe operations on the moved-from object are destruction
+     * or overwriting it via a new move-assignment.
+     */
+    PagedArenaBitset(PagedArenaBitset&& rhs) noexcept;
+
+    /**
+     * @brief Move assignment operator. Replaces current content with resources from @p other.
+     * * @details This operation is O(1) and noexcept. It releases current resources
+     * and steals the heap pointers from the source object.
+     * * @param rhs The bitset to move from.
+     * @return A reference to this bitset.
+     * * @note **Moved-from State (The Zombie):** Identical to the move constructor; the
+     * source object is left with its metadata intact but its physical storage destroyed.
+     * * @warning **Caveat:** Do not attempt to reuse @p other. Any call to `add()`,
+     * `remove()`, or `operator[]` will result in an immediate segment fault.
+     * Re-initialization via `clear()` is not supported for moved-from objects
+     * in this implementation.
+     */
+    PagedArenaBitset& operator=(PagedArenaBitset&& rhs) noexcept;
+
+    // not copy-assignable
+    PagedArenaBitset& operator=(PagedArenaBitset const& rhs) = delete;
+
+    /**
+     * @brief Returns a copy of this bitset.
+     */
+    PagedArenaBitset clone() const;
+
+    /**
+     * @brief copies the other bitset into this bitset and returns a reference to this.
+     */
+    PagedArenaBitset& copyFrom(const PagedArenaBitset& other);
+
+    /**
+     * @brief Returns the total number of set bits.
+     */
+    size_t size() const;
+
+    /**
+     * @brief Checks if the bitset has zero bits set.
+     */
+    bool empty() const;
+
+    /**
+     * @brief Tests if a specific bit is set.
+     * @param index The bit index to test.
+     * @return true if the bit is set, false otherwise.
+     */
+    bool operator[](uint32_t index) const;
+
+    /**
+     * @brief Sets a bit and returns its previous state.
+     * @param index The bit index to set.
+     * @return true if the bit was already set, false if it was newly set.
+     */
+    bool fetchAdd(uint32_t index);
+
+    /**
+     * @brief Clears a bit and returns its previous state.
+     * @param index The bit index to clear.
+     * @return true if the bit was set before clearing, false if it was already cleared.
+     */
+    bool fetchRemove(uint32_t index);
+
+    /**
+     * @brief Sets a bit.
+     */
+    void add(uint32_t index);
+
+    /**
+     * @brief Clears a bit.
+     */
+    void remove(uint32_t index);
+
+    /**
+     * @brief Clears all bits, resets the arena, and zeroes internal state.
+     */
+    void clear();
+
+    /**
+     * @brief Eliminates ghost pages and tightly packs active pages in physical memory.
+     * @details Scans the logical directory, drops any pages whose popcount is 0, and
+     * relocates all remaining pages to perfectly match logical directory order. This
+     * guarantees maximum hardware prefetcher efficiency for subsequent iterations.
+     */
+    void defragment();
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // intersection
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * @brief Performs an in-place intersection (this &= other).
+     * @param other The bitset to intersect with.
+     */
+    PagedArenaBitset& intersect(const PagedArenaBitset& other);
+
+    /**
+     * @brief Variadic intersection (Multi-way Path).
+     * @details Handles 3+ arguments by forwarding to the order-independent span implementation.
+     */
+    template<typename... Rest>
+    static PagedArenaBitset& intersect(PagedArenaBitset* out,
+            const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const PagedArenaBitset& third,
+            const Rest&... rest) {
+        static_assert((std::is_same_v<PagedArenaBitset, Rest> && ...),
+                "All arguments to intersect must be PagedArenaBitset");
+
+        std::array<const PagedArenaBitset*, sizeof...(rest) + 3> inputs = {&first, &second, &third, &rest...};
+        return intersectSpan(out, {inputs.data(), inputs.size()});
+    }
+
+    template<typename... Rest>
+    static PagedArenaBitset intersect(const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const PagedArenaBitset& third,
+            const Rest&... rest) {
+        PagedArenaBitset out;
+        out.reserve(std::min({
+            first.mArena.size(), second.mArena.size(), third.mArena.size(),
+            rest.mArena.size()...
+        }));
+        intersect(&out, first, second, third, rest...);
+        return out;
+    }
+
+    /**
+     * @brief Variadic intersection size (Multi-way Path).
+     * @details Handles 2+ arguments by forwarding to the order-independent span implementation.
+     */
+    template<typename... Rest>
+    static uint32_t intersectSize(const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const Rest&... rest) noexcept {
+        static_assert((std::is_same_v<PagedArenaBitset, Rest> && ...),
+                "All arguments to intersect must be PagedArenaBitset");
+
+        std::array<const PagedArenaBitset*, sizeof...(rest) + 2> inputs = {&first, &second, &rest...};
+        return intersectSizeSpan({inputs.data(), inputs.size()});
+    }
+
+    static PagedArenaBitset& intersect(PagedArenaBitset* out, const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    static PagedArenaBitset intersect(const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // merge
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * @brief Performs an in-place merge (Union) (this |= other).
+     * @param other The bitset to merge with.
+     */
+    PagedArenaBitset& merge(const PagedArenaBitset& other);
+
+    /**
+     * @brief Variadic merge (Union) (Multi-way Path).
+     * @details Handles 3+ arguments by forwarding to the order-independent span implementation.
+     */
+    template<typename... Rest>
+    static PagedArenaBitset& merge(PagedArenaBitset* out,
+            const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const PagedArenaBitset& third,
+            const Rest&... rest) {
+        static_assert((std::is_same_v<PagedArenaBitset, Rest> && ...),
+                "All arguments to merge must be PagedArenaBitset");
+
+        std::array<const PagedArenaBitset*, sizeof...(rest) + 3> inputs = {&first, &second, &third, &rest...};
+        return mergeSpan(out, {inputs.data(), inputs.size()});
+    }
+
+    template<typename... Rest>
+    static PagedArenaBitset merge(const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const PagedArenaBitset& third,
+            const Rest&... rest) {
+        PagedArenaBitset out;
+        // TODO: max is probably too small, but that the minimum we need
+        out.reserve(std::max({
+            first.mArena.size(), second.mArena.size(), third.mArena.size(),
+            rest.mArena.size()...
+        }));
+        merge(&out, first, second, third, rest...);
+        return out;
+    }
+
+    /**
+     * @brief Variadic merge (union) size (Multi-way Path).
+     * @details Handles 2+ arguments by forwarding to the order-independent span implementation.
+     */
+    template<typename... Rest>
+    static uint32_t mergeSize(const PagedArenaBitset& first,
+            const PagedArenaBitset& second,
+            const Rest&... rest) noexcept {
+        static_assert((std::is_same_v<PagedArenaBitset, Rest> && ...),
+                "All arguments to merge must be PagedArenaBitset");
+
+        std::array<const PagedArenaBitset*, sizeof...(rest) + 2> inputs = {&first, &second, &rest...};
+        return mergeSizeSpan({inputs.data(), inputs.size()});
+    }
+
+    static PagedArenaBitset& merge(PagedArenaBitset* out, const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    static PagedArenaBitset merge(const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // difference
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * @brief Performs an in-place difference (this &= ~other).
+     * @param other The bitset to subtract.
+     */
+    PagedArenaBitset& difference(const PagedArenaBitset& other);
+
+    /**
+     * @brief Calculates the number of bits in `a` that are not set in `b`.
+     */
+    static uint32_t differenceSize(const PagedArenaBitset& a, const PagedArenaBitset& b) noexcept;
+
+    static PagedArenaBitset& difference(PagedArenaBitset* out, const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    static PagedArenaBitset difference(const PagedArenaBitset& a, const PagedArenaBitset& b);
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // iterations
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * @brief Materializes the set bits into a contiguous array for maximum iteration speed.
+     */
+    void extractTo(std::vector<uint32_t>& outBuffer) const;
+
+    /**
+     * @brief Iterates over all set bits in ascending numerical order.
+     * @tparam Func A callable type accepting a uint32_t.
+     * @param callback The function to execute for each set bit.
+     */
+    template <typename Func>
+    void forEachSetBit(Func&& callback) const {
+        for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+            uint64_t masterMask = mMasterMask[m];
+            while (masterMask) {
+                int const maskBit = ctz(masterMask);
+                masterMask &= masterMask - 1;
+
+                uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+                uint64_t mask = mSummaryMask[maskIdx];
+
+                while (mask) {
+                    int const bit = ctz(mask);
+                    mask &= mask - 1;
+
+                    uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+                    uint16_t const physicalIdx = mDirectory[dirIdx];
+
+                    assert(physicalIdx != INVALID_PAGE && "Summary mask desynchronized");
+                    auto const& [activeWordsMask, words] = mArena[physicalIdx];
+                    uint64_t activeMask = activeWordsMask;
+
+                    while (activeMask != 0) {
+                        int const w = ctz(activeMask);
+                        uint64_t word = words[w];
+                        while (word) {
+                            int const wBit = ctz(word);
+                            word &= word - 1;
+
+                            // Calculate the unique Entity ID from the hierarchy indices
+                            uint32_t const id = (dirIdx << PAGE_SHIFT) | (w << WORD_SHIFT) | wBit;
+
+                            if constexpr (std::is_convertible_v<std::invoke_result_t<Func, uint32_t>, bool>) {
+                                if (!callback(id)) return;
+                            } else {
+                                callback(id);
+                            }
+                        }
+                        activeMask &= (activeMask - 1);
+                    }
+                }
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // subset / superset queries
+    // ----------------------------------------------------------------------------------------------------------------
+
+    // Optimized Subset Check: Returns true if (subset & superset) == subset
+    static bool isSubset(const PagedArenaBitset& subset, const PagedArenaBitset& superset) noexcept;
+
+    static bool isStrictSubset(const PagedArenaBitset& subset, const PagedArenaBitset& superset) noexcept {
+        // A strict subset MUST be smaller than the superset
+        if (subset.size() >= superset.size()) {
+            return false;
+        }
+        return isSubset(subset, superset);
+    }
+
+    bool isSubsetOf(PagedArenaBitset const& superset) const noexcept {
+        return isSubset(*this, superset);
+    }
+
+    bool isStrictSubsetOf(PagedArenaBitset const& superset) const noexcept {
+        return isStrictSubset(*this, superset);
+    }
+
+    bool isSupersetOf(const PagedArenaBitset& other) const noexcept {
+        return other.isSubsetOf(*this);
+    }
+
+    bool isStrictSupersetOf(const PagedArenaBitset& other) const noexcept {
+        if (size() <= other.size()) {
+            return false;
+        }
+        return other.isSubsetOf(*this);
+    }
+
+    void swap(PagedArenaBitset& other) noexcept;
+
+    friend void swap(PagedArenaBitset& a, PagedArenaBitset& b) noexcept {
+        a.swap(b);
+    }
+
+    friend PagedArenaBitset exchange(PagedArenaBitset& object, PagedArenaBitset&& newValue);
+    friend PagedArenaBitset exchangeAndClear(PagedArenaBitset& object);
+
+private:
+    // Directory Size
+    static constexpr uint32_t DIR_SIZE = 1U << (DOMAIN_BITS - PAGE_SHIFT);
+
+    // Summary Mask Size (1 bit per Directory Entry)
+    // Shifting right by WORD_SHIFT is equivalent to dividing by 64.
+    static constexpr uint32_t MASK_WORDS = DIR_SIZE >> WORD_SHIFT;
+
+    // Master Mask Size (1 bit per Summary Mask Word)
+    // We still use integer ceiling division here to guarantee at least 1 word
+    // in case a small domain results in MASK_WORDS < 64.
+    static constexpr uint32_t MASTER_WORDS = (MASK_WORDS + ((1U << WORD_SHIFT) - 1)) >> WORD_SHIFT;
+
+    static constexpr uint32_t WORDS_PER_PAGE = 1U << (PAGE_SHIFT - WORD_SHIFT);
+    static constexpr uint32_t WORD_MASK = ((1U << WORD_SHIFT) - 1);
+    static constexpr uint16_t INVALID_PAGE = 0xFFFF;
+
+    static_assert(WORDS_PER_PAGE == 64, "WORDS_PER_PAGE must be 64 to match the 64-bit activeWordsMask!");
+
+    // Do NOT pad or align this struct to 64 bytes (576) or 512 bytes.
+    // Maintaining a non-cache-line-multiple size (520) creates a natural 
+    // memory stagger. In Multi-Way operations (Merge6, Intersect6), this stagger 
+    // prevents 4K Cache Set Aliasing and L1 Cache Thrashing, resulting in 
+    // up to an 8x performance increase.
+    struct Page {
+        uint64_t activeWordsMask = 0;
+        uint64_t words[WORDS_PER_PAGE] = {};
+        void clear();
+        uint32_t popcount() const;
+    };
+
+    std::vector<uint64_t> mSummaryMask;     // always  4 KiB
+    std::vector<uint16_t> mDirectory;       // always 64 KiB
+    std::vector<Page> mArena;               // each page is 512 bytes
+    std::vector<uint16_t> mFreePages;       // list of free pages
+    uint32_t mSize = 0;                     // size of the set (how many bits are 1)
+    std::array<uint64_t, MASTER_WORDS> mMasterMask = {};
+
+    PagedArenaBitset(PagedArenaBitset const& rhs);
+
+    uint16_t allocatePage();
+    void freePage(uint32_t dirIdx);
+    void reserve(size_t size);
+
+    template<typename Collection>
+    static PagedArenaBitset& intersectInternal(PagedArenaBitset* out, const Collection& inputs);
+    static PagedArenaBitset& intersectSpan(PagedArenaBitset* out, Slice<const PagedArenaBitset* const> inputs);
+
+    template<typename Collection>
+    static uint32_t intersectSizeInternal(const Collection& inputs);
+    static uint32_t intersectSizeSpan(Slice<const PagedArenaBitset* const> inputs);
+
+    template<typename Collection>
+    static PagedArenaBitset& mergeInternal(PagedArenaBitset* out, const Collection& inputs);
+    static PagedArenaBitset& mergeSpan(PagedArenaBitset* out, Slice<const PagedArenaBitset* const> inputs);
+
+    template<typename Collection>
+    static uint32_t mergeSizeInternal(const Collection& inputs);
+    static uint32_t mergeSizeSpan(Slice<const PagedArenaBitset* const> inputs);
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_PAGEARENABITSET_H

--- a/libs/utils/src/PagedArenaBitset.cpp
+++ b/libs/utils/src/PagedArenaBitset.cpp
@@ -1,0 +1,1353 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/PagedArenaBitset.h>
+
+#include <utils/compiler.h>
+#include <utils/Slice.h>
+
+#include <algorithm>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <cassert>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace utils {
+
+/**
+ * PagedArenaBitset: THE HIERARCHY INVARIANT
+ * ----------------------------------------
+ * This bitset operates on a 4-level "Trust the Mask" architecture to enable
+ * aggressive pruning of sparse domains. To maintain search integrity and
+ * prevent memory corruption, the following structural invariant must be
+ * preserved by all mutating operations:
+ *
+ * 1. INCLUSIVITY RULE:
+ *    The hierarchy is strictly inclusive from the bottom up.
+ *    [L3: Arena Bit] -> [L3: activeWordsMask] -> [L2: Directory Entry] -> [L1: Summary] -> [L0: Master]
+ *
+ *    - If a bit is set in an L3 word, its corresponding bit in `activeWordsMask` MUST be set.
+ *    - If `activeWordsMask` is non-zero, the L2 Directory Entry MUST be a valid index.
+ *    - If an L2 entry is valid, the corresponding bit in L1 MUST be set.
+ *    - If any bit in L1 is set, the corresponding bit in L0 MUST be set.
+ *
+ * 2. THE GHOST-BIT PROHIBITION:
+ *    Top-down updates are forbidden. Never update a Mask (L0/L1) before
+ *    confirming the population (popcount > 0) of the underlying L3 page.
+ *    Failure to follow this results in "Ghost Bits"—where a mask directs
+ *    traversal to a region that has an INVALID_PAGE directory entry,
+ *    triggering out-of-bounds access or assertions.
+ *
+ * 3. THE GARBAGE CONTRACT:
+ *    Page allocations (L3) via emplace_back are uninitialized (garbage) for
+ *    Data-Oriented Design.
+ *    - RECYCLE: allocatePage() calls clear() ONLY when pulling from the free-list.
+ *    - FULL WRITES: Merge/Union operations MUST fully overwrite the 64-word
+ *      page array to clean garbage.
+ *    - PARTIAL WRITES: Single-bit set() or sparse operations MUST manually
+ *      clear the page upon its first allocation.
+ *
+ * 4. SEARCH PRUNING:
+ *    Traversals (intersect, difference, forEach) skip entire 2^12 bit domains
+ *    if the L0/L1 masks are 0. Furthermore, inside active pages, operations
+ *    leverage the `activeWordsMask` to skip empty words via hardware CTZ intrinsics.
+ *
+
+ */
+
+PagedArenaBitset::PagedArenaBitset()
+    : mSummaryMask(MASK_WORDS, 0),          // All bits 0 (512 * u64 ->  4KiB)
+      mDirectory(DIR_SIZE, INVALID_PAGE),   // All entries 0xFFFF (32768 * u16 -> 64KiB)
+      mMasterMask({})
+{
+    // Place these near the top of PagedArenaBitset.cpp
+    static_assert(std::is_trivially_copyable_v<Page>,
+        "Page must be trivially copyable for high-performance vector reallocations.");
+
+    static_assert(std::is_standard_layout_v<Page>,
+        "Page must have standard layout for binary compatibility and memory alignment.");
+
+    static_assert(sizeof(Page) == (WORDS_PER_PAGE + 1) * sizeof(uint64_t),
+        "Page size mismatch: Expected words array + activeWordsMask.");
+
+    // No reserve(mArena) here!
+    // We only reserve mArena in intersect() where we know the size.
+}
+
+PagedArenaBitset::~PagedArenaBitset() = default;
+PagedArenaBitset::PagedArenaBitset(PagedArenaBitset&&) noexcept = default;
+PagedArenaBitset::PagedArenaBitset(PagedArenaBitset const&) = default;
+
+uint16_t PagedArenaBitset::allocatePage() {
+    if (!mFreePages.empty()) {
+        uint16_t const idx = mFreePages.back();
+        mFreePages.pop_back();
+        assert(idx < mArena.size() && "Free list contains invalid arena index");
+        mArena[idx].clear();
+        return idx;
+    }
+
+    assert(mArena.size() < PagedArenaBitset::INVALID_PAGE && "Arena capacity exceeded directory index size");
+    uint16_t const idx = static_cast<uint16_t>(mArena.size());
+    mArena.emplace_back();
+    return idx;
+}
+
+void PagedArenaBitset::freePage(uint32_t const dirIdx) {
+    assert(dirIdx < PagedArenaBitset::DIR_SIZE && "Directory index out of bounds");
+    uint16_t const pageIdx = mDirectory[dirIdx];
+
+    assert(pageIdx != PagedArenaBitset::INVALID_PAGE && "Attempting to free an unallocated page");
+    assert(pageIdx < mArena.size() && "Page index out of bounds");
+
+    mFreePages.push_back(pageIdx);
+    mDirectory[dirIdx] = INVALID_PAGE;
+    mSummaryMask[dirIdx >> WORD_SHIFT] &= ~(1ULL << (dirIdx & WORD_MASK));
+}
+
+void PagedArenaBitset::reserve(size_t const size) {
+    mArena.reserve(size);
+}
+
+PagedArenaBitset& PagedArenaBitset::copyFrom(const PagedArenaBitset& other) {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+
+    if (this == &other) return *this;
+
+    mArena = other.mArena;
+    mDirectory = other.mDirectory;
+    mSummaryMask = other.mSummaryMask;
+
+    // Simple scalar copies
+    mMasterMask = other.mMasterMask;
+    mSize = other.mSize;
+    return *this;
+}
+
+bool PagedArenaBitset::operator[](uint32_t const index) const {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    assert(index < (1ULL << DOMAIN_BITS) && "Index out of bounds");
+
+    uint32_t const dirIdx = index >> PAGE_SHIFT;
+    uint32_t const maskIdx = dirIdx >> WORD_SHIFT;
+    uint32_t const bitInMask = dirIdx & WORD_MASK;
+
+    if ((mSummaryMask[maskIdx] & (1ULL << bitInMask)) == 0) return false;
+
+    uint16_t const pageIdx = mDirectory[dirIdx];
+    uint32_t const wordIdx = (index >> WORD_SHIFT) & WORD_MASK;
+    uint32_t const bitIdx = index & WORD_MASK;
+    return (mArena[pageIdx].words[wordIdx] >> bitIdx) & 1ULL;
+}
+
+bool PagedArenaBitset::fetchAdd(uint32_t const index) {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    assert(index < (1ULL << DOMAIN_BITS) && "Index out of bounds");
+
+    uint32_t const dirIdx = index >> PAGE_SHIFT;
+    uint32_t const maskIdx = dirIdx >> WORD_SHIFT;
+    uint32_t const bitInMask = dirIdx & WORD_MASK;
+    bool const pageExists = (mSummaryMask[maskIdx] & (1ULL << bitInMask)) != 0;
+
+    uint16_t pageIdx;
+    if (!pageExists) {
+        pageIdx = allocatePage();
+        mDirectory[dirIdx] = pageIdx;
+        mSummaryMask[maskIdx] |= (1ULL << bitInMask);
+        mMasterMask[maskIdx >> WORD_SHIFT] |= (1ULL << (maskIdx & WORD_MASK));
+    } else {
+        pageIdx = mDirectory[dirIdx];
+    }
+
+    uint32_t const wordIdx = (index >> WORD_SHIFT) & WORD_MASK;
+    uint32_t const bitIdx = index & WORD_MASK;
+
+    uint64_t& word = mArena[pageIdx].words[wordIdx];
+    uint64_t const mask = 1ULL << bitIdx;
+
+    bool const wasSet = (word & mask) != 0;
+    if (!wasSet) {
+        word |= mask;
+        mArena[pageIdx].activeWordsMask |= (1ULL << wordIdx);
+        mSize++;
+    }
+    return wasSet;
+}
+
+bool PagedArenaBitset::fetchRemove(uint32_t const index) {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    assert(index < (1ULL << DOMAIN_BITS) && "Index out of bounds");
+
+    uint32_t const dirIdx = index >> PAGE_SHIFT;
+    uint32_t const maskIdx = dirIdx >> WORD_SHIFT;
+    uint32_t const bitInMask = dirIdx & WORD_MASK;
+
+    if ((mSummaryMask[maskIdx] & (1ULL << bitInMask)) == 0) return false;
+
+    uint16_t const pageIdx = mDirectory[dirIdx];
+
+    uint32_t const wordIdx = (index >> WORD_SHIFT) & WORD_MASK;
+    uint32_t const bitIdx = index & WORD_MASK;
+
+    uint64_t& word = mArena[pageIdx].words[wordIdx];
+    uint64_t const mask = 1ULL << bitIdx;
+
+    bool const wasSet = (word & mask) != 0;
+    if (wasSet) {
+        word &= ~mask;
+        if (word == 0) {
+            mArena[pageIdx].activeWordsMask &= ~(1ULL << wordIdx);
+        }
+        assert(mSize > 0 && "Size underflow");
+        mSize--;
+    }
+    return wasSet;
+}
+
+PagedArenaBitset& PagedArenaBitset::intersect(const PagedArenaBitset& other) {
+    // Assert moved-from state check (adjust macro based on your framework)
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+
+    // Algorithmic Early Exits
+    if (empty()) {
+        return *this;
+    }
+    if (other.empty()) {
+        clear();
+        return *this;
+    }
+
+    // Traverse the 3-level directory hierarchy
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t myMaster = mMasterMask[m];
+
+        // Level 1: Master Directory Traversal
+        while (myMaster) {
+            int const maskBit = std::countr_zero(myMaster);
+            myMaster &= myMaster - 1; // Clear lowest set bit to advance loop
+
+            // Compute index into Level 2 (Summary Masks)
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            // Load the summary masks (representing 64 software blocks/pages)
+            uint64_t const myMask = mSummaryMask[maskIdx];
+            uint64_t const otherMask = other.mSummaryMask[maskIdx];
+
+            // Bits set in both summary masks mean pages overlap
+            uint64_t keepMask = myMask & otherMask;
+            // Bits set in mine but NOT in other mean pages must be dropped entirely
+            uint64_t dropMask = myMask & ~otherMask;
+
+            // --- DROP PASS ---
+            // Efficiently free large ranges that exist in this bitset but not 'other'
+            while (dropMask) {
+                int const bit = std::countr_zero(dropMask);
+                dropMask &= dropMask - 1; // Clear bit immediately for pipelining
+
+                // Convert summary index bit to directory index (pointing to the Page ptr)
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                // Subtract entire population of this page before freeing
+                mSize -= mArena[mDirectory[dirIdx]].popcount();
+                freePage(dirIdx);
+            }
+
+            // --- KEEP PASS (Optimization Hybrid) ---
+            // Process software blocks where data might actually intersect
+            while (keepMask) {
+                int const bit = std::countr_zero(keepMask);
+                keepMask &= keepMask - 1; // Clear bit immediately to unblock CPU pipeline
+
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                // Lookup actual Page structs in the Arena
+                auto& [activeWordsMask, words] = mArena[mDirectory[dirIdx]];
+                auto const& [activeWordsMaskOther, wordsOther] = other.mArena[other.mDirectory[dirIdx]];
+
+                // Use the newly added page-level active words mask
+                const uint64_t current_active_mask = activeWordsMask;
+
+                uint32_t removedInPage = 0;
+                uint64_t new_active_mask = 0;
+
+                // 1. Process Overlapping Words
+                // Words that contain data in BOTH pages.
+                uint64_t overlap = current_active_mask & activeWordsMaskOther;
+                while (overlap != 0) {
+                    int const w = std::countr_zero(overlap);
+                    overlap &= (overlap - 1); // Advance immediately for instruction parallelism
+
+                    uint64_t const oldWord = words[w];
+                    uint64_t const newWord = oldWord & wordsOther[w];
+                    words[w] = newWord;
+
+                    removedInPage += std::popcount(oldWord ^ newWord);
+
+                    // Branchless mask update (newWord might become 0 after intersection)
+                    new_active_mask |= (uint64_t(newWord != 0) << w);
+                }
+
+                // 2. Process Dead Words (Ghost Data Handling)
+                // Words active in this page, but entirely empty in the other page.
+                // Must be explicitly zeroed in memory to prevent memory corruption.
+                uint64_t dead = current_active_mask & ~activeWordsMaskOther;
+                while (dead != 0) {
+                    int const w = std::countr_zero(dead);
+                    dead &= (dead - 1); // Advance loop immediately
+
+                    // Entirety of oldWord is being removed
+                    removedInPage += std::popcount(words[w]);
+                    words[w] = 0; // CRITICAL: Zero out dead word!
+                    // Bit corresponding to word 'w' remains 0 in new_active_mask.
+                }
+
+                // Apply finalized updates to the page
+                activeWordsMask = new_active_mask;
+                mSize -= removedInPage;
+
+                // Level 3 Cleanup: If entire page is now zero, free it
+                if (new_active_mask == 0) {
+                    freePage(dirIdx);
+                }
+            }
+
+            // Level 2 Cleanup: If the entire summary mask word became zero,
+            // clear its corresponding bit in the Master mask.
+            if (mSummaryMask[maskIdx] == 0) {
+                mMasterMask[m] &= ~(1ULL << maskBit);
+            }
+        }
+    }
+
+    return *this;
+}
+
+PagedArenaBitset& PagedArenaBitset::difference(const PagedArenaBitset& other) {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+
+    if (empty() || other.empty()) {
+        return *this;
+    }
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t overlapMaster = mMasterMask[m] & other.mMasterMask[m];
+
+        while (overlapMaster) {
+            int const maskBit = std::countr_zero(overlapMaster);
+            overlapMaster &= overlapMaster - 1;
+
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t overlapMask = mSummaryMask[maskIdx] & other.mSummaryMask[maskIdx];
+
+            while (overlapMask) {
+                int const bit = std::countr_zero(overlapMask);
+                overlapMask &= overlapMask - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                auto& [activeWordsMask, words] = mArena[mDirectory[dirIdx]];
+                auto const& [activeWordsMaskOther, wordsOther] = other.mArena[other.mDirectory[dirIdx]];
+
+                uint32_t removedInPage = 0;
+                uint64_t new_mask = 0;
+
+                // Overlap
+                uint64_t overlap = activeWordsMask & activeWordsMaskOther;
+                while (overlap != 0) {
+                    int const w = std::countr_zero(overlap);
+                    overlap &= (overlap - 1); // Advance immediately
+
+                    uint64_t const oldWord = words[w];
+                    uint64_t const newWord = oldWord & ~wordsOther[w];
+                    words[w] = newWord;
+
+                    removedInPage += std::popcount(oldWord ^ newWord);
+                    new_mask |= (uint64_t(newWord != 0) << w);
+                }
+
+                // Preserved Words
+                uint64_t const preserved = activeWordsMask & ~activeWordsMaskOther;
+                new_mask |= preserved;
+
+                activeWordsMask = new_mask;
+                mSize -= removedInPage;
+
+                if (activeWordsMask == 0) {
+                    freePage(dirIdx);
+                }
+            }
+
+            if (mSummaryMask[maskIdx] == 0) {
+                mMasterMask[m] &= ~(1ULL << maskBit);
+            }
+        }
+    }
+    return *this;
+}
+
+PagedArenaBitset& PagedArenaBitset::merge(const PagedArenaBitset& other) {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+
+    if (other.empty() || this == &other) {
+        return *this;
+    }
+
+    if (empty() && !other.empty()) {
+        copyFrom(other);
+        return *this;
+    }
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t otherMaster = other.mMasterMask[m];
+        if (!otherMaster) continue;
+
+        // Note: Don't update mMasterMask[m] yet.
+
+        while (otherMaster) {
+            int const maskBit = std::countr_zero(otherMaster);
+            otherMaster &= otherMaster - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t otherMask = other.mSummaryMask[maskIdx];
+            // Note: Don't update mSummaryMask[maskIdx] yet.
+
+            while (otherMask) {
+                int const bit = std::countr_zero(otherMask);
+                otherMask &= otherMask - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t const otherPageIdx = other.mDirectory[dirIdx];
+                uint16_t myPageIdx = mDirectory[dirIdx];
+
+                if (myPageIdx == INVALID_PAGE) {
+                    myPageIdx = allocatePage();
+                    mDirectory[dirIdx] = myPageIdx;
+
+                    const auto& srcPage = other.mArena[otherPageIdx];
+                    mArena[myPageIdx] = srcPage;
+
+                    uint32_t const pCount = srcPage.popcount();
+                    mSize += pCount;
+
+                    // Update masks only because we confirmed data was added
+                    mSummaryMask[maskIdx] |= (1ULL << bit);
+                    mMasterMask[m] |= (1ULL << maskBit);
+                } else {
+                    auto& [activeWordsMask, words] = mArena[myPageIdx];
+                    auto const& [activeWordsMaskOther, wordsOther] = other.mArena[otherPageIdx];
+                    uint32_t newlySetBits = 0;
+
+                    // Active Src Words
+                    uint64_t srcMask = activeWordsMaskOther;
+                    while (srcMask != 0) {
+                        int const w = std::countr_zero(srcMask);
+                        srcMask &= (srcMask - 1); // Advance immediately
+
+                        uint64_t const oldWord = words[w];
+                        uint64_t const otherWord = wordsOther[w];
+                        uint64_t const newWord = oldWord | otherWord;
+                        words[w] = newWord;
+
+                        newlySetBits += std::popcount(oldWord ^ newWord);
+                    }
+
+                    activeWordsMask |= activeWordsMaskOther;
+
+                    if (newlySetBits > 0) {
+                        mSize += newlySetBits;
+                        mSummaryMask[maskIdx] |= (1ULL << bit);
+                        mMasterMask[m] |= (1ULL << maskBit);
+                    }
+                }
+            }
+
+
+        }
+    }
+    return *this;
+}
+
+void PagedArenaBitset::defragment() {
+    std::vector<Page> newArena;
+    newArena.reserve(mArena.size() - mFreePages.size());
+
+    uint32_t actualSize = 0;
+
+    // Trust the mask to find active pages
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t myMaster = mMasterMask[m];
+        while (myMaster) {
+            int const maskBit = std::countr_zero(myMaster);
+            myMaster &= myMaster - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t myMask = mSummaryMask[maskIdx];
+            while (myMask) {
+                int const bit = std::countr_zero(myMask);
+                myMask &= myMask - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t const oldPageIdx = mDirectory[dirIdx];
+                Page const& page = mArena[oldPageIdx];
+                uint32_t const pop = page.popcount();
+
+                if (pop == 0) {
+                    // Drop the ghost page
+                    mDirectory[dirIdx] = INVALID_PAGE;
+                    mSummaryMask[maskIdx] &= ~(1ULL << bit);
+                } else {
+                    // Pack the surviving page
+                    uint16_t const newPageIdx = static_cast<uint16_t>(newArena.size());
+                    newArena.push_back(page);
+                    mDirectory[dirIdx] = newPageIdx;
+                    actualSize += pop;
+                }
+            }
+        }
+    }
+
+    assert(mSize == actualSize && "Size invariant violated during defragmentation");
+    mSize = actualSize;
+
+    mArena = std::move(newArena);
+    mFreePages.clear();
+
+    // Recalculate master mask
+    std::fill(mMasterMask.begin(), mMasterMask.end(), 0);
+    for (uint32_t i = 0; i < MASK_WORDS; ++i) {
+        if (mSummaryMask[i] != 0) {
+            mMasterMask[i >> WORD_SHIFT] |= (1ULL << (i & WORD_MASK));
+        }
+    }
+}
+
+void PagedArenaBitset::extractTo(std::vector<uint32_t>& outBuffer) const {
+    outBuffer.clear();
+    if (empty()) {
+        return;
+    }
+
+    outBuffer.reserve(mSize);
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterMask = mMasterMask[m];
+        while (masterMask) {
+            int const maskBit = std::countr_zero(masterMask);
+            masterMask &= masterMask - 1;
+
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+            uint64_t mask = mSummaryMask[maskIdx];
+
+            while (mask) {
+                int const bit = std::countr_zero(mask);
+                mask &= mask - 1;
+
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+                auto const& [activeWordsMask, words] = mArena[mDirectory[dirIdx]];
+                uint64_t activeMask = activeWordsMask;
+
+                while (activeMask != 0) {
+                    int const w = std::countr_zero(activeMask);
+                    uint64_t word = words[w];
+                    while (word) {
+                        int const wBit = std::countr_zero(word);
+                        word &= word - 1;
+                        outBuffer.push_back((dirIdx << PAGE_SHIFT) | (w << WORD_SHIFT) | wBit);
+                    }
+                    activeMask &= (activeMask - 1);
+                }
+            }
+        }
+    }
+}
+
+void PagedArenaBitset::Page::clear() {
+    for (int i = 0; i < WORDS_PER_PAGE; ++i) {
+        words[i] = 0;
+    }
+    activeWordsMask = 0;
+}
+
+uint32_t PagedArenaBitset::Page::popcount() const {
+    uint32_t count = 0;
+    uint64_t mask = activeWordsMask;
+    while (mask != 0) {
+        int const w = std::countr_zero(mask);
+        count += std::popcount(words[w]);
+        mask &= (mask - 1);
+    }
+    return count;
+}
+
+size_t PagedArenaBitset::size() const {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    return mSize;
+}
+
+bool PagedArenaBitset::empty() const {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    return mSize == 0;
+}
+
+void PagedArenaBitset::clear() {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    std::fill(mSummaryMask.begin(), mSummaryMask.end(), 0);
+    std::fill(mMasterMask.begin(), mMasterMask.end(), 0);
+    mArena.clear();
+    mFreePages.clear();
+    mSize = 0;
+}
+
+void PagedArenaBitset::add(uint32_t const index) {
+    fetchAdd(index);
+}
+
+void PagedArenaBitset::remove(uint32_t const index) {
+    fetchRemove(index);
+}
+
+PagedArenaBitset& PagedArenaBitset::operator=(PagedArenaBitset&& rhs) noexcept {
+    if (this != &rhs) {
+        mSummaryMask = std::move(rhs.mSummaryMask);
+        mDirectory = std::move(rhs.mDirectory);
+        mArena = std::move(rhs.mArena);
+        mFreePages = std::move(rhs.mFreePages);
+        mSize = rhs.mSize;
+        mMasterMask = rhs.mMasterMask;
+
+        rhs.mSize = 0;
+        std::fill(rhs.mMasterMask.begin(), rhs.mMasterMask.end(), 0);
+    }
+    return *this;
+}
+
+PagedArenaBitset PagedArenaBitset::clone() const {
+    assert(mSummaryMask.size() == MASK_WORDS && "FATAL: Attempted to use a moved-from PagedArenaBitset!");
+    return *this;
+}
+
+bool PagedArenaBitset::isSubset(const PagedArenaBitset& subset, const PagedArenaBitset& superset) noexcept {
+    // 1. Trivial Size & Identity Checks
+    if (subset.mSize > superset.mSize) return false;
+    if (subset.empty() || &subset == &superset) return true;
+    if (superset.empty()) return false;
+
+    // 2. Hierarchical Inclusion Check
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t const subL0 = subset.mMasterMask[m];
+        uint64_t const superL0 = superset.mMasterMask[m];
+
+        // --- LEVEL 0 CONFLICT PASS ---
+        // Blocks that exist in subset but NOT in superset.
+        // This is only legal if EVERY underlying page inside them is an empty Ghost Page.
+        uint64_t conflictL0 = subL0 & ~superL0;
+        while (conflictL0) {
+            int const maskBit = std::countr_zero(conflictL0);
+            conflictL0 &= conflictL0 - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t subL1 = subset.mSummaryMask[maskIdx];
+            while (subL1) {
+                int const bit = std::countr_zero(subL1);
+                subL1 &= subL1 - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+                if (subset.mArena[subset.mDirectory[dirIdx]].activeWordsMask != 0) {
+                    return false; // Found an actual active bit unique to subset!
+                }
+            }
+        }
+
+        // --- LEVEL 0 OVERLAP PASS ---
+        // Process blocks shared by both sets.
+        uint64_t overlapL0 = subL0 & superL0;
+        while (overlapL0) {
+            int const maskBit = std::countr_zero(overlapL0);
+            overlapL0 &= overlapL0 - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t const subL1 = subset.mSummaryMask[maskIdx];
+            uint64_t const superL1 = superset.mSummaryMask[maskIdx];
+
+            // --- LEVEL 1 CONFLICT PASS ---
+            // Pages unique to subset inside a shared block. Must be Ghost Pages.
+            uint64_t conflictL1 = subL1 & ~superL1;
+            while (conflictL1) {
+                int const bit = std::countr_zero(conflictL1);
+                conflictL1 &= conflictL1 - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+                if (subset.mArena[subset.mDirectory[dirIdx]].activeWordsMask != 0) {
+                    return false;
+                }
+            }
+
+            // --- LEVEL 1 OVERLAP PASS ---
+            // Both sets share these physical pages; perform word-level checks.
+            uint64_t overlapL1 = subL1 & superL1;
+            while (overlapL1) {
+                int const bit = std::countr_zero(overlapL1);
+                overlapL1 &= overlapL1 - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t const dirSub = subset.mDirectory[dirIdx];
+                uint16_t const dirSuper = superset.mDirectory[dirIdx];
+
+                auto const& pageSub = subset.mArena[dirSub];
+                auto const& pageSuper = superset.mArena[dirSuper];
+
+                // Subset cannot have active words that superset lacks
+                if ((pageSub.activeWordsMask & ~pageSuper.activeWordsMask) != 0) {
+                    return false;
+                }
+
+                uint64_t maskOverlap = pageSub.activeWordsMask & pageSuper.activeWordsMask;
+                while (maskOverlap != 0) {
+                    int const w = std::countr_zero(maskOverlap);
+                    maskOverlap &= (maskOverlap - 1);
+                    if ((pageSub.words[w] & ~pageSuper.words[w]) != 0) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// Internal helpers for N-way population count without allocations.
+// Uses a template to support both utils::Slice and std::array (for unrolling).
+// - If Collection is std::array: Compiler unrolls the loops (Inlined Path).
+// - If Collection is utils::Slice: Compiler generates a standard loop (Dynamic Path).
+
+template<typename Collection>
+PagedArenaBitset& PagedArenaBitset::intersectInternal(PagedArenaBitset* UTILS_RESTRICT out, const Collection& inputs) {
+    assert(std::size(inputs) <= MAX_MULTI_WAY_INPUTS && "FATAL: Exceeded maximum multi-way bitset inputs!");
+
+    out->clear();
+    if (std::empty(inputs)) {
+        return *out;
+    }
+
+    // If ANY operand is empty, the intersection is totally empty.
+    for (auto const* input : inputs) {
+        if (input->empty()) {
+            return *out;
+        }
+    }
+
+    size_t const count = std::size(inputs);
+
+    // The Generic N-Way Loop
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterOverlap = inputs[0]->mMasterMask[m];
+
+        // For std::array<..., 2>, the compiler fully unrolls this loop and eliminates the branch.
+        for (size_t i = 1; i < count; ++i) {
+            masterOverlap &= inputs[i]->mMasterMask[m];
+        }
+
+        while (masterOverlap) {
+            int const maskBit = std::countr_zero(masterOverlap);
+            masterOverlap &= masterOverlap - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t overlap = inputs[0]->mSummaryMask[maskIdx];
+            for (size_t i = 1; i < count; ++i) {
+                overlap &= inputs[i]->mSummaryMask[maskIdx];
+            }
+
+            while (overlap) {
+                int const bit = std::countr_zero(overlap);
+                overlap &= overlap - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                out->mArena.emplace_back();
+                auto& [activeWordsMask, words] = out->mArena.back();
+                uint32_t pop = 0;
+
+                uint16_t dirs[MAX_MULTI_WAY_INPUTS];
+                for (size_t i = 0; i < count; ++i) {
+                    dirs[i] = inputs[i]->mDirectory[dirIdx];
+                }
+
+                uint64_t overlapWords = inputs[0]->mArena[dirs[0]].activeWordsMask;
+                for (size_t i = 1; i < count; ++i) {
+                    overlapWords &= inputs[i]->mArena[dirs[i]].activeWordsMask;
+                }
+
+                while (overlapWords != 0) {
+                    int const w = std::countr_zero(overlapWords);
+                    overlapWords &= (overlapWords - 1); // Advance immediately
+
+                    uint64_t word = inputs[0]->mArena[dirs[0]].words[w];
+                    for (size_t i = 1; i < count; ++i) {
+                        word &= inputs[i]->mArena[dirs[i]].words[w];
+                    }
+
+                    words[w] = word;
+                    activeWordsMask |= (uint64_t(word != 0) << w);
+                    pop += std::popcount(word);
+                }
+
+                if (pop > 0) {
+                    uint16_t const newPageIdx = static_cast<uint16_t>(out->mArena.size() - 1);
+                    out->mDirectory[dirIdx] = newPageIdx;
+                    out->mSummaryMask[maskIdx] |= (1ULL << bit);
+                    out->mSize += pop;
+                    out->mMasterMask[m] |= (1ULL << maskBit);
+                } else {
+                    out->mArena.pop_back();
+                }
+            }
+        }
+    }
+    return *out;
+}
+
+template<typename Collection>
+uint32_t PagedArenaBitset::intersectSizeInternal(const Collection& inputs) {
+    assert(std::size(inputs) <= MAX_MULTI_WAY_INPUTS && "FATAL: Exceeded maximum multi-way bitset inputs!");
+
+    if (std::empty(inputs)) {
+        return 0;
+    }
+    if (std::size(inputs) == 1) {
+        return inputs[0]->size();
+    }
+
+    // If ANY operand is empty, the intersection is totally empty.
+    for (auto const* input : inputs) {
+        if (input->empty()) {
+            return 0;
+        }
+    }
+
+    uint32_t totalPop = 0;
+    const size_t count = std::size(inputs);
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterOverlap = inputs[0]->mMasterMask[m];
+        for (size_t i = 1; i < count; ++i) {
+            masterOverlap &= inputs[i]->mMasterMask[m];
+            if (masterOverlap == 0) break;
+        }
+
+        while (masterOverlap) {
+            int const maskBit = std::countr_zero(masterOverlap);
+            masterOverlap &= masterOverlap - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t overlap = inputs[0]->mSummaryMask[maskIdx];
+            for (size_t i = 1; i < count; ++i) {
+                overlap &= inputs[i]->mSummaryMask[maskIdx];
+                if (overlap == 0) break;
+            }
+
+            while (overlap) {
+                int const bit = std::countr_zero(overlap);
+                overlap &= overlap - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t dirs[MAX_MULTI_WAY_INPUTS];
+                for (size_t i = 0; i < count; ++i) {
+                    dirs[i] = inputs[i]->mDirectory[dirIdx];
+                }
+
+                uint64_t overlapWords = inputs[0]->mArena[dirs[0]].activeWordsMask;
+                for (size_t i = 1; i < count; ++i) {
+                    overlapWords &= inputs[i]->mArena[dirs[i]].activeWordsMask;
+                }
+
+                while (overlapWords != 0) {
+                    int const w = std::countr_zero(overlapWords);
+                    uint64_t word = inputs[0]->mArena[dirs[0]].words[w];
+                    for (size_t i = 1; i < count; ++i) {
+                        word &= inputs[i]->mArena[dirs[i]].words[w];
+                    }
+                    totalPop += std::popcount(word);
+                    overlapWords &= (overlapWords - 1);
+                }
+            }
+        }
+    }
+    return totalPop;
+}
+
+/**
+ * N-WAY MERGE (REDUCTION PATTERN)
+ * -------------------------------
+ * While a single-pass N-way traversal is theoretically O(N) at the hierarchy
+ * level, it is physically constrained by CPU register pressure and pointer
+ * indirection inside the hottest loops.
+ *
+ * We implement this as a Pairwise Reduction (copyFrom + merge chain) because:
+ * 1. INSTRUCTION DENSITY: The 2-way merge loop is simple enough for the CPU
+ *    to fully pipeline, unroll, and potentially vectorize.
+ * 2. REGISTER ALLOCATION: 2-way ops allow the compiler to pin pointers in
+ *    registers, avoiding the stack spills caused by iterating over a collection.
+ * 3. BRANCH PREDICTABILITY: Removing the inner collection loop eliminates
+ *    thousands of unpredictable micro-branches per page.
+ *
+ * Result: Observed 3.4x speedup over N-way traversal in 6-way merge tests.
+ */
+template<typename Collection>
+PagedArenaBitset& PagedArenaBitset::mergeInternal(PagedArenaBitset* UTILS_RESTRICT out, const Collection& inputs) {
+    out->clear();
+    if (std::empty(inputs)) return *out;
+
+    auto it = std::begin(inputs);
+    auto end = std::end(inputs);
+
+    // 1. Initialize the output with the first non-empty bitset
+    // We use copyFrom to get memcpy-like performance for the first set
+    while (it != end && (*it)->empty()) {
+        ++it;
+    }
+
+    if (it == end) {
+        return *out; // All were empty
+    }
+
+    out->copyFrom(**it);
+    ++it;
+
+    // 2. Reduce the rest using the optimized in-place 2-way merge
+    for (; it != end; ++it) {
+        if (!(*it)->empty()) {
+            out->merge(**it);
+        }
+    }
+    return *out;
+}
+
+template<typename Collection>
+uint32_t PagedArenaBitset::mergeSizeInternal(const Collection& inputs) {
+    assert(std::size(inputs) <= MAX_MULTI_WAY_INPUTS && "FATAL: Exceeded maximum multi-way bitset inputs!");
+
+    if (std::empty(inputs)) return 0;
+    const size_t count = std::size(inputs);
+    if (count == 1) return inputs[0]->size();
+
+    uint32_t totalPop = 0;
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterUnion = 0;
+        for (size_t i = 0; i < count; ++i) {
+            masterUnion |= inputs[i]->mMasterMask[m];
+        }
+
+        while (masterUnion) {
+            int const maskBit = std::countr_zero(masterUnion);
+            masterUnion &= masterUnion - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t summaryUnion = 0;
+            for (size_t i = 0; i < count; ++i) {
+                summaryUnion |= inputs[i]->mSummaryMask[maskIdx];
+            }
+
+            while (summaryUnion) {
+                int const bit = std::countr_zero(summaryUnion);
+                summaryUnion &= summaryUnion - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                // --- OPTIMIZATION START ---
+                // Collect pointers to active word arrays once per page.
+                // This eliminates 'hasPage' checks inside the 64-word loop.
+                const uint64_t* activePages[MAX_MULTI_WAY_INPUTS];
+                uint64_t combinedMask = 0;
+                uint32_t activeCount = 0;
+                for (size_t i = 0; i < count; ++i) {
+                    uint16_t const d = inputs[i]->mDirectory[dirIdx];
+                    if (d != INVALID_PAGE) {
+                        auto const& page = inputs[i]->mArena[d];
+                        activePages[activeCount++] = page.words;
+                        combinedMask |= page.activeWordsMask;
+                    }
+                }
+                // --- OPTIMIZATION END ---
+
+                while (combinedMask != 0) {
+                    int const w = std::countr_zero(combinedMask);
+                    uint64_t combinedWord = 0;
+                    for (uint32_t i = 0; i < activeCount; ++i) {
+                        combinedWord |= activePages[i][w];
+                    }
+                    totalPop += std::popcount(combinedWord);
+                    combinedMask &= (combinedMask - 1);
+                }
+            }
+        }
+    }
+    return totalPop;
+}
+
+// ----------------------------------------------------------------------------------------------------------------
+
+PagedArenaBitset& PagedArenaBitset::intersect(PagedArenaBitset* UTILS_RESTRICT out,
+        const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    assert(out != &a && out != &b);
+    out->clear();
+    if (a.empty() || b.empty()) {
+        return *out;
+    }
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterOverlap = a.mMasterMask[m] & b.mMasterMask[m];
+
+        while (masterOverlap) {
+            int const maskBit = std::countr_zero(masterOverlap);
+            masterOverlap &= masterOverlap - 1;
+
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+            uint64_t summaryOverlap = a.mSummaryMask[maskIdx] & b.mSummaryMask[maskIdx];
+
+            while (summaryOverlap) {
+                int const bit = std::countr_zero(summaryOverlap);
+                summaryOverlap &= summaryOverlap - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t const pageAIdx = a.mDirectory[dirIdx];
+                uint16_t const pageBIdx = b.mDirectory[dirIdx];
+
+                assert(pageAIdx != PagedArenaBitset::INVALID_PAGE && pageBIdx != PagedArenaBitset::INVALID_PAGE &&
+                        "Summary mask desync");
+
+                auto const& [activeWordsMaskA, wordsA] = a.mArena[pageAIdx];
+                auto const& [activeWordsMaskB, wordsB] = b.mArena[pageBIdx];
+
+                out->mArena.emplace_back();
+                auto& [activeWordsMask, words] = out->mArena.back();
+                uint32_t pop = 0;
+
+                uint64_t wordsOverlap = activeWordsMaskA & activeWordsMaskB;
+                while (wordsOverlap != 0) {
+                    int const w = std::countr_zero(wordsOverlap);
+                    wordsOverlap &= (wordsOverlap - 1); // Advance immediately
+
+                    uint64_t const val = wordsA[w] & wordsB[w];
+                    words[w] = val;
+                    activeWordsMask |= (uint64_t(val != 0) << w);
+                    pop += std::popcount(val);
+                }
+
+                if (pop > 0) {
+                    uint16_t const newPageIdx = static_cast<uint16_t>(out->mArena.size() - 1);
+                    out->mDirectory[dirIdx] = newPageIdx;
+                    out->mSummaryMask[maskIdx] |= (1ULL << bit);
+                    out->mSize += pop;
+                    out->mMasterMask[m] |= (1ULL << maskBit);
+                } else {
+                    out->mArena.pop_back();
+                }
+            }
+        }
+    }
+    return *out;
+}
+
+PagedArenaBitset PagedArenaBitset::intersect(const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    PagedArenaBitset out;
+    out.reserve(std::min(a.mArena.size(), b.mArena.size()));
+    intersect(&out, a, b);
+    return out;
+}
+
+PagedArenaBitset& PagedArenaBitset::intersectSpan(PagedArenaBitset* UTILS_RESTRICT out,
+        Slice<const PagedArenaBitset* const> const inputs) {
+    return intersectInternal(out, inputs);
+}
+
+uint32_t PagedArenaBitset::intersectSizeSpan(Slice<const PagedArenaBitset* const> const inputs) {
+    // Passes as a dynamic runtime span. The compiler will preserve the loops in `intersectSizeInternal`.
+    return intersectSizeInternal(inputs);
+}
+
+// ----------------------------------------------------------------------------------------------------------------
+
+PagedArenaBitset& PagedArenaBitset::difference(PagedArenaBitset* UTILS_RESTRICT out,
+        const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    assert(out != &a && out != &b);
+    out->clear();
+    if (a.empty() || &a == &b) {
+        return *out;
+    }
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t maskA = a.mMasterMask[m];
+        while (maskA) {
+            int const maskBit = std::countr_zero(maskA);
+            maskA &= maskA - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t const sumA = a.mSummaryMask[maskIdx];
+            uint64_t const sumB = b.mSummaryMask[maskIdx];
+
+            uint64_t disjoint = sumA & ~sumB;
+            uint64_t overlap = sumA & sumB;
+
+            while (disjoint) {
+                int const bit = std::countr_zero(disjoint);
+                disjoint &= disjoint - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                const Page& pageA = a.mArena[a.mDirectory[dirIdx]];
+
+                uint16_t const newPageIdx = static_cast<uint16_t>(out->mArena.size());
+                out->mArena.push_back(pageA);
+
+                out->mDirectory[dirIdx] = newPageIdx;
+                out->mSummaryMask[maskIdx] |= (1ULL << bit);
+                out->mSize += pageA.popcount();
+                out->mMasterMask[m] |= (1ULL << maskBit);
+            }
+
+            while (overlap) {
+                int const bit = std::countr_zero(overlap);
+                overlap &= overlap - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                auto const& [activeWordsMaskA, wordsA] = a.mArena[a.mDirectory[dirIdx]];
+                auto const& [activeWordsMaskB, wordsB] = b.mArena[b.mDirectory[dirIdx]];
+
+                out->mArena.emplace_back();
+                auto& [activeWordsMask, words] = out->mArena.back();
+                uint32_t pop = 0;
+
+                // Overlap
+                uint64_t overlapWords = activeWordsMaskA & activeWordsMaskB;
+                while (overlapWords != 0) {
+                    int const w = std::countr_zero(overlapWords);
+                    overlapWords &= (overlapWords - 1); // Advance immediately
+
+                    uint64_t const val = wordsA[w] & ~wordsB[w];
+                    words[w] = val;
+                    activeWordsMask |= (uint64_t(val != 0) << w);
+                    pop += std::popcount(val);
+                }
+
+                // Unique to A
+                uint64_t uniqueA = activeWordsMaskA & ~activeWordsMaskB;
+                while (uniqueA != 0) {
+                    int const w = std::countr_zero(uniqueA);
+                    uint64_t const val = wordsA[w];
+                    words[w] = val;
+                    activeWordsMask |= (1ULL << w);
+                    pop += std::popcount(val);
+                    uniqueA &= (uniqueA - 1);
+                }
+
+                if (pop > 0) {
+                    uint16_t const newPageIdx = static_cast<uint16_t>(out->mArena.size() - 1);
+                    out->mDirectory[dirIdx] = newPageIdx;
+                    out->mSummaryMask[maskIdx] |= (1ULL << bit);
+                    out->mSize += pop;
+                    out->mMasterMask[m] |= (1ULL << maskBit);
+                } else {
+                    out->mArena.pop_back();
+                }
+            }
+        }
+    }
+    return *out;
+}
+
+PagedArenaBitset PagedArenaBitset::difference(const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    PagedArenaBitset out;
+    out.reserve(a.mArena.size());
+    difference(&out, a, b);
+    return out;
+}
+
+uint32_t PagedArenaBitset::differenceSize(const PagedArenaBitset& a, const PagedArenaBitset& b) noexcept {
+    if (a.empty() || &a == &b) {
+        return 0;
+    }
+    if (b.empty()) {
+        return a.size();
+    }
+
+    uint32_t totalPop = 0;
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t aMaster = a.mMasterMask[m];
+        if (aMaster == 0) continue;
+
+        while (aMaster) {
+            int const maskBit = std::countr_zero(aMaster);
+            aMaster &= aMaster - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t aSummary = a.mSummaryMask[maskIdx];
+            uint64_t const bSummary = b.mSummaryMask[maskIdx];
+
+            while (aSummary) {
+                int const bit = std::countr_zero(aSummary);
+                aSummary &= aSummary - 1;
+
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+                uint16_t const dirA = a.mDirectory[dirIdx];
+
+                // OPTIMIZATION: Trust the L1 mask!
+                // If B doesn't have this bit set, skip reading B's directory entirely.
+                if ((bSummary & (1ULL << bit)) == 0) {
+                    auto const& [activeWordsMaskA, wordsA] = a.mArena[dirA];
+                    uint64_t maskA = activeWordsMaskA;
+                    while (maskA != 0) {
+                        int const w = std::countr_zero(maskA);
+                        totalPop += std::popcount(wordsA[w]);
+                        maskA &= (maskA - 1);
+                    }
+                } else {
+                    uint16_t const dirB = b.mDirectory[dirIdx];
+                    auto const& [activeWordsMaskA, wordsA] = a.mArena[dirA];
+                    auto const& [activeWordsMaskB, wordsB] = b.mArena[dirB];
+
+                    // Overlap
+                    uint64_t overlap = activeWordsMaskA & activeWordsMaskB;
+                    while (overlap != 0) {
+                        int const w = std::countr_zero(overlap);
+                        totalPop += std::popcount(wordsA[w] & ~wordsB[w]);
+                        overlap &= (overlap - 1);
+                    }
+
+                    // Unique to A
+                    uint64_t uniqueA = activeWordsMaskA & ~activeWordsMaskB;
+                    while (uniqueA != 0) {
+                        int const w = std::countr_zero(uniqueA);
+                        totalPop += std::popcount(wordsA[w]);
+                        uniqueA &= (uniqueA - 1);
+                    }
+                }
+            }
+        }
+    }
+    return totalPop;
+}
+
+// ----------------------------------------------------------------------------------------------------------------
+
+PagedArenaBitset& PagedArenaBitset::merge(PagedArenaBitset* UTILS_RESTRICT out,
+        const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    assert(out != &a && out != &b);
+
+    if (a.empty()) {
+        out->copyFrom(b);
+        return *out;
+    }
+    if (b.empty()) {
+        out->copyFrom(a);
+        return *out;
+    }
+
+    out->clear();
+
+    for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
+        uint64_t masterUnion = a.mMasterMask[m] | b.mMasterMask[m];
+        while (masterUnion) {
+            int const maskBit = std::countr_zero(masterUnion);
+            masterUnion &= masterUnion - 1;
+            uint32_t const maskIdx = (m << WORD_SHIFT) | maskBit;
+
+            uint64_t summaryUnion = a.mSummaryMask[maskIdx] | b.mSummaryMask[maskIdx];
+            while (summaryUnion) {
+                int const bit = std::countr_zero(summaryUnion);
+                summaryUnion &= summaryUnion - 1;
+                uint32_t const dirIdx = (maskIdx << WORD_SHIFT) | bit;
+
+                uint16_t const pageAIdx = a.mDirectory[dirIdx];
+                uint16_t const pageBIdx = b.mDirectory[dirIdx];
+
+                out->mArena.emplace_back();
+                Page& newPage = out->mArena.back();
+                uint32_t pop = 0;
+
+                if (pageAIdx != INVALID_PAGE && pageBIdx != INVALID_PAGE) {
+                    auto const& [activeWordsMaskA, wordsA] = a.mArena[pageAIdx];
+                    auto const& [activeWordsMaskB, wordsB] = b.mArena[pageBIdx];
+
+                    newPage.activeWordsMask = activeWordsMaskA | activeWordsMaskB;
+                    uint64_t combinedMask = newPage.activeWordsMask;
+
+                    while (combinedMask != 0) {
+                        int const w = std::countr_zero(combinedMask);
+                        newPage.words[w] = wordsA[w] | wordsB[w];
+                        pop += std::popcount(newPage.words[w]);
+                        combinedMask &= (combinedMask - 1);
+                    }
+                } else {
+                    // Optimized: Use a reference to avoid a Page copy if pop ends up being 0
+                    // (though for merge, if the page exists in A or B, pop is guaranteed > 0)
+                    const Page& source = (pageAIdx != INVALID_PAGE) ? a.mArena[pageAIdx] : b.mArena[pageBIdx];
+                    newPage = source;
+                    pop = source.popcount(); // Ensure this uses std::popcount loop
+                }
+
+                if (pop > 0) {
+                    // Only update masks and directory if the page actually contains data
+                    uint16_t const newPageIdx = static_cast<uint16_t>(out->mArena.size() - 1);
+                    out->mDirectory[dirIdx] = newPageIdx;
+
+                    // Update masks lazily here
+                    out->mSummaryMask[maskIdx] |= (1ULL << bit);
+                    out->mMasterMask[m] |= (1ULL << maskBit);
+
+                    out->mSize += pop;
+                } else {
+                    out->mArena.pop_back();
+                }
+            }
+        }
+    }
+    return *out;
+}
+
+PagedArenaBitset PagedArenaBitset::merge(const PagedArenaBitset& a, const PagedArenaBitset& b) {
+    PagedArenaBitset out;
+    out.reserve(std::max(a.mArena.size(), b.mArena.size()));
+    merge(&out, a, b);
+    return out;
+}
+
+PagedArenaBitset& PagedArenaBitset::mergeSpan(PagedArenaBitset* UTILS_RESTRICT out,
+        Slice<const PagedArenaBitset* const> const inputs) {
+    return mergeInternal(out, inputs);
+}
+
+uint32_t PagedArenaBitset::mergeSizeSpan(Slice<const PagedArenaBitset* const> const inputs) {
+    // Passes as a dynamic runtime span. The compiler will preserve the loops in `intersectSizeInternal`.
+    return mergeSizeInternal(inputs);
+}
+
+void PagedArenaBitset::swap(PagedArenaBitset& other) noexcept {
+    mSummaryMask.swap(other.mSummaryMask);
+    mDirectory.swap(other.mDirectory);
+    mArena.swap(other.mArena);
+    mFreePages.swap(other.mFreePages);
+    std::swap(mSize, other.mSize);
+    std::swap(mMasterMask, other.mMasterMask);
+}
+
+PagedArenaBitset exchange(PagedArenaBitset& object, PagedArenaBitset&& newValue) {
+    return std::exchange(object, std::move(newValue));
+}
+
+PagedArenaBitset exchangeAndClear(PagedArenaBitset& object) {
+    // this is similar to std::move() but this leaves the object in the default constructed state (cleared)
+    return std::exchange(object, {});
+}
+
+} // namespace utils

--- a/libs/utils/test/test_EntitySet.cpp
+++ b/libs/utils/test/test_EntitySet.cpp
@@ -1,0 +1,785 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <utils/PagedArenaBitset.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+using namespace utils;
+
+template<typename T>
+class EntitySetTest : public ::testing::Test {
+protected:
+    EntitySetTest() = default;
+    ~EntitySetTest() override = default;
+};
+
+using Implementations = ::testing::Types<PagedArenaBitset>;
+TYPED_TEST_SUITE(EntitySetTest, Implementations);
+
+TYPED_TEST(EntitySetTest, Basic) {
+    TypeParam set;
+    EXPECT_TRUE(set.empty());
+
+    set.add(10);
+    EXPECT_FALSE(set.empty());
+    EXPECT_EQ(set.size(), 1);
+    EXPECT_TRUE(set[10]);
+
+    bool found = false;
+    set.forEachSetBit([&found](uint32_t const bit) {
+        if (bit == 10) found = true;
+    });
+    EXPECT_TRUE(found);
+
+    set.remove(10);
+    EXPECT_TRUE(set.empty());
+    EXPECT_EQ(set.size(), 0);
+    EXPECT_FALSE(set[10]);
+}
+
+TYPED_TEST(EntitySetTest, Intersection) {
+    TypeParam set1;
+    TypeParam set2;
+
+    set1.add(10);
+    set1.add(20);
+    set1.add(30);
+
+    set2.add(20);
+    set2.add(30);
+    set2.add(40);
+
+    set1.intersect(set2);
+
+    std::vector<uint32_t> bits;
+    set1.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    std::sort(bits.begin(), bits.end());
+
+    EXPECT_EQ(bits.size(), 2);
+    EXPECT_EQ(bits[0], 20);
+    EXPECT_EQ(bits[1], 30);
+}
+
+TYPED_TEST(EntitySetTest, UnsortedRemoval) {
+    TypeParam set;
+    set.add(30);
+    set.add(10);
+    set.add(20);
+    set.add(10); // Duplicate
+
+    set.remove(10); // Remove 10
+
+    std::vector<uint32_t> bits;
+    set.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    std::sort(bits.begin(), bits.end());
+
+    EXPECT_EQ(bits.size(), 2);
+    EXPECT_EQ(bits[0], 20);
+    EXPECT_EQ(bits[1], 30);
+}
+
+TYPED_TEST(EntitySetTest, IntersectionNonMember) {
+    TypeParam set1;
+    TypeParam set2;
+
+    set1.add(10);
+    set1.add(20);
+
+    set2.add(20);
+    set2.add(30);
+
+    TypeParam const result = TypeParam::intersect(set1, set2);
+
+    std::vector<uint32_t> bits;
+    result.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    EXPECT_EQ(bits.size(), 1);
+    EXPECT_EQ(bits[0], 20);
+}
+
+TYPED_TEST(EntitySetTest, IntersectMove) {
+    TypeParam set1;
+    TypeParam set2;
+
+    set1.add(10);
+    set1.add(20);
+
+    set2.add(20);
+    set2.add(30);
+
+    TypeParam result;
+    set1.intersect(set2);
+    std::swap(result, set1);
+
+    EXPECT_TRUE(set1.empty()); // Because it was swapped
+    EXPECT_FALSE(result.empty());
+
+    std::vector<uint32_t> bits;
+    result.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    EXPECT_EQ(bits.size(), 1);
+    EXPECT_EQ(bits[0], 20);
+}
+
+TYPED_TEST(EntitySetTest, Difference) {
+    TypeParam set1;
+    TypeParam set2;
+
+    set1.add(10);
+    set1.add(20);
+    set1.add(30);
+
+    set2.add(20);
+    set2.add(30);
+    set2.add(40);
+
+    set1.difference(set2);
+
+    std::vector<uint32_t> bits;
+    set1.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    EXPECT_EQ(bits.size(), 1);
+    EXPECT_EQ(bits[0], 10);
+}
+
+TYPED_TEST(EntitySetTest, DifferenceNonMember) {
+    TypeParam set1;
+    TypeParam set2;
+
+    set1.add(10);
+    set1.add(20);
+
+    set2.add(20);
+    set2.add(30);
+
+    TypeParam result = TypeParam::difference(set1, set2);
+
+    std::vector<uint32_t> bits;
+    result.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    EXPECT_EQ(bits.size(), 1);
+    EXPECT_EQ(bits[0], 10);
+
+    // Verify set1 and set2 are not changed
+    EXPECT_TRUE(set1[10]);
+    EXPECT_TRUE(set1[20]);
+    EXPECT_TRUE(set2[20]);
+    EXPECT_TRUE(set2[30]);
+}
+
+TYPED_TEST(EntitySetTest, EarlyBreak) {
+    TypeParam set;
+    set.add(10);
+    set.add(20);
+    set.add(30);
+
+    size_t count = 0;
+    set.forEachSetBit([&count](uint32_t) {
+        count++;
+        return false; // Break immediately
+    });
+
+    EXPECT_EQ(count, 1);
+}
+
+TYPED_TEST(EntitySetTest, Iteration) {
+    TypeParam bs;
+    bs.add(1);
+    bs.add(64);
+    bs.add(127);
+
+    std::vector<uint32_t> bits;
+    bs.forEachSetBit([&bits](uint32_t const bit) {
+        bits.push_back(bit);
+    });
+
+    std::sort(bits.begin(), bits.end());
+
+    EXPECT_EQ(bits.size(), 3);
+    EXPECT_EQ(bits[0], 1);
+    EXPECT_EQ(bits[1], 64);
+    EXPECT_EQ(bits[2], 127);
+}
+
+TEST(PagedArenaBitsetTest, ExtractTo) {
+    PagedArenaBitset bs;
+    bs.add(1);
+    bs.add(64);
+    bs.add(127);
+
+    std::vector<uint32_t> bits;
+    bs.extractTo(bits);
+
+    EXPECT_EQ(bits.size(), 3);
+    EXPECT_EQ(bits[0], 1);
+    EXPECT_EQ(bits[1], 64);
+    EXPECT_EQ(bits[2], 127);
+}
+
+TEST(PagedArenaBitsetTest, IntersectMulti) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+    PagedArenaBitset bs3;
+
+    bs1.add(1);
+    bs1.add(64);
+    bs1.add(127);
+
+    bs2.add(64);
+    bs2.add(127);
+    bs2.add(255);
+
+    bs3.add(127);
+    bs3.add(255);
+    bs3.add(511);
+
+    // 2 arguments
+    PagedArenaBitset const res2 = PagedArenaBitset::intersect(bs1, bs2);
+    EXPECT_EQ(res2.size(), 2);
+    EXPECT_TRUE(res2[64]);
+    EXPECT_TRUE(res2[127]);
+
+    // 3 arguments
+    PagedArenaBitset const res3 = PagedArenaBitset::intersect(bs1, bs2, bs3);
+    EXPECT_EQ(res3.size(), 1);
+    EXPECT_TRUE(res3[127]);
+}
+
+TEST(PagedArenaBitsetTest, IntersectMultiEmpty) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset const bs2;
+
+    bs1.add(1);
+
+    PagedArenaBitset const res = PagedArenaBitset::intersect(bs1, bs2);
+    EXPECT_TRUE(res.empty());
+}
+
+TEST(PagedArenaBitsetTest, Defragment) {
+    PagedArenaBitset bs;
+    bs.add(10); // Page 0
+    bs.add(5000); // Page 1 (since 5000 > 4096!)
+
+    EXPECT_EQ(bs.size(), 2);
+
+    // Remove bits from page 1!
+    bs.remove(5000);
+
+    EXPECT_EQ(bs.size(), 1);
+
+    // Now page 1 is a ghost page!
+    // Let's defragment!
+    bs.defragment();
+
+    EXPECT_EQ(bs.size(), 1);
+    EXPECT_TRUE(bs[10]);
+    EXPECT_FALSE(bs[5000]);
+}
+
+TEST(PagedArenaBitsetTest, LargeIndices) {
+    PagedArenaBitset bs;
+    uint32_t const largeIndex = (1U << 25) - 1; // Limit suggested by user!
+    bs.add(largeIndex);
+    EXPECT_TRUE(bs[largeIndex]);
+    EXPECT_EQ(bs.size(), 1);
+
+    bs.remove(largeIndex);
+    EXPECT_FALSE(bs[largeIndex]);
+    EXPECT_TRUE(bs.empty());
+}
+
+TEST(PagedArenaBitsetTest, DifferenceEdgeCases) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    bs1.add(10);
+    bs1.add(20);
+
+    // Subtract from itself!
+    PagedArenaBitset res1 = PagedArenaBitset::difference(bs1, bs1);
+    EXPECT_TRUE(res1.empty());
+
+    // Subtract empty set!
+    PagedArenaBitset res2 = PagedArenaBitset::difference(bs1, bs2);
+    EXPECT_EQ(res2.size(), 2);
+    EXPECT_TRUE(res2[10]);
+    EXPECT_TRUE(res2[20]);
+
+    // Subtract superset!
+    bs2.add(10);
+    bs2.add(20);
+    bs2.add(30);
+    PagedArenaBitset res3 = PagedArenaBitset::difference(bs1, bs2);
+    EXPECT_TRUE(res3.empty());
+}
+
+TEST(PagedArenaBitsetTest, Clear) {
+    PagedArenaBitset bs;
+    bs.add(10);
+    bs.add(20);
+    EXPECT_FALSE(bs.empty());
+    EXPECT_EQ(bs.size(), 2);
+
+    bs.clear();
+    EXPECT_TRUE(bs.empty());
+    EXPECT_EQ(bs.size(), 0);
+    EXPECT_FALSE(bs[10]);
+}
+
+TEST(PagedArenaBitsetTest, Clone) {
+    PagedArenaBitset bs1;
+    bs1.add(10);
+    bs1.add(20);
+
+    PagedArenaBitset bs2 = bs1.clone();
+    EXPECT_EQ(bs2.size(), 2);
+    EXPECT_TRUE(bs2[10]);
+    EXPECT_TRUE(bs2[20]);
+
+    bs2.add(30);
+    EXPECT_FALSE(bs1[30]); // Verify deep copy!
+}
+
+TEST(PagedArenaBitsetTest, IntersectSize) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+    PagedArenaBitset bs3;
+
+    bs1.add(1);
+    bs1.add(64);
+    bs1.add(127);
+
+    bs2.add(64);
+    bs2.add(127);
+    bs2.add(255);
+
+    bs3.add(127);
+    bs3.add(255);
+    bs3.add(511);
+
+    // 2 arguments
+    uint32_t size2 = PagedArenaBitset::intersectSize(bs1, bs2);
+    EXPECT_EQ(size2, 2);
+
+    // 3 arguments
+    uint32_t size3 = PagedArenaBitset::intersectSize(bs1, bs2, bs3);
+    EXPECT_EQ(size3, 1);
+}
+
+TEST(PagedArenaBitsetTest, SelfIntersection) {
+    PagedArenaBitset bs;
+    bs.add(10);
+    bs.add(20);
+
+    bs.intersect(bs);
+    EXPECT_EQ(bs.size(), 2);
+    EXPECT_TRUE(bs[10]);
+    EXPECT_TRUE(bs[20]);
+}
+
+TEST(PagedArenaBitsetTest, MaxIndex) {
+    PagedArenaBitset bs;
+    uint32_t const maxIndex = (1U << 27) - 1;
+    bs.add(maxIndex);
+    EXPECT_TRUE(bs[maxIndex]);
+    EXPECT_EQ(bs.size(), 1);
+
+    bs.remove(maxIndex);
+    EXPECT_FALSE(bs[maxIndex]);
+    EXPECT_TRUE(bs.empty());
+}
+
+TEST(PagedArenaBitsetTest, IsSubset) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    // Empty sets!
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs1, bs2));
+
+    bs1.add(10);
+    bs1.add(20);
+
+    // bs1 is NOT subset of empty bs2!
+    EXPECT_FALSE(PagedArenaBitset::isSubset(bs1, bs2));
+
+    // Empty bs2 is subset of bs1!
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs2, bs1));
+
+    bs2.add(10);
+    bs2.add(20);
+
+    // Equal sets!
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs1, bs2));
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs2, bs1));
+
+    bs2.add(30);
+
+    // bs1 is subset of bs2!
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs1, bs2));
+
+    // bs2 is NOT subset of bs1!
+    EXPECT_FALSE(PagedArenaBitset::isSubset(bs2, bs1));
+
+    bs1.add(40);
+
+    // Disjoint parts!
+    EXPECT_FALSE(PagedArenaBitset::isSubset(bs1, bs2));
+}
+
+TEST(PagedArenaBitsetTest, IsStrictSubset) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    // Both empty! Not strict subset!
+    EXPECT_FALSE(PagedArenaBitset::isStrictSubset(bs1, bs2));
+
+    bs1.add(10);
+    bs1.add(20);
+
+    // Empty bs2 is strict subset of non-empty bs1!
+    EXPECT_TRUE(PagedArenaBitset::isStrictSubset(bs2, bs1));
+
+    bs2.add(10);
+    bs2.add(20);
+
+    // Equal sets! Not strict subset!
+    EXPECT_FALSE(PagedArenaBitset::isStrictSubset(bs1, bs2));
+    EXPECT_FALSE(PagedArenaBitset::isStrictSubset(bs2, bs1));
+
+    bs2.add(30);
+
+    // bs1 is strict subset of bs2!
+    EXPECT_TRUE(PagedArenaBitset::isStrictSubset(bs1, bs2));
+
+    // bs2 is NOT strict subset of bs1!
+    EXPECT_FALSE(PagedArenaBitset::isStrictSubset(bs2, bs1));
+}
+
+TEST(PagedArenaBitsetTest, Merge) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    bs1.add(10);
+    bs1.add(20);
+
+    bs2.add(20);
+    bs2.add(30);
+
+    // In-place merge!
+    PagedArenaBitset bs3 = bs1.clone();
+    bs3.merge(bs2);
+    EXPECT_EQ(bs3.size(), 3);
+    EXPECT_TRUE(bs3[10]);
+    EXPECT_TRUE(bs3[20]);
+    EXPECT_TRUE(bs3[30]);
+
+    // Static merge!
+    PagedArenaBitset res = PagedArenaBitset::merge(bs1, bs2);
+    EXPECT_EQ(res.size(), 3);
+    EXPECT_TRUE(res[10]);
+    EXPECT_TRUE(res[20]);
+    EXPECT_TRUE(res[30]);
+
+    // Variadic merge!
+    PagedArenaBitset bs4;
+    bs4.add(40);
+    PagedArenaBitset res4 = PagedArenaBitset::merge(bs1, bs2, bs4);
+    EXPECT_EQ(res4.size(), 4);
+    EXPECT_TRUE(res4[10]);
+    EXPECT_TRUE(res4[20]);
+    EXPECT_TRUE(res4[30]);
+    EXPECT_TRUE(res4[40]);
+}
+
+TEST(PagedArenaBitsetTest, MergeSize) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    bs1.add(10);
+    bs1.add(20);
+
+    bs2.add(20);
+    bs2.add(30);
+
+    EXPECT_EQ(PagedArenaBitset::mergeSize(bs1, bs2), 3);
+
+    PagedArenaBitset bs3;
+    bs3.add(40);
+    EXPECT_EQ(PagedArenaBitset::mergeSize(bs1, bs2, bs3), 4);
+}
+
+TEST(PagedArenaBitsetTest, MergeGhostBitBug) {
+    PagedArenaBitset a;
+    PagedArenaBitset b;
+    PagedArenaBitset c;
+
+    a.add(100);
+    a.remove(100); // A has ghost page at 0!
+
+    // B and C are empty!
+
+    PagedArenaBitset result;
+    // Use 3 arguments to force variadic path
+    PagedArenaBitset::merge(&result, a, b, c);
+
+    // If the bug exists, result claims to have bits but is empty!
+    // And forEachSetBit might crash!
+
+    size_t count = 0;
+    result.forEachSetBit([&](uint32_t bit) {
+        count++;
+    });
+
+    EXPECT_EQ(count, 0);
+    EXPECT_EQ(result.size(), 0);
+}
+
+TEST(PagedArenaBitsetTest, Swap) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    bs1.add(10);
+    bs1.add(20);
+
+    bs2.add(30);
+
+    // Member swap
+    bs1.swap(bs2);
+    EXPECT_EQ(bs1.size(), 1);
+    EXPECT_TRUE(bs1[30]);
+    EXPECT_FALSE(bs1[10]);
+
+    EXPECT_EQ(bs2.size(), 2);
+    EXPECT_TRUE(bs2[10]);
+    EXPECT_TRUE(bs2[20]);
+
+    // Free function swap
+    using std::swap;
+    swap(bs1, bs2);
+    EXPECT_EQ(bs1.size(), 2);
+    EXPECT_TRUE(bs1[10]);
+    EXPECT_TRUE(bs1[20]);
+
+    EXPECT_EQ(bs2.size(), 1);
+    EXPECT_TRUE(bs2[30]);
+}
+
+TEST(PagedArenaBitsetTest, IsSubsetGhostPageBug) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    // Add a shared valid bit so subset is not empty
+    bs1.add(10);
+    bs2.add(10);
+
+    // Force a ghost page in bs1 at a distinct location
+    bs1.add(10000);
+    bs1.remove(10000);
+
+    // bs1 has [10], bs2 has [10].
+    // bs1 is mathematically a subset of bs2.
+    EXPECT_TRUE(PagedArenaBitset::isSubset(bs1, bs2));
+}
+
+TEST(PagedArenaBitsetTest, FetchAddRemoveReturnValues) {
+    PagedArenaBitset bs;
+
+    // fetchAdd on brand new bit should return false
+    EXPECT_FALSE(bs.fetchAdd(42));
+    // fetchAdd on duplicate bit should return true
+    EXPECT_TRUE(bs.fetchAdd(42));
+
+    EXPECT_EQ(bs.size(), 1);
+
+    // fetchRemove on active bit should return true
+    EXPECT_TRUE(bs.fetchRemove(42));
+    // fetchRemove on dead bit should return false
+    EXPECT_FALSE(bs.fetchRemove(42));
+
+    EXPECT_TRUE(bs.empty());
+}
+
+TEST(PagedArenaBitsetTest, MemberQueryOperators) {
+    PagedArenaBitset bs1;
+    PagedArenaBitset bs2;
+
+    // Both empty sets boundary check
+    EXPECT_TRUE(bs1.isSubsetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSubsetOf(bs2));
+    EXPECT_TRUE(bs1.isSupersetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSupersetOf(bs2));
+
+    bs1.add(10);
+    // Non-empty bs1 vs empty bs2
+    EXPECT_FALSE(bs1.isSubsetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSubsetOf(bs2));
+    EXPECT_TRUE(bs1.isSupersetOf(bs2));
+    EXPECT_TRUE(bs1.isStrictSupersetOf(bs2));
+
+    // Empty bs2 vs non-empty bs1
+    EXPECT_TRUE(bs2.isSubsetOf(bs1));
+    EXPECT_TRUE(bs2.isStrictSubsetOf(bs1));
+    EXPECT_FALSE(bs2.isSupersetOf(bs1));
+    EXPECT_FALSE(bs2.isStrictSupersetOf(bs1));
+
+    bs1.add(20);
+    bs2.add(10);
+    bs2.add(20);
+
+    // Identical sets
+    EXPECT_TRUE(bs1.isSubsetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSubsetOf(bs2));
+    EXPECT_TRUE(bs1.isSupersetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSupersetOf(bs2));
+
+    // bs1 is subset of bs2
+    bs2.add(30);
+    EXPECT_TRUE(bs1.isSubsetOf(bs2));
+    EXPECT_TRUE(bs1.isStrictSubsetOf(bs2));
+    EXPECT_FALSE(bs1.isSupersetOf(bs2));
+    EXPECT_FALSE(bs1.isStrictSupersetOf(bs2));
+
+    // bs2 is superset of bs1
+    EXPECT_FALSE(bs2.isSubsetOf(bs1));
+    EXPECT_FALSE(bs2.isStrictSubsetOf(bs1));
+    EXPECT_TRUE(bs2.isSupersetOf(bs1));
+    EXPECT_TRUE(bs2.isStrictSupersetOf(bs1));
+}
+
+TEST(PagedArenaBitsetTest, MoveConstructorAndAssignment) {
+    PagedArenaBitset source;
+    source.add(100);
+    source.add(200);
+
+    // Move Constructor
+    PagedArenaBitset target(std::move(source));
+    EXPECT_EQ(target.size(), 2);
+    EXPECT_TRUE(target[100]);
+    EXPECT_TRUE(target[200]);
+
+    // Move Assignment
+    PagedArenaBitset assignTarget;
+    assignTarget.add(50);
+    assignTarget = std::move(target);
+
+    EXPECT_EQ(assignTarget.size(), 2);
+    EXPECT_TRUE(assignTarget[100]);
+    EXPECT_TRUE(assignTarget[200]);
+    EXPECT_FALSE(assignTarget[50]); // Old data should be dropped
+}
+
+TEST(PagedArenaBitsetTest, DefragmentEdgeCases) {
+    PagedArenaBitset emptyBs;
+    // Should be completely safe on empty sets
+    emptyBs.defragment();
+    EXPECT_TRUE(emptyBs.empty());
+
+    PagedArenaBitset bs;
+    bs.add(10);    // Page 0
+    bs.add(5000);  // Page 1
+    bs.add(10000); // Page 2
+
+    bs.remove(5000);  // Page 1 ghost
+    bs.remove(10000); // Page 2 ghost
+
+    // Defragmenting multiple consecutive ghosts
+    bs.defragment();
+    EXPECT_EQ(bs.size(), 1);
+    EXPECT_TRUE(bs[10]);
+}
+
+TEST(PagedArenaBitsetTest, ExchangeAndSelfMove) {
+    PagedArenaBitset bs1;
+    bs1.add(10);
+    bs1.add(20);
+
+    // Test free function exchange
+    PagedArenaBitset bs2;
+    bs2.add(30);
+
+    PagedArenaBitset old1 = exchange(bs1, std::move(bs2));
+    EXPECT_EQ(old1.size(), 2);
+    EXPECT_TRUE(old1[10]);
+    EXPECT_TRUE(old1[20]);
+
+    EXPECT_EQ(bs1.size(), 1);
+    EXPECT_TRUE(bs1[30]);
+
+    // Test exchangeAndClear
+    PagedArenaBitset oldClear = exchangeAndClear(bs1);
+    EXPECT_EQ(oldClear.size(), 1);
+    EXPECT_TRUE(oldClear[30]);
+    EXPECT_TRUE(bs1.empty());
+
+    // Test self move-assignment
+    PagedArenaBitset selfMoveBs;
+    selfMoveBs.add(42);
+
+    // Force self-move via reference to avoid compiler warnings
+    PagedArenaBitset& ref = selfMoveBs;
+    selfMoveBs = std::move(ref);
+
+    EXPECT_EQ(selfMoveBs.size(), 1);
+    EXPECT_TRUE(selfMoveBs[42]);
+}
+
+TEST(PagedArenaBitsetTest, CopyFrom) {
+    PagedArenaBitset source;
+    source.add(10);
+    source.add(5000);
+
+    PagedArenaBitset target;
+    target.add(20);
+
+    // Perform copyFrom
+    target.copyFrom(source);
+    EXPECT_EQ(target.size(), 2);
+    EXPECT_TRUE(target[10]);
+    EXPECT_TRUE(target[5000]);
+    EXPECT_FALSE(target[20]); // Old target data should be wiped
+
+    // Source should be unaffected
+    EXPECT_EQ(source.size(), 2);
+    EXPECT_TRUE(source[10]);
+    EXPECT_TRUE(source[5000]);
+
+    // Self-copy safety check
+    target.copyFrom(target);
+    EXPECT_EQ(target.size(), 2);
+    EXPECT_TRUE(target[10]);
+    EXPECT_TRUE(target[5000]);
+}
+


### PR DESCRIPTION
Introduce PagedArenaBitset to the utils library.
This implementation is optimized for handling large, sparse integer domains (up to 2^27) and is specifically tailored for Entity Component System (ECS) workloads.

1. PagedArenaBitset:
- 4-level hierarchical design (Master/Summary Masks, Directory, Arena).
- "Trust the Mask" architecture enables ultra-fast clears (<20ns).
- Arena-based storage ensures cache-coherent page access.
- Optimized multi-way intersections and defragmentation support.
- Strict move semantics to prevent accidental expensive copies.

2. Testing and Benchmarking:
- Comprehensive benchmarks comparing performance across different bit densities and operations.
- Full unit test coverage for the implementation.