### PR TITLE
Add colorGrading method to Engine::Builder for default LUT configuration

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -19,6 +19,7 @@
 #include <exception>
 
 #include <filament/Camera.h>
+#include <filament/ColorGrading.h>
 #include <filament/Engine.h>
 #include <filament/MorphTargetBuffer.h>
 
@@ -715,6 +716,15 @@ Java_com_google_android_filament_Engine_nSetBuilderFeature(JNIEnv *env, jclass c
     const char *name = env->GetStringUTFChars(name_, 0);
     builder->feature(name, (bool)value);
     env->ReleaseStringUTFChars(name_, name);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_Engine_nSetBuilderColorGrading(JNIEnv *env, jclass clazz,
+        jlong nativeBuilder, jlong nativeColorGradingBuilder) {
+    Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
+    ColorGrading::Builder const* colorGradingBuilder = (ColorGrading::Builder const*) nativeColorGradingBuilder;
+    builder->colorGrading(*colorGradingBuilder);
 }
 
 extern "C" JNIEXPORT jlong JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -152,6 +152,10 @@ public class ColorGrading {
             mFinalizer = new BuilderFinalizer(mNativeBuilder);
         }
 
+        long getNativeBuilder() {
+            return mNativeBuilder;
+        }
+
         /**
          * Sets the quality level of the color grading. When color grading is implemented using
          * a 3D LUT, the quality level may impact the resolution and bit depth of the backing

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -315,6 +315,17 @@ public class Engine {
         }
 
         /**
+         * Sets the builder used to create the default ColorGrading object.
+         * @param colorGrading Builder used to create the default color grading.
+         * @return A reference to this Builder for chaining calls.
+         */
+        @NonNull
+        public Builder colorGrading(@NonNull ColorGrading.Builder colorGrading) {
+            nSetBuilderColorGrading(mNativeBuilder, colorGrading.getNativeBuilder());
+            return this;
+        }
+
+        /**
          * Creates an instance of Engine
          *
          * @return A newly created <code>Engine</code>, or <code>null</code> if the GPU driver couldn't
@@ -1617,5 +1628,6 @@ public class Engine {
     private static native void nSetBuilderSharedContext(long nativeBuilder, long sharedContext);
     private static native void nSetBuilderPaused(long nativeBuilder, boolean paused);
     private static native void nSetBuilderFeature(long nativeBuilder, String name, boolean value);
+    private static native void nSetBuilderColorGrading(long nativeBuilder, long nativeColorGradingBuilder);
     private static native long nBuilderBuild(long nativeBuilder);
 }

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -19,6 +19,7 @@
 
 
 #include <filament/FilamentAPI.h>
+#include <filament/ColorGrading.h>
 
 #include <backend/DriverEnums.h>
 #include <backend/Platform.h>
@@ -569,6 +570,13 @@ public:
          * @return A reference to this Builder for chaining calls.
          */
         Builder& features(std::initializer_list<char const *> list) noexcept;
+
+        /**
+         * Sets the builder used to create the default ColorGrading object.
+         * @param colorGrading Builder used to create the default color grading.
+         * @return A reference to this Builder for chaining calls.
+         */
+        Builder& colorGrading(ColorGrading::Builder const& colorGrading) noexcept;
 
 #if UTILS_HAS_THREADING
         /**

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -177,6 +177,7 @@ struct Engine::BuilderDetails {
     void* mSharedContext = nullptr;
     bool mPaused = false;
     std::unordered_map<CString, bool> mFeatureFlags;
+    ColorGrading::Builder mColorGradingBuilder;
 
     static Config validateConfig(Config config) noexcept;
 };
@@ -313,7 +314,8 @@ FEngine::FEngine(Builder const& builder) :
         mEngineEpoch(std::chrono::steady_clock::now()),
         mDriverBarrier(1),
         mMainThreadId(ThreadUtils::getThreadId()),
-        mConfig(builder->mConfig)
+        mConfig(builder->mConfig),
+        mColorGradingBuilder(builder->mColorGradingBuilder)
 {
     // update all the features flags specified in the builder
     for (auto const& [feature, value] : builder->mFeatureFlags) {
@@ -523,7 +525,7 @@ void FEngine::init() {
             mUboManager = new UboManager(getDriverApi(), slotSize, mConfig.sharedUboInitialSizeInBytes);
         }
 
-        mDefaultColorGrading = downcast(ColorGrading::Builder().build(*this));
+        mDefaultColorGrading = downcast(mColorGradingBuilder.build(*this));
 
         constexpr float3 dummyPositions[1] = {};
         constexpr short4 dummyTangents[1] = {};
@@ -1883,6 +1885,11 @@ Engine::Builder& Engine::Builder::features(std::initializer_list<char const *> c
             feature(name, true);
         }
     }
+    return *this;
+}
+
+Engine::Builder& Engine::Builder::colorGrading(ColorGrading::Builder const& colorGrading) noexcept {
+    mImpl->mColorGradingBuilder = colorGrading;
     return *this;
 }
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -745,6 +745,7 @@ private:
 
     // Creation parameters
     Config mConfig;
+    ColorGrading::Builder mColorGradingBuilder;
 
     std::vector<std::function<bool()>> mDeferredAsyncObjectDestruction;
 


### PR DESCRIPTION
This change enhances Engine::Builder by adding a colorGrading method that accepts a pre-configured ColorGrading::Builder. This allows developers to explicitly specify the default color grading and tone mapping parameters used to initialize the engine's default color grading instance upon startup, rather than relying on an unconfigurable default.

In addition to the core C++ implementation, this API is fully exposed in the Java/JNI bindings on Engine.Builder.

Key changes:
- C++: Declare colorGrading(ColorGrading::Builder const&) on Engine::Builder and update FEngine constructor and init() to evaluate and build the user-configured default LUT.
- Java: Expose colorGrading(ColorGrading.Builder) on Engine.Builder and add package-private getNativeBuilder() to ColorGrading.Builder.
- JNI: Implement nSetBuilderColorGrading wrapper in Engine.cpp.