### PR TITLE
Feature: Introduce View-specific caching via SceneCacheData

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1392,7 +1392,7 @@ ShadowMapDescriptorSet::Transaction ShadowMap::open(DriverApi& driver) noexcept 
 }
 
 void ShadowMap::commit(Transaction& transaction,
-        FEngine& engine, DriverApi& driver) const noexcept {
+        FEngine const& engine, DriverApi& driver) const noexcept {
     mPerShadowMapUniforms.commit(transaction, engine, driver);
 }
 

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -204,7 +204,7 @@ public:
     static void prepareShadowMapping(Transaction const& transaction,
             float vsmExponent, float vsmMaxMoment) noexcept;
     static ShadowMapDescriptorSet::Transaction open(backend::DriverApi& driver) noexcept;
-    void commit(Transaction& transaction, FEngine& engine, backend::DriverApi& driver) const noexcept;
+    void commit(Transaction& transaction, FEngine const& engine, backend::DriverApi& driver) const noexcept;
     void bind(backend::DriverApi& driver) const noexcept;
 
 private:

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -175,7 +175,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
     calculateTextureRequirements(engine, view, lightData);
 
     // Compute scene-dependent values shared across all shadow maps
-    ShadowMap::SceneInfo const info{ view.getScene()->getRenderableData(), view.getVisibleLayers() };
+    ShadowMap::SceneInfo const info{ view.getRenderableData(), view.getVisibleLayers() };
 
     shadowTechnique |= updateCascadeShadowMaps(
             engine, view, cameraInfo, renderableData, lightData, info);
@@ -238,8 +238,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
         FView& view, CameraInfo const& mainCameraInfo,
         float4 const& userTime) noexcept {
 
-    FScene* scene = view.getScene();
-    assert_invariant(scene);
+    assert_invariant(view.getScene());
 
     // make a copy here, because it's a very small structure
     VsmShadowOptions const& vsmShadowOptions = view.getVsmShadowOptions();
@@ -309,11 +308,11 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                                 break;
                             case ShadowType::SPOT:
                                 prepareSpotShadowMap(shadowMap, engine, view, mainCameraInfo,
-                                        scene->getLightData(), mSceneInfo);
+                                        view.getLightData(), mSceneInfo);
                                 break;
                             case ShadowType::POINT:
                                 preparePointShadowMap(shadowMap, engine, view, mainCameraInfo,
-                                        scene->getLightData());
+                                        view.getLightData());
                                 break;
                         }
 
@@ -344,8 +343,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
             },
             [=, this,
                     passBuilder = passBuilder,
-                    &engine = const_cast<FEngine /*const*/ &>(engine), // FIXME: we want this const
-                    &view = view]
+                    &engine = static_cast<FEngine const &>(engine),
+                    &view = static_cast<FView const&>(view)]
                     (FrameGraphResources const&, auto const& data, DriverApi& driver) mutable {
 
                 // Note: we could almost parallel_for the loop below, the problem currently is
@@ -368,7 +367,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     //       recorded in the command buffer, per shadow map. Maybe this could
                     //       be done with indirect draw calls.
 
-                    // Note: the output of culling below is stored in scene->getRenderableData()
+                    // Note: the output of culling below is stored in view.getRenderableData()
 
                     switch (shadowMap.getShadowType()) {
                         case ShadowType::DIRECTIONAL:
@@ -377,15 +376,15 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                         case ShadowType::SPOT:
                             if (shadowMap.hasVisibleShadows()) {
                                 ShadowMapManager::cullSpotShadowMap(shadowMap, engine, view,
-                                        scene->getRenderableData(), entry.range,
-                                        scene->getLightData());
+                                        view.getRenderableData(), entry.range,
+                                        view.getLightData());
                             }
                             break;
                         case ShadowType::POINT:
                             if (shadowMap.hasVisibleShadows()) {
                                 ShadowMapManager::cullPointShadowMap(shadowMap, view,
-                                        scene->getRenderableData(), entry.range,
-                                        scene->getLightData());
+                                        view.getRenderableData(), entry.range,
+                                        view.getLightData());
                             }
                             break;
                     }
@@ -406,7 +405,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     shadowMap.commit(transaction, engine, driver);
 
                     // updatePrimitivesLod must be run before RenderPass::appendCommands.
-                    FView::updatePrimitivesLod(scene->getRenderableData(), engine, cameraInfo, entry.range);
+                    FView::updatePrimitivesLod(view.getRenderableData(), engine, cameraInfo, entry.range);
 
                     // generate and sort the commands for rendering the shadow map
 
@@ -426,7 +425,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                             .renderFlags(RenderPass::HAS_DEPTH_CLAMP, renderPassFlags)
                             .camera(cameraInfo.getPosition(), cameraInfo.getForwardVector())
                             .visibilityMask(entry.visibilityMask)
-                            .geometry(scene->getRenderableData(), entry.range)
+                            .geometry(view.getRenderableData(), entry.range)
                             .commandTypeFlags(RenderPass::CommandTypeFlags::SHADOW)
                             .build(engine, driver);
 
@@ -809,7 +808,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
                 normalize(cameraInfo.worldTransform[0].xyz));
 
         // Compute scene-dependent values shared across all cascades
-        ShadowMap::updateSceneInfoDirectional(MvAtOrigin, view.getScene()->getRenderableData(), sceneInfo);
+        ShadowMap::updateSceneInfoDirectional(MvAtOrigin, view.getRenderableData(), sceneInfo);
 
         // we always do culling without depth clamp, because objects behind the camera
         // must be rendered regardless
@@ -975,7 +974,7 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap, FEngine& engin
     };
 
     auto const shaderParameters = shadowMap.updateSpot(engine,
-            lightData, lightIndex, mainCameraInfo, shadowMapInfo, view.getScene()->getRenderableData(), sceneInfo);
+            lightData, lightIndex, mainCameraInfo, shadowMapInfo, view.getRenderableData(), sceneInfo);
 
     // and if we need to generate it, update all the UBO data
     if (shadowMap.hasVisibleShadows()) {
@@ -1070,7 +1069,7 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
     };
 
     auto const shaderParameters = shadowMap.updatePoint(engine, lightData, lightIndex,
-            mainCameraInfo, shadowMapInfo, view.getScene()->getRenderableData(), face);
+            mainCameraInfo, shadowMapInfo, view.getRenderableData(), face);
 
     // and if we need to generate it, update all the UBO data
     if (shadowMap.hasVisibleShadows()) {

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -955,8 +955,6 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
      * Allocate command buffer
      */
 
-    FScene& scene = *view.getScene();
-
     // Allocate some space for our commands in the per-frame Arena, and use that space as
     // an Arena for commands. All this space is released when we exit this method.
     size_t const perFrameCommandsSize = engine.getPerFrameCommandsSize();
@@ -1061,7 +1059,7 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
             .clearFlags = getClearFlags(),
             .clearColor = clearColor,
             .clearStencil = clearStencil,
-            .hasContactShadows = scene.hasContactShadows(),
+            .hasContactShadows = view.hasContactShadows(),
             // at this point we don't know if we have refraction, but that's handled later
             .hasScreenSpaceReflectionsOrRefractions = ssReflectionsOptions.enabled,
             .enabledStencilBuffer = view.isStencilBufferEnabled(),
@@ -1076,11 +1074,11 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
 
     // updatePrimitivesLod must be run before appendCommands and once for each set
     // of RenderPass::setCamera / RenderPass::setGeometry calls.
-    FView::updatePrimitivesLod(scene.getRenderableData(),
+    FView::updatePrimitivesLod(view.getRenderableData(),
             engine, cameraInfo, view.getVisibleRenderables());
 
     passBuilder.camera(cameraInfo.getPosition(), cameraInfo.getForwardVector());
-    passBuilder.geometry(scene.getRenderableData(), view.getVisibleRenderables());
+    passBuilder.geometry(view.getRenderableData(), view.getVisibleRenderables());
 
     // --------------------------------------------------------------------------------------------
     // structure pass -- automatically culled if not used

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -24,6 +24,7 @@
 
 #include "details/Engine.h"
 #include "details/Skybox.h"
+#include "details/View.h"
 
 #include <backend/Handle.h>
 
@@ -79,7 +80,8 @@ FScene::~FScene() noexcept = default;
 void FScene::prepare(JobSystem& js,
         RootArenaScope& rootArenaScope,
         mat4 const& worldTransform,
-        bool shadowReceiversAreCasters) noexcept {
+        bool shadowReceiversAreCasters,
+        FScene::SceneCacheData& cache) noexcept {
     // TODO: can we skip this in most cases? Since we rely on indices staying the same,
     //       we could only skip, if nothing changed in the RCM.
 
@@ -96,8 +98,8 @@ void FScene::prepare(JobSystem& js,
     FTransformManager const& tcm = engine.getTransformManager();
     FLightManager const& lcm = engine.getLightManager();
     // go through the list of entities, and gather the data of those that are renderables
-    auto& sceneData = mRenderableData;
-    auto& lightData = mLightData;
+    auto& sceneData = cache.renderableData;
+    auto& lightData = cache.lightData;
     auto const& entities = mEntities;
 
     using RenderableContainerData = std::pair<RenderableManager::Instance, TransformManager::Instance>;
@@ -354,19 +356,18 @@ void FScene::prepare(JobSystem& js,
     FILAMENT_TRACING_NAME_END(FILAMENT_TRACING_CATEGORY_FILAMENT);
 }
 
-void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables) noexcept {
+void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables, FScene::SceneCacheData& cache) const noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
-    RenderableSoa& sceneData = mRenderableData;
-    FRenderableManager const& rcm = mEngine.getRenderableManager();
-
-    mHasContactShadows = false;
+    RenderableSoa& sceneData = cache.renderableData;
+    
+    cache.hasContactShadows = false;
     for (uint32_t const i : visibleRenderables) {
         PerRenderableData& uboData = sceneData.elementAt<UBO>(i);
 
         auto const visibility = sceneData.elementAt<VISIBILITY_STATE>(i);
         auto const skinning = sceneData.elementAt<SKINNING_STATE>(i);
         auto const& model = sceneData.elementAt<WORLD_TRANSFORM>(i);
-        auto const ri = mEngine.getRenderableManager().getInstance(sceneData.elementAt<RENDERABLE_ENTITY>(i));
+        auto const entity = sceneData.elementAt<RENDERABLE_ENTITY>(i);
 
         // Using mat3f::getTransformForNormals handles non-uniform scaling, but DOESN'T guarantee that
         // the transformed normals will have unit-length, therefore they need to be normalized
@@ -402,23 +403,26 @@ void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables) noexc
 
         uboData.morphTargetCount = sceneData.elementAt<MORPHING_BUFFER>(i).count;
 
-        uboData.objectId = rcm.getEntity(ri).getId();
+        uboData.objectId = int32_t(entity.getId());
 
         // TODO: We need to find a better way to provide the scale information per object
         uboData.userData = sceneData.elementAt<USER_DATA>(i);
 
-        mHasContactShadows = mHasContactShadows || visibility.screenSpaceContactShadows;
+        cache.hasContactShadows = cache.hasContactShadows || visibility.screenSpaceContactShadows;
     }
 }
 
 void FScene::terminate(FEngine&) {
+    while (!mViewCaches.empty()) {
+        mViewCaches.begin()->first->invalidateCache(this);
+    }
 }
 
 void FScene::prepareDynamicLights(const CameraInfo& camera,
-        Handle<HwBufferObject> lightUbh) noexcept {
+        Handle<HwBufferObject> lightUbh, FScene::SceneCacheData& cache) noexcept {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     FLightManager const& lcm = mEngine.getLightManager();
-    LightSoa& lightData = getLightData();
+    LightSoa& lightData = cache.lightData;
 
     /*
      * Here we copy our lights data into the GPU buffer.
@@ -460,6 +464,27 @@ void FScene::prepareDynamicLights(const CameraInfo& camera,
     }
 
     driver.updateBufferObject(lightUbh, {lp, positionalLightCount * sizeof(LightsUib)}, 0);
+}
+
+bool FScene::hasContactShadows(SceneCacheData const& cache) const noexcept {
+    // at least some renderables in the scene must have contact-shadows enabled
+    if (!cache.hasContactShadows) {
+        return false;
+    }
+
+    // find out if at least one light has contact-shadow enabled
+    auto const& lcm = mEngine.getLightManager();
+    auto const* pLightEntities = cache.lightData.data<FScene::LIGHT_ENTITY>();
+    for (size_t i = 0, c = cache.lightData.size(); i < c; i++) {
+        Entity const entity = pLightEntities[i];
+        if (!entity.isNull()) {
+            auto const& shadowOptions = lcm.getShadowOptions(lcm.getInstance(entity));
+            if (shadowOptions.screenSpaceContactShadows) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 // These methods need to exist so clang honors the __restrict__ keyword, which in turn
@@ -554,28 +579,17 @@ void FScene::setSkybox(FSkybox* skybox) noexcept {
     }
 }
 
-bool FScene::hasContactShadows() const noexcept {
-    // at least some renderables in the scene must have contact-shadows enabled
-    // TODO: we should refine this with only the visible ones
-    if (!mHasContactShadows) {
-        return false;
+FScene::SceneCacheData* FScene::registerView(FView const* view) noexcept {
+    auto [it, inserted] = mViewCaches.try_emplace(view, nullptr);
+    assert_invariant(inserted);
+    if (inserted) {
+        it->second = std::make_unique<SceneCacheData>();
     }
+    return it->second.get();
+}
 
-    // find out if at least one light has contact-shadow enabled
-    // TODO: we could cache the result of this Loop in the LightManager
-    auto const& lcm = mEngine.getLightManager();
-    const auto *pFirst = mLightData.begin<LIGHT_ENTITY>();
-    const auto *pLast = mLightData.end<LIGHT_ENTITY>();
-    while (pFirst != pLast) {
-        if (!pFirst->isNull()) {
-            auto const& shadowOptions = lcm.getShadowOptions(lcm.getInstance(*pFirst));
-            if (shadowOptions.screenSpaceContactShadows) {
-                return true;
-            }
-        }
-        ++pFirst;
-    }
-    return false;
+void FScene::unregisterView(FView const* view) noexcept {
+    mViewCaches.erase(view);
 }
 
 UTILS_NOINLINE

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -42,6 +42,7 @@
 namespace filament {
 
 struct CameraInfo;
+class FView;
 class FEngine;
 class FIndirectLight;
 class FRenderer;
@@ -49,6 +50,8 @@ class FSkybox;
 
 class FScene : public Scene {
 public:
+    struct SceneCacheData;
+
     /*
      * Filament-scope Public API
      */
@@ -66,12 +69,12 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(utils::JobSystem& js, RootArenaScope& rootArenaScope,
-            math::mat4 const& worldTransform, bool shadowReceiversAreCasters) noexcept;
+            math::mat4 const& worldTransform, bool shadowReceiversAreCasters, SceneCacheData& cache) noexcept;
 
-    void prepareVisibleRenderables(utils::Range<uint32_t> visibleRenderables) noexcept;
+    void prepareVisibleRenderables(utils::Range<uint32_t> visibleRenderables, SceneCacheData& cache) const noexcept;
 
     void prepareDynamicLights(const CameraInfo& camera,
-            backend::Handle<backend::HwBufferObject> lightUbh) noexcept;
+            backend::Handle<backend::HwBufferObject> lightUbh, SceneCacheData& cache) noexcept;
 
     /*
      * Storage for per-frame renderable data
@@ -126,8 +129,9 @@ public:
             float                                       // USER_DATA
     >;
 
-    RenderableSoa const& getRenderableData() const noexcept { return mRenderableData; }
-    RenderableSoa& getRenderableData() noexcept { return mRenderableData; }
+    
+
+    bool hasContactShadows(SceneCacheData const& cache) const noexcept;
 
     static uint32_t getPrimitiveCount(RenderableSoa const& soa,
             uint32_t const first, uint32_t const last) noexcept {
@@ -178,10 +182,11 @@ public:
             ShadowInfo
     >;
 
-    LightSoa const& getLightData() const noexcept { return mLightData; }
-    LightSoa& getLightData() noexcept { return mLightData; }
-
-    bool hasContactShadows() const noexcept;
+    struct SceneCacheData {
+        RenderableSoa renderableData;
+        LightSoa lightData;
+        bool hasContactShadows = false;
+    };
 
 private:
     using EntitySet = utils::PagedArenaBitset;
@@ -213,9 +218,10 @@ private:
      * In essence, this data should be owned by View, but it's so scene-specific, that for now
      * we store it here.
      */
-    RenderableSoa mRenderableData;
-    LightSoa mLightData;
-    bool mHasContactShadows = false;
+    friend class FView;
+    SceneCacheData* registerView(FView const* view) noexcept;
+    void unregisterView(FView const* view) noexcept;
+    std::unordered_map<FView const*, std::unique_ptr<SceneCacheData>> mViewCaches;
     EntitySet mEntities;
 };
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -202,7 +202,23 @@ FView::FView(FEngine& engine)
 
 FView::~FView() noexcept = default;
 
+void FView::setScene(FScene* scene) {
+    if (mScene != scene) {
+        if (mScene) {
+            invalidateCache(mScene);
+        }
+        mScene = scene;
+        if (scene) {
+            mCurrentViewCache = scene->registerView(this);
+        }
+    }
+}
+
 void FView::terminate(FEngine& engine) {
+    if (mScene) {
+        invalidateCache(mScene);
+    }
+
     // Here we would cleanly free resources we've allocated, or we own (currently none).
 
     clearPickingQueries();
@@ -488,14 +504,14 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
     FILAMENT_TRACING_CONTEXT(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     FScene* const scene = mScene;
-    auto const& lightData = scene->getLightData();
+    auto const& lightData = mCurrentViewCache->lightData;
 
     /*
      * Dynamic lights
      */
 
     if (hasDynamicLighting()) {
-        scene->prepareDynamicLights(cameraInfo, mLightUbh);
+        scene->prepareDynamicLights(cameraInfo, mLightUbh, *mCurrentViewCache);
     }
 
     // here the array of visible lights has been shrunk to CONFIG_MAX_LIGHT_COUNT
@@ -714,7 +730,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
      */
     scene->prepare(js, rootArenaScope,
             cameraInfo.worldTransform,
-            hasVSM());
+            hasVSM(), *mCurrentViewCache);
 
     /*
      * Light culling: runs in parallel with Renderable culling (below)
@@ -722,7 +738,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
     JobSystem::Job* froxelizeLightsJob = nullptr;
     JobSystem::Job* prepareVisibleLightsJob = nullptr;
-    size_t const lightCount = scene->getLightData().size();
+    size_t const lightCount = mCurrentViewCache->lightData.size();
     if (lightCount > FScene::DIRECTIONAL_LIGHTS_COUNT) {
         // create and start the prepareVisibleLights job
         // note: this job updates LightData (non const)
@@ -734,7 +750,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         prepareVisibleLightsJob = js.runAndRetain(js.createJob(nullptr,
                 [&engine, distances, positionalLightCount, &viewMatrix = cameraInfo.view, &cullingFrustum,
-                 &lightData = scene->getLightData()]
+                 &lightData = mCurrentViewCache->lightData]
                         (JobSystem&, JobSystem::Job*) {
                     prepareVisibleLights(engine.getLightManager(),
                             { distances, distances + positionalLightCount },
@@ -748,7 +764,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
     Range merged;
 
     { // all the operations in this scope must happen sequentially
-        FScene::RenderableSoa& renderableData = scene->getRenderableData();
+        FScene::RenderableSoa& renderableData = mCurrentViewCache->renderableData;
 
         Slice<Culler::result_type> cullingMask = renderableData.slice<FScene::VISIBLE_MASK>();
         std::uninitialized_fill(cullingMask.begin(), cullingMask.end(), 0);
@@ -772,7 +788,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
         }
 
         // lightData is const from this point on (can only happen after prepareVisibleLightsJob)
-        auto const& lightData = scene->getLightData();
+        auto const& lightData = mCurrentViewCache->lightData;
 
         // now we know if we have dynamic lighting (i.e.: dynamic lights are visible)
         mHasDynamicLighting = lightData.size() > FScene::DIRECTIONAL_LIGHTS_COUNT;
@@ -876,7 +892,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
         // TODO: when any spotlight is used, `merged` ends-up being the whole list. However,
         //       some of the items will end-up not being visible by any light. Can we do better?
         //       e.g. could we deffer some of the prepareVisibleRenderables() to later?
-        scene->prepareVisibleRenderables(merged);
+        scene->prepareVisibleRenderables(merged, *mCurrentViewCache);
 
         // update those UBOs
         if (!merged.empty()) {
@@ -894,7 +910,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
     { // this must happen after mRenderableUbh is created/updated
         // prepare skinning, morphing and hybrid instancing
-        auto& sceneData = scene->getRenderableData();
+        auto& sceneData = mCurrentViewCache->renderableData;
         for (uint32_t const i : merged) {
             auto const& skinning = sceneData.elementAt<FScene::SKINNING_BUFFER>(i);
             auto const& morphing = sceneData.elementAt<FScene::MORPHING_BUFFER>(i);
@@ -1666,6 +1682,22 @@ float4 FView::getMaterialGlobal(uint32_t const index) const {
     FILAMENT_CHECK_PRECONDITION(index < 4)
             << "material global variable index (" << +index << ") out of range";
     return mMaterialGlobals[index];
+}
+
+bool FView::hasContactShadows() const noexcept {
+    if (mCurrentViewCache) {
+        assert_invariant(mScene);
+        return mScene->hasContactShadows(*mCurrentViewCache);
+    }
+    return false;
+}
+
+void FView::invalidateCache(FScene* scene) const noexcept {
+    assert_invariant(scene);
+    if (mCurrentViewCache && mScene == scene) {
+        scene->unregisterView(this);
+        mCurrentViewCache = nullptr;
+    }
 }
 
 } // namespace filament

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -103,6 +103,15 @@ public:
     explicit FView(FEngine& engine);
     ~FView() noexcept;
 
+    FScene::RenderableSoa& getRenderableData() const noexcept {
+        assert_invariant(mCurrentViewCache);
+        return mCurrentViewCache->renderableData;
+    }
+    FScene::LightSoa& getLightData() const noexcept {
+        assert_invariant(mCurrentViewCache);
+        return mCurrentViewCache->lightData;
+    }
+
     void terminate(FEngine& engine);
 
     CameraInfo computeCameraInfo(FEngine const& engine) const noexcept;
@@ -113,9 +122,12 @@ public:
             Viewport viewport, CameraInfo cameraInfo,
             math::float4 const& userTime, bool needsAlphaChannel) noexcept;
 
-    void setScene(FScene* scene) { mScene = scene; }
+    void setScene(FScene* scene);
     FScene const* getScene() const noexcept { return mScene; }
     FScene* getScene() noexcept { return mScene; }
+
+    bool hasContactShadows() const noexcept;
+    void invalidateCache(FScene* scene) const noexcept;
 
     void setCullingCamera(FCamera* camera) noexcept { mCullingCamera = camera; }
     void setViewingCamera(FCamera* camera) noexcept { mViewingCamera = camera; }
@@ -579,6 +591,7 @@ private:
     DescriptorSet mCommonRenderableDescriptorSet;
 
     FScene* mScene = nullptr;
+    mutable FScene::SceneCacheData* mCurrentViewCache = nullptr;
     // The camera set by the user, used for culling and viewing
     FCamera* mCullingCamera = nullptr;
     // The optional (debug) camera, used only for viewing

--- a/filament/src/ds/ShadowMapDescriptorSet.cpp
+++ b/filament/src/ds/ShadowMapDescriptorSet.cpp
@@ -107,7 +107,7 @@ ShadowMapDescriptorSet::Transaction ShadowMapDescriptorSet::open(DriverApi& driv
 }
 
 void ShadowMapDescriptorSet::commit(Transaction& transaction,
-        FEngine& engine, DriverApi& driver) noexcept {
+        FEngine const& engine, DriverApi& driver) noexcept {
     driver.updateBufferObject(mUniformBufferHandle, {
             transaction.uniforms, sizeof(PerViewUib) }, 0);
     mDescriptorSet.commit(engine.getPerViewDescriptorSetLayoutDepthVariant(), driver);

--- a/filament/src/ds/ShadowMapDescriptorSet.h
+++ b/filament/src/ds/ShadowMapDescriptorSet.h
@@ -80,7 +80,7 @@ public:
     static Transaction open(backend::DriverApi& driver) noexcept;
 
     // update local data into GPU UBO
-    void commit(Transaction& transaction, FEngine& engine, backend::DriverApi& driver) noexcept;
+    void commit(Transaction& transaction, FEngine const& engine, backend::DriverApi& driver) noexcept;
 
     // bind this UBO
     void bind(backend::DriverApi& driver) noexcept;


### PR DESCRIPTION
Motivation:
Previously, caching intermediate rendering state (like culling results and visible lights) was difficult due to the engine's architecture. Scene contains the flat list of objects but cannot cache state because it depends on the camera. View has the camera, but caching scene-data there means the cache is lost if the scene changes. Renderer is transient and only receives a view at render time. We needed a cache location dependent on the intersection of both a Scene and a View.

Implementation:
Introduced SceneCacheData to hold view-dependent scene state (e.g., RenderableSoa, LightSoa, and contact shadow flags).

Instead of storing this globally, Scene now owns a collection of these caches, keyed by View. When a View is assigned to a Scene, it registers itself and is granted a dedicated cache slot. This allows Renderer and ShadowMapManager to fetch state specific to the current View without interference.

Performance Characteristics:
This architecture is explicitly optimized for the common case: a single Scene rendered by multiple Views simultaneously. Each view maintains persistent state within the scene. However, calling View::setScene() explicitly invalidates the cache for that view. Therefore, using a single View to sequentially render multiple different scenes is intentionally not optimized and will result in cache recreation.