### PR TITLE
engine: fix VSM mipmaping and blur

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -422,18 +422,13 @@ public:
 
     void resetForRender();
 
-    MaterialInstanceManager& getMaterialInstanceManager() noexcept {
-            return mMaterialInstanceManager;
-    }
-
     static void unbindAllDescriptorSets(backend::DriverApi& driver) noexcept;
-
-private:
 
     // Helpers to get MaterialInstances.
     //
-    // These funcions additionally ensure that the necessary shader programs are compiled via
+    // These functions additionally ensure that the necessary shader programs are compiled via
     // prepareProgram().
+
     FMaterialInstance* getMaterialInstance(backend::DriverApi& driver, FMaterial const* ma,
             Variant::type_t variant) const;
 
@@ -452,17 +447,17 @@ private:
             uint32_t tag, Variant::type_t variant) const;
 
     FMaterialInstance* getMaterialInstanceWithTag(backend::DriverApi& driver, FMaterial const* ma,
-            uint32_t tag, PostProcessVariant variant = PostProcessVariant::OPAQUE) const {
+            uint32_t const tag, PostProcessVariant variant = PostProcessVariant::OPAQUE) const {
         return getMaterialInstanceWithTag(driver, ma, tag, Variant::type_t(variant));
     }
 
     FMaterialInstance* getMaterialInstanceWithTag(FEngine& engine, backend::DriverApi& driver,
-            PostProcessMaterial const& material, uint32_t tag,
+            PostProcessMaterial const& material, uint32_t const tag,
             PostProcessVariant variant = PostProcessVariant::OPAQUE) const {
-        return getMaterialInstanceWithTag(driver, material.getMaterial(engine), tag,
-                Variant::type_t(variant));
+        return getMaterialInstanceWithTag(driver, material.getMaterial(engine), tag, Variant::type_t(variant));
     }
 
+private:
     UboManager* getUboManager() const noexcept;
 
     backend::RenderPrimitiveHandle mFullScreenQuadRph;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -663,7 +663,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianBlurSeparatedPass(
                 generateGaussianWeights(kernel, radius, sigma);
 
                 backend::Viewport const scissor = shadowMap->getScissor();
-                auto const mi = ppm.getMaterialInstanceManager().getMaterialInstance(ma);
+                auto const mi = ppm.getMaterialInstance(driver, ma);
+
                 mi->setScissor(scissor);
                 mi->setParameter("input", hwIn, SamplerParams{
                     .filterMag = SamplerMagFilter::NEAREST,
@@ -734,7 +735,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
 
                 auto& material = ppm.getPostProcessMaterial("vsmMipmap");
                 FMaterial const* const ma = material.getMaterial(engine);
-                auto const mi = ppm.getMaterialInstanceManager().getMaterialInstance(ma);
+                auto const mi = ppm.getMaterialInstance(driver, ma);
 
                 auto const pipeline = ppm.getPipelineState(mi);
                 backend::Viewport const scissor = { 0, 0, dim, dim };


### PR DESCRIPTION
It's incorrect to use the MaterialInstanceManager directly because  it doesn't prepare the programs. Instead we need to go through PostProcessManager.