### PR TITLE
Add Camera::getEyeFromViewMatrix

### DIFF
--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -457,6 +457,14 @@ public:
     //! Returns the camera's view matrix (inverse of the model matrix)
     math::mat4 getViewMatrix() const noexcept;
 
+    /** Returns the eye from view matrix for the specified eye.
+     *
+     * @param eyeId the index of the eye to return the eye from view matrix for, must be
+     *              < config.stereoscopicEyeCount
+     * @return The eye from view matrix
+     */
+    math::mat4 getEyeFromViewMatrix(uint8_t eyeId = 0) const noexcept;
+
     //! Returns the camera's position in world space
     math::double3 getPosition() const noexcept;
 

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -142,6 +142,10 @@ mat4 Camera::getViewMatrix() const noexcept {
     return downcast(this)->getViewMatrix();
 }
 
+mat4 Camera::getEyeFromViewMatrix(uint8_t const eyeId) const noexcept {
+    return downcast(this)->getEyeFromViewMatrix(eyeId);
+}
+
 double3 Camera::getPosition() const noexcept {
     return downcast(this)->getPosition();
 }


### PR DESCRIPTION
Exposes this camera setting at the user level so it can be used elsewhere.