### PR TITLE
matdbg: fix format string vulnerability in GLSL shader endpoint

### DIFF
--- a/libs/matdbg/src/ApiHandler.cpp
+++ b/libs/matdbg/src/ApiHandler.cpp
@@ -185,7 +185,7 @@ bool ApiHandler::handleGetApiShader(struct mg_connection* conn,
                     (uint32_t const*) content.data(), content.size() / 4);
             std::string const shader = mFormatter.format((char const*) glsl.c_str());
             mg_printf(conn, kSuccessHeader.data(), "application/txt");
-            mg_printf(conn, shader.c_str(), shader.size());
+            mg_write(conn, shader.c_str(), shader.size());
             return true;
         }
 


### PR DESCRIPTION
## Summary

In `libs/matdbg/src/ApiHandler.cpp`, the code path that returns a GLSL shader
used `mg_printf(conn, shader.c_str(), shader.size())`, passing the shader
source as the *format string* argument to `mg_printf`.

The ESSL and SPIR-V paths in the same function both use `mg_write`, which
takes a length-bounded buffer and does no format-string interpretation.

## Impact

The `matdbg` debug server listens on a network port (default 8080) and has
no authentication. A shader asset containing `%s`, `%n`, or other format
specifiers would cause `mg_printf` to read from or (with `%n`) write to
arbitrary stack locations, resulting in:
- Information disclosure (stack/heap memory leaked to the HTTP response)
- Remote crash of the process hosting the debug server

Any network peer reachable to the debug port, or any attacker who can influence
what shader is loaded (e.g., via a crafted asset file), can trigger this.

## Fix

Replace the single `mg_printf` call with `mg_write`, matching the pattern
already used for the ESSL and SPIR-V code paths:

```cpp
// Before (vulnerable)
mg_printf(conn, shader.c_str(), shader.size());

// After (safe)
mg_write(conn, shader.c_str(), shader.size());
```