### PR TITLE
Trust VkFormat from Vulkan for external images

### DIFF
--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -90,64 +90,10 @@ bool isProtectedFromUsage(uint64_t usage) {
     return usage & AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT;
 }
 
-std::pair<VkFormat, VkImageUsageFlags> getVKFormatAndUsage(const AHardwareBuffer_Desc& desc,
-        bool sRGB) {
-    VkFormat format = VK_FORMAT_UNDEFINED;
+VkImageUsageFlags getVkUsage(const AHardwareBuffer_Desc& desc, VkFormat format, bool sRGB) {
     VkImageUsageFlags usage = 0;
-    // Refer to "11.2.17. External Memory Handle Types" in the spec, and
-    // Tables 13/14 for how the following derivation works.
-    bool isDepthFormat = false;
-    switch (desc.format) {
-        case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
-            format = VK_FORMAT_R8G8B8A8_UNORM;
-            break;
-        case AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM:
-            format = VK_FORMAT_R8G8B8A8_UNORM;
-            break;
-        case AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM:
-            format = VK_FORMAT_R8G8B8_UNORM;
-            break;
-        case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
-            format = VK_FORMAT_R5G6B5_UNORM_PACK16;
-            break;
-        case AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT:
-            format = VK_FORMAT_R16G16B16A16_SFLOAT;
-            break;
-        case AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM:
-            format = VK_FORMAT_A2B10G10R10_UNORM_PACK32;
-            break;
-        case AHARDWAREBUFFER_FORMAT_D16_UNORM:
-            isDepthFormat = true;
-            format = VK_FORMAT_D16_UNORM;
-            break;
-        case AHARDWAREBUFFER_FORMAT_D24_UNORM:
-            isDepthFormat = true;
-            format = VK_FORMAT_X8_D24_UNORM_PACK32;
-            break;
-        case AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT:
-            isDepthFormat = true;
-            format = VK_FORMAT_D24_UNORM_S8_UINT;
-            break;
-        case AHARDWAREBUFFER_FORMAT_D32_FLOAT:
-            isDepthFormat = true;
-            format = VK_FORMAT_D32_SFLOAT;
-            break;
-        case AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT:
-            isDepthFormat = true;
-            format = VK_FORMAT_D32_SFLOAT_S8_UINT;
-            break;
-        case AHARDWAREBUFFER_FORMAT_S8_UINT:
-            isDepthFormat = true;
-            format = VK_FORMAT_S8_UINT;
-            break;
-        default:
-            format = VK_FORMAT_UNDEFINED;
-    }
-
-    format = transformVkFormat(format, sRGB);
-
+    bool isDepthStencilFormat = fvkutils::isVkDepthFormat(format) || fvkutils::isVkStencilFormat(format);
     // The following only concern usage flags derived from Table 14.
-    usage = 0;
     if (desc.usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
         usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
 
@@ -155,7 +101,7 @@ std::pair<VkFormat, VkImageUsageFlags> getVKFormatAndUsage(const AHardwareBuffer
         // usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     }
     if (desc.usage & AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER) {
-        if (isDepthFormat) {
+        if (isDepthStencilFormat) {
             usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
         } else {
             usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -165,7 +111,7 @@ std::pair<VkFormat, VkImageUsageFlags> getVKFormatAndUsage(const AHardwareBuffer
         usage = VK_IMAGE_USAGE_STORAGE_BIT;
     }
 
-    return { format, usage };
+    return usage;
 }
 
 std::pair<TextureFormat, TextureUsage> getFilamentFormatAndUsage(const AHardwareBuffer_Desc& desc,
@@ -354,8 +300,26 @@ VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImag
         metadata.samples = VK_SAMPLE_COUNT_1_BIT;
         metadata.isStagingRequired = isSoftwareDecodedYUV(bufferDesc.format, bufferDesc.usage);
 
-        std::tie(metadata.format, metadata.usage) =
-            getVKFormatAndUsage(bufferDesc, fvkExternalImage->sRGB);
+        // Get the VkFormat directly from the driver.
+        VkAndroidHardwareBufferFormatPropertiesANDROID formatInfo = {
+            .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+        };
+        VkAndroidHardwareBufferPropertiesANDROID properties = {
+            .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+            .pNext = &formatInfo,
+        };
+        VkResult result = vkGetAndroidHardwareBufferPropertiesANDROID(getDevice(), buffer, &properties);
+        FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS)
+            << "vkGetAndroidHardwareBufferProperties failed with error="
+            << static_cast<int32_t>(result);
+
+        VkFormat bufferPropertiesFormat = transformVkFormat(formatInfo.format, fvkExternalImage->sRGB);
+        metadata.format = bufferPropertiesFormat;
+        metadata.usage = getVkUsage(bufferDesc, metadata.format, fvkExternalImage->sRGB);
+
+        // TODO: Right now, if we get a format that isn't explicitly supported by Filament, the
+        // reverse mapping to a Filament format may be empty. We can fix this by deriving the format
+        // from the VkFormat directly, but for now this should be ok.
         std::tie(metadata.filamentFormat, metadata.filamentUsage) =
             getFilamentFormatAndUsage(bufferDesc, fvkExternalImage->sRGB);
 
@@ -371,23 +335,6 @@ VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImag
         if (any(metadata.filamentUsage & (TextureUsage::BLIT_DST | TextureUsage::UPLOADABLE))) {
             metadata.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         }
-
-        VkAndroidHardwareBufferFormatPropertiesANDROID formatInfo = {
-            .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
-        };
-        VkAndroidHardwareBufferPropertiesANDROID properties = {
-            .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
-            .pNext = &formatInfo,
-        };
-        VkResult result = vkGetAndroidHardwareBufferPropertiesANDROID(getDevice(), buffer, &properties);
-        FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS)
-            << "vkGetAndroidHardwareBufferProperties failed with error="
-            << static_cast<int32_t>(result);
-
-        VkFormat bufferPropertiesFormat = transformVkFormat(formatInfo.format, fvkExternalImage->sRGB);
-        FILAMENT_CHECK_POSTCONDITION(metadata.format == bufferPropertiesFormat)
-            << "mismatched image format( " << metadata.format << ") and queried format("
-            << bufferPropertiesFormat << ") for external image (AHB)";
 
         metadata.allocationSize = properties.allocationSize;
         metadata.memoryTypeBits = properties.memoryTypeBits;


### PR DESCRIPTION
Right now, we have a hardcoded mapping for VkFormats that we expect from AHardwareBuffers, which can fail in the case of legacy formats that Android CTS expects us to support. The driver knows the right VkFormat to use, and we're currently using that format for validation. Instead, let's have that format now be the source-of-truth, and trust it - that way, any legacy formats that we don't anticipate do not crash the headset.

This would be using the VkFormat we already get from the driver. The difference now is, if the format is one we don't recognize, we'll still be able to provide some level of support for it. This will not affect android apps - it will only affect system processes.

Alternatives considered:
-  Add support for the format directly (HAL pixel format constants that are not exposed through AHardwareBuffer)
  - This felt like a bad approach as it would involve hardcoding internal formats, not anchored by a source of truth
- Remove the postcondition check
  - This might not work, as the underlying format wouldn't be set
 - Reverse lookups from VkFormat to get Filament format
   - I think we should defer on this, because these formats should not be accessible by Android apps, and even system apps likely don't use them. They only appear in some CTS tests. Any format that isn't in our old mapping is one that has long been deprecated. But we could use the VkFormat from the query to find the Filament format as well, if we wanted to go further from this change.