### PR TITLE
fix(ktxreader): Validate Ktx1Bundle::getBlob return in Ktx1Reader::createTexture fixes 

### DIFF
--- a/libs/ktxreader/src/Ktx1Reader.cpp
+++ b/libs/ktxreader/src/Ktx1Reader.cpp
@@ -70,13 +70,24 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
         }
     };
 
-    uint8_t* data;
-    uint32_t size;
+    // Initialize defensively: getBlob leaves out-params uninitialized on zero-sized mip.
+    uint8_t* data = nullptr;
+    uint32_t size = 0;
+
+    // Account for per-level callback when skipping a mip to prevent memory leaks.
+    auto skipLevel = [&]() {
+        if (--cbuser->remainingBuffers == 0) {
+            if (cbuser->callback) {
+                cbuser->callback(cbuser->userdata);
+            }
+            delete cbuser;
+        }
+    };
 
     if (isCompressed(ktxinfo)) {
         if (ktx.isCubemap()) {
             for (uint32_t level = 0; level < nmips; ++level) {
-                ktx.getBlob({ level, 0, 0 }, &data, &size);
+                if (!ktx.getBlob({ level, 0, 0 }, &data, &size)) { skipLevel(); continue; }
                 const uint32_t dim = texture->getWidth(level);
                 texture->setImage(*engine, level, 0, 0, 0, dim, dim, 6, {
                         data, size * 6, cdatatype, size, cb, cbuser
@@ -85,7 +96,7 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
             return texture;
         }
         for (uint32_t level = 0; level < nmips; ++level) {
-            ktx.getBlob({ level, 0, 0 }, &data, &size);
+            if (!ktx.getBlob({ level, 0, 0 }, &data, &size)) { skipLevel(); continue; }
             texture->setImage(*engine, level, {
                     data, size, cdatatype, size, cb, cbuser
             });
@@ -95,7 +106,7 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
 
     if (ktx.isCubemap()) {
         for (uint32_t level = 0; level < nmips; ++level) {
-            ktx.getBlob({ level, 0, 0 }, &data, &size);
+            if (!ktx.getBlob({ level, 0, 0 }, &data, &size)) { skipLevel(); continue; }
             const uint32_t dim = texture->getWidth(level);
             texture->setImage(*engine, level, 0, 0, 0, dim, dim, 6, {
                     data, size * 6, dataformat, datatype, cb, cbuser
@@ -105,7 +116,7 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
     }
 
     for (uint32_t level = 0; level < nmips; ++level) {
-        ktx.getBlob({level, 0, 0}, &data, &size);
+        if (!ktx.getBlob({level, 0, 0}, &data, &size)) { skipLevel(); continue; }
         PixelBufferDescriptor pbd(data, size, dataformat, datatype, cb, cbuser);
         texture->setImage(*engine, level, std::move(pbd));
     }


### PR DESCRIPTION
## Description
This PR addresses a memory safety vulnerability where `Ktx1Reader::createTexture` passes uninitialized stack memory to the Filament backend.  fixes #9986 

When parsing a KTX1 file with a mip level size of 0, `Ktx1Bundle::getBlob` returns `false` without writing to the output parameters `*data` and `*size`. Previously, `createTexture` dropped this return value and used the uninitialized stack locals (`uint8_t* data; uint32_t size;`), passing garbage pointers and sizes to `texture->setImage()`. This results in Undefined Behavior and a reliable application crash (segmentation fault) when the GPU backend attempts to read the data.

## Changes Made
1. **Defensive Initialization:** `data` and `size` are initialized to `nullptr` and `0` respectively.
2. **Validation:** Added a boolean check on the return value of `ktx.getBlob`. If `false` is returned, the loop skips the mip level.
3. **Callback Invariants:** Created a `skipLevel()` lambda to manually decrement `cbuser->remainingBuffers` and fire the free callback if it reaches zero. This ensures that skipping a mip level does not cause a memory leak of the `Ktx1Bundle`.

## Testing
- Verified via Valgrind memcheck that the uninitialized memory use is resolved.
- Verified that the `remainingBuffers` count correctly reaches zero, triggering the expected callback.
