### PR TITLE
ci: declare workflow-level `contents: read` on 1 workflows

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -7,6 +7,9 @@ on:
       - release
       - rc/**
 
+permissions:
+  contents: read
+
 jobs:
   build-android:
     name: build-android


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 1 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `postsubmit-main.yml`, `presubmit.yml`, `status-android.yml`, `status-ios.yml`, `status-linux.yml`, `status-macos.yml`, `status-web.yml`, `status-windows.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.