### PR TITLE
utils: Track entities in core managers using PagedArenaBitset

### DIFF
--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -74,6 +74,10 @@ public:
         return mManager.getEntities();
     }
 
+    const utils::PagedArenaBitset& getEntityBitset() const noexcept {
+        return mManager.getEntityBitset();
+    }
+
     void create(const Builder& builder, utils::Entity entity);
 
     void destroy(utils::Entity e) noexcept;

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -123,6 +123,10 @@ public:
         return mManager.getEntities();
     }
 
+    const utils::PagedArenaBitset& getEntityBitset() const noexcept {
+        return mManager.getEntityBitset();
+    }
+
     void create(const Builder& builder, utils::Entity entity);
 
     void destroy(utils::Entity e, backend::DriverApi& driver) noexcept;

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -69,6 +69,10 @@ public:
         return mManager.getEntities();
     }
 
+    const utils::PagedArenaBitset& getEntityBitset() const noexcept {
+        return mManager.getEntityBitset();
+    }
+
     void setAccurateTranslationsEnabled(bool enable) noexcept;
 
     bool isAccurateTranslationsEnabled() const noexcept {

--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -20,6 +20,7 @@
 #include <utils/Entity.h>
 #include <utils/compiler.h>
 #include <utils/Slice.h>
+#include <utils/PagedArenaBitset.h>
 
 #include <assert.h>
 #include <stddef.h>
@@ -114,6 +115,8 @@ public:
     // unregisters a listener.
     void unregisterListener(Listener* l) noexcept;
 
+    // Returns the bitset of alive entities.
+    PagedArenaBitset getAliveEntities() const noexcept;
 
 
     /* no user serviceable parts below */

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -20,6 +20,7 @@
 #include <utils/compiler.h>
 #include <utils/Entity.h>
 #include <utils/EntityInstance.h>
+#include <utils/PagedArenaBitset.h>
 #include <utils/EntityManager.h>
 #include <utils/Invocable.h>
 #include <utils/Slice.h>
@@ -251,6 +252,10 @@ public:
         using SoA::template Field<E>::operator =;
     };
 
+    const PagedArenaBitset& getEntityBitset() const noexcept {
+        return mEntities;
+    }
+
 protected:
     template<size_t ElementIndex>
     typename SoA::template TypeAt<ElementIndex>* data() noexcept {
@@ -317,6 +322,7 @@ private:
     // maps an entity to an instance index
     tsl::robin_map<Entity, Instance, Entity::Hasher> mInstanceMap;
     default_random_engine mRng;
+    PagedArenaBitset mEntities;
 };
 
 // Keep these outside of the class because CLion has trouble parsing them
@@ -331,6 +337,7 @@ SingleInstanceComponentManager<Elements ...>::addComponent(Entity e) {
             // index 0 is used when the component doesn't exist
             ci = Instance(mData.size() - 1);
             mInstanceMap[e] = ci;
+            mEntities.add(e.getId());
             notifyChange(e);
         } else {
             // if the entity already has this component, just return its instance
@@ -363,6 +370,7 @@ SingleInstanceComponentManager<Elements ... >::removeComponent(Entity const e) {
         }
         mData.pop_back();
         map.erase(pos);
+        mEntities.remove(e.getId());
         notifyChange(e);
         return last;
     }

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -19,6 +19,7 @@
 #include "EntityManagerImpl.h"
 
 #include <utils/Entity.h>
+#include <utils/PagedArenaBitset.h>
 
 #include <cassert>
 #include <cstddef>
@@ -86,6 +87,12 @@ void EntityManager::dumpActiveEntities(utils::io::ostream& out) const {
 
 bool EntityManager::isAlive(Entity const e) const noexcept {
     return static_cast<EntityManagerImpl const *>(this)->isAlive(e);
+}
+
+PagedArenaBitset EntityManager::getAliveEntities() const noexcept {
+    auto const* impl = static_cast<EntityManagerImpl const*>(this);
+    std::lock_guard const lock(impl->mFreeListLock);
+    return impl->mAliveEntities.clone();
 }
 
 } // namespace utils

--- a/libs/utils/src/EntityManagerImpl.h
+++ b/libs/utils/src/EntityManagerImpl.h
@@ -18,6 +18,7 @@
 #define TNT_UTILS_ENTITYMANAGERIMPL_H
 
 #include <utils/EntityManager.h>
+#include <utils/PagedArenaBitset.h>
 
 #include <utils/compiler.h>
 #include <utils/debug.h>
@@ -76,6 +77,7 @@ public:
 
         std::lock_guard const lock(mFreeListLock);
         bool const alive = (getGeneration(e) == mGens[getIndex(e)]);
+        assert(alive == mAliveEntities[e.getId()]);
         return alive;
     }
 
@@ -114,6 +116,7 @@ public:
                 index = currentIndex++;
             }
             entities[i] = Entity{ makeIdentity(gens[index], index) };
+            mAliveEntities.add(entities[i].getId());
 #if FILAMENT_UTILS_TRACK_ENTITIES
             mDebugActiveEntities.emplace(entities[i], CallStack::unwind(5));
 #endif
@@ -144,6 +147,7 @@ public:
                 Entity::Type const index = getIndex(entities[i]);
                 freeList.push_back(index);
                 gens[index]++;
+                mAliveEntities.remove(entities[i].getId());
 
 #if FILAMENT_UTILS_TRACK_ENTITIES
                 mDebugActiveEntities.erase(entities[i]);
@@ -264,6 +268,7 @@ private:
     uint32_t mCurrentIndex = 1;
     std::deque<Entity::Type> mFreeList;     // stores indices that got freed
     uint8_t* const mGens;                   // stores the generation of each index.
+    PagedArenaBitset mAliveEntities;        // stores entities that are alive
 
     mutable Mutex mListenerLock;
     tsl::robin_set<Listener*> mListeners;


### PR DESCRIPTION
Integrate `PagedArenaBitset` into `EntityManager` and `SingleInstanceComponentManager` to track alive entities and component ownership respectively:

- Add `mAliveEntities` to `EntityManagerImpl` and `mEntities` to `SingleInstanceComponentManager`.
- Expose these bitsets via public `getAliveEntities()` and `getEntityBitset()` for efficient multi-intersection queries.
- Keep bitsets in sync during creation, destruction, and component mutation.
- Add a debug assert in `isAlive()` to verify consistency between the bitset and `mGens`.