### PR TITLE
webgpu: fix state and encoder mismatch in buffer update

### DIFF
--- a/filament/backend/src/webgpu/WebGPUBufferBase.cpp
+++ b/filament/backend/src/webgpu/WebGPUBufferBase.cpp
@@ -86,8 +86,9 @@ void WebGPUBufferBase::updateGPUBuffer(BufferDescriptor const& bufferDescriptor,
     const size_t stagingBufferSize =
             remainder == 0 ? bufferDescriptor.size : mainBulk + FILAMENT_WEBGPU_BUFFER_SIZE_MODULUS;
 
-    wgpu::Buffer stagingBuffer = webGPUStagePool->acquireBuffer(stagingBufferSize,
-            webGPUQueueManager->getLatestSubmissionState());
+    auto [encoder, submissionState] = webGPUQueueManager->getCommandEncoderWithState();
+
+    wgpu::Buffer stagingBuffer = webGPUStagePool->acquireBuffer(stagingBufferSize, submissionState);
 
     void* mappedRange = stagingBuffer.GetMappedRange();
     assert_invariant(mappedRange);
@@ -103,8 +104,7 @@ void WebGPUBufferBase::updateGPUBuffer(BufferDescriptor const& bufferDescriptor,
     stagingBuffer.Unmap();
 
     // Copy the staging buffer contents to the destination buffer.
-    webGPUQueueManager->getCommandEncoder().CopyBufferToBuffer(stagingBuffer, 0, mBuffer,
-            byteOffset,
+    encoder.CopyBufferToBuffer(stagingBuffer, 0, mBuffer, byteOffset,
             remainder == 0 ? bufferDescriptor.size
                            : mainBulk + FILAMENT_WEBGPU_BUFFER_SIZE_MODULUS);
 }

--- a/filament/backend/src/webgpu/WebGPUQueueManager.cpp
+++ b/filament/backend/src/webgpu/WebGPUQueueManager.cpp
@@ -69,6 +69,14 @@ wgpu::CommandEncoder WebGPUQueueManager::getCommandEncoder() {
     return mCommandEncoder;
 }
 
+// Returns the command encoder and the submission state of the encoder.
+std::pair<wgpu::CommandEncoder, std::shared_ptr<WebGPUSubmissionState>>
+        WebGPUQueueManager::getCommandEncoderWithState() {
+    auto encoder = getCommandEncoder();
+    auto state = getLatestSubmissionState();
+    return { encoder, state };
+}
+
 void WebGPUQueueManager::flush() {
     submit();
 }

--- a/filament/backend/src/webgpu/WebGPUQueueManager.h
+++ b/filament/backend/src/webgpu/WebGPUQueueManager.h
@@ -58,14 +58,18 @@ public:
     // Returns the command encoder for the current workload. Creates one if it doesn't exist.
     wgpu::CommandEncoder getCommandEncoder();
 
+    // Returns a shared pointer to the latest submission state.
+    std::shared_ptr<WebGPUSubmissionState> getLatestSubmissionState();
+
+    // Returns the command encoder and the submission state of the encoder.
+    std::pair<wgpu::CommandEncoder, std::shared_ptr<WebGPUSubmissionState>>
+            getCommandEncoderWithState();
+
     // Submits the current command buffer and creates a new submission state.
     void flush();
 
     // Submits the current command buffer and blocks until the work is done.
     void finish();
-
-    // Returns a shared pointer to the latest submission state.
-    std::shared_ptr<WebGPUSubmissionState> getLatestSubmissionState();
 
 private:
     void submit();


### PR DESCRIPTION
It's possible for WebGPUQueueManager::getLatestSubmissionState to return a submission state that does not match the encoder of the buffer copy. Here we make sure that the submission state specifically refers to the encoder of the copy.

This fix is prompted by #10031