### PR TITLE
Address VK mem leak on skipFrame

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -432,8 +432,9 @@ void VulkanDriver::tick(int) {
     mCommands.updateFences();
 
     // If the Renderer is skipping a lot of frames, it's possible for
-    // memory to accumulate. This ensures that gc does still run in
-    // these cases.
+    // commands to accumulate, since we only flush command buffers if
+    // driver.flush() is called, or in endFrame(). This ensures that
+    // flush and gc run regularly, even during skipped frames.
     if (++mTicksSinceLastGc == MAX_TICKS_BETWEEN_GC) {
         flush();
         collectGarbage(); // Resets mTicksSinceLastGc to 0.

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -64,6 +64,8 @@ namespace filament::backend {
 
 namespace {
 
+static constexpr uint8_t MAX_TICKS_BETWEEN_GC = 3;
+
 VmaAllocator createAllocator(VkInstance instance, VkPhysicalDevice physicalDevice,
         VkDevice device) {
     VmaAllocator allocator;
@@ -428,6 +430,14 @@ void VulkanDriver::terminate() {
 
 void VulkanDriver::tick(int) {
     mCommands.updateFences();
+
+    // If the Renderer is skipping a lot of frames, it's possible for
+    // memory to accumulate. This ensures that gc does still run in
+    // these cases.
+    if (++mTicksSinceLastGc == MAX_TICKS_BETWEEN_GC) {
+        flush();
+        collectGarbage(); // Resets mTicksSinceLastGc to 0.
+    }
 }
 
 // Garbage collection should not occur too frequently, only about once per frame. Internally, the
@@ -436,6 +446,8 @@ void VulkanDriver::tick(int) {
 // been destroyed for safe destruction, due to outstanding command buffers and triple buffering.
 void VulkanDriver::collectGarbage() {
     FVK_SYSTRACE_SCOPE();
+    mTicksSinceLastGc = 0;
+
     // Command buffers need to be submitted and completed before other resources can be gc'd.
     mCommands.gc();
     mDescriptorSetCache.gc();

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -219,6 +219,8 @@ private:
     uint8_t const mStereoscopicEyeCount;
     backend::AsynchronousMode const mAsynchronousMode;
 
+    uint8_t mTicksSinceLastGc = 0;
+
     // setAcquiredImage is a DECL_DRIVER_API_SYNCHRONOUS_N which means we don't necessarily have the
     // data to process it at call time. So we store it and process it during updateStreams.
     std::vector<resource_ptr<VulkanStream>> mStreamsWithPendingAcquiredImage;


### PR DESCRIPTION
If a lot of frames are being skipped, it's possible for an accumulation of a) unsubmitted command buffer commands, and b) a long period between collectGarbage() calls. This ensures that when frames are skipped, any pending commands are flushed, and if there are a lot of flushes with no gc calls, that gc eventually is called every few ticks.

As per discussion yesterday. Wanted to open up discussion on this change and see if there's a better approach. A couple options considered:
* Adding a skipFrame method to DriverApi, so that backends can do any periodic cleanup they need to do
* Adding a way for engine.gc() to somehow also invoke driver's gc if a backend has a gc method
* Always call collectGarbage() in tick, and remove it from endFrame()
* add flush + gc to tick() if command buffer is still recording

This seemed like the least intrusive approach, that does still ensure that cleanup happens. Note: we can't use the current frame count for the tick count, as it does not advance when skipping frames.