### PR TITLE
Refactor: Replace Component Instances with Entities in SoAs

### DIFF
--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -659,13 +659,12 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
     Slice<FroxelThreadData> froxelThreadData = mFroxelShardedData;
     memset(froxelThreadData.data(), 0, froxelThreadData.sizeInBytes());
 
-    auto& lcm = engine.getLightManager();
     auto const* UTILS_RESTRICT spheres      = lightData.data<FScene::POSITION_RADIUS>();
     auto const* UTILS_RESTRICT directions   = lightData.data<FScene::DIRECTION>();
-    auto const* UTILS_RESTRICT instances    = lightData.data<FScene::LIGHT_INSTANCE>();
+    auto const* UTILS_RESTRICT spotParams   = lightData.data<FScene::SPOT_PARAMS>();
 
     auto process = [ this, &froxelThreadData,
-                     spheres, directions, instances, &viewMatrix, &lcm ]
+                     spheres, directions, spotParams, &viewMatrix ]
             (size_t const count, size_t const offset, size_t const stride) {
 
         FILAMENT_TRACING_NAME(FILAMENT_TRACING_CATEGORY_FILAMENT, "FroxelizeLoop Job");
@@ -680,12 +679,12 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
 
         for (size_t i = offset; i < count; i += stride) {
             const size_t j = i + FScene::DIRECTIONAL_LIGHTS_COUNT;
-            FLightManager::Instance const li = instances[j];
+            float2 const params = spotParams[j];
             LightParams light = {
                     .position = (viewMatrix * float4{ spheres[j].xyz, 1 }).xyz,     // to view-space
-                    .cosSqr = std::min(maxCosSquared, lcm.getCosOuterSquared(li)),  // spot only
+                    .cosSqr = std::min(maxCosSquared, params.x),                    // spot only
                     .axis = vn * directions[j],                                     // spot only
-                    .invSin = lcm.getSinInverse(li),                                // spot only
+                    .invSin = params.y,                                             // spot only
                     .radius = spheres[j].w,
             };
             // infinity means "point-light"

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -134,7 +134,8 @@ ShadowMap::ShaderParameters ShadowMap::updateDirectional(FEngine& engine,
     mHasVisibleShadows = false;
 
     FLightManager const& lcm = engine.getLightManager();
-    FLightManager::Instance const li = lightData.elementAt<FScene::LIGHT_INSTANCE>(index);
+    Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(index);
+    FLightManager::Instance const li = lcm.getInstance(entity);
     FLightManager::ShadowParams const params = lcm.getShadowParams(li);
 
     const auto direction = lightData.elementAt<FScene::SHADOW_DIRECTION>(index);
@@ -271,7 +272,7 @@ ShadowMap::ShaderParameters ShadowMap::updateDirectional(FEngine& engine,
 
 ShadowMap::ShaderParameters ShadowMap::updatePunctual(
         mat4f const& Mv, float const outerConeAngle, float const nearPlane, float const farPlane,
-        const ShadowMapInfo& shadowMapInfo, const FLightManager::ShadowParams& params) noexcept {
+        const ShadowMapInfo& shadowMapInfo, FLightManager::ShadowParams const& params) noexcept {
     const mat4f Mp = mat4f::perspective(
             outerConeAngle * f::RAD_TO_DEG * 2.0f, 1.0f, nearPlane, farPlane);
 
@@ -330,14 +331,15 @@ ShadowMap::ShaderParameters ShadowMap::updateSpot(FEngine& engine,
         const FScene::LightSoa& lightData, size_t index,
         CameraInfo const&,
         const ShadowMapInfo& shadowMapInfo,
-        FScene const& scene, SceneInfo sceneInfo) noexcept {
+        FScene::RenderableSoa const& renderableData, SceneInfo sceneInfo) noexcept {
 
-    auto& lcm = engine.getLightManager();
-    auto position   = lightData.elementAt<FScene::POSITION_RADIUS>(index).xyz;
-    auto direction  = lightData.elementAt<FScene::DIRECTION>(index);
-    auto radius     = lightData.elementAt<FScene::POSITION_RADIUS>(index).w;
-    auto li         = lightData.elementAt<FScene::LIGHT_INSTANCE>(index);
-    const FLightManager::ShadowParams& params = lcm.getShadowParams(li);
+    auto const& lcm = engine.getLightManager();
+    auto const position   = lightData.elementAt<FScene::POSITION_RADIUS>(index).xyz;
+    auto const direction  = lightData.elementAt<FScene::DIRECTION>(index);
+    auto const radius     = lightData.elementAt<FScene::POSITION_RADIUS>(index).w;
+    auto const entity     = lightData.elementAt<FScene::LIGHT_ENTITY>(index);
+    auto const li         = lcm.getInstance(entity);
+    FLightManager::ShadowParams const& params = lcm.getShadowParams(li);
     const mat4f Mv = getDirectionalLightViewMatrix(direction, { 0, 1, 0 }, position);
 
     // We only keep this for reference. updateSceneInfoSpot() is quite expensive on large scenes
@@ -347,7 +349,7 @@ ShadowMap::ShaderParameters ShadowMap::updateSpot(FEngine& engine,
     //       by the light -- which should be much smaller.
     if constexpr (false) {
         // find decent near/far
-        updateSceneInfoSpot(Mv, scene, sceneInfo);
+        updateSceneInfoSpot(Mv, renderableData, sceneInfo);
     } else {
         sceneInfo.lsCastersNearFar = { -0.01f, -radius };
     }
@@ -368,11 +370,10 @@ ShadowMap::ShaderParameters ShadowMap::updateSpot(FEngine& engine,
 
 ShadowMap::ShaderParameters ShadowMap::updatePoint(FEngine& engine,
         const FScene::LightSoa& lightData, size_t const index, CameraInfo const&,
-        const ShadowMapInfo& shadowMapInfo, FScene const& scene, uint8_t face) noexcept {
+        const ShadowMapInfo& shadowMapInfo, FScene::RenderableSoa const& soa, uint8_t face) noexcept {
 
     // check if this shadow map has anything to render
     mHasVisibleShadows = false;
-    FScene::RenderableSoa const& UTILS_RESTRICT soa = scene.getRenderableData();
     auto const* const UTILS_RESTRICT visibleMasks = soa.data<FScene::VISIBLE_MASK>();
     size_t const c = soa.size();
     for (size_t i = 0; i < c; i++) {
@@ -385,11 +386,12 @@ ShadowMap::ShaderParameters ShadowMap::updatePoint(FEngine& engine,
         return {};
     }
 
-    auto& lcm = engine.getLightManager();
-    auto position   = lightData.elementAt<FScene::POSITION_RADIUS>(index).xyz;
-    auto radius     = lightData.elementAt<FScene::POSITION_RADIUS>(index).w;
-    auto li         = lightData.elementAt<FScene::LIGHT_INSTANCE>(index);
-    const FLightManager::ShadowParams& params = lcm.getShadowParams(li);
+    auto const& lcm = engine.getLightManager();
+    auto const position   = lightData.elementAt<FScene::POSITION_RADIUS>(index).xyz;
+    auto const radius     = lightData.elementAt<FScene::POSITION_RADIUS>(index).w;
+    auto const entity     = lightData.elementAt<FScene::LIGHT_ENTITY>(index);
+    auto const li         = lcm.getInstance(entity);
+    FLightManager::ShadowParams const& params = lcm.getShadowParams(li);
     const mat4f Mv = getPointLightViewMatrix(TextureCubemapFace(face), position);
     return updatePunctual(Mv, 45.0f * f::DEG_TO_RAD, 0.01f, radius, shadowMapInfo, params);
 }
@@ -799,7 +801,7 @@ float4 ShadowMap::computeBoundingSphere(float3 const* vertices, size_t count) no
 Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
         float3 const* wsVertices, size_t const count) noexcept {
     Aabb bounds{};
-    Slice<const float3> vertices{ wsVertices, count };
+    Slice<const float3> const vertices{ wsVertices, count };
     for (auto const& vertice : vertices) {
         const float3 v = mat4f::project(lightView, vertice);
         bounds.min.xy = min(bounds.min.xy, v.xy);
@@ -1185,11 +1187,10 @@ float2 ShadowMap::texelSizeWorldSpace(mat4f const& S, uint16_t const shadowDimen
 }
 
 template<typename Visitor>
-void ShadowMap::visitScene(const FScene& scene, uint32_t const visibleLayers, Visitor visitor) noexcept {
+void ShadowMap::visitScene(FScene::RenderableSoa const& soa, uint32_t const visibleLayers, Visitor visitor) noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     using State = FRenderableManager::Visibility;
-    FScene::RenderableSoa const& soa = scene.getRenderableData();
     float3 const* const worldAABBCenter = soa.data<FScene::WORLD_AABB_CENTER>();
     float3 const* const worldAABBExtent = soa.data<FScene::WORLD_AABB_EXTENT>();
     uint8_t const* const layers = soa.data<FScene::LAYERS>();
@@ -1208,7 +1209,7 @@ void ShadowMap::visitScene(const FScene& scene, uint32_t const visibleLayers, Vi
 }
 
 ShadowMap::SceneInfo::SceneInfo(
-        FScene const& scene, uint8_t const visibleLayers) noexcept
+        FScene::RenderableSoa const& soa, uint8_t const visibleLayers) noexcept
         : visibleLayers(visibleLayers) {
 
     // the code below only works with affine transforms
@@ -1220,7 +1221,7 @@ ShadowMap::SceneInfo::SceneInfo(
     // Compute scene bounds in world space, as well as the light-space and view-space near/far planes
     wsShadowCastersVolume = {};
     wsShadowReceiversVolume = {};
-    visitScene(scene, visibleLayers,
+    visitScene(soa, visibleLayers,
             [this](Aabb const& aabb, Culler::result_type, FRenderableManager::Visibility const visibility) {
                 if (visibility.castShadows) {
                     wsShadowCastersVolume.min = min(wsShadowCastersVolume.min, aabb.min);
@@ -1234,7 +1235,7 @@ ShadowMap::SceneInfo::SceneInfo(
     );
 }
 
-void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene const& scene,
+void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene::RenderableSoa const& renderableData,
         SceneInfo& sceneInfo) {
 
     // the code below only works with affine transforms
@@ -1242,7 +1243,7 @@ void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene const& scene,
 
     sceneInfo.lsCastersNearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
     sceneInfo.lsReceiversNearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
-    visitScene(scene, sceneInfo.visibleLayers,
+    visitScene(renderableData, sceneInfo.visibleLayers,
             [&](Aabb const& aabb, Culler::result_type const vis, FRenderableManager::Visibility const visibility) {
                 if (visibility.castShadows) {
                     auto const r = Aabb::transform(Mv.upperLeft(), Mv[3].xyz, aabb);
@@ -1253,7 +1254,7 @@ void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene const& scene,
                     // account only for objects that are visible by the camera
                     constexpr auto mask = 1u << VISIBLE_RENDERABLE_BIT;
                     if ((vis & mask) == mask) {
-                        auto r = Aabb::transform(Mv.upperLeft(), Mv[3].xyz, aabb);
+                        auto const r = Aabb::transform(Mv.upperLeft(), Mv[3].xyz, aabb);
                         sceneInfo.lsReceiversNearFar.x = max(sceneInfo.lsReceiversNearFar.x, r.max.z);
                         sceneInfo.lsReceiversNearFar.y = min(sceneInfo.lsReceiversNearFar.y, r.min.z);
                     }
@@ -1262,7 +1263,7 @@ void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene const& scene,
     );
 }
 
-void ShadowMap::updateSceneInfoSpot(mat4f const& Mv, FScene const& scene,
+void ShadowMap::updateSceneInfoSpot(mat4f const& Mv, FScene::RenderableSoa const& renderableData,
         SceneInfo& sceneInfo) {
 
     // the code below only works with affine transforms
@@ -1270,7 +1271,7 @@ void ShadowMap::updateSceneInfoSpot(mat4f const& Mv, FScene const& scene,
 
     sceneInfo.lsCastersNearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
     // account only for objects that are visible by both the camera and the light
-    visitScene(scene, sceneInfo.visibleLayers,
+    visitScene(renderableData, sceneInfo.visibleLayers,
             [&](Aabb const& aabb, Culler::result_type const vis, FRenderableManager::Visibility const visibility) {
                 if (visibility.castShadows) {
                     constexpr auto mask = VISIBLE_DYN_SHADOW_RENDERABLE;

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -106,7 +106,7 @@ public:
     struct SceneInfo {
 
         SceneInfo() noexcept = default;
-        SceneInfo(FScene const& scene, uint8_t visibleLayers) noexcept;
+        SceneInfo(FScene::RenderableSoa const& renderableData, uint8_t visibleLayers) noexcept;
 
         // scratch data: light's near/far expressed in light-space, calculated from the scene's
         // content assuming the light is at the origin.
@@ -150,12 +150,12 @@ public:
     ShaderParameters updateSpot(FEngine& engine,
             const FScene::LightSoa& lightData, size_t index,
             CameraInfo const& camera,
-            const ShadowMapInfo& shadowMapInfo, FScene const& scene,
+            const ShadowMapInfo& shadowMapInfo, FScene::RenderableSoa const& renderableData,
             SceneInfo sceneInfo) noexcept;
 
     ShaderParameters updatePoint(FEngine& engine,
             const FScene::LightSoa& lightData, size_t index, CameraInfo const& camera,
-            const ShadowMapInfo& shadowMapInfo, FScene const& scene, uint8_t face) noexcept;
+            const ShadowMapInfo& shadowMapInfo, FScene::RenderableSoa const& renderableData, uint8_t face) noexcept;
 
     // Do we have visible shadows. Valid after calling update().
     bool hasVisibleShadows() const noexcept { return mHasVisibleShadows; }
@@ -167,10 +167,10 @@ public:
     FCamera const* getDebugCamera() const noexcept { return mDebugCamera; }
 
     // Update SceneInfo struct for a given light
-    static void updateSceneInfoDirectional(const math::mat4f& Mv, FScene const& scene,
+    static void updateSceneInfoDirectional(const math::mat4f& Mv, FScene::RenderableSoa const& renderableData,
             SceneInfo& sceneInfo);
 
-    static void updateSceneInfoSpot(const math::mat4f& Mv, FScene const& scene,
+    static void updateSceneInfoSpot(const math::mat4f& Mv, FScene::RenderableSoa const& renderableData,
             SceneInfo& sceneInfo);
 
     LightManager::ShadowOptions const& getShadowOptions() const noexcept {
@@ -277,7 +277,7 @@ private:
             math::float3 const* vertices, size_t count) noexcept;
 
     template<typename Visitor>
-    static void visitScene(FScene const& scene, uint32_t visibleLayers, Visitor visitor) noexcept;
+    static void visitScene(FScene::RenderableSoa const& soa, uint32_t visibleLayers, Visitor visitor) noexcept;
 
     static inline Aabb compute2DBounds(const math::mat4f& lightView,
             math::float3 const* wsVertices, size_t count) noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -175,7 +175,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
     calculateTextureRequirements(engine, view, lightData);
 
     // Compute scene-dependent values shared across all shadow maps
-    ShadowMap::SceneInfo const info{ *view.getScene(), view.getVisibleLayers() };
+    ShadowMap::SceneInfo const info{ view.getScene()->getRenderableData(), view.getVisibleLayers() };
 
     shadowTechnique |= updateCascadeShadowMaps(
             engine, view, cameraInfo, renderableData, lightData, info);
@@ -207,8 +207,8 @@ ShadowMapManager::Builder& ShadowMapManager::Builder::directionalShadowMap(size_
 ShadowMapManager::Builder& ShadowMapManager::Builder::shadowMap(size_t const lightIndex, bool const spotlight,
         LightManager::ShadowOptions const* options) noexcept {
     if (spotlight) {
-        const size_t c = mSpotShadowMapCount++;
-        const size_t i = c + CONFIG_MAX_SHADOW_CASCADES;
+        size_t const c = mSpotShadowMapCount++;
+        size_t const i = c + CONFIG_MAX_SHADOW_CASCADES;
         assert_invariant(i < CONFIG_MAX_SHADOWMAPS);
         mShadowMaps.push_back({
                 .lightIndex = lightIndex,
@@ -219,8 +219,8 @@ ShadowMapManager::Builder& ShadowMapManager::Builder::shadowMap(size_t const lig
     } else {
         // point-light, generate 6 independent shadowmaps
         for (size_t face = 0; face < 6; face++) {
-            const size_t c = mSpotShadowMapCount++;
-            const size_t i = c + CONFIG_MAX_SHADOW_CASCADES;
+            size_t const c = mSpotShadowMapCount++;
+            size_t const i = c + CONFIG_MAX_SHADOW_CASCADES;
             assert_invariant(i < CONFIG_MAX_SHADOWMAPS);
             mShadowMaps.push_back({
                     .lightIndex = lightIndex,
@@ -263,7 +263,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
         FixedCapacityVector<ShadowPass> passList;
     };
 
-    auto& prepareShadowPass = fg.addPass<PrepareShadowPassData>("Prepare Shadow Pass",
+    auto const& prepareShadowPass = fg.addPass<PrepareShadowPassData>("Prepare Shadow Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.passList.reserve(getMaxShadowMapCount());
                 data.shadows = builder.createTexture("Shadowmap", {
@@ -345,7 +345,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
             [=, this,
                     passBuilder = passBuilder,
                     &engine = const_cast<FEngine /*const*/ &>(engine), // FIXME: we want this const
-                    &view = const_cast<FView const&>(view)]
+                    &view = view]
                     (FrameGraphResources const&, auto const& data, DriverApi& driver) mutable {
 
                 // Note: we could almost parallel_for the loop below, the problem currently is
@@ -468,8 +468,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
     while (first != passList.end()) {
         auto const& entry = *first;
 
-        const uint8_t layer = entry.shadowMap->getLayer();
-        const auto msaaSamples = textureRequirements.msaaSamples;
+        uint8_t const layer = entry.shadowMap->getLayer();
+        auto const msaaSamples = textureRequirements.msaaSamples;
 
         auto last = first;
         // loop over each shadow pass to find its layer range
@@ -480,7 +480,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
         assert_invariant(mFeatureShadowAllocator || std::distance(first, last) == 1);
 
         // And render all shadow pass of a given layer as a single render pass
-        auto& shadowPass = fg.addPass<ShadowPassData>("Shadow Pass",
+        auto const& shadowPass = fg.addPass<ShadowPassData>("Shadow Pass",
                 [&](FrameGraph::Builder& builder, auto& data) {
 
                     FrameGraphRenderPass::Descriptor renderTargetDesc{};
@@ -627,7 +627,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianBlurSeparatedPass(
         [=, &engine](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
             using FGTSD = FrameGraphTexture::SubResourceDescriptor;
             FGTSD const& inSubDesc = resources.getSubResourceDescriptor(data.in);
-            auto hwOutRT = resources.getRenderPassInfo(0);
+            auto const hwOutRT = resources.getRenderPassInfo(0);
             auto hwIn = resources.getTexture(data.in);
 
             auto& ppm = engine.getPostProcessManager();
@@ -768,11 +768,12 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         FView& view, CameraInfo cameraInfo, FScene::RenderableSoa& renderableData,
         FScene::LightSoa const& lightData, ShadowMap::SceneInfo sceneInfo) noexcept {
 
-    FScene const* const scene = view.getScene();
-    auto const& vsmShadowOptions = view.getVsmShadowOptions();
-    auto& lcm = engine.getLightManager();
 
-    FLightManager::Instance const directionalLight = lightData.elementAt<FScene::LIGHT_INSTANCE>(0);
+    auto const& vsmShadowOptions = view.getVsmShadowOptions();
+    auto const& lcm = engine.getLightManager();
+
+    Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(0);
+    FLightManager::Instance const directionalLight = lcm.getInstance(entity);
     FLightManager::ShadowOptions const& options = lcm.getShadowOptions(directionalLight);
     FLightManager::ShadowParams const& params = lcm.getShadowParams(directionalLight);
 
@@ -782,7 +783,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         updateNearFarPlanes(&cameraInfo.cullingProjection, cameraInfo.zn, cameraInfo.zf);
     }
 
-    const ShadowMap::ShadowMapInfo shadowMapInfo{
+    ShadowMap::ShadowMapInfo const shadowMapInfo{
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options.mapSize),
             .shadowDimension     = uint16_t(options.mapSize - 2u),
@@ -808,7 +809,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
                 normalize(cameraInfo.worldTransform[0].xyz));
 
         // Compute scene-dependent values shared across all cascades
-        ShadowMap::updateSceneInfoDirectional(MvAtOrigin, *scene, sceneInfo);
+        ShadowMap::updateSceneInfoDirectional(MvAtOrigin, view.getScene()->getRenderableData(), sceneInfo);
 
         // we always do culling without depth clamp, because objects behind the camera
         // must be rendered regardless
@@ -880,7 +881,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             mCascadesShaderParameters[i] = shaderParameters;
 
             if (shadowMap.hasVisibleShadows()) {
-                const size_t shadowIndex = shadowMap.getShadowIndex();
+                size_t const shadowIndex = shadowMap.getShadowIndex();
                 assert_invariant(shadowIndex == i);
 
                 // Texel size is constant for directional light (although that's not true when LISPSM
@@ -928,7 +929,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         .cascades = cascades,
         .atlasResolution = { mTextureAtlasRequirements.size, 1.0f / float(mTextureAtlasRequirements.size) }
     };
-    
+
     return shadowTechnique;
 }
 
@@ -958,12 +959,12 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap, FEngine& engin
         CameraInfo const& mainCameraInfo,
         FScene::LightSoa const& lightData, ShadowMap::SceneInfo const& sceneInfo) noexcept {
 
-    const size_t lightIndex = shadowMap.getLightIndex();
+    size_t const lightIndex = shadowMap.getLightIndex();
     FLightManager::ShadowOptions const& options = shadowMap.getShadowOptions();
     auto const& vsmShadowOptions = view.getVsmShadowOptions();
 
     // update the shadow map frustum/camera
-    const ShadowMap::ShadowMapInfo shadowMapInfo{
+    ShadowMap::ShadowMapInfo const shadowMapInfo{
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options.mapSize),
             .shadowDimension     = uint16_t(options.mapSize - 2u),
@@ -973,12 +974,12 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap, FEngine& engin
             .vsm                 = view.hasVSM()
     };
 
-    auto shaderParameters = shadowMap.updateSpot(engine,
-            lightData, lightIndex, mainCameraInfo, shadowMapInfo, *view.getScene(), sceneInfo);
+    auto const shaderParameters = shadowMap.updateSpot(engine,
+            lightData, lightIndex, mainCameraInfo, shadowMapInfo, view.getScene()->getRenderableData(), sceneInfo);
 
     // and if we need to generate it, update all the UBO data
     if (shadowMap.hasVisibleShadows()) {
-        const size_t shadowIndex = shadowMap.getShadowIndex();
+        size_t const shadowIndex = shadowMap.getShadowIndex();
         const float2 wsTexelSizeAtOneMeter = shaderParameters.texelSizeAtOneMeterWs;
         // note: normalBias is set to zero for VSM
         const float normalBias = shadowMapInfo.vsm ? 0.0f : options.normalBias;
@@ -1005,10 +1006,11 @@ void ShadowMapManager::cullSpotShadowMap(ShadowMap const& shadowMap,
         FEngine const& engine, FView const& view,
         FScene::RenderableSoa& renderableData, Range<uint32_t> range,
         FScene::LightSoa const& lightData) noexcept {
-    auto& lcm = engine.getLightManager();
+    auto const& lcm = engine.getLightManager();
 
-    const size_t lightIndex = shadowMap.getLightIndex();
-    const FLightManager::Instance li = lightData.elementAt<FScene::LIGHT_INSTANCE>(lightIndex);
+    size_t const lightIndex = shadowMap.getLightIndex();
+    Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(lightIndex);
+    FLightManager::Instance const li = lcm.getInstance(entity);
 
     // compute the frustum for this light
     // for spotlights, we cull shadow casters first because we already know the frustum,
@@ -1051,13 +1053,13 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
         FEngine& engine, FView& view, CameraInfo const& mainCameraInfo,
         FScene::LightSoa const& lightData) const noexcept {
 
-    const uint8_t face = shadowMap.getFace();
-    const size_t lightIndex = shadowMap.getLightIndex();
+    uint8_t const face = shadowMap.getFace();
+    size_t const lightIndex = shadowMap.getLightIndex();
     FLightManager::ShadowOptions const& options = shadowMap.getShadowOptions();
     auto const& vsmShadowOptions = view.getVsmShadowOptions();
 
     // update the shadow map frustum/camera
-    const ShadowMap::ShadowMapInfo shadowMapInfo{
+    ShadowMap::ShadowMapInfo const shadowMapInfo{
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options.mapSize),
             .shadowDimension     = uint16_t(options.mapSize), // point-lights don't have a border
@@ -1067,12 +1069,12 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
             .vsm                 = view.hasVSM()
     };
 
-    auto shaderParameters = shadowMap.updatePoint(engine, lightData, lightIndex,
-            mainCameraInfo, shadowMapInfo, *view.getScene(), face);
+    auto const shaderParameters = shadowMap.updatePoint(engine, lightData, lightIndex,
+            mainCameraInfo, shadowMapInfo, view.getScene()->getRenderableData(), face);
 
     // and if we need to generate it, update all the UBO data
     if (shadowMap.hasVisibleShadows()) {
-        const size_t shadowIndex = shadowMap.getShadowIndex();
+        size_t const shadowIndex = shadowMap.getShadowIndex();
         const float2 wsTexelSizeAtOneMeter = shaderParameters.texelSizeAtOneMeterWs;
         // note: normalBias is set to zero for VSM
         const float normalBias = shadowMapInfo.vsm ? 0.0f : options.normalBias;
@@ -1149,7 +1151,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
     if (!spotShadowMaps.empty()) {
         shadowTechnique |= ShadowTechnique::SHADOW_MAP;
         for (ShadowMap const& shadowMap : spotShadowMaps) {
-            const size_t lightIndex = shadowMap.getLightIndex();
+            size_t const lightIndex = shadowMap.getLightIndex();
             // Gather the per-light (not per shadow map) information. For point lights we will
             // "see" 6 shadowmaps (one per face), we must use the first face one, the shader
             // knows how to find the entry for other faces (they're guaranteed to be sequential).
@@ -1161,11 +1163,12 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
     }
 
     // screen-space contact shadows for point/spotlights
-    auto& lcm = engine.getLightManager();
-    auto *pLightInstances = lightData.data<FScene::LIGHT_INSTANCE>();
+    auto const& lcm = engine.getLightManager();
+    auto const* pLightEntities = lightData.data<FScene::LIGHT_ENTITY>();
     for (size_t i = 0, c = lightData.size(); i < c; i++) {
         // screen-space contact shadows
-        LightManager::ShadowOptions const& shadowOptions = lcm.getShadowOptions(pLightInstances[i]);
+        Entity const entity = pLightEntities[i];
+        LightManager::ShadowOptions const& shadowOptions = lcm.getShadowOptions(lcm.getInstance(entity));
         if (shadowOptions.screenSpaceContactShadows) {
             shadowTechnique |= ShadowTechnique::SCREEN_SPACE;
             shadowInfo[i].contactShadows = true;
@@ -1202,7 +1205,7 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
         ShadowMap* pShadowMap) mutable {
         // Allocate shadowmap from our Atlas Allocator
         auto const& options = pShadowMap->getShadowOptions();
-        auto allocation = allocator.allocate(options.mapSize);
+        auto const allocation = allocator.allocate(options.mapSize);
         assert_invariant(allocation.isValid());
         assert_invariant(!allocation.viewport.empty());
         pShadowMap->setAllocation(allocation.layer, allocation.viewport);

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -224,7 +224,7 @@ void FScene::prepare(JobSystem& js,
             size_t const index = std::distance(first, p) + i;
             assert_invariant(index < sceneData.size());
 
-            sceneData.elementAt<RENDERABLE_INSTANCE>(index) = ri;
+            sceneData.elementAt<RENDERABLE_ENTITY>(index) = rcm.getEntity(ri);
             sceneData.elementAt<WORLD_TRANSFORM>(index)     = shaderWorldTransform;
             sceneData.elementAt<VISIBILITY_STATE>(index)    = visibility;
             sceneData.elementAt<SKINNING_BUFFER>(index)     = rcm.getSkinningBufferInfo(ri);
@@ -245,8 +245,7 @@ void FScene::prepare(JobSystem& js,
         }
     };
 
-    auto lightWork = [first = lightInstances.data(), &lcm, &tcm, &worldTransform,
-            &lightData](auto* p, auto c) {
+    auto lightWork = [first = lightInstances.data(), &lcm, &tcm, &worldTransform, &lightData](auto* p, auto c) {
         FILAMENT_TRACING_NAME(FILAMENT_TRACING_CATEGORY_FILAMENT, "lightWork");
         for (size_t i = 0; i < c; i++) {
             auto [li, ti] = p[i];
@@ -264,7 +263,8 @@ void FScene::prepare(JobSystem& js,
             assert_invariant(index < lightData.size());
             lightData.elementAt<POSITION_RADIUS>(index) = float4{ position.xyz, lcm.getRadius(li) };
             lightData.elementAt<DIRECTION>(index) = d;
-            lightData.elementAt<LIGHT_INSTANCE>(index) = li;
+            lightData.elementAt<SPOT_PARAMS>(index) = float2{lcm.getCosOuterSquared(li), lcm.getSinInverse(li)};
+            lightData.elementAt<LIGHT_ENTITY>(index) = li ? lcm.getEntity(li) : utils::Entity{};
         }
     };
 
@@ -326,9 +326,9 @@ void FScene::prepare(JobSystem& js,
         lightData.elementAt<DIRECTION>(0) = normalize(d);
         lightData.elementAt<SHADOW_DIRECTION>(0) = normalize(s);
         lightData.elementAt<SHADOW_REF>(0) = lsReferencePoint;
-        lightData.elementAt<LIGHT_INSTANCE>(0) = li;
+        lightData.elementAt<LIGHT_ENTITY>(0) = li ? lcm.getEntity(li) : utils::Entity{};
     } else {
-        lightData.elementAt<LIGHT_INSTANCE>(0) = 0;
+        lightData.elementAt<LIGHT_ENTITY>(0) = utils::Entity{};
     }
 
     // some elements past the end of the array will be accessed by SIMD code, we need to make
@@ -366,7 +366,7 @@ void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables) noexc
         auto const visibility = sceneData.elementAt<VISIBILITY_STATE>(i);
         auto const skinning = sceneData.elementAt<SKINNING_STATE>(i);
         auto const& model = sceneData.elementAt<WORLD_TRANSFORM>(i);
-        auto const ri = sceneData.elementAt<RENDERABLE_INSTANCE>(i);
+        auto const ri = mEngine.getRenderableManager().getInstance(sceneData.elementAt<RENDERABLE_ENTITY>(i));
 
         // Using mat3f::getTransformForNormals handles non-uniform scaling, but DOESN'T guarantee that
         // the transformed normals will have unit-length, therefore they need to be normalized
@@ -438,11 +438,11 @@ void FScene::prepareDynamicLights(const CameraInfo& camera,
     LightsUib* const lp = driver.allocatePod<LightsUib>(positionalLightCount);
 
     auto const* UTILS_RESTRICT directions       = lightData.data<DIRECTION>();
-    auto const* UTILS_RESTRICT instances        = lightData.data<LIGHT_INSTANCE>();
+    auto const* UTILS_RESTRICT entities         = lightData.data<LIGHT_ENTITY>();
     auto const* UTILS_RESTRICT shadowInfo       = lightData.data<SHADOW_INFO>();
     for (size_t i = DIRECTIONAL_LIGHTS_COUNT, c = size; i < c; ++i) {
         const size_t gpuIndex = i - DIRECTIONAL_LIGHTS_COUNT;
-        auto const li = instances[i];
+        auto const li = lcm.getInstance(entities[i]);
         lp[gpuIndex].positionFalloff      = { spheres[i].xyz, lcm.getSquaredFalloffInv(li) };
         lp[gpuIndex].direction            = directions[i];
         lp[gpuIndex].reserved1            = {};
@@ -564,11 +564,11 @@ bool FScene::hasContactShadows() const noexcept {
     // find out if at least one light has contact-shadow enabled
     // TODO: we could cache the result of this Loop in the LightManager
     auto const& lcm = mEngine.getLightManager();
-    const auto *pFirst = mLightData.begin<LIGHT_INSTANCE>();
-    const auto *pLast = mLightData.end<LIGHT_INSTANCE>();
+    const auto *pFirst = mLightData.begin<LIGHT_ENTITY>();
+    const auto *pLast = mLightData.end<LIGHT_ENTITY>();
     while (pFirst != pLast) {
-        if (pFirst->isValid()) {
-            auto const& shadowOptions = lcm.getShadowOptions(*pFirst);
+        if (!pFirst->isNull()) {
+            auto const& shadowOptions = lcm.getShadowOptions(lcm.getInstance(*pFirst));
             if (shadowOptions.screenSpaceContactShadows) {
                 return true;
             }

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -80,7 +80,7 @@ public:
     using VisibleMaskType = Culler::result_type;
 
     enum {
-        RENDERABLE_INSTANCE,    //   4 | instance of the Renderable component
+        RENDERABLE_ENTITY,      //   4 | Entity of the Renderable component
         WORLD_TRANSFORM,        //  16 | instance of the Transform component
         VISIBILITY_STATE,       //   2 | visibility data of the component
         SKINNING_STATE,         //   1 | skinning data of the component
@@ -106,7 +106,7 @@ public:
     };
 
     using RenderableSoa = utils::StructureOfArrays<
-            utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
+            utils::Entity,                              // RENDERABLE_ENTITY
             math::mat4f,                                // WORLD_TRANSFORM
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             FRenderableManager::Skinning,               // SKINNING_STATE
@@ -159,7 +159,8 @@ public:
         DIRECTION,
         SHADOW_DIRECTION,
         SHADOW_REF,
-        LIGHT_INSTANCE,
+        LIGHT_ENTITY,
+        SPOT_PARAMS,
         VISIBILITY,
         SCREEN_SPACE_Z_RANGE,
         SHADOW_INFO
@@ -170,7 +171,8 @@ public:
             math::float3,
             math::float3,
             math::double2,
-            FLightManager::Instance,
+            utils::Entity,
+            math::float2,
             Culler::result_type,
             math::float2,
             ShadowInfo

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -421,7 +421,8 @@ void FView::prepareShadowing(FEngine& engine, DriverApi& driver,
     ShadowMapManager::Builder builder;
 
     // dominant directional light is always as index 0
-    FLightManager::Instance const directionalLight = lightData.elementAt<FScene::LIGHT_INSTANCE>(0);
+    utils::Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(0);
+    FLightManager::Instance const directionalLight = engine.getLightManager().getInstance(entity);
     const bool hasDirectionalShadows = directionalLight && lcm.isShadowCaster(directionalLight);
     if (UTILS_UNLIKELY(hasDirectionalShadows)) {
         const auto& shadowOptions = lcm.getShadowOptions(directionalLight);
@@ -441,7 +442,8 @@ void FView::prepareShadowing(FEngine& engine, DriverApi& driver,
         // when we get here all the lights should be visible
         assert_invariant(lightData.elementAt<FScene::VISIBILITY>(l));
 
-        FLightManager::Instance const li = lightData.elementAt<FScene::LIGHT_INSTANCE>(l);
+        utils::Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(l);
+        FLightManager::Instance const li = lcm.getInstance(entity);
 
         if (UTILS_LIKELY(!li)) {
             continue; // invalid instance
@@ -528,7 +530,8 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
      * Directional light (always at index 0)
      */
 
-    FLightManager::Instance const directionalLight = lightData.elementAt<FScene::LIGHT_INSTANCE>(0);
+    utils::Entity const entity = lightData.elementAt<FScene::LIGHT_ENTITY>(0);
+    FLightManager::Instance const directionalLight = engine.getLightManager().getInstance(entity);
     const float3 sceneSpaceDirection = lightData.elementAt<FScene::DIRECTION>(0); // guaranteed normalized
     getColorPassDescriptorSet().prepareDirectionalLight(engine, exposure, sceneSpaceDirection, directionalLight);
 }
@@ -776,7 +779,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         // we also know if we have a directional light
         FLightManager::Instance const directionalLight =
-                lightData.elementAt<FScene::LIGHT_INSTANCE>(0);
+                engine.getLightManager().getInstance(lightData.elementAt<FScene::LIGHT_ENTITY>(0));
         mHasDirectionalLighting = directionalLight.isValid();
 
         // As soon as prepareVisibleLight finishes, we can kick-off the froxelization
@@ -899,8 +902,8 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
             // FIXME: when only one is active the UBO handle of the other is null
             //        (probably a problem on vulkan)
             if (UTILS_UNLIKELY(skinning.handle || morphing.handle)) {
-                auto const ci = sceneData.elementAt<FScene::RENDERABLE_INSTANCE>(i);
                 FRenderableManager& rcm = engine.getRenderableManager();
+                auto const ci = rcm.getInstance(sceneData.elementAt<FScene::RENDERABLE_ENTITY>(i));
                 auto& descriptorSet = rcm.getDescriptorSet(ci);
 
                 auto const& layout = engine.getPerRenderableDescriptorSetLayout();
@@ -1344,7 +1347,7 @@ void FView::prepareVisibleLights(FLightManager const& lcm,
 
     auto const* UTILS_RESTRICT sphereArray     = lightData.data<FScene::POSITION_RADIUS>();
     auto const* UTILS_RESTRICT directions      = lightData.data<FScene::DIRECTION>();
-    auto const* UTILS_RESTRICT instanceArray   = lightData.data<FScene::LIGHT_INSTANCE>();
+    auto const* UTILS_RESTRICT entityArray   = lightData.data<FScene::LIGHT_ENTITY>();
     auto      * UTILS_RESTRICT visibleArray    = lightData.data<FScene::VISIBILITY>();
 
     Culler::intersects(visibleArray, frustum, sphereArray, lightData.size());
@@ -1354,7 +1357,7 @@ void FView::prepareVisibleLights(FLightManager const& lcm,
     size_t visibleLightCount = FScene::DIRECTIONAL_LIGHTS_COUNT;
     // skip directional light
     for (size_t i = FScene::DIRECTIONAL_LIGHTS_COUNT; i < lightData.size(); i++) {
-        FLightManager::Instance const li = instanceArray[i];
+        FLightManager::Instance const li = lcm.getInstance(entityArray[i]);
         if (visibleArray[i]) {
             if (!lcm.isLightCaster(li)) {
                 visibleArray[i] = 0;
@@ -1449,7 +1452,7 @@ void FView::updatePrimitivesLod(FScene::RenderableSoa& renderableData,
     FRenderableManager const& rcm = engine.getRenderableManager();
     for (uint32_t const index : visible) {
         uint8_t const level = 0; // TODO: pick the proper level of detail
-        auto ri = renderableData.elementAt<FScene::RENDERABLE_INSTANCE>(index);
+        auto ri = rcm.getInstance(renderableData.elementAt<FScene::RENDERABLE_ENTITY>(index));
         renderableData.elementAt<FScene::PRIMITIVES>(index) = rcm.getRenderPrimitives(ri, level);
     }
 }

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -839,18 +839,19 @@ TEST(FilamentTest, FroxelData) {
     EXPECT_FLOAT_EQ(        100,-l.planes[Froxel::FAR].w);
 
     // create a dummy point light that can be referenced in LightSoa
+    auto& lcm = engine->getLightManager();
     Entity e = engine->getEntityManager().create();
     LightManager::Builder(LightManager::Type::POINT).build(*engine, e);
-    LightManager::Instance instance = engine->getLightManager().getInstance(e);
+    LightManager::Instance li = lcm.getInstance(e);
+    float2 const spotParams = float2{lcm.getCosOuterSquared(li), lcm.getSinInverse(li)};
 
     FScene::LightSoa lights;
-    lights.push_back({}, {}, {}, {}, {}, {}, {}, {});   // first one is always skipped
-    lights.push_back(float4{ 0, 0, -5, 1 }, {}, {}, {}, instance, 1, {}, {});
+    lights.push_back({}, {}, {}, {}, {}, {}, {}, {}, {});   // first one is always skipped
+    lights.push_back(float4{ 0, 0, -5, 1 }, {}, {}, {}, e, spotParams, 1, {}, {});
 
     {
         froxelData.froxelizeLights(*engine, {}, lights);
         auto const& froxelBuffer = froxelData.getFroxelBufferUser();
-        auto const& recordBuffer = froxelData.getRecordBufferUser();
         // light straddles the "light near" plane
         size_t pointCount = 0;
         for (const auto& entry : froxelBuffer) {


### PR DESCRIPTION
The gist of this change is to remove the RenderableManager::Instance and LightManager::Instance dependency in SceneData.  Basically, the SceneData (lights and renderable) SoA used to store an Instance to each component, instead we store the Entity itself and we resolve the Instance at the point we need it.  This change makes SceneData immune to adding/removing components.

For some data, we instead copy the component data we need directly into the SoA, for other, we resolve it using the Entity (depending on cost).

This is a pre-requisite to a future change where we want to keep the SceneData around.

There shouldn't be *any* behavior changes.