### PR TITLE
skybox: fix sun disk parameters

### DIFF
--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -625,15 +625,15 @@ public:
          *
          * The Sun as seen from Earth has an angular size of 0.526° to 0.545°
          *
-         * @param angularRadius sun's radius in degree. Default is 0.545°.
+         * @param angularRadiusDeg sun's radius in degree. Default is 0.545°.
          *
          * @return This Builder, for chaining calls.
          */
-        Builder& sunAngularRadius(float angularRadius) noexcept;
+        Builder& sunAngularRadius(float angularRadiusDeg) noexcept;
 
         /**
          * Defines the halo radius of the sun. The radius of the halo is defined as a
-         * multiplier of the sun angular radius.
+         * multiplier of the sun angular radius.  Must be at least 1.0.
          *
          * @param haloSize radius multiplier. Default is 10.0.
          *
@@ -643,7 +643,7 @@ public:
 
         /**
          * Defines the halo falloff of the sun. The falloff is a dimensionless number
-         * used as an exponent.
+         * used as an exponent. Must be at least 1.0.
          *
          * @param haloFalloff halo falloff. Default is 80.0.
          *

--- a/filament/src/LightManager.cpp
+++ b/filament/src/LightManager.cpp
@@ -115,12 +115,12 @@ float LightManager::getSpotLightInnerCone(Instance const i) const noexcept {
 }
 
 void LightManager::setSunAngularRadius(Instance const i, float const angularRadius) noexcept {
-    downcast(this)->setSunAngularRadius(i, angularRadius);
+    downcast(this)->setSunAngularRadiusRad(i, angularRadius * f::DEG_TO_RAD);
 }
 
 float LightManager::getSunAngularRadius(Instance const i) const noexcept {
-    float radius = downcast(this)->getSunAngularRadius(i);
-    return radius * f::RAD_TO_DEG;
+    float const angularRadiusRad = downcast(this)->getSunAngularRadiusRad(i);
+    return angularRadiusRad * f::RAD_TO_DEG;
 }
 
 void LightManager::setSunHaloSize(Instance const i, float const haloSize) noexcept {

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -57,7 +57,7 @@ struct LightManager::BuilderDetails {
     FLightManager::IntensityUnit mIntensityUnit = FLightManager::IntensityUnit::LUMEN_LUX;
     float3 mDirection = { 0.0f, -1.0f, 0.0f };
     float2 mSpotInnerOuter = { f::PI_4 * 0.75f, f::PI_4 };
-    float mSunAngle = 0.00951f; // 0.545° in radians
+    float mSunAngularRadiusRad = 0.545f * f::DEG_TO_RAD;
     float mSunHaloSize = 10.0f;
     float mSunHaloFalloff = 80.0f;
     ShadowOptions mShadowOptions;
@@ -133,8 +133,8 @@ LightManager::Builder& LightManager::Builder::spotLightCone(float inner, float o
     return *this;
 }
 
-LightManager::Builder& LightManager::Builder::sunAngularRadius(float const sunAngle) noexcept {
-    mImpl->mSunAngle = sunAngle;
+LightManager::Builder& LightManager::Builder::sunAngularRadius(float const angularRadiusDeg) noexcept {
+    mImpl->mSunAngularRadiusRad = angularRadiusDeg * f::DEG_TO_RAD;
     return *this;
 }
 
@@ -207,7 +207,7 @@ void FLightManager::create(const Builder& builder, Entity const entity) {
         setIntensity(i, builder->mIntensity, builder->mIntensityUnit);
 
         setFalloff(i, builder->mCastLight ? builder->mFalloff : 0);
-        setSunAngularRadius(i, builder->mSunAngle);
+        setSunAngularRadiusRad(i, builder->mSunAngularRadiusRad);
         setSunHaloSize(i, builder->mSunHaloSize);
         setSunHaloFalloff(i, builder->mSunHaloFalloff);
     }
@@ -436,19 +436,19 @@ void FLightManager::setSpotLightCone(Instance const i, float const inner, float 
     }
 }
 
-void FLightManager::setSunAngularRadius(Instance const i, float angularRadius) noexcept {
+void FLightManager::setSunAngularRadiusRad(Instance const i, float angularRadiusRad) noexcept {
     if (i && isSunLight(i)) {
-        angularRadius = clamp(angularRadius, 0.25f, 20.0f);
-        float const newRadius = angularRadius * f::DEG_TO_RAD;
-        if (mManager[i].sunAngularRadius != newRadius) {
-            mManager[i].sunAngularRadius = newRadius;
+        angularRadiusRad = clamp(angularRadiusRad, 0.25f * f::DEG_TO_RAD, 20.0f * f::DEG_TO_RAD);
+        if (mManager[i].sunAngularRadiusRad != angularRadiusRad) {
+            mManager[i].sunAngularRadiusRad = angularRadiusRad;
             mManager.notifyChange(getEntity(i));
         }
     }
 }
 
-void FLightManager::setSunHaloSize(Instance const i, float const haloSize) noexcept {
+void FLightManager::setSunHaloSize(Instance const i, float haloSize) noexcept {
     if (i && isSunLight(i)) {
+        haloSize = std::max(haloSize, 1.0f);
         if (mManager[i].sunHaloSize != haloSize) {
             mManager[i].sunHaloSize = haloSize;
             mManager.notifyChange(getEntity(i));
@@ -456,8 +456,9 @@ void FLightManager::setSunHaloSize(Instance const i, float const haloSize) noexc
     }
 }
 
-void FLightManager::setSunHaloFalloff(Instance const i, float const haloFalloff) noexcept {
+void FLightManager::setSunHaloFalloff(Instance const i, float haloFalloff) noexcept {
     if (i && isSunLight(i)) {
+        haloFalloff = std::max(haloFalloff, 1.0f);
         if (mManager[i].sunHaloFalloff != haloFalloff) {
             mManager[i].sunHaloFalloff = haloFalloff;
             mManager.notifyChange(getEntity(i));

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -126,7 +126,7 @@ public:
     UTILS_NOINLINE void setIntensity(Instance i, float intensity, IntensityUnit unit) noexcept;
     UTILS_NOINLINE void setFalloff(Instance i, float radius) noexcept;
     UTILS_NOINLINE void setShadowCaster(Instance i, bool shadowCaster) noexcept;
-    UTILS_NOINLINE void setSunAngularRadius(Instance i, float angularRadius) noexcept;
+    UTILS_NOINLINE void setSunAngularRadiusRad(Instance i, float angularRadiusRad) noexcept;
     UTILS_NOINLINE void setSunHaloSize(Instance i, float haloSize) noexcept;
     UTILS_NOINLINE void setSunHaloFalloff(Instance i, float haloFalloff) noexcept;
 
@@ -198,8 +198,8 @@ public:
         return mManager[i].intensity;
     }
 
-    float getSunAngularRadius(Instance const i) const noexcept {
-        return mManager[i].sunAngularRadius;
+    float getSunAngularRadiusRad(Instance const i) const noexcept {
+        return mManager[i].sunAngularRadiusRad;
     }
 
     float getSunHaloSize(Instance const i) const noexcept {
@@ -305,7 +305,7 @@ private:
                 Field<COLOR>                color;
                 Field<SHADOW_PARAMS>        shadowParams;
                 Field<SPOT_PARAMS>          spotParams;
-                Field<SUN_ANGULAR_RADIUS>   sunAngularRadius;
+                Field<SUN_ANGULAR_RADIUS>   sunAngularRadiusRad;
                 Field<SUN_HALO_SIZE>        sunHaloSize;
                 Field<SUN_HALO_FALLOFF>     sunHaloFalloff;
                 Field<INTENSITY>            intensity;

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -42,12 +42,14 @@
 
 #include <math/mat4.h>
 #include <math/mat3.h>
+#include <math/scalar.h>
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
 
 #include <utils/compiler.h>
 #include <utils/debug.h>
+#include <utils/Logger.h>
 
 #include <algorithm>
 #include <array>
@@ -331,12 +333,12 @@ void ColorPassDescriptorSet::prepareDirectionalLight(FEngine& engine,
         if (UTILS_UNLIKELY(isSun && colorIntensity.w > 0.0f)) {
             // Currently we have only a single directional light, so it's probably likely that it's
             // also the Sun. However, conceptually, most directional lights won't be sun lights.
-            float const radius = lcm.getSunAngularRadius(directionalLight);
+            float const radius = lcm.getSunAngularRadiusRad(directionalLight);
             float const haloSize = lcm.getSunHaloSize(directionalLight);
             float const haloFalloff = lcm.getSunHaloFalloff(directionalLight);
             sun.x = std::cos(radius);
             sun.y = std::sin(radius);
-            sun.z = 1.0f / (std::cos(radius * haloSize) - sun.x);
+            sun.z = 1.0f / -std::max(1e-5f, sun.x - std::cos(clamp(radius * haloSize, 0.0f, f::PI_2)));
             sun.w = haloFalloff;
         }
         s.sun = sun;

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -254,7 +254,7 @@ struct LightDefinition {
     float spotOuter = 0.0f;
     float sunHaloSize = 10.0f;
     float sunHaloFalloff = 80.0f;
-    float sunAngularRadius = 1.9f;
+    float sunAngularRadiusDeg = 0.545f;
     bool castShadows = false;
     LightManager::ShadowOptions shadowOptions;
 };

--- a/libs/viewer/src/AutomationEngine.cpp
+++ b/libs/viewer/src/AutomationEngine.cpp
@@ -363,7 +363,7 @@ void AutomationEngine::updateCustomLights(Engine* engine,
                 .castShadows(def.castShadows)
                 .sunHaloSize(def.sunHaloSize)
                 .sunHaloFalloff(def.sunHaloFalloff)
-                .sunAngularRadius(def.sunAngularRadius)
+                .sunAngularRadius(def.sunAngularRadiusDeg)
                 .build(*engine, mCustomLights[i]);
 
         // Shadow options must be set on the instance after creation

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -534,7 +534,7 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, LightDef
         } else if (compare(tok, jsonChunk, "sunHaloFalloff") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->sunHaloFalloff);
         } else if (compare(tok, jsonChunk, "sunAngularRadius") == 0) {
-            i = parse(tokens, i + 1, jsonChunk, &out->sunAngularRadius);
+            i = parse(tokens, i + 1, jsonChunk, &out->sunAngularRadiusDeg);
         } else if (compare(tok, jsonChunk, "castShadows") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->castShadows);
         } else if (compare(tok, jsonChunk, "shadowOptions") == 0) {
@@ -885,7 +885,7 @@ void applySettings(Engine* engine, const LightSettings& settings, IndirectLight*
         lm->setIntensity(light, settings.sunlight.intensity);
         lm->setSunHaloSize(light, settings.sunlight.sunHaloSize);
         lm->setSunHaloFalloff(light, settings.sunlight.sunHaloFalloff);
-        lm->setSunAngularRadius(light, settings.sunlight.sunAngularRadius);
+        lm->setSunAngularRadius(light, settings.sunlight.sunAngularRadiusDeg);
         lm->setDirection(light, normalize(settings.sunlight.direction));
         lm->setColor(light, settings.sunlight.color);
         lm->setShadowCaster(light, settings.sunlight.castShadows && settings.enableShadows);
@@ -1275,7 +1275,7 @@ static std::ostream& operator<<(std::ostream& out, const LightDefinition& in) {
                << "\"spotOuter\": " << in.spotOuter << ",\n"
                << "\"sunHaloSize\": " << in.sunHaloSize << ",\n"
                << "\"sunHaloFalloff\": " << in.sunHaloFalloff << ",\n"
-               << "\"sunAngularRadius\": " << in.sunAngularRadius << ",\n"
+               << "\"sunAngularRadius\": " << in.sunAngularRadiusDeg << ",\n"
                << "\"castShadows\": " << to_string(in.castShadows) << ",\n"
                << "\"shadowOptions\": " << in.shadowOptions << "\n"
                << "}";

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -438,7 +438,7 @@ ViewerGui::ViewerGui(filament::Engine* engine, filament::Scene* scene, filament:
         .intensity(mSettings.lighting.sunlight.intensity)
         .direction(normalize(mSettings.lighting.sunlight.direction))
         .castShadows(true)
-        .sunAngularRadius(mSettings.lighting.sunlight.sunAngularRadius)
+        .sunAngularRadius(mSettings.lighting.sunlight.sunAngularRadiusDeg)
         .sunHaloSize(mSettings.lighting.sunlight.sunHaloSize)
         .sunHaloFalloff(mSettings.lighting.sunlight.sunHaloFalloff)
         .build(*engine, mSunlight);
@@ -954,9 +954,9 @@ void ViewerGui::updateUserInterface() {
         if (ImGui::CollapsingHeader("Sunlight")) {
             ImGui::Checkbox("Enable sunlight", &light.enableSunlight);
             ImGui::SliderFloat("Sun intensity", &light.sunlight.intensity, 0.0f, 150000.0f);
-            ImGui::SliderFloat("Halo size", &light.sunlight.sunHaloSize, 1.01f, 40.0f);
-            ImGui::SliderFloat("Halo falloff", &light.sunlight.sunHaloFalloff, 4.0f, 1024.0f);
-            ImGui::SliderFloat("Sun radius", &light.sunlight.sunAngularRadius, 0.1f, 10.0f);
+            ImGui::SliderFloat("Sun radius [deg]", &light.sunlight.sunAngularRadiusDeg, 0.25f, 20.0f);
+            ImGui::SliderFloat("Halo size", &light.sunlight.sunHaloSize, 1.0f, 100.0f);
+            ImGui::SliderFloat("Halo falloff", &light.sunlight.sunHaloFalloff, 1.0f, 1000.0f);
             ImGuiExt::DirectionWidget("Sun direction", light.sunlight.direction.v);
             ImGui::SliderFloat("Shadow Far", &light.sunlight.shadowOptions.shadowFar, 0.0f,
                     mSettings.camera.far);


### PR DESCRIPTION
- the public API is always using degrees, but there was some inconsistencies.

- sanitize the sun disk calculations so that the halo size can be set independently from the sun angular radius without blowing up.

- update gltf_viewer default values to better match Earth's Sun (i.e. keep the default values, which are now working).