### PR TITLE
backend: workaround broken WebGL spec-constant UBO array sizes

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -42,6 +42,8 @@
 #include <array>
 #include <atomic>
 #include <cctype>
+#include <cstdio>
+#include <cstring>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -792,6 +794,40 @@ void ShaderCompilerService::cancelPendingSynchronousProgram(program_token_t cons
             if (multiview && stage == ShaderStage::VERTEX) {
                 process_OVR_multiview2(context, numViews, shader_src, shader_len);
             }
+
+#ifdef __EMSCRIPTEN__
+            // WebGL workaround: ANGLE-on-D3D11 and some Android GLES drivers don't
+            // propagate `const int CONFIG_FOO = SPIRV_CROSS_CONSTANT_ID_<id>` into
+            // uniform-block array sizes, so they layout the block using the matc-baked
+            // default and disagree with the runtime-bound range — every instanced draw
+            // then fails the WebGL2 validator with "uniform buffer too small".
+            // Rewrite the symbolic array lengths to literals in place (padded with
+            // spaces to preserve byte count) so the GLSL compiler can't get it wrong.
+            // Values mirror what the engine binds with __EMSCRIPTEN__; backend can't
+            // include EngineEnums.h (layering — same precedent as CONFIG_STEREO_EYE_COUNT
+            // hardcoded above). Spec-constant-aware analogue of the 2022 hack at
+            // commit fe3790cb9 (#5859), removed when spec constants were assumed
+            // portable.
+            {
+                auto rewriteArraySize = [&](std::string_view symbolic, size_t value) {
+                    char replacement[32];
+                    int const n = std::snprintf(replacement, sizeof(replacement), "[%zu", value);
+                    if (n <= 0 || (size_t)n >= symbolic.size()) {
+                        return;
+                    }
+                    std::memset(replacement + n, ' ', symbolic.size() - n - 1);
+                    replacement[symbolic.size() - 1] = ']';
+                    std::string_view view{ shader_src, shader_len };
+                    for (size_t p = view.find(symbolic); p != std::string_view::npos;
+                            p = view.find(symbolic, p + symbolic.size())) {
+                        std::memcpy(shader_src + p, replacement, symbolic.size());
+                    }
+                };
+                rewriteArraySize("[CONFIG_MAX_INSTANCES]", 8);
+                rewriteArraySize("[CONFIG_FROXEL_BUFFER_HEIGHT]", 1024);
+                rewriteArraySize("[CONFIG_FROXEL_RECORD_BUFFER_HEIGHT]", 1024);
+            }
+#endif
 
             // add support for ARB_shading_language_packing if needed
             auto const packingFunctions = process_ARB_shading_language_packing(context);


### PR DESCRIPTION
## Symptom

On Chromium-on-Windows and several Android Chromium configurations, every `glDrawElementsInstanced` call spams the WebGL2 validator:

```
GL_INVALID_OPERATION: glDrawElementsInstanced:
  It is undefined behaviour to use a uniform buffer that is too small.
```

On the affected drivers the draw is silently dropped, so any lit material is invisible. Chromium-on-macOS (ANGLE-Metal) tolerates the mismatch and renders correctly, which is why this had gone unnoticed.

This problem was noticed in one of my projects while testing a scene on different browsers, you can check the broken version on the following Github Pages -> Selection the button "Solar".

https://erkko68.github.io/filament-kmp/

Before
<img width="1854" height="807" alt="image002" src="https://github.com/user-attachments/assets/55b08c1d-16af-4c19-bc92-cfe70d22dcef" />

After
<img width="1848" height="824" alt="image001" src="https://github.com/user-attachments/assets/1f44628d-b2a6-4531-86ce-e4af8eaa9cb5" />

## Cause

ANGLE-on-D3D11 and some Android GLES drivers don't propagate `const int CONFIG_FOO = SPIRV_CROSS_CONSTANT_ID_<id>` into the uniform-block array size — they layout the block using the matc-baked default and disagree with the runtime-bound range.

Same shape as the bug originally fixed by [`fe3790cb9`](https://github.com/google/filament/commit/fe3790cb9) (#5859, "WASM: Set CONFIG_MAX_INSTANCES to a small value + hack the GLSL"). That hack was removed when spec constants were assumed portable.

## Fix

Spec-constant-aware revival of the 2022 hack: in `ShaderCompilerService::compileShaders`, gate on `#ifdef __EMSCRIPTEN__`, walk the shader source, and rewrite each symbolic array length to a literal (padded with spaces to keep byte count). Affects three arrays in shipped FL1 materials: `CONFIG_MAX_INSTANCES`, `CONFIG_FROXEL_BUFFER_HEIGHT`, `CONFIG_FROXEL_RECORD_BUFFER_HEIGHT`.
