### PR TITLE
test: clean-up unit tests

### DIFF
--- a/build/common/test_list.txt
+++ b/build/common/test_list.txt
@@ -1,5 +1,5 @@
 libs/viewer/test_settings
-filament/test/test_filament --gtest_filter=-FilamentTest.FroxelData:FilamentExposureWithEngineTest.SetExposure:FilamentExposureWithEngineTest.ComputeEV100:RenderingTest.*
+filament/test/test_filament --gtest_filter=-RenderingTest.*
 libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -90,6 +90,8 @@ protected:
         //utils::io::sstream graphviz;
         //fg.export_graphviz(graphviz);
         //DLOG(INFO) << graphviz.c_str();
+
+        PlatformFactory::destroy(&platform);
     }
 
     Backend backend = Backend::NOOP;

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -782,7 +782,7 @@ TEST(FilamentTest, ColorConversion) {
 TEST(FilamentTest, FroxelData) {
     using namespace filament;
 
-    FEngine* engine = downcast(Engine::create());
+    FEngine* engine = downcast(Engine::Builder().backend(Engine::Backend::NOOP).build());
 
     LinearAllocatorArena arena("FRenderer: per-frame allocator", 3 * 1024 * 1024);
     utils::ArenaScope<LinearAllocatorArena> scope(arena);

--- a/filament/test/filament_test_exposure.cpp
+++ b/filament/test/filament_test_exposure.cpp
@@ -29,7 +29,7 @@ using namespace filament;
 class FilamentExposureWithEngineTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        engine = Engine::create(Engine::Backend::OPENGL);
+        engine = Engine::create(Engine::Backend::NOOP);
     }
 
     void TearDown() override {


### PR DESCRIPTION
 - Make sure platform is destroyed for framegraph tests
 - Mkae sure exposure is tested with NOOP backend