### PR TITLE
ktx1: validate numberOfFaces in KTX1 deserialization

### DIFF
--- a/libs/image/src/Ktx1Bundle.cpp
+++ b/libs/image/src/Ktx1Bundle.cpp
@@ -140,6 +140,11 @@ Ktx1Bundle::Ktx1Bundle(uint8_t const* bytes, uint32_t nbytes) :
     // with only one element". For now, ignoring this distinction seems fine.
     mNumMipLevels = header->numberOfMipmapLevels ? header->numberOfMipmapLevels : 1;
     mArrayLength = header->numberOfArrayElements ? header->numberOfArrayElements : 1;
+    FILAMENT_CHECK_POSTCONDITION(
+            header->numberOfFaces == 0 ||
+            header->numberOfFaces == 1 ||
+            header->numberOfFaces == 6)
+            << "KTX numberOfFaces must be 1 or 6";
     mNumCubeFaces = header->numberOfFaces ? header->numberOfFaces : 1;
 
     uint64_t const totalBlobs = (uint64_t)mNumMipLevels * mArrayLength * mNumCubeFaces;


### PR DESCRIPTION
The KTX1 spec requires numberOfFaces to be either 1 (non-cubemap) or
6 (cubemap). The deserializer accepts any value, but the flatten()
indexing function assumes the face count is exactly 1 or 6. When
numberOfFaces is between 2 and 5, the blob array is sized for N faces
but flatten() computes indices assuming 6, causing out-of-bounds access.

Add validation that rejects numberOfFaces values other than 0, 1, or 6
during deserialization, consistent with the KTX1 specification.