### PR TITLE
github: auto-deploy CocoaPods on release

### DIFF
--- a/.github/workflows/cocoapods-manual-deploy.yml
+++ b/.github/workflows/cocoapods-manual-deploy.yml
@@ -1,7 +1,8 @@
-name: CocoaPods Deploy
+name: CocoaPods Manual Deploy
 
-# This must be run after the iOS release job has finished, and the iOS release
-# asset has been uploaded to Github.
+# Manual fallback for the CocoaPods deploy that normally runs as part of the
+# Release workflow. Use this if the automatic deploy was skipped or failed.
+# The iOS release asset must already be uploaded to GitHub before running.
 on:
   workflow_dispatch:
     inputs:
@@ -11,8 +12,8 @@ on:
         default: 'v1.42.2'
 
 jobs:
-  cocoapods-deploy:
-    name: cocoapods-deploy
+  cocoapods-manual-deploy:
+    name: cocoapods-manual-deploy
     runs-on: macos-14
     steps:
       - name: Check out iOS/CocoaPods directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,31 @@ jobs:
             const globber = await glob.create('out/*.tgz');
             await upload({ github, context }, await globber.glob(), TAG);
 
+  cocoapods-deploy:
+    name: cocoapods-deploy
+    runs-on: macos-14
+    needs: [build-ios]
+    if: github.event_name == 'release' || github.event.inputs.platform == 'ios'
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4.1.6
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Move podspec to root
+        run: mv ios/CocoaPods/*.podspec .
+      - name: Install CocoaPods
+        run: gem install cocoapods
+      - uses: michaelhenry/deploy-to-cocoapods-github-action@745686ab065f90596e0d5cfcf97bb2416d94262e
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
   build-windows:
     name: build-windows
     runs-on: windows-2022-32core

--- a/docs_src/src_mdbook/src/release/guide.md
+++ b/docs_src/src_mdbook/src/release/guide.md
@@ -129,14 +129,16 @@ workflow](https://github.com/google/filament/actions/workflows/release.yml). Hit
 dropdown. Modify _Platform to build_ and _Release tag to build_, then hit _Run workflow_. This will
 initiate a new release run.
 
-## 11. Kick off the npm and CocoaPods release jobs
+## 11. Kick off the npm release job
 
 Navigate to [Filament's npm deploy
 workflow](https://github.com/google/filament/actions/workflows/npm-deploy.yml).
 Hit the _Run workflow_ dropdown. Modify _Release tag to deploy_ to the tag corresponding to this
 release (for example, v1.42.2).
 
-Navigate to [Filament's CocoaPods deploy
-workflow](https://github.com/google/filament/actions/workflows/cocopods-deploy.yml).
-Hit the _Run workflow_ dropdown. Modify _Release tag to deploy_ to the tag corresponding to this
-release (for example, v1.42.2).
+The CocoaPods deploy runs automatically as part of the release workflow once the iOS build
+finishes. If it was skipped or failed, you can re-run it manually via [Filament's CocoaPods
+manual deploy
+workflow](https://github.com/google/filament/actions/workflows/cocoapods-manual-deploy.yml):
+hit the _Run workflow_ dropdown and set _Release tag to deploy_ to the tag corresponding to
+this release (for example, v1.42.2).


### PR DESCRIPTION
## Summary

The CocoaPods deploy workflow was `workflow_dispatch`-only, so a new GitHub release never triggered it: the pod had to be published manually after every release. This PR wires the deploy into the release flow.

- Adds a `cocoapods-deploy` job to `.github/workflows/release.yml` that `needs: [build-ios]` and runs on the `release` event (and on `workflow_dispatch` with `platform=ios`). This mirrors the existing `sonatype-publish` job, which hangs off `build-android` for the Maven publish.
- Renames `.github/workflows/cocopods-deploy.yml` → `.github/workflows/cocoapods-manual-deploy.yml` (also fixing the original `cocopods` typo) and reframes it as a manual fallback for re-runs. The job inside is renamed to `cocoapods-manual-deploy` to disambiguate from the in-release one.
- Updates `docs_src/src_mdbook/src/release/guide.md` section 11 so the release guide describes CocoaPods as automatic, with the manual workflow documented as a fallback.

The dependency chain is correct: `pod trunk push` validates `spec.source` (`https://github.com/google/filament/releases/download/${TAG}/filament-${TAG}-ios.tgz`), and `needs: [build-ios]` guarantees the asset upload step has completed before the deploy runs.