### PR TITLE
build: pin actions/github-script to commit SHA in workflow_run workflows

### DIFF
--- a/.github/workflows/status-android.yml
+++ b/.github/workflows/status-android.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({


### PR DESCRIPTION
Pin `actions/github-script` to full commit SHA instead of mutable `v7` tag
  across all `status-*.yml` workflows.

  These workflows use `workflow_run` trigger which runs in a privileged context
  with write permissions. Pinning to SHA ensures immutability and prevents
  supply chain attacks via tag manipulation.

  Files changed:
  - .github/workflows/status-android.yml
  - .github/workflows/status-ios.yml
  - .github/workflows/status-linux.yml
  - .github/workflows/status-macos.yml
  - .github/workflows/status-web.yml
  - .github/workflows/status-windows.yml

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions