### PR TITLE
utils: Fix out-of-bounds iterator decrement in RangeMap::mergeLeft

### DIFF
--- a/libs/utils/include/utils/RangeMap.h
+++ b/libs/utils/include/utils/RangeMap.h
@@ -252,8 +252,12 @@ private:
     // Checks if there is range to the left that touches the given range.
     // If so, erases it, extends the given range leftwards, and returns true.
     bool mergeLeft(Iterator iter) {
+        if (iter == begin()) {
+            return false;
+        }
         Iterator prev = iter;
-        if (--prev == end() || getValue(prev) != getValue(iter)) {
+        --prev;
+        if (getValue(prev) != getValue(iter)) {
             return false;
         }
         if (getRange(prev).last != getRange(iter).first) {


### PR DESCRIPTION
AddressSanitizer reported a stack-buffer-overflow when running test_RangeMap due to an out-of-bounds iterator decrement in RangeMap::mergeLeft. When an interval started at the beginning of the map (mMap.begin()), the line `--prev` triggered undefined behavior by decrementing the begin iterator, leading to out-of-bounds stack access in the internal tree-traversal helper functions.

Fixed by explicitly checking `iter == begin()` prior to decrementing.