### PR TITLE
Metal: handle newSharedEvent returning nil

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -1401,7 +1401,12 @@ MetalFence::MetalFence(MetalContext& context) : context(context), value(context.
 
 void MetalFence::encode() {
     if (@available(iOS 12, *)) {
+        // newSharedEvent can very seldomly return nil if the GPU is busy or in a bad state.
         event = [context.device newSharedEvent];
+        if (UTILS_VERY_UNLIKELY(event == nil)) {
+            context.driver->signalFence([&] { state->status = FenceStatus::ERROR; });
+            return;
+        }
         [getPendingCommandBuffer(&context) encodeSignalEvent:event value:value];
 
         // Using a weak_ptr here because the Fence could be deleted before the block executes.
@@ -1419,7 +1424,13 @@ void MetalFence::encode() {
 }
 
 void MetalFence::onSignal(MetalFenceSignalBlock block) {
-    [event notifyListener:context.eventListener atValue:value block:block];
+    if (UTILS_VERY_LIKELY(event)) {
+        if (@available(iOS 12, *)) {
+            [event notifyListener:context.eventListener atValue:value block:block];
+        }
+    } else {
+        block(nil, value);
+    }
 }
 
 FenceStatus MetalFence::wait(uint64_t timeoutNs) {


### PR DESCRIPTION
`newSharedEvent` can, in rare cases, return `nil`. This guards against that by setting the fence's status to an error.

BUGS=[509328653]