### PR TITLE
Metal: fix async image loading with swizzled textures

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -612,6 +612,8 @@ void MetalDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> src
             construct_handle<MetalTexture>(th, *mContext, src, baseLevel, levelCount);
     mContext->textures.insert(texture);
     texture->setLabel(tag);
+    DEBUG_LOG("createTextureViewR(th = %d, srch = %d, baseLevel = %d, levelCount = %d)\n",
+            th.getId(), srch.getId(), baseLevel, levelCount);
     mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
 }
 
@@ -622,6 +624,8 @@ void MetalDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTextu
     MetalTexture* texture = construct_handle<MetalTexture>(th, *mContext, src, r, g, b, a);
     mContext->textures.insert(texture);
     texture->setLabel(tag);
+    DEBUG_LOG("createTextureViewSwizzleR(th = %d, srch = %d, r = %d, g = %d, b = %d, a = %d)\n",
+            th.getId(), srch.getId(), r, g, b, a);
     mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
 }
 
@@ -629,8 +633,15 @@ void MetalDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<Hw
         backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
         backend::TextureSwizzle a, CallbackHandler* handler,
         CallbackHandler::Callback const callback, void* user, utils::ImmutableCString&& tag) {
-    createTextureViewSwizzleR(th, srch, r, g, b, a, std::move(tag));
+    MetalTexture const* src = handle_cast<MetalTexture>(srch);
+    MetalTexture* texture = construct_handle<MetalTexture>(th, *mContext, src, r, g, b, a, true);
+    mContext->textures.insert(texture);
+    texture->setLabel(tag);
+    DEBUG_LOG(
+            "createTextureViewSwizzleAsyncR(th = %d, srch = %d, r = %d, g = %d, b = %d, a = %d)\n",
+            th.getId(), srch.getId(), r, g, b, a);
     scheduleCallback(handler, user, callback);
+    mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
 }
 
 void MetalDriver::createTextureExternalImage2R(Handle<HwTexture> th,
@@ -1645,6 +1656,14 @@ void MetalDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th, u
     id<MTLCommandBuffer> cmdBuffer = [mContext->commandQueue commandBuffer];
     auto* tex = handle_cast<MetalTexture>(th);
     auto tag = mHandleAllocator.getHandleTag(th.getId());
+
+    DEBUG_LOG("update3DImageAsyncR(th = %d, level = %d, xoffset = %d, yoffset = %d, zoffset = %d, "
+              "width = "
+              "%d, height = %d, depth = %d, data = ?)\n",
+            th.getId(), level, xoffset, yoffset, zoffset, width, height, depth);
+
+    FILAMENT_CHECK_PRECONDITION(tex->asynchronous)
+            << "update3DImageAsyncR must be called with an asynchronous texture.";
 
     getJobQueue()->push(
             [this, cmdBuffer, tex, level, xoffset, yoffset, zoffset, width, height, depth,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -314,7 +314,7 @@ public:
     MetalTexture(MetalContext& context, MetalTexture const* src, uint8_t baseLevel,
             uint8_t levelCount) noexcept;
     MetalTexture(MetalContext& context, MetalTexture const* src, TextureSwizzle r, TextureSwizzle g,
-            TextureSwizzle b, TextureSwizzle a) noexcept;
+            TextureSwizzle b, TextureSwizzle a, bool async = false) noexcept;
 
     // Constructor for importing an id<MTLTexture> outside of Filament.
     MetalTexture(MetalContext& context, SamplerType target, uint8_t levels, TextureFormat format,

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -771,12 +771,12 @@ MetalTexture::MetalTexture(MetalContext& context, MetalTexture const* src, uint8
 }
 
 MetalTexture::MetalTexture(MetalContext& context, MetalTexture const* src, TextureSwizzle r,
-        TextureSwizzle g, TextureSwizzle b, TextureSwizzle a) noexcept
-    : HwTexture(src->target, src->levels, src->samples, src->width, src->height, src->depth,
-              src->format, src->usage, false),
-      context(context),
-      devicePixelFormat(src->devicePixelFormat),
-      externalImage(src->externalImage) {
+        TextureSwizzle g, TextureSwizzle b, TextureSwizzle a, bool async) noexcept
+        : HwTexture(src->target, src->levels, src->samples, src->width, src->height, src->depth,
+                  src->format, src->usage, async),
+          context(context),
+          devicePixelFormat(src->devicePixelFormat),
+          externalImage(src->externalImage) {
     texture = src->getMtlTextureForRead();
     if (context.supportsTextureSwizzling) {
         // Even though we've already checked context.supportsTextureSwizzling, we still need to


### PR DESCRIPTION
Swizzled textures weren't getting marked as async. This caused `helloasync` to occasionally crash upon exiting, due to texture destructors being called on the driver thread instead of the job queue.