### PR TITLE
several security fixes

### DIFF
--- a/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
+++ b/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
@@ -236,7 +236,7 @@ void FilamentApp::setupMaterial() {
 
 void FilamentApp::setupMesh() {
     MeshReader::Mesh mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_CUBE_DATA,
-            nullptr, nullptr, app.materialInstance);
+            RESOURCES_CUBE_SIZE, nullptr, nullptr, app.materialInstance);
     app.materialInstance->setParameter("baseColor", RgbType::sRGB, {0.71f, 0.0f, 0.0f});
 
     app.renderable = mesh.renderable;

--- a/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
+++ b/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
@@ -88,7 +88,7 @@ void FilamentApp::initialize() {
 
     app.materialInstance = app.mat->createInstance();
     MeshReader::Mesh mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_MATERIAL_SPHERE_DATA,
-            nullptr, nullptr, app.materialInstance);
+            RESOURCES_MATERIAL_SPHERE_SIZE, nullptr, nullptr, app.materialInstance);
     app.materialInstance->setParameter("baseColor", RgbType::sRGB, {0.71f, 0.0f, 0.0f});
 
     app.renderable = mesh.renderable;

--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -102,7 +102,7 @@ public:
      * named "DefaultMaterial" to the registry.
      */
     static Mesh loadMeshFromBuffer(filament::Engine* engine,
-            void const* data, Callback destructor, void* user,
+            void const* data, size_t dataSize, Callback destructor, void* user,
             MaterialRegistry& materials);
 
     /**
@@ -111,7 +111,7 @@ public:
      * renderable are assigned the specified default material.
      */
     static Mesh loadMeshFromBuffer(filament::Engine* engine,
-            void const* data, Callback destructor, void* user,
+            void const* data, size_t dataSize, Callback destructor, void* user,
             filament::MaterialInstance* defaultMaterial);
 };
 

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -213,7 +213,8 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     const uint8_t* p = (const uint8_t*) data;
     const uint8_t* end = p + dataSize;
     if (end < p) { // check pointer wraparound
-        end = (const uint8_t*) std::numeric_limits<uintptr_t>::max();
+        utils::slog.e << "Invalid (too large) dataSize: " << dataSize << utils::io::endl;
+        return {};
     }
 
     if (dataSize < 8 || strncmp(MAGICID, (const char *) p, 8)) {
@@ -240,12 +241,19 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     }
     const size_t partsBytes = header.parts * sizeof(Part);
 
-    // Aligned payload verification
-    const size_t requiredSize = size_t(header.vertexSize) + size_t(header.indexSize) + partsBytes;
-    if (requiredSize < header.vertexSize || requiredSize < header.indexSize) {
+    // Aligned payload verification (mathematically foolproof subtraction checks)
+    size_t requiredSize = header.vertexSize;
+    if (std::numeric_limits<size_t>::max() - requiredSize < header.indexSize) {
         utils::slog.e << "Payload sizes overflow." << utils::io::endl;
         return {};
     }
+    requiredSize += header.indexSize;
+
+    if (std::numeric_limits<size_t>::max() - requiredSize < partsBytes) {
+        utils::slog.e << "Payload sizes overflow." << utils::io::endl;
+        return {};
+    }
+    requiredSize += partsBytes;
 
     if (size_t(end - p) < requiredSize) {
         utils::slog.e << "Buffer truncation in mesh payload." << utils::io::endl;
@@ -307,12 +315,14 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         
         if (indexCount > std::numeric_limits<size_t>::max() / indexSize) {
             utils::slog.e << "Uncompressed index count overflow." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
         size_t uncompressedSize = indexSize * indexCount;
         void* uncompressed = malloc(uncompressedSize);
         if (!uncompressed) {
             utils::slog.e << "Out of memory allocating uncompressed index buffer." << utils::io::endl;
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
 
@@ -321,6 +331,7 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         if (err) {
             utils::slog.e << "Unable to decode index buffer." << utils::io::endl;
             free(uncompressed);
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
         if (destructor) {
@@ -374,18 +385,24 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
         if (vertexCount > std::numeric_limits<size_t>::max() / vertexSize) {
             utils::slog.e << "Uncompressed vertex count overflow." << utils::io::endl;
+            engine->destroy(mesh.vertexBuffer);
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
         size_t uncompressedSize = vertexSize * vertexCount;
         void* uncompressed = malloc(uncompressedSize);
         if (!uncompressed) {
             utils::slog.e << "Out of memory allocating uncompressed vertex buffer." << utils::io::endl;
+            engine->destroy(mesh.vertexBuffer);
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
 
         if (verticesSize < sizeof(CompressionHeader)) {
             utils::slog.e << "Compressed vertex buffer too small for header." << utils::io::endl;
             free(uncompressed);
+            engine->destroy(mesh.vertexBuffer);
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
 
@@ -407,6 +424,8 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
             if (compressedSum > verticesSize) {
                 utils::slog.e << "Compressed vertex buffer elements exceed bounds." << utils::io::endl;
                 free(uncompressed);
+                engine->destroy(mesh.vertexBuffer);
+                engine->destroy(mesh.indexBuffer);
                 return {};
             }
 
@@ -436,6 +455,8 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         if (err) {
             utils::slog.e << "Unable to decode vertex buffer." << utils::io::endl;
             free(uncompressed);
+            engine->destroy(mesh.vertexBuffer);
+            engine->destroy(mesh.indexBuffer);
             return {};
         }
         if (destructor) {

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <string>
+#include <limits>
 
 #include <fcntl.h>
 #if !defined(WIN32)
@@ -159,96 +159,168 @@ static size_t fileSize(int fd) {
 
 namespace filamesh {
 
+template <typename T>
+inline bool readChecked(T& dest, const uint8_t*& p, const uint8_t* end) {
+    if (size_t(end - p) < sizeof(T)) {
+        return false;
+    }
+    memcpy(&dest, p, sizeof(T));
+    p += sizeof(T);
+    return true;
+}
+
 MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const utils::Path& path,
         MaterialRegistry& materials) {
 
     Mesh mesh;
 
     int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        utils::slog.e << "Unable to open filamesh file: " << path.c_str() << utils::io::endl;
+        return {};
+    }
 
     size_t size = fileSize(fd);
     char* data = (char*) malloc(size);
-    read(fd, data, size);
-
-    if (data) {
-        char *p = data;
-        char *magic = p;
-        p += sizeof(MAGICID);
-
-        if (!strncmp(MAGICID, magic, 8)) {
-            mesh = loadMeshFromBuffer(engine, data, nullptr, nullptr, materials);
-        }
-
-        Fence::waitAndDestroy(engine->createFence());
-        free(data);
+    if (!data) {
+        close(fd);
+        return {};
     }
+
+    size_t bytesRead = read(fd, data, size);
+    if (bytesRead == size) {
+        mesh = loadMeshFromBuffer(engine, data, size, nullptr, nullptr, materials);
+    }
+
+    Fence::waitAndDestroy(engine->createFence());
+    free(data);
     close(fd);
 
     return mesh;
 }
 
 MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
-        void const* data, Callback destructor, void* user,
+        void const* data, size_t dataSize, Callback destructor, void* user,
         MaterialInstance* defaultMaterial) {
     MaterialRegistry reg;
     reg.registerMaterialInstance(utils::CString(DEFAULT_MATERIAL), defaultMaterial);
-    return loadMeshFromBuffer(engine, data, destructor, user, reg);
+    return loadMeshFromBuffer(engine, data, dataSize, destructor, user, reg);
 }
 
 MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
-        void const* data, Callback destructor, void* user,
+        void const* data, size_t dataSize, Callback destructor, void* user,
         MaterialRegistry& materials) {
     const uint8_t* p = (const uint8_t*) data;
-    if (strncmp(MAGICID, (const char *) p, 8)) {
-        utils::slog.e << "Magic string not found." << utils::io::endl;
+    const uint8_t* end = p + dataSize;
+    if (end < p) { // check pointer wraparound
+        end = (const uint8_t*) std::numeric_limits<uintptr_t>::max();
+    }
+
+    if (dataSize < 8 || strncmp(MAGICID, (const char *) p, 8)) {
+        utils::slog.e << "Magic string not found or buffer too small." << utils::io::endl;
         return {};
     }
     p += 8;
 
-    Header* header = (Header*) p;
-    p += sizeof(Header);
+    Header header;
+    if (!readChecked(header, p, end)) {
+        utils:: slog.e << "Header truncation." << utils::io::endl;
+        return {};
+    }
+
+    if (header.version != VERSION) {
+        utils::slog.e << "Unsupported filamesh version: " << header.version << utils::io::endl;
+        return {};
+    }
+
+    // Check integer overflow on header.parts * sizeof(Part)
+    if (size_t(header.parts) > std::numeric_limits<size_t>::max() / sizeof(Part)) {
+        utils::slog.e << "Too many mesh parts (overflow)." << utils::io::endl;
+        return {};
+    }
+    const size_t partsBytes = header.parts * sizeof(Part);
+
+    // Aligned payload verification
+    const size_t requiredSize = size_t(header.vertexSize) + size_t(header.indexSize) + partsBytes;
+    if (requiredSize < header.vertexSize || requiredSize < header.indexSize) {
+        utils::slog.e << "Payload sizes overflow." << utils::io::endl;
+        return {};
+    }
+
+    if (size_t(end - p) < requiredSize) {
+        utils::slog.e << "Buffer truncation in mesh payload." << utils::io::endl;
+        return {};
+    }
 
     uint8_t const* vertexData = p;
-    p += header->vertexSize;
+    p += header.vertexSize;
 
     uint8_t const* indices = p;
-    p += header->indexSize;
+    p += header.indexSize;
 
-    Part* parts = (Part*) p;
-    p += header->parts * sizeof(Part);
+    std::vector<Part> parts(header.parts);
+    for (size_t i = 0; i < header.parts; i++) {
+        if (!readChecked(parts[i], p, end)) {
+            utils::slog.e << "Buffer truncation in parts array." << utils::io::endl;
+            return {};
+        }
+    }
 
-    uint32_t materialCount = (uint32_t) *p;
-    p += sizeof(uint32_t);
+    uint32_t materialCount = 0;
+    if (!readChecked(materialCount, p, end)) {
+        utils::slog.e << "Buffer truncation reading material count." << utils::io::endl;
+        return {};
+    }
 
     std::vector<std::string> partsMaterial(materialCount);
     for (size_t i = 0; i < materialCount; i++) {
-        uint32_t nameLength = (uint32_t) *p;
-        p += sizeof(uint32_t);
-        partsMaterial[i] = (const char*) p;
-        p += nameLength + 1; // null terminated
+        uint32_t nameLength = 0;
+        if (!readChecked(nameLength, p, end)) {
+            utils::slog.e << "Buffer truncation reading material name length." << utils::io::endl;
+            return {};
+        }
+        if (size_t(nameLength) >= std::numeric_limits<size_t>::max() - 1) {
+            utils::slog.e << "Material name length overflow." << utils::io::endl;
+            return {};
+        }
+        const size_t nameBytes = size_t(nameLength) + 1; // including null terminator
+        if (size_t(end - p) < nameBytes) {
+            utils::slog.e << "Buffer truncation reading material name." << utils::io::endl;
+            return {};
+        }
+        partsMaterial[i] = std::string((const char*) p, nameLength);
+        p += nameBytes;
     }
 
     Mesh mesh;
 
     mesh.indexBuffer = IndexBuffer::Builder()
-            .indexCount(header->indexCount)
-            .bufferType(header->indexType == UI16 ? IndexBuffer::IndexType::USHORT
+            .indexCount(header.indexCount)
+            .bufferType(header.indexType == UI16 ? IndexBuffer::IndexType::USHORT
                     : IndexBuffer::IndexType::UINT)
             .build(*engine);
 
-    // If the index buffer is compressed, then decode the indices into a temporary buffer.
-    // The user callback can be called immediately afterwards because the source data does not get
-    // passed to the GPU.
-    const size_t indicesSize = header->indexSize;
-    if (header->flags & COMPRESSION) {
-        size_t indexSize = header->indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
-        size_t indexCount = header->indexCount;
+    const size_t indicesSize = header.indexSize;
+    if (header.flags & COMPRESSION) {
+        size_t indexSize = header.indexType == UI16 ? sizeof(uint16_t) : sizeof(uint32_t);
+        size_t indexCount = header.indexCount;
+        
+        if (indexCount > std::numeric_limits<size_t>::max() / indexSize) {
+            utils::slog.e << "Uncompressed index count overflow." << utils::io::endl;
+            return {};
+        }
         size_t uncompressedSize = indexSize * indexCount;
         void* uncompressed = malloc(uncompressedSize);
+        if (!uncompressed) {
+            utils::slog.e << "Out of memory allocating uncompressed index buffer." << utils::io::endl;
+            return {};
+        }
+
         int err = meshopt_decodeIndexBuffer(uncompressed, indexCount, indexSize, indices,
                 indicesSize);
         if (err) {
             utils::slog.e << "Unable to decode index buffer." << utils::io::endl;
+            free(uncompressed);
             return {};
         }
         if (destructor) {
@@ -263,79 +335,107 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     }
 
     VertexBuffer::Builder vbb;
-    vbb.vertexCount(header->vertexCount)
+    vbb.vertexCount(header.vertexCount)
             .bufferCount(1)
             .normalized(VertexAttribute::COLOR)
             .normalized(VertexAttribute::TANGENTS);
 
-    VertexBuffer::AttributeType uvtype = (header->flags & TEXCOORD_SNORM16) ?
+    VertexBuffer::AttributeType uvtype = (header.flags & TEXCOORD_SNORM16) ?
             VertexBuffer::AttributeType::SHORT2 : VertexBuffer::AttributeType::HALF2;
 
     vbb
             .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::HALF4,
-                        header->offsetPosition, uint8_t(header->stridePosition))
+                        header.offsetPosition, uint8_t(header.stridePosition))
             .attribute(VertexAttribute::TANGENTS, 0, VertexBuffer::AttributeType::SHORT4,
-                        header->offsetTangents, uint8_t(header->strideTangents))
+                        header.offsetTangents, uint8_t(header.strideTangents))
             .attribute(VertexAttribute::COLOR, 0, VertexBuffer::AttributeType::UBYTE4,
-                        header->offsetColor, uint8_t(header->strideColor))
+                        header.offsetColor, uint8_t(header.strideColor))
             .attribute(VertexAttribute::UV0, 0, uvtype,
-                        header->offsetUV0, uint8_t(header->strideUV0))
-            .normalized(VertexAttribute::UV0, header->flags & TEXCOORD_SNORM16);
+                        header.offsetUV0, uint8_t(header.strideUV0))
+            .normalized(VertexAttribute::UV0, header.flags & TEXCOORD_SNORM16);
 
     constexpr uint32_t uintmax = std::numeric_limits<uint32_t>::max();
-    const bool hasUV1 = header->offsetUV1 != uintmax && header->strideUV1 != uintmax;
+    const bool hasUV1 = header.offsetUV1 != uintmax && header.strideUV1 != uintmax;
 
     if (hasUV1) {
         vbb
             .attribute(VertexAttribute::UV1, 0, VertexBuffer::AttributeType::HALF2,
-                    header->offsetUV1, uint8_t(header->strideUV1))
+                    header.offsetUV1, uint8_t(header.strideUV1))
             .normalized(VertexAttribute::UV1);
     }
 
     mesh.vertexBuffer = vbb.build(*engine);
 
-    // If the vertex buffer is compressed, then decode the vertices into a temporary buffer.
-    // The user callback can be called immediately afterwards because the source data does not get
-    // passed to the GPU.
-    const size_t verticesSize = header->vertexSize;
-    if (header->flags & COMPRESSION) {
+    const size_t verticesSize = header.vertexSize;
+    if (header.flags & COMPRESSION) {
         size_t vertexSize = sizeof(half4) + sizeof(short4) + sizeof(ubyte4) + sizeof(ushort2) +
                 (hasUV1 ? sizeof(ushort2) : 0);
-        size_t vertexCount = header->vertexCount;
+        size_t vertexCount = header.vertexCount;
+
+        if (vertexCount > std::numeric_limits<size_t>::max() / vertexSize) {
+            utils::slog.e << "Uncompressed vertex count overflow." << utils::io::endl;
+            return {};
+        }
         size_t uncompressedSize = vertexSize * vertexCount;
         void* uncompressed = malloc(uncompressedSize);
+        if (!uncompressed) {
+            utils::slog.e << "Out of memory allocating uncompressed vertex buffer." << utils::io::endl;
+            return {};
+        }
+
+        if (verticesSize < sizeof(CompressionHeader)) {
+            utils::slog.e << "Compressed vertex buffer too small for header." << utils::io::endl;
+            free(uncompressed);
+            return {};
+        }
+
         const uint8_t* srcdata = vertexData + sizeof(CompressionHeader);
         int err = 0;
-        if (header->flags & INTERLEAVED) {
+        if (header.flags & INTERLEAVED) {
             err |= meshopt_decodeVertexBuffer(uncompressed, vertexCount, vertexSize, srcdata,
                     vertexSize);
         } else {
-            const CompressionHeader* sizes = (CompressionHeader*) vertexData;
+            CompressionHeader sizes;
+            memcpy(&sizes, vertexData, sizeof(CompressionHeader));
+
+            size_t compressedSum = sizeof(CompressionHeader) +
+                                   size_t(sizes.positions) +
+                                   size_t(sizes.tangents) +
+                                   size_t(sizes.colors) +
+                                   size_t(sizes.uv0) +
+                                   size_t(sizes.uv1);
+            if (compressedSum > verticesSize) {
+                utils::slog.e << "Compressed vertex buffer elements exceed bounds." << utils::io::endl;
+                free(uncompressed);
+                return {};
+            }
+
             uint8_t* dstdata = (uint8_t*) uncompressed;
             auto decode = meshopt_decodeVertexBuffer;
 
-            err |= decode(dstdata, vertexCount, sizeof(half4), srcdata, sizes->positions);
-            srcdata += sizes->positions;
+            err |= decode(dstdata, vertexCount, sizeof(half4), srcdata, sizes.positions);
+            srcdata += sizes.positions;
             dstdata += sizeof(half4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(short4), srcdata, sizes->tangents);
-            srcdata += sizes->tangents;
+            err |= decode(dstdata, vertexCount, sizeof(short4), srcdata, sizes.tangents);
+            srcdata += sizes.tangents;
             dstdata += sizeof(short4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(ubyte4), srcdata, sizes->colors);
-            srcdata += sizes->colors;
+            err |= decode(dstdata, vertexCount, sizeof(ubyte4), srcdata, sizes.colors);
+            srcdata += sizes.colors;
             dstdata += sizeof(ubyte4) * vertexCount;
 
-            err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes->uv0);
+            err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes.uv0);
 
-            if (sizes->uv1) {
-                srcdata += sizes->uv0;
+            if (sizes.uv1) {
+                srcdata += sizes.uv0;
                 dstdata += sizeof(ushort2) * vertexCount;
-                err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes->uv1);
+                err |= decode(dstdata, vertexCount, sizeof(ushort2), srcdata, sizes.uv1);
             }
         }
         if (err) {
             utils::slog.e << "Unable to decode vertex buffer." << utils::io::endl;
+            free(uncompressed);
             return {};
         }
         if (destructor) {
@@ -351,17 +451,15 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
     mesh.renderable = utils::EntityManager::get().create();
 
-    RenderableManager::Builder builder(header->parts);
-    builder.boundingBox(header->aabb);
+    RenderableManager::Builder builder(header.parts);
+    builder.boundingBox(header.aabb);
 
     const auto defaultmi = materials.getMaterialInstance(utils::CString(DEFAULT_MATERIAL));
-    for (size_t i = 0; i < header->parts; i++) {
+    for (size_t i = 0; i < header.parts; i++) {
         builder.geometry(i, RenderableManager::PrimitiveType::TRIANGLES,
                 mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
                 parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
 
-        // It may happen that there are more parts than materials
-        // therefore we have to use Part::material instead of i.
         uint32_t materialIndex = parts[i].material;
         if (materialIndex >= partsMaterial.size()) {
             utils::slog.e << "Material index (" << materialIndex << ") of mesh part ("

--- a/libs/filameshio/tests/test_filamesh.cpp
+++ b/libs/filameshio/tests/test_filamesh.cpp
@@ -157,7 +157,8 @@ TEST_F(FilameshTest, NonInterleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    string serialized = stream.str();
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, serialized.data(), serialized.size(), nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);
@@ -206,13 +207,95 @@ TEST_F(FilameshTest, Interleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    string serialized = stream.str();
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, serialized.data(), serialized.size(), nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);
 
     // Cleanup.
     engine->destroy(mesh.renderable);
+    engine->destroy(mi);
+}
+
+TEST_F(FilameshTest, TruncatedBuffer) {
+    const Header header {
+        .version = VERSION,
+        .parts = 1,
+        .aabb = unitBox,
+        .offsetTangents = sizeof(positions),
+        .offsetColor = sizeof(positions) + sizeof(tangents),
+        .offsetUV0 = sizeof(positions) + sizeof(tangents) + sizeof(colors),
+        .strideUV1 = maxint,
+        .vertexCount = vertexCount,
+        .vertexSize = sizeof(positions) + sizeof(tangents) + sizeof(colors) + sizeof(uv0),
+        .indexType = IndexType::UI16,
+        .indexCount = 3,
+        .indexSize = sizeof(uint16_t) * 3
+    };
+    const uint32_t nmats = 1;
+    const string matname = "DefaultMaterial";
+    const uint32_t matnamelength = matname.size();
+
+    stringstream stream(ios_base::out);
+    write(stream, MAGICID, sizeof(MAGICID));
+    write(stream, &header, sizeof(header));
+    write(stream, positions, sizeof(positions));
+    write(stream, tangents, sizeof(tangents));
+    write(stream, colors, sizeof(colors));
+    write(stream, uv0, sizeof(uv0));
+    write(stream, indices, sizeof(indices));
+    write(stream, parts, sizeof(parts));
+    write(stream, &nmats, sizeof(nmats));
+    write(stream, &matnamelength, sizeof(matnamelength));
+    write(stream, matname.c_str(), matnamelength + 1);
+
+    string serialized = stream.str();
+    MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
+
+    // Verify that truncating at any byte position returns an empty mesh cleanly
+    for (size_t size = 0; size < serialized.size(); ++size) {
+        auto mesh = MeshReader::loadMeshFromBuffer(engine, serialized.data(), size, nullptr, nullptr, mi);
+        EXPECT_EQ(mesh.vertexBuffer, nullptr);
+        EXPECT_EQ(mesh.indexBuffer, nullptr);
+    }
+
+    engine->destroy(mi);
+}
+
+TEST_F(FilameshTest, MalformedHeaderPartsOverflow) {
+    // Craft a header claiming a huge number of parts that would overflow during multiplication
+    const Header header {
+        .version = VERSION,
+        .parts = 0xFFFFFFFF, // overflow
+        .aabb = unitBox,
+        .vertexCount = vertexCount,
+        .vertexSize = sizeof(positions),
+        .indexType = IndexType::UI16,
+        .indexCount = 3,
+        .indexSize = sizeof(uint16_t) * 3
+    };
+    const uint32_t nmats = 1;
+    const string matname = "DefaultMaterial";
+    const uint32_t matnamelength = matname.size();
+
+    stringstream stream(ios_base::out);
+    write(stream, MAGICID, sizeof(MAGICID));
+    write(stream, &header, sizeof(header));
+    write(stream, positions, sizeof(positions));
+    write(stream, indices, sizeof(indices));
+    write(stream, parts, sizeof(parts));
+    write(stream, &nmats, sizeof(nmats));
+    write(stream, &matnamelength, sizeof(matnamelength));
+    write(stream, matname.c_str(), matnamelength + 1);
+
+    string serialized = stream.str();
+    MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
+
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, serialized.data(), serialized.size(), nullptr, nullptr, mi);
+    EXPECT_EQ(mesh.vertexBuffer, nullptr);
+    EXPECT_EQ(mesh.indexBuffer, nullptr);
+
     engine->destroy(mi);
 }
 

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -28,7 +28,6 @@
 #include <filament/BufferObject.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
-#include <filament/MaterialInstance.h>
 #include <filament/Texture.h>
 #include <filament/VertexBuffer.h>
 #include <filament/MorphTargetBuffer.h>
@@ -239,18 +238,41 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
         const cgltf_accessor* srcMatrices = srcSkin.inverse_bind_matrices;
         FixedCapacityVector<mat4f> inverseBindMatrices(srcSkin.joints_count);
         if (srcMatrices) {
+            if (!srcMatrices->buffer_view ||
+                (!srcMatrices->buffer_view->has_meshopt_compression &&
+                 (!srcMatrices->buffer_view->buffer || !srcMatrices->buffer_view->buffer->data))) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, missing buffer view or buffer data.";
+                continue;
+            }
+
+            cgltf_size bufferSize = 0;
+            cgltf_size totalOffset = 0;
             uint8_t* bytes = nullptr;
             uint8_t* srcBuffer = nullptr;
+
             if (srcMatrices->buffer_view->has_meshopt_compression) {
+                if (!srcMatrices->buffer_view->data) {
+                    LOG(WARNING) << "Cannot copy inverse bind matrices, compressed buffer data is null.";
+                    continue;
+                }
+                bufferSize = srcMatrices->buffer_view->size;
+                totalOffset = srcMatrices->offset;
                 bytes = (uint8_t*) srcMatrices->buffer_view->data;
-                srcBuffer = bytes + srcMatrices->offset;
+                srcBuffer = bytes + totalOffset;
             } else {
+                bufferSize = srcMatrices->buffer_view->buffer->size;
+                totalOffset = srcMatrices->offset + srcMatrices->buffer_view->offset;
                 bytes = (uint8_t*) srcMatrices->buffer_view->buffer->data;
-                srcBuffer = bytes + srcMatrices->offset + srcMatrices->buffer_view->offset;
+                srcBuffer = bytes + totalOffset;
             }
-            assert_invariant(bytes);
-            memcpy((uint8_t*) inverseBindMatrices.data(), (const void*) srcBuffer,
-                    srcSkin.joints_count * sizeof(mat4f));
+
+            const cgltf_size requiredBytes = srcSkin.joints_count * sizeof(mat4f);
+            if (totalOffset > bufferSize || requiredBytes > bufferSize - totalOffset) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer bounds.";
+                continue;
+            }
+
+            memcpy((uint8_t*) inverseBindMatrices.data(), (const void*) srcBuffer, requiredBytes);
         }
         FFilamentAsset::Skin skin{
                 .name = std::move(name),
@@ -290,6 +312,10 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
             const size_t floatsByteCount = sizeof(float) * floatsCount;
             
             float* floatsData = (float*)malloc(floatsByteCount);
+            if (!floatsData) {
+                LOG(WARNING) << "Failed to allocate memory for morph target unpacking, skipping.";
+                continue;
+            }
             cgltf_accessor_unpack_floats(accessor, floatsData, floatsCount);
 
             if (accessor->type == cgltf_type_vec3) {
@@ -360,6 +386,10 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                 const size_t floatsByteCount = sizeof(float) * floatsCount;
                 
                 float* floatsData = (float*) malloc(floatsByteCount);
+                if (!floatsData) {
+                    LOG(WARNING) << "Failed to allocate memory for vertex buffer conversion, skipping.";
+                    continue;
+                }
                 cgltf_accessor_unpack_floats(accessor, floatsData, floatsCount);
                 BufferObject* bo = BufferObject::Builder().size(floatsByteCount).build(engine);
                 asset->mBufferObjects.push_back(bo);
@@ -376,8 +406,16 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
             continue;
         } else if (slot.indexBuffer) {
             if (accessor->component_type == cgltf_component_type_r_8u) {
-                const size_t size16 = size * 2;
+                if (size_t(size) > std::numeric_limits<size_t>::max() / 2) {
+                    LOG(WARNING) << "Index buffer size would overflow on conversion, skipping.";
+                    continue;
+                }
+                const size_t size16 = size_t(size) * 2;
                 uint16_t* data16 = (uint16_t*) malloc(size16);
+                if (!data16) {
+                    LOG(WARNING) << "Failed to allocate memory for index buffer conversion, skipping.";
+                    continue;
+                }
                 utility::convertBytesToShorts(data16, data, size);
                 IndexBuffer::BufferDescriptor bd(data16, size16, FREE_CALLBACK);
 
@@ -432,6 +470,10 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
             const size_t floatsByteCount = sizeof(float) * floatsCount;
 
             float* floatsData = (float*) malloc(floatsByteCount);
+            if (!floatsData) {
+                LOG(WARNING) << "Failed to allocate memory for morph target packing, skipping.";
+                continue;
+            }
             cgltf_accessor_unpack_floats(accessor, floatsData, floatsCount);
             if (accessor->type == cgltf_type_vec3) {
                 slot.morphTargetBuffer->setPositionsAt(engine, slot.bufferIndex,

--- a/libs/image/include/image/LinearImage.h
+++ b/libs/image/include/image/LinearImage.h
@@ -57,6 +57,9 @@ public:
     LinearImage(const LinearImage& that);
     LinearImage& operator=(const LinearImage& that);
 
+    LinearImage(LinearImage&& that) noexcept;
+    LinearImage& operator=(LinearImage&& that) noexcept;
+
     /**
      * Creates an empty (invalid) image.
      */

--- a/libs/image/src/Ktx1Bundle.cpp
+++ b/libs/image/src/Ktx1Bundle.cpp
@@ -140,6 +140,9 @@ Ktx1Bundle::Ktx1Bundle(uint8_t const* bytes, uint32_t nbytes) :
     // with only one element". For now, ignoring this distinction seems fine.
     mNumMipLevels = header->numberOfMipmapLevels ? header->numberOfMipmapLevels : 1;
     mArrayLength = header->numberOfArrayElements ? header->numberOfArrayElements : 1;
+
+    FILAMENT_CHECK_POSTCONDITION(header->numberOfFaces == 0 || header->numberOfFaces == 1 || header->numberOfFaces == 6)
+            << "KTX numberOfFaces must be 1 or 6";
     mNumCubeFaces = header->numberOfFaces ? header->numberOfFaces : 1;
 
     uint64_t const totalBlobs = (uint64_t)mNumMipLevels * mArrayLength * mNumCubeFaces;

--- a/libs/image/src/LinearImage.cpp
+++ b/libs/image/src/LinearImage.cpp
@@ -16,15 +16,42 @@
 
 #include <image/LinearImage.h>
 
+#include <utils/Logger.h>
+
+#include <cstdint>
 #include <cstring> // for memset
 #include <memory>
+#include <new>
+#include <limits>
 
 namespace image  {
 
 struct LinearImage::SharedReference {
-    SharedReference(uint32_t width, uint32_t height, uint32_t channels) {
-        const uint32_t nfloats = width * height * channels;
-        float* floats = new float[nfloats];
+    SharedReference(uint32_t const width, uint32_t const height, uint32_t const channels) {
+        if (channels == 0) {
+            return;
+        }
+        // Calculate width * height in 64-bit to prevent intermediate overflow
+        const uint64_t pixelsCount = uint64_t(width) * height;
+        if (width > 0 && pixelsCount / width != height) {
+            return;
+        }
+
+        // Calculate floats count with channels overflow validation
+        if (pixelsCount > std::numeric_limits<uint64_t>::max() / channels) {
+            return;
+        }
+        const uint64_t nfloats = pixelsCount * channels;
+
+        // Validate against size_t max / sizeof(float) before allocating
+        if (nfloats > std::numeric_limits<size_t>::max() / sizeof(float)) {
+            return;
+        }
+
+        float* floats = new(std::nothrow) float[nfloats];
+        if (!floats) {
+            return;
+        }
         memset(floats, 0, sizeof(float) * nfloats);
         pixels = std::shared_ptr<float>(floats, std::default_delete<float[]>());
     }
@@ -35,26 +62,71 @@ LinearImage::~LinearImage() {
     delete mDataRef;
 }
 
-LinearImage::LinearImage(uint32_t width, uint32_t height, uint32_t channels) :
-    mDataRef(new SharedReference(width, height, channels)),
-    mData(mDataRef->pixels.get()),
-    mWidth(width), mHeight(height), mChannels(channels) {}
-
-LinearImage::LinearImage(const LinearImage& that) {
-    *this = that;
+LinearImage::LinearImage(uint32_t const width, uint32_t const height, uint32_t const channels) :
+    mDataRef(new(std::nothrow) SharedReference(width, height, channels)),
+    mData(mDataRef && mDataRef->pixels ? mDataRef->pixels.get() : nullptr),
+    mWidth(mData && mDataRef ? width : 0),
+    mHeight(mData && mDataRef ? height : 0),
+    mChannels(mData && mDataRef ? channels : 0) {
+    if (!mData) {
+        LOG(ERROR) << "LinearImage allocation failed (overflow or out of memory).";
+        delete mDataRef;
+        mDataRef = nullptr;
+    }
 }
 
+LinearImage::LinearImage(const LinearImage& that) :
+    mDataRef(that.mDataRef ? new(std::nothrow) SharedReference(*that.mDataRef) : nullptr),
+    mData(mDataRef && mDataRef->pixels ? mDataRef->pixels.get() : nullptr),
+    mWidth(mData ? that.mWidth : 0),
+    mHeight(mData ? that.mHeight : 0),
+    mChannels(mData ? that.mChannels : 0) {}
+
 LinearImage& LinearImage::operator=(const LinearImage& that) {
-    auto newDataRef = that.mDataRef
-        ? new SharedReference(*that.mDataRef)
-        : nullptr;
-    delete mDataRef;
-    mDataRef = newDataRef;
-    
-    mData = that.mData;
-    mWidth = that.mWidth;
-    mHeight = that.mHeight;
-    mChannels = that.mChannels;
+    if (this != &that) {
+        SharedReference* const newDataRef = that.mDataRef
+            ? new(std::nothrow) SharedReference(*that.mDataRef)
+            : nullptr;
+
+        delete mDataRef;
+        mDataRef = newDataRef;
+
+        mData = mDataRef && mDataRef->pixels ? mDataRef->pixels.get() : nullptr;
+        mWidth = mData ? that.mWidth : 0;
+        mHeight = mData ? that.mHeight : 0;
+        mChannels = mData ? that.mChannels : 0;
+    }
+    return *this;
+}
+
+LinearImage::LinearImage(LinearImage&& that) noexcept :
+    mDataRef(that.mDataRef),
+    mData(that.mData),
+    mWidth(that.mWidth),
+    mHeight(that.mHeight),
+    mChannels(that.mChannels) {
+    that.mDataRef = nullptr;
+    that.mData = nullptr;
+    that.mWidth = 0;
+    that.mHeight = 0;
+    that.mChannels = 0;
+}
+
+LinearImage& LinearImage::operator=(LinearImage&& that) noexcept {
+    if (this != &that) {
+        delete mDataRef;
+        mDataRef = that.mDataRef;
+        mData = that.mData;
+        mWidth = that.mWidth;
+        mHeight = that.mHeight;
+        mChannels = that.mChannels;
+
+        that.mDataRef = nullptr;
+        that.mData = nullptr;
+        that.mWidth = 0;
+        that.mHeight = 0;
+        that.mChannels = 0;
+    }
     return *this;
 }
 

--- a/libs/image/tests/test_image.cpp
+++ b/libs/image/tests/test_image.cpp
@@ -692,3 +692,11 @@ static LinearImage diffImages(const LinearImage& a, const LinearImage& b) {
     }
     return result;
 }
+
+TEST_F(ImageTest, LinearImageDimensionOverflow) { // NOLINT
+    LinearImage img1(std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(), 3);
+    EXPECT_FALSE(img1);
+
+    LinearImage img2(2, 2, 0);
+    EXPECT_FALSE(img2);
+}

--- a/libs/ktxreader/src/Ktx1Reader.cpp
+++ b/libs/ktxreader/src/Ktx1Reader.cpp
@@ -44,6 +44,26 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
     }
 #endif
 
+    // Pre-validate all mip levels and cubemap faces to prevent uninitialized/UAF issues
+    uint8_t* dummyData = nullptr;
+    uint32_t dummySize = 0;
+    for (uint32_t level = 0; level < nmips; ++level) {
+        if (ktx.isCubemap()) {
+            for (uint32_t face = 0; face < 6; ++face) {
+                if (!ktx.getBlob({ level, 0, face }, &dummyData, &dummySize)) {
+                    utils::slog.e << "Missing or invalid face " << face << " for mip level "
+                                  << level << utils::io::endl;
+                    return nullptr;
+                }
+            }
+        } else {
+            if (!ktx.getBlob({ level, 0, 0 }, &dummyData, &dummySize)) {
+                utils::slog.e << "Missing or invalid mip level " << level << utils::io::endl;
+                return nullptr;
+            }
+        }
+    }
+
     Texture* texture = Texture::Builder()
         .width(ktxinfo.pixelWidth)
         .height(ktxinfo.pixelHeight)
@@ -70,8 +90,8 @@ Texture* createTexture(Engine* engine, const Ktx1Bundle& ktx, bool srgb,
         }
     };
 
-    uint8_t* data;
-    uint32_t size;
+    uint8_t* data = nullptr;
+    uint32_t size = 0;
 
     if (isCompressed(ktxinfo)) {
         if (ktx.isCubemap()) {

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
         mi->setParameter("reflectance", 0.5f);
 
         // Add geometry into the scene.
-        app.mesh = MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, mi);
+        app.mesh = MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, mi);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.mesh.renderable), false);

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
 
         // Add a monkey and a light source into the main scene.
         app.monkeyMesh = MeshReader::loadMeshFromBuffer(
-                engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, mi);
+                engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, mi);
         auto ti = tcm.getInstance(app.monkeyMesh.renderable);
         app.monkeyTransform = mat4f{mat3f(1), monkeyPosition } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.monkeyMesh.renderable), false);

--- a/samples/materialinstancestress.cpp
+++ b/samples/materialinstancestress.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {
         app.desiredObjectCount = app.ui.objectCountSlider;
         app.suzanneTemplate = MeshReader::loadMeshFromBuffer(engine,
-                MONKEY_SUZANNE_DATA, nullptr, nullptr, nullptr);
+                MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, nullptr);
 
         app.litMaterial = Material::Builder()
                 .package(RESOURCES_AIDEFAULTMAT_DATA, RESOURCES_AIDEFAULTMAT_SIZE)

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -294,7 +294,7 @@ void setup_static_scene(Window& w, Engine* engine) {
     w.materialInstance->setParameter("sheenColor", 0.00f);
     w.materialInstance->setParameter("clearCoat", 1.00f);
     w.materialInstance->setParameter("clearCoatRoughness", 0.00f);
-    w.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, w.materialInstance);
+    w.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, w.materialInstance);
     w.scene->addEntity(w.mesh.renderable);
 
     int width, height;
@@ -327,7 +327,7 @@ void setup_animating_scene(Window& w, Engine* engine) {
     w.materialInstance->setParameter("sheenColor", 0.00f);
     w.materialInstance->setParameter("clearCoat", 0.00f);
     w.materialInstance->setParameter("clearCoatRoughness", 0.00f);
-    w.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, w.materialInstance);
+    w.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, w.materialInstance);
     w.scene->addEntity(w.mesh.renderable);
 
     int width, height;

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
         mi->setParameter("reflectance", 0.5f);
 
         // Add monkey into the scene.
-        app.monkeyMesh = MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, mi);
+        app.monkeyMesh = MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr, nullptr, mi);
         auto ti = tcm.getInstance(app.monkeyMesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.monkeyMesh.renderable), false);

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
         ibl->setRotation(mat3f::rotation(0.5f, float3{ 0, 1, 0 }));
 
         // Add geometry into the scene.
-        app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr,
+        app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, MONKEY_SUZANNE_SIZE, nullptr,
                 nullptr, app.materialInstance);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1921,7 +1921,7 @@ class_<MeshReader>("MeshReader")
         };
         // Parse the filamesh buffer. This creates the VB, IB, and renderable.
         return MeshReader::loadMeshFromBuffer(
-                engine, buffer.bd->buffer,
+                engine, buffer.bd->buffer, buffer.bd->size,
                 destructor, bundle, matreg);
     }), allow_raw_pointers());
 


### PR DESCRIPTION
- filameshio: Hardens the filamesh parser with size-validated buffer overloads, aligned memory access, and integer overflow safeguards.
- image: Protects LinearImage against dimension overflows using exception-free checks, and fully refactors its copy/move lifecycle operators.
- image/ktxreader: Hardens KTX1 bundle loading via numberOfFaces checks and pre-validates mip levels to prevent use-after-free bugs during texture creation.
- gltfio: Hardens index buffer conversion and skin bind matrix copying against integer overflows and out-of-bounds reads.