### PR TITLE
Use fence pool in Vulkan to ensure conversion to FD always provides an FD

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -210,6 +210,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanDriverFactory.h
             src/vulkan/VulkanExternalImageManager.cpp
             src/vulkan/VulkanExternalImageManager.h
+            src/vulkan/VulkanFencePool.h
+            src/vulkan/VulkanFencePool.cpp
             src/vulkan/VulkanStreamedImageManager.cpp
             src/vulkan/VulkanStreamedImageManager.h
             src/vulkan/VulkanFboCache.cpp

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -262,12 +262,10 @@ public:
     /**
      * Creates a Platform::Sync object, which tracks a fence and its status,
      * and allows conversion to an external sync.
-     * @param fence         The underlying VkFence to use for synchronization.
-     * @param fenceStatus   An object tracking the fence's state
+     * @param fenceStatus   An object tracking the fence and its current state.
      * @return              A Platform::Sync object tracking the provided fence.
      */
-    virtual Platform::Sync* createSync(VkFence fence,
-            std::shared_ptr<VulkanCmdFence> fenceStatus) noexcept;
+    virtual Platform::Sync* createSync(std::shared_ptr<VulkanCmdFence> fenceStatus) noexcept;
 
     /**
      * Destroys a sync. If called with a sync not created by this platform
@@ -458,7 +456,6 @@ public:
 
 protected:
     struct VulkanSync : public Platform::Sync {
-        VkFence fence;
         std::shared_ptr<VulkanCmdFence> fenceStatus;
     };
 

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -200,6 +200,21 @@ std::shared_ptr<VulkanCmdFence> VulkanCmdFence::completed() noexcept {
     return cmdFence;
 }
 
+VkResult VulkanCmdFence::updateStatus(VkDevice device) {
+    VkResult status = mStatus;
+    {
+        std::shared_lock rl(mLock);
+        if (mFence != VK_NULL_HANDLE) {
+            status = vkGetFenceStatus(device, mFence);
+        }
+    }
+
+    if (status == VK_SUCCESS) {
+        setStatus(status);
+    }
+    return mStatus;
+}
+
 FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     std::chrono::steady_clock::time_point const until) {
 

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -210,41 +210,41 @@ VkResult VulkanCmdFence::updateStatus(VkDevice device) {
 
 FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     std::chrono::steady_clock::time_point const until) {
-    // Hold the fence until we've determined we've checked the status, and
-    // want to wait on the fence.
-    std::shared_lock rl(mLock);
+    {
+        // Hold the fence until we've determined we've checked the status, and
+        // want to wait on the fence.
+        std::shared_lock rl(mLock);
 
-    // If the vulkan fence has not been submitted yet, we need to wait for that before we
-    // can use vkWaitForFences()
-    if (mStatus == VK_INCOMPLETE) {
-        bool const success = mCond.wait_until(rl, until, [this] {
-            // Internally we use the VK_INCOMPLETE status to mean "not yet submitted".
-            // When this fence gets submitted, its status changes to VK_NOT_READY.
-            return mStatus != VK_INCOMPLETE || mCanceled;
-        });
-        if (!success) {
-            // !success indicates a timeout or cancel
-            return mCanceled ? FenceStatus::ERROR : FenceStatus::TIMEOUT_EXPIRED;
+        // If the vulkan fence has not been submitted yet, we need to wait for that before we
+        // can use vkWaitForFences()
+        if (mStatus == VK_INCOMPLETE) {
+            bool const success = mCond.wait_until(rl, until, [this] {
+                // Internally we use the VK_INCOMPLETE status to mean "not yet submitted".
+                // When this fence gets submitted, its status changes to VK_NOT_READY.
+                return mStatus != VK_INCOMPLETE || mCanceled;
+            });
+            if (!success) {
+                // !success indicates a timeout or cancel
+                return mCanceled ? FenceStatus::ERROR : FenceStatus::TIMEOUT_EXPIRED;
+            }
         }
-    }
 
-    // The fence could have already signaled, avoid calling into vkWaitForFences()
-    if (mStatus == VK_SUCCESS) {
-        return FenceStatus::CONDITION_SATISFIED;
-    }
+        // The fence could have already signaled, avoid calling into vkWaitForFences()
+        if (mStatus == VK_SUCCESS) {
+            return FenceStatus::CONDITION_SATISFIED;
+        }
 
-    // Or it could have been canceled, return immediately
-    if (mCanceled) {
-        return FenceStatus::ERROR;
+        // Or it could have been canceled, return immediately
+        if (mCanceled) {
+            return FenceStatus::ERROR;
+        }
     }
 
     // If we're here, we know that vkQueueSubmit has been called (because it sets the status
     // to VK_NOT_READY).
     // However, since we're going to wait on the fence, and because the fence is guaranteed
-    // to stay in scope as long as this reference is still alive, we can unlock the lock here.
-    rl.unlock();
-
-    // Wait on the fence, without any lock.
+    // to stay in scope as long as this VulkanCmdFence is still alive, we do not need a lock
+    // here.
     VkResult const status = vkWaitForFences(device, 1, &mFence, VK_TRUE, timeout);
     if (status == VK_TIMEOUT) {
         return FenceStatus::TIMEOUT_EXPIRED;

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -17,6 +17,7 @@
 #include "VulkanAsyncHandles.h"
 
 #include "VulkanConstants.h"
+#include "VulkanFencePool.h"
 
 #include "vulkan/utils/Spirv.h"
 
@@ -181,8 +182,20 @@ void VulkanProgram::flushPushConstants(VkPipelineLayout layout) {
     mQueuedPushConstants.clear();
 }
 
+VulkanCmdFence::VulkanCmdFence(VkFence fence, std::function<void(VkFence)> recycleFn)
+    : mFence(fence), mRecycleFn(recycleFn) {
+}
+
+VulkanCmdFence::~VulkanCmdFence() {
+    // Ensure the fence can't be cleared during this operation.
+    std::shared_lock rl(mLock);
+    if (mFence != VK_NULL_HANDLE && mRecycleFn != nullptr) {
+        mRecycleFn(mFence);
+    }
+}
+
 std::shared_ptr<VulkanCmdFence> VulkanCmdFence::completed() noexcept {
-    auto cmdFence = std::make_shared<VulkanCmdFence>(VK_NULL_HANDLE);
+    auto cmdFence = std::make_unique<VulkanCmdFence>(VK_NULL_HANDLE);
     cmdFence->mStatus = VK_SUCCESS;
     return cmdFence;
 }
@@ -224,6 +237,12 @@ FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     // place simultaneously. vkResetFence is only called once it knows the fence has signaled,
     // which guaranties that vkResetFence won't have to wait too long, just enough for
     // all the vkWaitForFences() to return.
+    if (mFence == VK_NULL_HANDLE) {
+        // This can happen if this is a 'completed' fence, or if
+        // the fence has been cleared because Filament is being
+        // terminated.
+        return FenceStatus::CONDITION_SATISFIED;
+    }
     VkResult const status = vkWaitForFences(device, 1, &mFence, VK_TRUE, timeout);
     if (status == VK_TIMEOUT) {
         return FenceStatus::TIMEOUT_EXPIRED;
@@ -237,15 +256,6 @@ FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     }
 
     return FenceStatus::ERROR; // not supported
-}
-
-void VulkanCmdFence::resetFence(VkDevice device) {
-    // This lock prevents vkResetFences() from being called simultaneously with vkWaitForFences(),
-    // but by construction, when we're here, we know that the fence has signaled and
-    // vkWaitForFences() will return shortly.
-    std::lock_guard const l(mLock);
-    assert_invariant(mStatus == VK_SUCCESS);
-    vkResetFences(device, 1, &mFence);
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -195,7 +195,7 @@ VulkanCmdFence::~VulkanCmdFence() {
 }
 
 std::shared_ptr<VulkanCmdFence> VulkanCmdFence::completed() noexcept {
-    auto cmdFence = std::make_unique<VulkanCmdFence>(VK_NULL_HANDLE);
+    auto cmdFence = std::make_shared<VulkanCmdFence>(VK_NULL_HANDLE);
     cmdFence->mStatus = VK_SUCCESS;
     return cmdFence;
 }
@@ -256,6 +256,16 @@ FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     }
 
     return FenceStatus::ERROR; // not supported
+}
+
+void VulkanCmdFence::clearFence() {
+    std::lock_guard const l(mLock);
+    if (mRecycleFn != nullptr) {
+        mRecycleFn(mFence);
+    }
+
+    mFence = VK_NULL_HANDLE;
+    mRecycleFn = nullptr;
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -187,9 +187,7 @@ VulkanCmdFence::VulkanCmdFence(VkFence fence, std::function<void(VkFence)> recyc
 }
 
 VulkanCmdFence::~VulkanCmdFence() {
-    // Ensure the fence can't be cleared during this operation.
-    std::shared_lock rl(mLock);
-    if (mFence != VK_NULL_HANDLE && mRecycleFn != nullptr) {
+    if (mRecycleFn != nullptr) {
         mRecycleFn(mFence);
     }
 }
@@ -201,24 +199,19 @@ std::shared_ptr<VulkanCmdFence> VulkanCmdFence::completed() noexcept {
 }
 
 VkResult VulkanCmdFence::updateStatus(VkDevice device) {
-    VkResult status = mStatus;
-    {
-        std::shared_lock rl(mLock);
-        if (mFence != VK_NULL_HANDLE) {
-            status = vkGetFenceStatus(device, mFence);
+    if (mFence != VK_NULL_HANDLE) {
+        VkResult status = vkGetFenceStatus(device, mFence);
+        if (status == VK_SUCCESS) {
+            setStatus(status);
         }
-    }
-
-    if (status == VK_SUCCESS) {
-        setStatus(status);
     }
     return mStatus;
 }
 
 FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
     std::chrono::steady_clock::time_point const until) {
-
-    // this lock MUST be held for READ when calling vkWaitForFences()
+    // Hold the fence until we've determined we've checked the status, and
+    // want to wait on the fence.
     std::shared_lock rl(mLock);
 
     // If the vulkan fence has not been submitted yet, we need to wait for that before we
@@ -247,40 +240,26 @@ FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,
 
     // If we're here, we know that vkQueueSubmit has been called (because it sets the status
     // to VK_NOT_READY).
-    // Now really wait for the fence while holding the shared_lock, this allows several
-    // threads to call vkWaitForFences(), but will prevent vkResetFence from taking
-    // place simultaneously. vkResetFence is only called once it knows the fence has signaled,
-    // which guaranties that vkResetFence won't have to wait too long, just enough for
-    // all the vkWaitForFences() to return.
-    if (mFence == VK_NULL_HANDLE) {
-        // This can happen if this is a 'completed' fence, or if
-        // the fence has been cleared because Filament is being
-        // terminated.
-        return FenceStatus::CONDITION_SATISFIED;
-    }
+    // However, since we're going to wait on the fence, and because the fence is guaranteed
+    // to stay in scope as long as this reference is still alive, we can unlock the lock here.
+    rl.unlock();
+
+    // Wait on the fence, without any lock.
     VkResult const status = vkWaitForFences(device, 1, &mFence, VK_TRUE, timeout);
     if (status == VK_TIMEOUT) {
         return FenceStatus::TIMEOUT_EXPIRED;
     }
 
     if (status == VK_SUCCESS) {
-        rl.unlock();
-        std::lock_guard const wl(mLock);
-        mStatus = status;
+        setStatus(status);
         return FenceStatus::CONDITION_SATISFIED;
     }
 
     return FenceStatus::ERROR; // not supported
 }
 
-void VulkanCmdFence::clearFence() {
-    std::lock_guard const l(mLock);
-    if (mRecycleFn != nullptr) {
-        mRecycleFn(mFence);
-    }
-
-    mFence = VK_NULL_HANDLE;
-    mRecycleFn = nullptr;
+void VulkanCmdFence::swapRecycleFn(std::function<void(VkFence)> recycleFn) {
+    mRecycleFn = recycleFn;
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -171,11 +171,15 @@ struct VulkanCmdFence {
     // and is not in the expected state anyway.
     static std::shared_ptr<VulkanCmdFence> completed() noexcept;
 
-    void setStatus(VkResult const value) {
-        std::lock_guard const l(mLock);
-        mStatus = value;
-        mCond.notify_all();
+    // Updates the status to reflect the fact that the underlying fence was
+    // used in a submission.
+    inline void markSubmitted() {
+        setStatus(VK_NOT_READY);
     }
+
+    // Checks the underlying fence to see if the underlying process is complete.
+    // Updates the underlying status, and returns it.
+    VkResult updateStatus(VkDevice device);
 
     // This is safe to use in the backend thread, as the backend
     // thread is the only thread that will be calling clearFence().
@@ -183,17 +187,12 @@ struct VulkanCmdFence {
         return mFence;
     }
 
+    // Checks what the status of the fence is. Note: this assumes that, in the
+    // most recent tick(), checkAndUpdateStatus() has been called. Otherwise,
+    // this may be out of date.
     VkResult getStatus() {
         std::shared_lock const l(mLock);
         return mStatus;
-    }
-
-    template <typename T>
-    T lockAndUseFence(std::function<T(VkFence)> cb) {
-        std::shared_lock const rl(mLock);
-        assert_invariant(cb != nullptr);
-        // Note - mFence *can* be nullptr.
-        return cb(mFence);
     }
 
     FenceStatus wait(VkDevice device, uint64_t timeout,
@@ -227,6 +226,14 @@ private:
     // dispose of the fence, or b) the creator of this object owns
     // the fence.
     void clearFence();
+
+    // Updates the status of the fence, notifying all listeners of
+    // mCond.
+    void setStatus(VkResult const value) {
+        std::lock_guard const l(mLock);
+        mStatus = value;
+        mCond.notify_all();
+    }
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -179,7 +179,7 @@ struct VulkanCmdFence {
 
     // This is safe to use in the backend thread, as the backend
     // thread is the only thread that will be calling clearFence().
-    inline VkFence getVkFence() {
+    inline VkFence getVkFence() const {
         return mFence;
     }
 
@@ -187,12 +187,6 @@ struct VulkanCmdFence {
         std::shared_lock const l(mLock);
         return mStatus;
     }
-
-    // Clears the fence from this struct. It assumes that either
-    // a) the recycleFn was defined in the ctor, and knows how to
-    // dispose of the fence, or b) the creator of this object owns
-    // the fence.
-    void clearFence();
 
     template <typename T>
     T lockAndUseFence(std::function<T(VkFence)> cb) {
@@ -212,6 +206,11 @@ struct VulkanCmdFence {
     }
 
 private:
+    // The lifecycle of this object will often be managed by a
+    // VulkanFencePool. This allows it to clear fence handles before
+    // Filament is shut down, etc.
+    friend class VulkanFencePool;
+
     std::shared_mutex mLock; // NOLINT(*-include-cleaner)
     std::condition_variable_any mCond;
     bool mCanceled = false;
@@ -222,6 +221,12 @@ private:
     VkFence mFence;
 
     std::function<void(VkFence)> mRecycleFn;
+
+    // Clears the fence from this struct. It assumes that either
+    // a) the recycleFn was defined in the ctor, and knows how to
+    // dispose of the fence, or b) the creator of this object owns
+    // the fence.
+    void clearFence();
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -37,6 +38,8 @@
 #include <vector>
 
 namespace filament::backend {
+
+class VulkanFencePool;
 
 using PushConstantNameArray = utils::FixedCapacityVector<char const*>;
 using PushConstantNameByStage = std::array<PushConstantNameArray, Program::SHADER_TYPE_COUNT>;
@@ -157,8 +160,9 @@ private:
 
 // Wrapper to enable use of shared_ptr for implementing shared ownership of low-level Vulkan fences.
 struct VulkanCmdFence {
-    explicit VulkanCmdFence(VkFence fence) : mFence(fence) { }
-    ~VulkanCmdFence() = default;
+    explicit VulkanCmdFence(VkFence fence,
+                            std::function<void(VkFence)> recycleFn = nullptr);
+    ~VulkanCmdFence();
 
     // Creates a VulkanCmdFence with its status set to VK_SUCCESS. It holds
     // a null handle; it is assumed that any user of this object will avoid
@@ -173,12 +177,38 @@ struct VulkanCmdFence {
         mCond.notify_all();
     }
 
+    // This is safe to use in the backend thread, as the backend
+    // thread is the only thread that will be calling clearFence().
+    inline VkFence getVkFence() {
+        return mFence;
+    }
+
     VkResult getStatus() {
         std::shared_lock const l(mLock);
         return mStatus;
     }
 
-    void resetFence(VkDevice device);
+    // Clears the fence from this struct. It assumes that either
+    // a) the recycleFn was defined in the ctor, and knows how to
+    // dispose of the fence, or b) the creator of this object owns
+    // the fence.
+    inline void clearFence() {
+        std::lock_guard l(mLock);
+        if (mRecycleFn != nullptr) {
+            mRecycleFn(mFence);
+        }
+
+        mFence = VK_NULL_HANDLE;
+        mRecycleFn = nullptr;
+    }
+
+    template <typename T>
+    T lockAndUseFence(std::function<T(VkFence)> cb) {
+        std::shared_lock const rl(mLock);
+        assert_invariant(cb != nullptr);
+        // Note - mFence *can* be nullptr.
+        return cb(mFence);
+    }
 
     FenceStatus wait(VkDevice device, uint64_t timeout,
         std::chrono::steady_clock::time_point until);
@@ -198,6 +228,8 @@ private:
     // finishes executing the command buffer, the status changes to VK_SUCCESS.
     VkResult mStatus{ VK_INCOMPLETE };
     VkFence mFence;
+
+    std::function<void(VkFence)> mRecycleFn;
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -209,17 +209,6 @@ private:
     // when the pool is being terminated.
     friend class VulkanFencePool;
 
-    std::shared_mutex mLock; // NOLINT(*-include-cleaner)
-    std::condition_variable_any mCond;
-    bool mCanceled = false;
-    // Internally we use the VK_INCOMPLETE status to mean "not yet submitted". When this fence
-    // gets submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually
-    // finishes executing the command buffer, the status changes to VK_SUCCESS.
-    VkResult mStatus{ VK_INCOMPLETE };
-    VkFence mFence;
-
-    std::function<void(VkFence)> mRecycleFn;
-
     // Updates the status of the fence, notifying all listeners of
     // mCond.
     void setStatus(VkResult const value) {
@@ -232,6 +221,17 @@ private:
     // used to transfer ownership of the VkFence from the fence pool
     // to this VulkanCmdFence.
     void swapRecycleFn(std::function<void(VkFence)> recycleFn);
+
+    std::shared_mutex mLock; // NOLINT(*-include-cleaner)
+    std::condition_variable_any mCond;
+    bool mCanceled = false;
+    // Internally we use the VK_INCOMPLETE status to mean "not yet submitted". When this fence
+    // gets submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually
+    // finishes executing the command buffer, the status changes to VK_SUCCESS.
+    VkResult mStatus{ VK_INCOMPLETE };
+    VkFence const mFence;
+
+    std::function<void(VkFence)> mRecycleFn;
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -192,15 +192,7 @@ struct VulkanCmdFence {
     // a) the recycleFn was defined in the ctor, and knows how to
     // dispose of the fence, or b) the creator of this object owns
     // the fence.
-    inline void clearFence() {
-        std::lock_guard l(mLock);
-        if (mRecycleFn != nullptr) {
-            mRecycleFn(mFence);
-        }
-
-        mFence = VK_NULL_HANDLE;
-        mRecycleFn = nullptr;
-    }
+    void clearFence();
 
     template <typename T>
     T lockAndUseFence(std::function<T(VkFence)> cb) {

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -178,12 +178,11 @@ struct VulkanCmdFence {
     }
 
     // Checks the underlying fence to see if the underlying process is complete.
-    // Updates the underlying status, and returns it.
+    // Updates the underlying status if the fence has signaled, and returns
+    // the current status.
     VkResult updateStatus(VkDevice device);
 
-    // This is safe to use in the backend thread, as the backend
-    // thread is the only thread that will be calling clearFence().
-    inline VkFence getVkFence() const {
+    inline VkFence getVkFence() {
         return mFence;
     }
 
@@ -191,7 +190,7 @@ struct VulkanCmdFence {
     // most recent tick(), checkAndUpdateStatus() has been called. Otherwise,
     // this may be out of date.
     VkResult getStatus() {
-        std::shared_lock const l(mLock);
+        std::shared_lock const rl(mLock);
         return mStatus;
     }
 
@@ -206,8 +205,8 @@ struct VulkanCmdFence {
 
 private:
     // The lifecycle of this object will often be managed by a
-    // VulkanFencePool. This allows it to clear fence handles before
-    // Filament is shut down, etc.
+    // VulkanFencePool. This allows it to update the recycle function
+    // when the pool is being terminated.
     friend class VulkanFencePool;
 
     std::shared_mutex mLock; // NOLINT(*-include-cleaner)
@@ -221,12 +220,6 @@ private:
 
     std::function<void(VkFence)> mRecycleFn;
 
-    // Clears the fence from this struct. It assumes that either
-    // a) the recycleFn was defined in the ctor, and knows how to
-    // dispose of the fence, or b) the creator of this object owns
-    // the fence.
-    void clearFence();
-
     // Updates the status of the fence, notifying all listeners of
     // mCond.
     void setStatus(VkResult const value) {
@@ -234,6 +227,11 @@ private:
         mStatus = value;
         mCond.notify_all();
     }
+
+    // Used by the fence pool when it terminates, essentially
+    // used to transfer ownership of the VkFence from the fence pool
+    // to this VulkanCmdFence.
+    void swapRecycleFn(std::function<void(VkFence)> recycleFn);
 };
 
 struct VulkanFence : public HwFence, fvkmemory::ThreadSafeResource {

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -220,7 +220,7 @@ fvkmemory::resource_ptr<VulkanSemaphore> VulkanCommandBuffer::submit() {
 
     UTILS_UNUSED_IN_RELEASE VkResult result =
         vkQueueSubmit(mQueue, 1, &submitInfo, getVkFence());
-    mFenceStatus->setStatus(VK_NOT_READY);
+    mFenceStatus->markSubmitted();
 
 #if FVK_ENABLED(FVK_DEBUG_COMMAND_BUFFER)
     if (result != VK_SUCCESS) {
@@ -315,10 +315,9 @@ void CommandBufferPool::gc() {
 void CommandBufferPool::update() {
     mSubmitted.forEachSetBit([this] (size_t index) {
         auto& buffer = mBuffers[index];
-        VkResult status = vkGetFenceStatus(mDevice, buffer->getVkFence());
-        if (status == VK_SUCCESS) {
-            buffer->setComplete();
-        }
+        // Updates the buffer's status, and marks it complete
+        // if the fence has signaled.
+        buffer->checkAndUpdateStatus(mDevice);
     });
 }
 

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -89,35 +89,20 @@ bool VulkanGroupMarkers::empty() const noexcept {
 
 uint32_t VulkanCommandBuffer::sAgeCounter = 0;
 
-VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, VkDevice device,
-        VkQueue queue, VkCommandPool pool, VulkanSemaphoreManager* semaphoreManager,
+VulkanCommandBuffer::VulkanCommandBuffer(VulkanContext const& context, 
+        VulkanFencePool& fencePool, VkDevice device, VkQueue queue,
+        VkCommandPool pool, VulkanSemaphoreManager* semaphoreManager,
         bool isProtected)
     : mContext(context),
+      mFencePool(fencePool),
       mMarkerCount(0),
       isProtected(isProtected),
-      mDevice(device),
       mQueue(queue),
       mSemaphoreManager(semaphoreManager),
       mBuffer(createCommandBuffer(device, pool)),
       mSubmission(semaphoreManager->acquire()),
       mAge(++sAgeCounter) {
-    VkFenceCreateInfo fenceCreateInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-    VkExportFenceCreateInfo exportFenceCreateInfo{
-        .sType = VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO,
-        .handleTypes = context.getFenceExportFlags()
-    };
-
-    // Necessary to guard this. Otherwise, swiftshader would throw an error.
-    if (context.getFenceExportFlags()) {
-        fenceCreateInfo.pNext = &exportFenceCreateInfo;
-    }
-    vkCreateFence(device, &fenceCreateInfo, VKALLOC, &mFence);
-
-    mFenceStatus = std::make_shared<VulkanCmdFence>(mFence);
-}
-
-VulkanCommandBuffer::~VulkanCommandBuffer() {
-    vkDestroyFence(mDevice, mFence, VKALLOC);
+    mFenceStatus = mFencePool.acquireFenceStatus();
 }
 
 void VulkanCommandBuffer::reset() noexcept {
@@ -128,13 +113,12 @@ void VulkanCommandBuffer::reset() noexcept {
     mAge = ++sAgeCounter;
     mSubmission = mSemaphoreManager->acquire();
 
-    // reset the fence with proper host synchronization
-    mFenceStatus->resetFence(mDevice);
-
     // Internally we use the VK_INCOMPLETE status to mean "not yet submitted". When this fence
     // gets, gets submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually
     // finishes executing the command buffer, the status changes to VK_SUCCESS.
-    mFenceStatus = std::make_shared<VulkanCmdFence>(mFence);
+    // The old fenceStatus may be held by other processes, so we simply create a new one when
+    // resetting.
+    mFenceStatus = mFencePool.acquireFenceStatus();
 }
 
 void VulkanCommandBuffer::pushMarker(char const* marker) noexcept {
@@ -235,7 +219,7 @@ fvkmemory::resource_ptr<VulkanSemaphore> VulkanCommandBuffer::submit() {
 #endif
 
     UTILS_UNUSED_IN_RELEASE VkResult result =
-        vkQueueSubmit(mQueue, 1, &submitInfo, mFence);
+        vkQueueSubmit(mQueue, 1, &submitInfo, getVkFence());
     mFenceStatus->setStatus(VK_NOT_READY);
 
 #if FVK_ENABLED(FVK_DEBUG_COMMAND_BUFFER)
@@ -251,7 +235,8 @@ fvkmemory::resource_ptr<VulkanSemaphore> VulkanCommandBuffer::submit() {
 CommandBufferPool::CommandBufferPool(VulkanContext const& context, VkDevice device, VkQueue queue,
         uint8_t queueFamilyIndex, VulkanSemaphoreManager* semaphoreManager, bool isProtected)
     : mDevice(device),
-      mRecording(INVALID) {
+      mRecording(INVALID),
+      mFencePool(context, device, CAPACITY) {
     VkCommandPoolCreateInfo createInfo = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
         .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT |
@@ -263,7 +248,7 @@ CommandBufferPool::CommandBufferPool(VulkanContext const& context, VkDevice devi
 
     for (size_t i = 0; i < CAPACITY; ++i) {
         mBuffers.emplace_back(std::make_unique<VulkanCommandBuffer>(
-                context, device, queue, mPool, semaphoreManager, isProtected));
+                context, mFencePool, device, queue, mPool, semaphoreManager, isProtected));
     }
 }
 
@@ -271,6 +256,7 @@ CommandBufferPool::~CommandBufferPool() {
     wait();
     gc();
     vkDestroyCommandPool(mDevice, mPool, VKALLOC);
+    mFencePool.terminate();
 }
 
 VulkanCommandBuffer& CommandBufferPool::getRecording() {
@@ -322,6 +308,7 @@ void CommandBufferPool::gc() {
         }
     });
     mSubmitted &= ~reclaimed;
+    mFencePool.gc();
     FVK_SYSTRACE_END();
 }
 
@@ -443,7 +430,6 @@ bool VulkanCommands::flush() {
     fvkmemory::resource_ptr<VulkanSemaphore> dependency;
     bool hasFlushed = false;
 
-    VkFence flushedFence = VK_NULL_HANDLE;
     std::shared_ptr<VulkanCmdFence> flushedFenceStatus;
 
     // Note that we've ordered it so that the non-protected commands are followed by the protected
@@ -467,7 +453,6 @@ bool VulkanCommands::flush() {
                     VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT);
             mLastSubmit = {};
         }
-        flushedFence = pool->getRecording().getVkFence();
         flushedFenceStatus = pool->getRecording().getFenceStatus();
         dependency = pool->flush();
         hasFlushed = true;
@@ -476,7 +461,6 @@ bool VulkanCommands::flush() {
     if (hasFlushed) {
         mInjectedDependency = VK_NULL_HANDLE;
         mLastSubmit = dependency;
-        mLastFence = flushedFence;
         mLastFenceStatus = flushedFenceStatus;
     }
 

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -24,6 +24,7 @@
 #include "VulkanAsyncHandles.h"
 #include "VulkanConstants.h"
 #include "VulkanContext.h"
+#include "VulkanFencePool.h"
 #include "VulkanSemaphoreManager.h"
 #include "vulkan/memory/ResourcePointer.h"
 #include "vulkan/utils/StaticVector.h"
@@ -65,13 +66,11 @@ private:
 // DriverApi fence object and should not be destroyed until both the DriverApi object is freed and
 // we're done waiting on the most recent submission of the given command buffer.
 struct VulkanCommandBuffer {
-    VulkanCommandBuffer(VulkanContext const& mContext, VkDevice device, VkQueue queue,
+    VulkanCommandBuffer(VulkanContext const& context, VulkanFencePool& fencePool, VkDevice device, VkQueue queue,
             VkCommandPool pool, VulkanSemaphoreManager* semaphoreManager, bool isProtected);
 
     VulkanCommandBuffer(VulkanCommandBuffer const&) = delete;
     VulkanCommandBuffer& operator=(VulkanCommandBuffer const&) = delete;
-
-    ~VulkanCommandBuffer();
 
     template <typename T,
               typename = std::enable_if_t<
@@ -108,7 +107,7 @@ struct VulkanCommandBuffer {
     }
 
     VkFence getVkFence() const {
-        return mFence;
+        return mFenceStatus->getVkFence();
     }
 
     VkCommandBuffer buffer() const {
@@ -126,16 +125,15 @@ private:
     static uint32_t sAgeCounter;
 
     VulkanContext const& mContext;
+    VulkanFencePool& mFencePool;
     uint8_t mMarkerCount;
     bool const isProtected;
-    VkDevice mDevice;
     VkQueue mQueue;
     VulkanSemaphoreManager* mSemaphoreManager;
     fvkutils::StaticVector<VkSemaphore, 2> mWaitSemaphores;
     fvkutils::StaticVector<VkPipelineStageFlags, 2> mWaitSemaphoreStages;
     VkCommandBuffer mBuffer;
     fvkmemory::resource_ptr<VulkanSemaphore> mSubmission;
-    VkFence mFence;
     std::shared_ptr<VulkanCmdFence> mFenceStatus;
     std::vector<HeldResource> mResources;
     uint32_t mAge;
@@ -181,6 +179,7 @@ private:
     ActiveBuffers mSubmitted;
     std::vector<std::unique_ptr<VulkanCommandBuffer>> mBuffers;
     int8_t mRecording;
+    VulkanFencePool mFencePool;
 
 #if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS)
     std::unique_ptr<VulkanGroupMarkers> mGroupMarkers;
@@ -238,10 +237,6 @@ public:
         return sem;
     }
 
-    VkFence getMostRecentFence() {
-        return mLastFence;
-    }
-
     std::shared_ptr<VulkanCmdFence> getMostRecentFenceStatus() {
         return mLastFenceStatus;
     }
@@ -277,14 +272,13 @@ private:
     uint32_t const mProtectedQueueFamilyIndex;
     VulkanContext const& mContext;
     VulkanSemaphoreManager* mSemaphoreManager;
-
+    
     std::unique_ptr<CommandBufferPool> mPool;
     std::unique_ptr<CommandBufferPool> mProtectedPool;
-
+    
     VkSemaphore mInjectedDependency = VK_NULL_HANDLE;
     fvkmemory::resource_ptr<VulkanSemaphore> mLastSubmit;
-
-    VkFence mLastFence = VK_NULL_HANDLE;
+    
     // Start out with a completed fence, because if no commands have
     // been queued or submited, then by definition, all pending work
     // is complete.

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -94,8 +94,8 @@ struct VulkanCommandBuffer {
     void begin() noexcept;
     fvkmemory::resource_ptr<VulkanSemaphore> submit();
 
-    inline void setComplete() {
-        mFenceStatus->setStatus(VK_SUCCESS);
+    inline void checkAndUpdateStatus(VkDevice device) {
+        mFenceStatus->updateStatus(device);
     }
 
     VkResult getStatus() {

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -272,13 +272,13 @@ private:
     uint32_t const mProtectedQueueFamilyIndex;
     VulkanContext const& mContext;
     VulkanSemaphoreManager* mSemaphoreManager;
-    
+
     std::unique_ptr<CommandBufferPool> mPool;
     std::unique_ptr<CommandBufferPool> mProtectedPool;
-    
+
     VkSemaphore mInjectedDependency = VK_NULL_HANDLE;
     fvkmemory::resource_ptr<VulkanSemaphore> mLastSubmit;
-    
+
     // Start out with a completed fence, because if no commands have
     // been queued or submited, then by definition, all pending work
     // is complete.

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1016,23 +1016,20 @@ void VulkanDriver::createFenceR(Handle<HwFence> fh, utils::ImmutableCString&& ta
 
 void VulkanDriver::createSyncR(Handle<HwSync> sh, utils::ImmutableCString&& tag) {
     auto sync = resource_ptr<VulkanSync>::cast(&mResourceManager, sh);
-    VkFence fence = VK_NULL_HANDLE;
     std::shared_ptr<VulkanCmdFence> fenceStatus;
     if (mCurrentRenderPass.commandBuffer) {
         VulkanCommandBuffer* cmdBuff = mCurrentRenderPass.commandBuffer;
-        fence = cmdBuff->getVkFence();
         fenceStatus = cmdBuff->getFenceStatus();
         // If we're currently recording, flush so that the fence only applies
         // to commands already issued.
         mCommands.flush();
     } else {
-        fence = mCommands.getMostRecentFence();
         fenceStatus = mCommands.getMostRecentFenceStatus();
     }
 
     {
         std::lock_guard<std::mutex> guard(sync->lock);
-        sync->sync = mPlatform->createSync(fence, fenceStatus);
+        sync->sync = mPlatform->createSync(fenceStatus);
     }
 
     for (auto& cbData : sync->conversionCallbacks) {

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <deque>
-#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -52,9 +51,7 @@ VulkanFencePool::VulkanFencePool(VulkanContext const& context,
 std::shared_ptr<VulkanCmdFence> VulkanFencePool::acquireFenceStatus() noexcept {
     VkFence fence = acquireFence();
     std::function<void(VkFence)> recycleFn = [this](VkFence fence) {
-        if (fence != VK_NULL_HANDLE) {
-            this->releaseFence(fence);
-        }
+        this->releaseFence(fence);
     };
     const auto fenceStatus = std::make_shared<VulkanCmdFence>(fence, recycleFn);
     // Store a weak pointer to the fence status, so we can clear the fence
@@ -78,7 +75,6 @@ void VulkanFencePool::gc() noexcept {
     // Lock now to avoid race conditions with other threads that may be
     // clearing fenceStatus objects, and trying to return fences to the
     // pool.
-    std::unique_lock<std::mutex> lock (mFenceListMutex);
     while (mNumFences > mMinPoolSize && !mFences.empty() &&
            mFences.front().first + TIME_BEFORE_EVICTION < mCurrFrame) {
         destroyFence(mFences.front().second);
@@ -90,9 +86,11 @@ void VulkanFencePool::gc() noexcept {
 void VulkanFencePool::terminate() noexcept {
     for (const auto& weakFenceStatus : mFenceStatuses) {
         if (const auto fenceStatus = weakFenceStatus.lock()) {
-            // Indirectly, this will return the fence to the pool,
-            // using the recycleFn.
-            fenceStatus->clearFence();
+            // Swap out the recycle function for the fence status, so that
+            // it doesn't try to return the fence to this pool.
+            fenceStatus->swapRecycleFn([device = mDevice](VkFence fence) {
+                vkDestroyFence(device, fence, VKALLOC);
+            });
         }
     }
     mFenceStatuses.clear();
@@ -108,7 +106,6 @@ void VulkanFencePool::terminate() noexcept {
 }
 
 VkFence VulkanFencePool::acquireFence() noexcept {
-    std::unique_lock<std::mutex> lock (mFenceListMutex);
     if (!mFences.empty()) {
         VkFence fence = mFences.back().second;
         mFences.pop_back();
@@ -131,7 +128,6 @@ void VulkanFencePool::releaseFence(VkFence fence) noexcept {
     vkResetFences(mDevice, 1, &fence);
 
     // Since fences may be released concurrently, make sure we lock.
-    std::unique_lock<std::mutex> lock (mFenceListMutex);
     mFences.push_back(std::make_pair(mCurrFrame, fence));
 }
 

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -115,20 +115,16 @@ VkFence VulkanFencePool::acquireFence() noexcept {
         return fence;
     } else {
         VkFence fence = allocateFence();
-        if (fence != VK_NULL_HANDLE) {
-            ++mNumFences;
-        }
+        FILAMENT_CHECK_POSTCONDITION(fence != VK_NULL_HANDLE);
+        ++mNumFences;
         return fence;
     }
 }
 
 void VulkanFencePool::releaseFence(VkFence fence) noexcept {
     // This only happens if fence allocation failed, which is a fairly
-    // major issue. 
-    assert_invariant(fence != VK_NULL_HANDLE);
-    if (fence == VK_NULL_HANDLE) {
-        return;
-    }
+    // major issue.
+    FILAMENT_CHECK_PRECONDITION(fence != VK_NULL_HANDLE);
 
     // Reset the fence before returning it to the pool of available
     // fences.

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -72,9 +72,6 @@ void VulkanFencePool::gc() noexcept {
         return;
     }
 
-    // Lock now to avoid race conditions with other threads that may be
-    // clearing fenceStatus objects, and trying to return fences to the
-    // pool.
     while (mNumFences > mMinPoolSize && !mFences.empty() &&
            mFences.front().first + TIME_BEFORE_EVICTION < mCurrFrame) {
         destroyFence(mFences.front().second);
@@ -95,9 +92,6 @@ void VulkanFencePool::terminate() noexcept {
     }
     mFenceStatuses.clear();
 
-    // No need to lock. We do not allow usages of fences aside from
-    // the ones provided in fenceStatuses, and we have reclaimed
-    // fences from all fenceStatus objects.
     for (const auto& fence : mFences) {
         destroyFence(fence.second);
     }
@@ -126,8 +120,6 @@ void VulkanFencePool::releaseFence(VkFence fence) noexcept {
     // Reset the fence before returning it to the pool of available
     // fences.
     vkResetFences(mDevice, 1, &fence);
-
-    // Since fences may be released concurrently, make sure we lock.
     mFences.push_back(std::make_pair(mCurrFrame, fence));
 }
 

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanConstants.h"
+#include "VulkanFencePool.h"
+
+using namespace bluevk;
+using namespace utils;
+
+namespace filament::backend {
+
+namespace {
+
+static constexpr uint32_t TIME_BEFORE_EVICTION = 3;
+
+}  // namespace
+
+VulkanFencePool::VulkanFencePool(VulkanContext const& context,
+                                 VkDevice device,
+                                 uint32_t minPoolSize)
+    : mContext(context), mDevice(device), mMinPoolSize(minPoolSize)
+{
+    mFences.reserve(minPoolSize);
+    for (size_t i = 0; i < minPoolSize; ++i) {
+        VkFence fence = allocateFence();
+        assert_invariant(fence != VK_NULL_HANDLE);
+        if (fence != VK_NULL_HANDLE) {
+            mFences.push_back(fence);
+            mFenceReturnTimestamps.push_back(mCurrFrame);
+        }
+    }
+    mNumFences = mFences.size();  // Only count the fences we successfully acquired.
+}
+
+std::shared_ptr<VulkanCmdFence> VulkanFencePool::acquireFenceStatus() noexcept {
+    VkFence fence = acquireFence();
+    std::function<void(VkFence)> recycleFn = [this](VkFence fence) {
+        if (fence != VK_NULL_HANDLE) {
+            this->releaseFence(fence);
+        }
+    };
+    const auto fenceStatus = std::make_shared<VulkanCmdFence>(fence, recycleFn);
+    // Store a weak pointer to the fence status, so we can clear the fence
+    // later if terminate() is called.
+    mFenceStatuses.push_back(std::weak_ptr<VulkanCmdFence>(fenceStatus));
+    return fenceStatus;
+}
+
+void VulkanFencePool::gc() noexcept {
+    // Clear any fence statuses that no longer exist.
+    for (auto it = mFenceStatuses.begin(); it != mFenceStatuses.end();) {
+        if (it->expired()) {
+            it = mFenceStatuses.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    if (++mCurrFrame <= TIME_BEFORE_EVICTION) {
+        return;
+    }
+
+    // Lock now to avoid race conditions with other threads that may be
+    // clearing fenceStatus objects, and trying to return fences to the
+    // pool.
+    std::unique_lock<std::mutex> lock (mFenceListMutex);
+    while (mNumFences > mMinPoolSize && !mFenceReturnTimestamps.empty() &&
+           mFenceReturnTimestamps.front() + TIME_BEFORE_EVICTION < mCurrFrame) {
+        mFenceReturnTimestamps.pop_front();
+        destroyFence(mFences.back());
+        mFences.pop_back();
+        --mNumFences;
+    }
+
+    // std::unique_lock<std::mutex> lock (mFenceListMutex);
+
+    // // Simply prevent holding more fences than the min pool size.
+    // // Is it possible we have more than the number of fences we
+    // // need? Yes, but we will never exceed that by more than mMinPoolSize.
+    // // TODO: destroy fences without holding lock.
+    // if (mFences.size() > mMinPoolSize) {
+    //     size_t numFencesToFree = mFences.size() - mMinPoolSize;
+    //     for (size_t i = 0; i < numFencesToFree; ++i) {
+    //         destroyFence(mFences.back());
+    //         mFences.pop_back();
+    //         --mNumFences;
+    //     }
+    // }
+}
+
+void VulkanFencePool::terminate() noexcept {
+    for (const auto& weakFenceStatus : mFenceStatuses) {
+        if (const auto fenceStatus = weakFenceStatus.lock()) {
+            // Indirectly, this will return the fence to the pool,
+            // using the recycleFn.
+            fenceStatus->clearFence();
+        }
+    }
+    mFenceStatuses.clear();
+
+    // No need to lock. We do not allow usages of fences aside from
+    // the ones provided in fenceStatuses, and we have reclaimed
+    // fences from all fenceStatus objects.
+    for (const auto fence : mFences) {
+        destroyFence(fence);
+    }
+    mFences.clear();
+    mNumFences = 0;
+}
+
+VkFence VulkanFencePool::acquireFence() noexcept {
+    std::unique_lock<std::mutex> lock (mFenceListMutex);
+    if (!mFences.empty()) {
+        VkFence fence = mFences.back();
+        mFences.pop_back();
+        mFenceReturnTimestamps.pop_back();
+        return fence;
+    } else {
+        VkFence fence = allocateFence();
+        if (fence != VK_NULL_HANDLE) {
+            ++mNumFences;
+        }
+        return fence;
+    }
+}
+
+void VulkanFencePool::releaseFence(VkFence fence) noexcept {
+    // This only happens if fence allocation failed, which is a fairly
+    // major issue. 
+    assert_invariant(fence != VK_NULL_HANDLE);
+    if (fence == VK_NULL_HANDLE) {
+        return;
+    }
+
+    // Reset the fence before returning it to the pool of available
+    // fences.
+    vkResetFences(mDevice, 1, &fence);
+
+    // Since fences may be released concurrently, make sure we lock.
+    std::unique_lock<std::mutex> lock (mFenceListMutex);
+    mFences.push_back(fence);
+    mFenceReturnTimestamps.push_back(mCurrFrame);
+}
+
+VkFence VulkanFencePool::allocateFence() const noexcept {
+    VkFence fence = VK_NULL_HANDLE;
+    VkFenceCreateInfo createInfo {
+        .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+        .pNext = VK_NULL_HANDLE,
+        .flags = 0,
+    };
+    VkExportFenceCreateInfo exportFenceCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO,
+        .handleTypes = mContext.getFenceExportFlags()
+    };
+    // Necessary to guard this. Otherwise, swiftshader would throw an error.
+    if (mContext.getFenceExportFlags()) {
+        createInfo.pNext = &exportFenceCreateInfo;
+    }
+    VkResult res = vkCreateFence(mDevice, &createInfo, VKALLOC, &fence);
+    if (res != VK_SUCCESS) {
+        FVK_LOGE << "Failed to create fence: " << res << "; skipping. This may cause issues later.";
+        return VK_NULL_HANDLE;
+    }
+    return fence;
+}
+
+void VulkanFencePool::destroyFence(VkFence fence) const noexcept {
+    vkDestroyFence(mDevice, fence, VKALLOC);
+}
+
+} // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -17,6 +17,7 @@
 #include "VulkanConstants.h"
 #include "VulkanFencePool.h"
 
+#include <algorithm>
 #include <deque>
 #include <mutex>
 #include <utility>
@@ -64,13 +65,11 @@ std::shared_ptr<VulkanCmdFence> VulkanFencePool::acquireFenceStatus() noexcept {
 
 void VulkanFencePool::gc() noexcept {
     // Clear any fence statuses that no longer exist.
-    for (auto it = mFenceStatuses.begin(); it != mFenceStatuses.end();) {
-        if (it->expired()) {
-            it = mFenceStatuses.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    auto expiredStatuses = std::remove_if(mFenceStatuses.begin(), mFenceStatuses.end(),
+        [](const auto& fenceStatus) {
+            return fenceStatus.expired();
+        });
+    mFenceStatuses.erase(expiredStatuses, mFenceStatuses.end());
 
     if (++mCurrFrame <= TIME_BEFORE_EVICTION) {
         return;

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -17,6 +17,11 @@
 #include "VulkanConstants.h"
 #include "VulkanFencePool.h"
 
+#include <deque>
+#include <mutex>
+#include <utility>
+#include <vector>
+
 using namespace bluevk;
 using namespace utils;
 
@@ -33,13 +38,11 @@ VulkanFencePool::VulkanFencePool(VulkanContext const& context,
                                  uint32_t minPoolSize)
     : mContext(context), mDevice(device), mMinPoolSize(minPoolSize)
 {
-    mFences.reserve(minPoolSize);
     for (size_t i = 0; i < minPoolSize; ++i) {
         VkFence fence = allocateFence();
         assert_invariant(fence != VK_NULL_HANDLE);
         if (fence != VK_NULL_HANDLE) {
-            mFences.push_back(fence);
-            mFenceReturnTimestamps.push_back(mCurrFrame);
+            mFences.push_back(std::make_pair(mCurrFrame, fence));
         }
     }
     mNumFences = mFences.size();  // Only count the fences we successfully acquired.
@@ -77,28 +80,12 @@ void VulkanFencePool::gc() noexcept {
     // clearing fenceStatus objects, and trying to return fences to the
     // pool.
     std::unique_lock<std::mutex> lock (mFenceListMutex);
-    while (mNumFences > mMinPoolSize && !mFenceReturnTimestamps.empty() &&
-           mFenceReturnTimestamps.front() + TIME_BEFORE_EVICTION < mCurrFrame) {
-        mFenceReturnTimestamps.pop_front();
-        destroyFence(mFences.back());
-        mFences.pop_back();
+    while (mNumFences > mMinPoolSize && !mFences.empty() &&
+           mFences.front().first + TIME_BEFORE_EVICTION < mCurrFrame) {
+        destroyFence(mFences.front().second);
+        mFences.pop_front();
         --mNumFences;
     }
-
-    // std::unique_lock<std::mutex> lock (mFenceListMutex);
-
-    // // Simply prevent holding more fences than the min pool size.
-    // // Is it possible we have more than the number of fences we
-    // // need? Yes, but we will never exceed that by more than mMinPoolSize.
-    // // TODO: destroy fences without holding lock.
-    // if (mFences.size() > mMinPoolSize) {
-    //     size_t numFencesToFree = mFences.size() - mMinPoolSize;
-    //     for (size_t i = 0; i < numFencesToFree; ++i) {
-    //         destroyFence(mFences.back());
-    //         mFences.pop_back();
-    //         --mNumFences;
-    //     }
-    // }
 }
 
 void VulkanFencePool::terminate() noexcept {
@@ -114,8 +101,8 @@ void VulkanFencePool::terminate() noexcept {
     // No need to lock. We do not allow usages of fences aside from
     // the ones provided in fenceStatuses, and we have reclaimed
     // fences from all fenceStatus objects.
-    for (const auto fence : mFences) {
-        destroyFence(fence);
+    for (const auto& fence : mFences) {
+        destroyFence(fence.second);
     }
     mFences.clear();
     mNumFences = 0;
@@ -124,9 +111,8 @@ void VulkanFencePool::terminate() noexcept {
 VkFence VulkanFencePool::acquireFence() noexcept {
     std::unique_lock<std::mutex> lock (mFenceListMutex);
     if (!mFences.empty()) {
-        VkFence fence = mFences.back();
+        VkFence fence = mFences.back().second;
         mFences.pop_back();
-        mFenceReturnTimestamps.pop_back();
         return fence;
     } else {
         VkFence fence = allocateFence();
@@ -151,8 +137,7 @@ void VulkanFencePool::releaseFence(VkFence fence) noexcept {
 
     // Since fences may be released concurrently, make sure we lock.
     std::unique_lock<std::mutex> lock (mFenceListMutex);
-    mFences.push_back(fence);
-    mFenceReturnTimestamps.push_back(mCurrFrame);
+    mFences.push_back(std::make_pair(mCurrFrame, fence));
 }
 
 VkFence VulkanFencePool::allocateFence() const noexcept {

--- a/filament/backend/src/vulkan/VulkanFencePool.cpp
+++ b/filament/backend/src/vulkan/VulkanFencePool.cpp
@@ -61,6 +61,9 @@ std::shared_ptr<VulkanCmdFence> VulkanFencePool::acquireFenceStatus() noexcept {
 }
 
 void VulkanFencePool::gc() noexcept {
+    FVK_SYSTRACE_CONTEXT();
+    FVK_SYSTRACE_START("vulkanfencepool::gc");
+
     // Clear any fence statuses that no longer exist.
     auto expiredStatuses = std::remove_if(mFenceStatuses.begin(), mFenceStatuses.end(),
         [](const auto& fenceStatus) {
@@ -78,6 +81,8 @@ void VulkanFencePool::gc() noexcept {
         mFences.pop_front();
         --mNumFences;
     }
+
+    FVK_SYSTRACE_END();
 }
 
 void VulkanFencePool::terminate() noexcept {

--- a/filament/backend/src/vulkan/VulkanFencePool.h
+++ b/filament/backend/src/vulkan/VulkanFencePool.h
@@ -51,14 +51,6 @@ public:
     void terminate() noexcept;
 
 private:
-    VulkanContext const& mContext;
-    const VkDevice mDevice;
-    const uint32_t mMinPoolSize;
-    std::deque<std::pair<uint64_t, VkFence>> mFences;
-    std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
-    uint32_t mNumFences = 0;
-    uint64_t mCurrFrame = 0;
-
     // Acquires a fence from the pool. This is private because we need mechanisms
     // to ensure that all fences are returned *during* terminate. Instead, users
     // can use acquireFenceStatus(), which tracks fences.
@@ -75,6 +67,14 @@ private:
     // Releases a fence from the pool. This is done when there are many idle fences,
     // as well as when the pool is terminated.
     void destroyFence(VkFence fence) const noexcept;
+
+    VulkanContext const& mContext;
+    const VkDevice mDevice;
+    const uint32_t mMinPoolSize;
+    std::deque<std::pair<uint64_t, VkFence>> mFences;
+    std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
+    uint32_t mNumFences = 0;
+    uint64_t mCurrFrame = 0;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanFencePool.h
+++ b/filament/backend/src/vulkan/VulkanFencePool.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKANFENCEPOOL_H
+#define TNT_FILAMENT_BACKEND_VULKANFENCEPOOL_H
+
+#include "VulkanAsyncHandles.h"
+#include "VulkanContext.h"
+
+#include <deque>
+#include <mutex>
+#include <vector>
+
+namespace filament::backend {
+
+class VulkanFencePool {
+public:
+    VulkanFencePool(VulkanContext const& context, VkDevice device, uint32_t minPoolSize);
+
+    // Acquires a shareable fence status object that contains
+    // a fence acquired from the pool. The fence status will
+    // be cleared, and the fence reclaimed, once the shared_ptr
+    // goes out of scope.
+    std::shared_ptr<VulkanCmdFence> acquireFenceStatus() noexcept;
+
+    // Clears idle fences, as well as cmdFences that are no longer alive.
+    void gc() noexcept;
+
+    // Reclaims fences from all fenceStatus objects, and then clears the
+    // fence list.
+    void terminate() noexcept;
+
+private:
+    std::mutex mFenceListMutex;
+    VulkanContext const& mContext;
+    VkDevice mDevice;
+    uint32_t mMinPoolSize;
+    std::vector<VkFence> mFences;
+    std::deque<uint64_t> mFenceReturnTimestamps;
+    std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
+    uint32_t mNumFences = 0;
+    uint64_t mCurrFrame = 0;
+
+    // Acquires a fence from the pool. This is private because we need mechanisms
+    // to ensure that all fences are returned *during* terminate. Instead, users
+    // can use acquireFenceStatus(), which tracks fences.
+    VkFence acquireFence() noexcept;
+
+    // Releases a fence back into the pool. Typically done in the recycle function
+    // of a VulkanCmdFence created by this pool.
+    void releaseFence(VkFence fence) noexcept;
+
+    // Allocates a fence within the pool. This is done when there are no free fences
+    // available to give out in acquireFence().
+    VkFence allocateFence() const noexcept;
+
+    // Releases a fence from the pool. This is done when there are many idle fences,
+    // as well as when the pool is terminated.
+    void destroyFence(VkFence fence) const noexcept;
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_VULKANFENCEPOOL_H

--- a/filament/backend/src/vulkan/VulkanFencePool.h
+++ b/filament/backend/src/vulkan/VulkanFencePool.h
@@ -22,6 +22,7 @@
 
 #include <deque>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace filament::backend {
@@ -48,8 +49,7 @@ private:
     VulkanContext const& mContext;
     VkDevice mDevice;
     uint32_t mMinPoolSize;
-    std::vector<VkFence> mFences;
-    std::deque<uint64_t> mFenceReturnTimestamps;
+    std::deque<std::pair<uint64_t, VkFence>> mFences;
     std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
     uint32_t mNumFences = 0;
     uint64_t mCurrFrame = 0;

--- a/filament/backend/src/vulkan/VulkanFencePool.h
+++ b/filament/backend/src/vulkan/VulkanFencePool.h
@@ -21,12 +21,15 @@
 #include "VulkanContext.h"
 
 #include <deque>
-#include <mutex>
 #include <utility>
 #include <vector>
 
 namespace filament::backend {
 
+/**
+ * Manages the lifecycle for VkFence objects. This is not thread-safe, and all fences
+ * acquired from this pool must be acquired and freed on the backend thread.
+ */
 class VulkanFencePool {
 public:
     VulkanFencePool(VulkanContext const& context, VkDevice device, uint32_t minPoolSize);
@@ -35,6 +38,9 @@ public:
     // a fence acquired from the pool. The fence status will
     // be cleared, and the fence reclaimed, once the shared_ptr
     // goes out of scope.
+    // TODO: this is not thread-safe, and should only be allowed to
+    // go out of scope on the backend thread. We should move away
+    // from shared_ptr.
     std::shared_ptr<VulkanCmdFence> acquireFenceStatus() noexcept;
 
     // Clears idle fences, as well as cmdFences that are no longer alive.
@@ -48,7 +54,6 @@ private:
     VulkanContext const& mContext;
     const VkDevice mDevice;
     const uint32_t mMinPoolSize;
-    std::mutex mFenceListMutex;
     std::deque<std::pair<uint64_t, VkFence>> mFences;
     std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
     uint32_t mNumFences = 0;

--- a/filament/backend/src/vulkan/VulkanFencePool.h
+++ b/filament/backend/src/vulkan/VulkanFencePool.h
@@ -45,10 +45,10 @@ public:
     void terminate() noexcept;
 
 private:
-    std::mutex mFenceListMutex;
     VulkanContext const& mContext;
-    VkDevice mDevice;
-    uint32_t mMinPoolSize;
+    const VkDevice mDevice;
+    const uint32_t mMinPoolSize;
+    std::mutex mFenceListMutex;
     std::deque<std::pair<uint64_t, VkFence>> mFences;
     std::vector<std::weak_ptr<VulkanCmdFence>> mFenceStatuses;
     uint32_t mNumFences = 0;

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -784,9 +784,9 @@ SwapChainPtr VulkanPlatform::createSwapChain(void* nativeWindow, uint64_t flags,
     return swapchain;
 }
 
-Platform::Sync* VulkanPlatform::createSync(VkFence fence,
+Platform::Sync* VulkanPlatform::createSync(
         std::shared_ptr<VulkanCmdFence> fenceStatus) noexcept {
-    return new VulkanSync{.fence = fence, .fenceStatus = fenceStatus};
+    return new VulkanSync{.fenceStatus = fenceStatus};
 }
 
 void VulkanPlatform::destroySync(Platform::Sync* sync) noexcept {

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -474,27 +474,25 @@ bool VulkanPlatformAndroid::convertSyncToFd(Platform::Sync* sync, int* fd) const
 
     VkDevice device = getDevice();
     VkExternalFenceHandleTypeFlagBits exportFlags = getFenceExportFlags();
-    auto convertFence = [&fd, device, exportFlags](VkFence fence) {
-        if (fence == VK_NULL_HANDLE) {
-            *fd = -1;
-            return true;
-        }
 
-        VkFenceGetFdInfoKHR getFdInfo = {
-            .sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
-            .fence = fence,
-            .handleType = exportFlags,
-        };
-        VkResult res = vkGetFenceFdKHR(device, &getFdInfo, fd);
-        if (res != VK_SUCCESS) {
-            LOG(ERROR) << "Failed to convert sync to fd: " << res;
-            return false;
-        }
-
+    VkFence fence = vulkanSync.fenceStatus->getVkFence();
+    if (fence == VK_NULL_HANDLE) {
+        *fd = -1;
         return true;
-    };
+    }
 
-    return vulkanSync.fenceStatus->lockAndUseFence<bool>(convertFence);
+    VkFenceGetFdInfoKHR getFdInfo = {
+        .sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
+        .fence = fence,
+        .handleType = exportFlags,
+    };
+    VkResult res = vkGetFenceFdKHR(device, &getFdInfo, fd);
+    if (res != VK_SUCCESS) {
+        LOG(ERROR) << "Failed to convert sync to fd: " << res;
+        return false;
+    }
+
+    return true;
 }
 
 VkExternalFenceHandleTypeFlagBits VulkanPlatformAndroid::getFenceExportFlags() const noexcept {

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -472,10 +472,7 @@ bool VulkanPlatformAndroid::convertSyncToFd(Platform::Sync* sync, int* fd) const
     VulkanSync& vulkanSync = static_cast<VulkanSync&>(*sync);
     assert_invariant(vulkanSync.fenceStatus);
 
-    VkDevice device = getDevice();
-    VkExternalFenceHandleTypeFlagBits exportFlags = getFenceExportFlags();
-
-    VkFence fence = vulkanSync.fenceStatus->getVkFence();
+    const auto fence = vulkanSync.fenceStatus->getVkFence();
     if (fence == VK_NULL_HANDLE) {
         *fd = -1;
         return true;
@@ -484,14 +481,13 @@ bool VulkanPlatformAndroid::convertSyncToFd(Platform::Sync* sync, int* fd) const
     VkFenceGetFdInfoKHR getFdInfo = {
         .sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
         .fence = fence,
-        .handleType = exportFlags,
+        .handleType = getFenceExportFlags(),
     };
-    VkResult res = vkGetFenceFdKHR(device, &getFdInfo, fd);
+    VkResult res = vkGetFenceFdKHR(getDevice(), &getFdInfo, fd);
     if (res != VK_SUCCESS) {
         LOG(ERROR) << "Failed to convert sync to fd: " << res;
         return false;
     }
-
     return true;
 }
 

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -472,24 +472,29 @@ bool VulkanPlatformAndroid::convertSyncToFd(Platform::Sync* sync, int* fd) const
     VulkanSync& vulkanSync = static_cast<VulkanSync&>(*sync);
     assert_invariant(vulkanSync.fenceStatus);
 
-    if (vulkanSync.fenceStatus->getStatus() == VK_SUCCESS) {
-        // We've already signaled; return -1 so that operations will proceed
-        // immediately. Also, signal that fence conversion was successful.
-        *fd = -1;
-        return true;
-    }
+    VkDevice device = getDevice();
+    VkExternalFenceHandleTypeFlagBits exportFlags = getFenceExportFlags();
+    auto convertFence = [&fd, device, exportFlags](VkFence fence) {
+        if (fence == VK_NULL_HANDLE) {
+            *fd = -1;
+            return true;
+        }
 
-    VkFenceGetFdInfoKHR getFdInfo = {
-        .sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
-        .fence = vulkanSync.fence,
-        .handleType = getFenceExportFlags(),
+        VkFenceGetFdInfoKHR getFdInfo = {
+            .sType = VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR,
+            .fence = fence,
+            .handleType = exportFlags,
+        };
+        VkResult res = vkGetFenceFdKHR(device, &getFdInfo, fd);
+        if (res != VK_SUCCESS) {
+            LOG(ERROR) << "Failed to convert sync to fd: " << res;
+            return false;
+        }
+
+        return true;
     };
-    VkResult res = vkGetFenceFdKHR(getDevice(), &getFdInfo, fd);
-    if (res != VK_SUCCESS) {
-        LOG(ERROR) << "Failed to convert sync to fd: " << res;
-        return false;
-    }
-    return true;
+
+    return vulkanSync.fenceStatus->lockAndUseFence<bool>(convertFence);
 }
 
 VkExternalFenceHandleTypeFlagBits VulkanPlatformAndroid::getFenceExportFlags() const noexcept {


### PR DESCRIPTION
In certain applications, even if a fence has already signaled by the time it's converted to an fd, it's important to be able to convert the fence to an fd to calculate things like frame timing. This is useful for apps that are pacing frames, like games.