### PR TITLE
MSYS2 environment is not supported

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -188,6 +188,8 @@ See [ios/samples/README.md](./ios/samples/README.md) for more information.
 
 ### Building on Windows with Visual Studio 2019 or later
 
+> ⚠️**NOTE:** Filament doesn't support MSYS2-based environment.
+
 Install the following components:
 
 - [Visual Studio 2019 or later](https://www.visualstudio.com/downloads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,17 @@ cmake_minimum_required(VERSION 3.22.1)
 # both release and debug).
 
 # ==================================================================================================
+# Unsupported environment
+# ==================================================================================================
+
+# Filament does not support MSYS2-based environment on Windows. See issue #9968.
+if(DEFINED ENV{MSYSTEM})
+    message(FATAL_ERROR
+        "MSYS2 Subsystem detected($ENV{MSYSTEM}). "
+        "Filament does not support MSYS2-based environment on Windows.")
+endif()
+
+# ==================================================================================================
 # Toolchain configuration
 # ==================================================================================================
 # On iOS, the deployment target is set inside third_party/clang/ios.cmake


### PR DESCRIPTION
The bluegl library requires the MASM assembler (ml.exe), and the MSYS2 doesn't have required environment variables to compile Filament.

Fixes #9968