### PR TITLE
Remove return value with data race

### DIFF
--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -198,14 +198,13 @@ std::shared_ptr<VulkanCmdFence> VulkanCmdFence::completed() noexcept {
     return cmdFence;
 }
 
-VkResult VulkanCmdFence::updateStatus(VkDevice device) {
+void VulkanCmdFence::refreshStatus(VkDevice device) {
     if (mFence != VK_NULL_HANDLE) {
         VkResult status = vkGetFenceStatus(device, mFence);
         if (status == VK_SUCCESS) {
             setStatus(status);
         }
     }
-    return mStatus;
 }
 
 FenceStatus VulkanCmdFence::wait(VkDevice device, uint64_t const timeout,

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -178,17 +178,16 @@ struct VulkanCmdFence {
     }
 
     // Checks the underlying fence to see if the underlying process is complete.
-    // Updates the underlying status if the fence has signaled, and returns
-    // the current status.
-    VkResult updateStatus(VkDevice device);
+    // Updates the underlying status if the fence has signaled.
+    void refreshStatus(VkDevice device);
 
     inline VkFence getVkFence() {
         return mFence;
     }
 
-    // Checks what the status of the fence is. Note: this assumes that, in the
-    // most recent tick(), checkAndUpdateStatus() has been called. Otherwise,
-    // this may be out of date.
+    // Checks what the status of the fence is. Note: refreshStatus() should be called
+    // prior to getStatus(), either on tick() or directly prior. This method will
+    // not proactively check if the fence has signaled since the status was last set.
     VkResult getStatus() {
         std::shared_lock const rl(mLock);
         return mStatus;

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -317,7 +317,7 @@ void CommandBufferPool::update() {
         auto& buffer = mBuffers[index];
         // Updates the buffer's status, and marks it complete
         // if the fence has signaled.
-        buffer->checkAndUpdateStatus(mDevice);
+        buffer->refreshStatus(mDevice);
     });
 }
 

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -94,8 +94,8 @@ struct VulkanCommandBuffer {
     void begin() noexcept;
     fvkmemory::resource_ptr<VulkanSemaphore> submit();
 
-    inline void checkAndUpdateStatus(VkDevice device) {
-        mFenceStatus->updateStatus(device);
+    inline void refreshStatus(VkDevice device) {
+        mFenceStatus->refreshStatus(device);
     }
 
     VkResult getStatus() {


### PR DESCRIPTION
Checking mStatus without locking a mutex opens the possibility of getting a cached, stale value. This was flagged by an analysis tool. The return value is not read, so we can remove it. Renaming the functions to be a bit clearer.

CC @rafadevai 