### PR TITLE
utils: lighter way to track changed entities

### DIFF
--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -72,6 +72,18 @@ public:
     void flushNotifications() noexcept;
 
     /**
+     * Registers a bitset to be updated when entities change.
+     * @param bitset A pointer to the PagedArenaBitset to register.
+     */
+    void registerBitset(PagedArenaBitset* bitset);
+
+    /**
+     * Unregisters a bitset.
+     * @param bitset A pointer to the PagedArenaBitset to unregister.
+     */
+    void unregisterBitset(PagedArenaBitset const* bitset);
+
+    /**
      * Records a change for the given entity.
      * Flushes notifications if the internal buffer becomes full.
      */
@@ -96,6 +108,7 @@ private:
     Entity mDirtyEntities[MAX_DIRTY_COUNT];
     size_t mDirtyCount = 0;
     std::vector<CallbackInfo> mChangeCallbacks;
+    std::vector<PagedArenaBitset*> mBitsets;
 };
 
 /*

--- a/libs/utils/src/SingleInstanceComponentManager.cpp
+++ b/libs/utils/src/SingleInstanceComponentManager.cpp
@@ -16,9 +16,11 @@
 
 #include <utils/SingleInstanceComponentManager.h>
 #include <utils/Entity.h>
+#include <utils/PagedArenaBitset.h>
 #include <utils/Slice.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <utility>
 
 namespace utils {
@@ -37,6 +39,10 @@ void SingleInstanceComponentManagerBase::unregisterChangeCallback(
 }
 
 void SingleInstanceComponentManagerBase::notifyChange(Entity const e) noexcept {
+    for (auto* bitset : mBitsets) {
+        bitset->add(e.getId());
+    }
+
     if constexpr (USE_SORTED_DIRTY_ARRAY) {
         auto const it = std::lower_bound(mDirtyEntities, mDirtyEntities + mDirtyCount, e);
         if (it != mDirtyEntities + mDirtyCount && *it == e) {
@@ -71,4 +77,11 @@ void SingleInstanceComponentManagerBase::flushNotifications() noexcept {
     }
 }
 
+void SingleInstanceComponentManagerBase::registerBitset(PagedArenaBitset* bitset) {
+    mBitsets.push_back(bitset);
+}
+
+void SingleInstanceComponentManagerBase::unregisterBitset(PagedArenaBitset const* bitset) {
+    mBitsets.erase(std::remove(mBitsets.begin(), mBitsets.end(), bitset), mBitsets.end());
+}
 } // namespace utils


### PR DESCRIPTION
SingleInstanceComponentManager can now register a PagedArenaBitset* which it will use to record entities that have changed. No need for callbacks.