### PR TITLE
gltfio: zero-initialize accessors with undefined bufferViews

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1013,6 +1013,10 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive& inPrim, const char* na
 
         const size_t indexDataSize = vertexCount * sizeof(uint32_t);
         uint32_t* indexData = (uint32_t*) malloc(indexDataSize);
+        if (!indexData) {
+            utils::slog.e << "Out of memory allocating generated index buffer." << utils::io::endl;
+            return false;
+        }
         for (size_t i = 0; i < vertexCount; ++i) {
             indexData[i] = i;
         }
@@ -1286,6 +1290,10 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive& inPrim, const char* na
             mDummyBufferObject = BufferObject::Builder().size(requiredSize).build(mEngine);
             fAsset->mBufferObjects.push_back(mDummyBufferObject);
             uint32_t* dummyData = (uint32_t*) malloc(requiredSize);
+            if (!dummyData) {
+                utils::slog.e << "Out of memory allocating dummy vertex data." << utils::io::endl;
+                return false;
+            }
             memset(dummyData, 0xff, requiredSize);
             VertexBuffer::BufferDescriptor bd(dummyData, requiredSize, FREE_CALLBACK);
             mDummyBufferObject->setBuffer(mEngine, std::move(bd));

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -284,15 +284,95 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
 
 inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
         UriDataCacheHandle uriDataCache) {
+    const cgltf_accessor* kGenerateTangents = &asset->mGenerateTangents;
+    const cgltf_accessor* kGenerateNormals = &asset->mGenerateNormals;
+
     // Upload VertexBuffer and IndexBuffer data to the GPU.
     auto& slots = std::get<FFilamentAsset::ResourceInfo>(asset->mResourceInfo).mBufferSlots;
     for (auto const& slot: slots) {
         const cgltf_accessor* accessor = slot.accessor;
         // Morph target accessors may not have a buffer_view (data is directly in the accessor)
         bool isMorphTarget = (slot.morphTargetBuffer != nullptr);
+        bool isSentinel = (accessor == kGenerateTangents || accessor == kGenerateNormals);
 
         if (!accessor->buffer_view && !isMorphTarget) {
-            continue;
+            // Per glTF 2.0 Accessor Schema: "When [bufferView is] undefined, the accessor MUST be
+            // initialized with zeros; sparse property or extensions MAY override zeros with
+            // actual values."
+            // Also Section 5.2.2.1: "When accessor.bufferView is undefined, the sparse accessor
+            // is initialized as an array of zeros..."
+
+            // If the accessor is sparse or requires conversion, we let it fall through to the
+            // conversion path which handles zero-initialization via cgltf_accessor_unpack_floats.
+            //
+            // We don't fall through for sentinels because they have invalid types. Sentinels
+            // occur when AssetLoader identifies that normals or tangents should be generated.
+            // Normally, TangentsJob processes these for triangle primitives. However, for line
+            // or point primitives, TangentsJob skips them. In such cases, we MUST zero-initialize
+            // the buffer here; otherwise, the VertexBuffer will have an enabled attribute with
+            // no bound buffer, causing a panic in the graphics driver.
+            if (!isSentinel && (accessor->is_sparse || (accessor->type != cgltf_type_invalid &&
+                                               utility::requiresConversion(accessor)))) {
+                // fall through
+            } else {
+                size_t count = accessor->count;
+                if (count == 0 && slot.vertexBuffer) {
+                    count = slot.vertexBuffer->getVertexCount();
+                }
+
+                size_t elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
+                if (elementSize == 0 && isSentinel) {
+                    // Sentinels are used for TBN (tangent, bitangent, normal) generation.
+                    // Filament encodes this TBN frame as a quaternion in a SHORT4 attribute
+                    // (8 bytes).
+                    elementSize = 8; // SHORT4
+                }
+
+                const size_t size = count * elementSize;
+                if (size == 0) {
+                    continue;
+                }
+                if (slot.vertexBuffer) {
+                    void* zeros = malloc(size);
+                    if (!zeros) {
+                        slog.e << "Out of memory allocating zeroed vertex buffer." << io::endl;
+                        continue;
+                    }
+                    memset(zeros, 0, size);
+                    BufferObject* bo = BufferObject::Builder().size(size).build(engine);
+                    asset->mBufferObjects.push_back(bo);
+                    bo->setBuffer(engine, BufferDescriptor(zeros, size, FREE_CALLBACK));
+                    slot.vertexBuffer->setBufferObjectAt(engine, slot.bufferIndex, bo);
+                    continue;
+                }
+
+                if (slot.indexBuffer) {
+                    if (accessor->component_type == cgltf_component_type_r_8u) {
+                        // glTF 8-bit indices are 1 byte, but Filament IndexBuffer requires at least
+                        // 16-bit indices. We allocate 2 bytes per index to match the expansion
+                        // performed in the conversion path below.
+                        const size_t size16 = count * sizeof(uint16_t);
+                        void* zeros = malloc(size16);
+                        if (!zeros) {
+                            slog.e << "Out of memory allocating zeroed index buffer." << io::endl;
+                            continue;
+                        }
+                        memset(zeros, 0, size16);
+                        IndexBuffer::BufferDescriptor bd(zeros, size16, FREE_CALLBACK);
+                        slot.indexBuffer->setBuffer(engine, std::move(bd));
+                    } else {
+                        void* zeros = malloc(size);
+                        if (!zeros) {
+                            slog.e << "Out of memory allocating zeroed index buffer." << io::endl;
+                            continue;
+                        }
+                        memset(zeros, 0, size);
+                        IndexBuffer::BufferDescriptor bd(zeros, size, FREE_CALLBACK);
+                        slot.indexBuffer->setBuffer(engine, std::move(bd));
+                    }
+                    continue;
+                }
+            }
         }
 
         // For morph targets without buffer_view, use cgltf_accessor_unpack_floats to unpack data directly
@@ -334,14 +414,15 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
 
         const uint8_t* bufferData = nullptr;
         const uint8_t* data = nullptr;
-        if (accessor->buffer_view->has_meshopt_compression) {
-            bufferData = (const uint8_t*) accessor->buffer_view->data;
-            data = bufferData + accessor->offset;
-        } else {
-            bufferData = (const uint8_t*) accessor->buffer_view->buffer->data;
-            data = utility::computeBindingOffset(accessor) + bufferData;
+        if (accessor->buffer_view) {
+            if (accessor->buffer_view->has_meshopt_compression) {
+                bufferData = (const uint8_t*) accessor->buffer_view->data;
+                data = bufferData + accessor->offset;
+            } else {
+                bufferData = (const uint8_t*) accessor->buffer_view->buffer->data;
+                data = utility::computeBindingOffset(accessor) + bufferData;
+            }
         }
-        assert_invariant(bufferData);
         const uint32_t size = utility::computeBindingSize(accessor);
         if (size == 0) {
             // Skip buffer upload for this accessor as requested by user
@@ -349,22 +430,25 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
         }
         if (slot.vertexBuffer) {
             if (utility::requiresConversion(accessor)) {
-                const cgltf_size bufferSize = accessor->buffer_view->buffer->size;
-                const cgltf_size totalOffset = accessor->buffer_view->offset + accessor->offset;
-                
-                if (totalOffset >= bufferSize) {
-                    continue;
+                // Conversion path (handles null buffer_view internally via unpacking)
+                cgltf_size maxCount = accessor->count;
+                if (accessor->buffer_view) {
+                    const cgltf_size bufferSize = accessor->buffer_view->buffer->size;
+                    const cgltf_size totalOffset = accessor->buffer_view->offset + accessor->offset;
+
+                    if (totalOffset >= bufferSize) {
+                        continue;
+                    }
+
+                    const cgltf_size availableBytes = bufferSize - totalOffset;
+                    const cgltf_size stride = accessor->stride;
+                    const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
+
+                    if (stride > 0 && availableBytes >= elementSize) {
+                        maxCount = 1 + (availableBytes - elementSize) / stride;
+                    }
                 }
-                
-                const cgltf_size availableBytes = bufferSize - totalOffset;
-                const cgltf_size stride = accessor->stride;
-                const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
-                
-                cgltf_size maxCount = 0;
-                if (stride > 0 && availableBytes >= elementSize) {
-                    maxCount = 1 + (availableBytes - elementSize) / stride;
-                }
-                
+
                 cgltf_size safeCount = accessor->count;
                 if (safeCount > maxCount) {
                     LOG(WARNING) << "Accessor count exceeds buffer capacity, clamping.";
@@ -398,6 +482,12 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                 continue;
             }
 
+            // Standard upload path (direct GPU copy). This requires valid source data to be present.
+            // If bufferData is null (e.g. no bufferView), we skip the direct copy.
+            if (!bufferData) {
+                continue;
+            }
+
             BufferObject* bo = BufferObject::Builder().size(size).build(engine);
             asset->mBufferObjects.push_back(bo);
             bo->setBuffer(engine, BufferDescriptor(data, size, uploadCallback,
@@ -405,6 +495,11 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
             slot.vertexBuffer->setBufferObjectAt(engine, slot.bufferIndex, bo);
             continue;
         } else if (slot.indexBuffer) {
+            // Standard upload path for index buffers.
+            if (!bufferData) {
+                continue;
+            }
+
             if (accessor->component_type == cgltf_component_type_r_8u) {
                 if (size_t(size) > std::numeric_limits<size_t>::max() / 2) {
                     LOG(WARNING) << "Index buffer size would overflow on conversion, skipping.";

--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -182,7 +182,16 @@ uint32_t computeBindingSize(cgltf_accessor const* accessor) {
         return 0;
     }
     cgltf_size element_size = cgltf_calc_size(accessor->type, accessor->component_type);
-    return uint32_t(accessor->stride * (accessor->count - 1) + element_size);
+    cgltf_size stride = accessor->stride > 0 ? accessor->stride : element_size;
+    if (stride > 0 && accessor->count - 1 >
+                              (std::numeric_limits<cgltf_size>::max() - element_size) / stride) {
+        return 0;
+    }
+    cgltf_size size = stride * (accessor->count - 1) + element_size;
+    if (size > std::numeric_limits<uint32_t>::max()) {
+        return 0;
+    }
+    return uint32_t(size);
 }
 
 void convertBytesToShorts(uint16_t* dst, uint8_t const* src, size_t count) {


### PR DESCRIPTION
- Per glTF 2.0 spec, accessors without a bufferView must be initialized with zeros. This change implements that requirement in ResourceLoader, ensuring all vertex attributes (including TBN sentinels for non-triangle primitives) have a valid bound buffer. This prevents driver panics caused by uninitialized enabled attributes.
- Added robust bounds-checking in computeBindingSize to prevent integer overflow when processing glTF files with unusually large bounds.
- Added extensive null-checks for malloc return values across ResourceLoader and AssetLoader. This prevents OOM panics and null-pointer dereferences when processing malformed glTF files requesting excessively large buffer allocation. This addresses potential Denial of Service (DoS) attack vectors via crashes from malicious glTF files.

Fixes #9387
Fixes #8537