### PR TITLE
utils: Implement Epoch-Based Reclamation (EBR) for Entity Management 

### DIFF
--- a/android/filament-android/src/main/cpp/EntityManager.cpp
+++ b/android/filament-android/src/main/cpp/EntityManager.cpp
@@ -15,9 +15,9 @@
  */
 
 
-#include <jni.h>
-
 #include <utils/EntityManager.h>
+
+#include <jni.h>
 
 using namespace utils;
 
@@ -75,4 +75,23 @@ Java_com_google_android_filament_EntityManager_nIsAlive(JNIEnv*, jclass,
     EntityManager *em = (EntityManager *) nativeEntityManager;
     Entity& entity = *reinterpret_cast<Entity*>(&entity_);
     return (jboolean) em->isAlive(entity);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_EntityManager_nAdvanceEpoch(JNIEnv*, jclass,
+        jlong nativeEntityManager) {
+    EntityManager *em = (EntityManager *) nativeEntityManager;
+    em->advanceEpoch();
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_EntityManager_nGetMaxEntityCount(JNIEnv*, jclass) {
+    return (jint) EntityManager::getMaxEntityCount();
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_EntityManager_nGetEntityCount(JNIEnv*, jclass,
+        jlong nativeEntityManager) {
+    EntityManager *em = (EntityManager *) nativeEntityManager;
+    return (jint) em->getEntityCount();
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/EntityManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/EntityManager.java
@@ -77,10 +77,25 @@ public class EntityManager {
         return mNativeObject;
     }
 
+    public void advanceEpoch() {
+        nAdvanceEpoch(mNativeObject);
+    }
+
+    public int getMaxEntityCount() {
+        return nGetMaxEntityCount();
+    }
+
+    public int getEntityCount() {
+        return nGetEntityCount(mNativeObject);
+    }
+
     private static native long nGetEntityManager();
     private static native void nCreateArray(long nativeEntityManager, int n, int[] entities);
     private static native int nCreate(long nativeEntityManager);
     private static native void nDestroyArray(long nativeEntityManager, int n, int[] entities);
     private static native void nDestroy(long nativeEntityManager, int entity);
     private static native boolean nIsAlive(long nativeEntityManager, int entity);
+    private static native void nAdvanceEpoch(long nativeEntityManager);
+    private static native int nGetMaxEntityCount();
+    private static native int nGetEntityCount(long nativeEntityManager);
 }

--- a/build.sh
+++ b/build.sh
@@ -913,7 +913,7 @@ function check_debug_release_build {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfgimp:q:uvWslwedtk:bVx:S:X:Py:E" opt; do
+while getopts ":hacCfgimp:q:uvWslwedtk:bVx:S:X:Py:ET" opt; do
     case ${opt} in
         h)
             print_help
@@ -1058,6 +1058,9 @@ while getopts ":hacCfgimp:q:uvWslwedtk:bVx:S:X:Py:E" opt; do
             ;;
         b)  ASAN_UBSAN_OPTION="-DFILAMENT_ENABLE_ASAN_UBSAN=ON"
             echo "Enabled ASAN/UBSAN"
+            ;;
+        T)  ASAN_UBSAN_OPTION="-DFILAMENT_ENABLE_TSAN=ON"
+            echo "Enabled TSan"
             ;;
         V)  COVERAGE_OPTION="-DFILAMENT_ENABLE_COVERAGE=ON"
             echo "Enabled coverage"

--- a/filament/benchmark/benchmark_filament.cpp
+++ b/filament/benchmark/benchmark_filament.cpp
@@ -15,17 +15,24 @@
  */
 
 #include "Culler.h"
+#include "downcast.h"
 #include "PerformanceCounters.h"
+
+#include "details/Engine.h"
 
 #include <filament/Box.h>
 #include <filament/ColorGrading.h>
 #include <filament/Engine.h>
 #include <filament/Frustum.h>
+#include <filament/LightManager.h>
+#include <filament/RenderableManager.h>
 #include <filament/ToneMapper.h>
+#include <filament/TransformManager.h>
 
 #include <utils/Allocator.h>
-#include <utils/FixedCapacityVector.h>
 #include <utils/compiler.h>
+#include <utils/EntityManager.h>
+#include <utils/FixedCapacityVector.h>
 
 #include <benchmark/benchmark.h>
 
@@ -392,4 +399,70 @@ BENCHMARK_F(ColorGradingFixture, lutGenerationGeneric)(benchmark::State& state) 
 }
 BENCHMARK_F(ColorGradingFixture, lutGenerationDisplayRange)(benchmark::State& state) {
     benchmarkToneMapper<DisplayRangeToneMapper>(engine, state);
+}
+
+class EngineGcWorstCaseFixture : public benchmark::Fixture {
+protected:
+    Engine* engine = nullptr;
+    EntityManager* em = nullptr;
+    TransformManager* tcm = nullptr;
+    LightManager* lcm = nullptr;
+    RenderableManager* rcm = nullptr;
+
+public:
+    void SetUp(const benchmark::State& state) override {
+        Engine::Config config;
+        engine = Engine::Builder()
+            .backend(Engine::Backend::NOOP)
+            .config(&config)
+            .build();
+        em = &engine->getEntityManager();
+        tcm = &engine->getTransformManager();
+        lcm = &engine->getLightManager();
+        rcm = &engine->getRenderableManager();
+    }
+
+    void TearDown(const benchmark::State& state) override {
+        Engine::destroy(&engine);
+    }
+};
+
+BENCHMARK_F(EngineGcWorstCaseFixture, worstCaseSequentialGc)(benchmark::State& state) {
+    constexpr size_t TOTAL_ENTITIES = 10000;
+    constexpr size_t DESTROYED_ENTITIES = 5000;
+
+    std::vector<Entity> entities(TOTAL_ENTITIES);
+
+    PerformanceCounters pc(state);
+    for (auto _ : state) {
+        state.PauseTiming();
+        for (size_t i = 0; i < TOTAL_ENTITIES; ++i) {
+            entities[i] = em->create();
+            tcm->create(entities[i], 0, mat4f());
+            LightManager::Builder(LightManager::Type::POINT).build(*engine, entities[i]);
+            RenderableManager::Builder(1).boundingBox({{0,0,0},{1,1,1}}).build(*engine, entities[i]);
+            engine->createCamera(entities[i]);
+        }
+        em->advanceEpoch();
+
+        for (size_t i = 0; i < DESTROYED_ENTITIES; ++i) {
+            em->destroy(entities[i]);
+        }
+        em->advanceEpoch();
+
+        state.ResumeTiming();
+
+        downcast(engine)->gc();
+
+        state.PauseTiming();
+        for (size_t i = DESTROYED_ENTITIES; i < TOTAL_ENTITIES; ++i) {
+            em->destroy(entities[i]);
+        }
+        em->advanceEpoch();
+        downcast(engine)->gc();
+        entities.clear();
+        entities.resize(TOTAL_ENTITIES);
+    }
+    pc.stop();
+    state.SetItemsProcessed(state.iterations() * DESTROYED_ENTITIES);
 }

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -554,13 +554,13 @@ public:
          * precedence.
          *
          * @param primitiveIndex the primitive of interest
-         * @param order draw order number (0 by default). Only the lowest 15 bits are used.
+         * @param blendOrder draw order number (0 by default). Only the lowest 15 bits are used.
          *
          * @return Builder reference for chaining calls.
          *
          * @see globalBlendOrderEnabled
          */
-        Builder& blendOrder(size_t primitiveIndex, uint16_t order) noexcept;
+        Builder& blendOrder(size_t primitiveIndex, uint16_t blendOrder) noexcept;
 
         /**
          * Sets whether the blend order is global or local to this Renderable (by default).
@@ -634,7 +634,7 @@ public:
          *            memory or other resources.
          * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
          */
-        Result build(Engine& engine, utils::Entity entity);
+        Result build(Engine& engine, utils::Entity entity) const;
 
     private:
         friend class FEngine;

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -22,13 +22,15 @@
 #include <utils/debug.h>
 #include <utils/Entity.h>
 #include <utils/Logger.h>
+#include <utils/PagedArenaBitsetPool.h>
 
 using namespace utils;
 using namespace filament::math;
 
 namespace filament {
 
-FCameraManager::FCameraManager(FEngine&) noexcept {
+FCameraManager::FCameraManager(FEngine& engine) noexcept
+        : mManager(engine.getEntityManager()) {
 }
 
 FCameraManager::~FCameraManager() noexcept = default;
@@ -39,24 +41,26 @@ void FCameraManager::terminate(FEngine& engine) noexcept {
         DLOG(INFO) << "cleaning up " << manager.getComponentCount() << " leaked Camera components";
         while (!manager.empty()) {
             Instance const ci = manager.end() - 1;
-            destroy(engine, manager.getEntity(ci));
+            destroy(manager.getEntity(ci), engine);
         }
     }
 }
 
-void FCameraManager::gc(FEngine& engine, EntityManager& em) noexcept {
-    auto& manager = mManager;
-    manager.gc(em, [this, &engine](Entity const e) {
-        destroy(engine, e);
-    });
+void FCameraManager::gc(FEngine& engine) noexcept {
+    mManager.gc(this, &FCameraManager::destroyComponents, engine);
 }
 
 FCamera* FCameraManager::create(FEngine& engine, Entity entity) {
     auto& manager = mManager;
 
+    Entity zombie;
+    if (UTILS_UNLIKELY(manager.popPendingZombie(entity, zombie))) {
+        destroy(zombie, engine);
+    }
+
     // if this entity already has Camera component, destroy it.
     if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
-        destroy(engine, entity);
+        destroy(entity, engine);
     }
 
     // add the Camera component to the entity
@@ -76,24 +80,27 @@ FCamera* FCameraManager::create(FEngine& engine, Entity entity) {
     return camera;
 }
 
-void FCameraManager::destroy(FEngine& engine, Entity const e) noexcept {
+void FCameraManager::destroyComponents(Entity const* entities, size_t const count, FEngine& engine) noexcept {
     auto& manager = mManager;
-    if (Instance const i = manager.getInstance(e) ; i) {
-        // destroy the FCamera object
-        bool const ownsTransformComponent = manager.elementAt<OWNS_TRANSFORM_COMPONENT>(i);
+    for (size_t k = 0; k < count; ++k) {
+        Entity const e = entities[k];
+        if (Instance const i = manager.getInstance(e) ; i) {
+            // destroy the FCamera object
+            bool const ownsTransformComponent = manager.elementAt<OWNS_TRANSFORM_COMPONENT>(i);
 
-        { // scope for camera -- it's invalid after this scope.
-            FCamera* const camera = manager.elementAt<CAMERA>(i);
-            assert_invariant(camera);
-            engine.getHeapAllocator().destroy(camera);
+            { // scope for camera -- it's invalid after this scope.
+                FCamera* const camera = manager.elementAt<CAMERA>(i);
+                assert_invariant(camera);
+                engine.getHeapAllocator().destroy(camera);
 
-            // Remove the camera component
-            manager.removeComponent(e);
-        }
+                // Remove the camera component
+                manager.removeComponent(e);
+            }
 
-        // if we added the transform component, remove it.
-        if (ownsTransformComponent) {
-            engine.getTransformManager().destroy(e);
+            // if we added the transform component, remove it.
+            if (ownsTransformComponent) {
+                engine.getTransformManager().destroy(e);
+            }
         }
     }
 }

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -46,7 +46,7 @@ public:
     // free-up all resources
     void terminate(FEngine& engine) noexcept;
 
-    void gc(FEngine& engine, utils::EntityManager& em) noexcept;
+    void gc(FEngine& engine) noexcept;
 
     /*
     * Component Manager APIs
@@ -82,7 +82,11 @@ public:
 
     FCamera* create(FEngine& engine, utils::Entity entity);
 
-    void destroy(FEngine& engine, utils::Entity e) noexcept;
+    void destroyComponents(utils::Entity const* entities, size_t count, FEngine& engine) noexcept;
+
+    void destroy(utils::Entity e, FEngine& engine) noexcept {
+        destroyComponents(&e, 1, engine);
+    }
 
 private:
 
@@ -94,6 +98,7 @@ private:
     using Base = utils::SingleInstanceComponentManager<FCamera*, bool>;
 
     struct CameraManagerImpl : public Base {
+        explicit CameraManagerImpl(utils::EntityManager& em) noexcept : Base(em, "CameraManager") {}
         using Base::gc;
         using Base::swap;
         using Base::hasComponent;

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -25,6 +25,7 @@
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Logger.h>
+#include <utils/PagedArenaBitsetPool.h>
 
 #include <math/fast.h>
 #include <math/scalar.h>
@@ -164,7 +165,8 @@ LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entit
 
 // ------------------------------------------------------------------------------------------------
 
-FLightManager::FLightManager(FEngine& engine) noexcept : mEngine(engine) {
+FLightManager::FLightManager(FEngine& engine) noexcept
+        : mManager(engine.getEntityManager()), mEngine(engine) {
     // DON'T use engine here in the ctor, because it's not fully constructed yet.
 }
 
@@ -179,6 +181,11 @@ void FLightManager::init(FEngine&) noexcept {
 
 void FLightManager::create(const Builder& builder, Entity const entity) {
     auto& manager = mManager;
+
+    Entity zombie;
+    if (UTILS_UNLIKELY(manager.popPendingZombie(entity, zombie))) {
+        destroy(zombie);
+    }
 
     if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
         destroy(entity);
@@ -216,11 +223,14 @@ void FLightManager::create(const Builder& builder, Entity const entity) {
 void FLightManager::prepare(backend::DriverApi&) const noexcept {
 }
 
-void FLightManager::destroy(Entity const e) noexcept {
-    Instance const i = getInstance(e);
-    if (i) {
-        auto& manager = mManager;
-        manager.removeComponent(e);
+void FLightManager::destroyComponents(Entity const* entities, size_t const count) noexcept {
+    auto& manager = mManager;
+    for (size_t k = 0; k < count; ++k) {
+        Entity const e = entities[k];
+        Instance const i = getInstance(e);
+        if (i) {
+            manager.removeComponent(e);
+        }
     }
 }
 
@@ -236,12 +246,9 @@ void FLightManager::terminate() noexcept {
         }
     }
 }
-void FLightManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity const e) {
-        destroy(e);
-    });
+void FLightManager::gc() noexcept {
+    mManager.gc(this, &FLightManager::destroyComponents);
 }
-
 void FLightManager::setShadowOptions(Instance const i, ShadowOptions const& options) noexcept {
     ShadowParams& params = mManager[i].shadowParams;
     params.options = options;
@@ -362,7 +369,7 @@ void FLightManager::setIntensity(Instance const i, float const intensity, Intens
                 }
                 break;
         }
-        
+
         bool changed = false;
         if (manager[i].intensity != luminousIntensity) {
             manager[i].intensity = luminousIntensity;
@@ -387,7 +394,7 @@ void FLightManager::setFalloff(Instance const i, float const falloff) noexcept {
         float const sqFalloff = falloff * falloff;
         float const squaredFallOffInv = sqFalloff > 0.0f ? (1 / sqFalloff) : 0;
         SpotParams& spotParams = manager[i].spotParams;
-        
+
         if (manager[i].squaredFallOffInv != squaredFallOffInv || spotParams.radius != falloff) {
             manager[i].squaredFallOffInv = squaredFallOffInv;
             spotParams.radius = falloff;
@@ -417,7 +424,7 @@ void FLightManager::setSpotLightCone(Instance const i, float const inner, float 
         if (spotParams.outerClamped != outerClamped ||
             spotParams.cosOuterSquared != cosOuterSquared ||
             spotParams.scaleOffset != scaleOffset) {
-            
+
             spotParams.outerClamped = outerClamped;
             spotParams.cosOuterSquared = cosOuterSquared;
             spotParams.sinInverse = 1.0f / std::sin(outerClamped);

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -44,7 +44,7 @@ public:
 
     void terminate() noexcept;
 
-    void gc(utils::EntityManager& em) noexcept;
+    void gc() noexcept;
 
     /*
      * Component Manager APIs
@@ -80,7 +80,11 @@ public:
 
     void create(const Builder& builder, utils::Entity entity);
 
-    void destroy(utils::Entity e) noexcept;
+    void destroyComponents(utils::Entity const* entities, size_t count) noexcept;
+
+    void destroy(utils::Entity e) noexcept {
+        destroyComponents(&e, 1);
+    }
 
     void prepare(backend::DriverApi& driver) const noexcept;
 
@@ -149,7 +153,7 @@ public:
     }
 
     bool isPointLight(Instance const i) const noexcept {
-        return getType(i) == Type::POINT; 
+        return getType(i) == Type::POINT;
     }
 
     bool isSpotLight(Instance const i) const noexcept {
@@ -167,7 +171,7 @@ public:
     }
 
     bool isSunLight(Instance const i) const noexcept {
-        return getType(i) == Type::SUN; 
+        return getType(i) == Type::SUN;
     }
 
     uint32_t getShadowMapSize(Instance const i) const noexcept {
@@ -288,6 +292,7 @@ private:
     >;
 
     struct Sim : public Base {
+        explicit Sim(utils::EntityManager& em) noexcept : Base(em, "LightManager") {}
         using Base::gc;
         using Base::swap;
 

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -131,8 +131,7 @@ struct RenderableManager::BuilderDetails {
             : mEntries(count), mCulling(true), mCastShadows(false),
               mReceiveShadows(true), mScreenSpaceContactShadows(false),
               mSkinningBufferMode(false), mFogEnabled(true),
-              mGeometryType(Builder::GeometryType::DYNAMIC),
-              mBonePairs() {
+              mGeometryType(Builder::GeometryType::DYNAMIC) {
     }
     // this is only needed for the explicit instantiation below
     BuilderDetails() = default;
@@ -328,7 +327,7 @@ RenderableManager::Builder& RenderableManager::Builder::morphing(
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level,
+RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t,
         size_t const primitiveIndex, size_t const offset) noexcept {
     // the last parameter "count" is unused, because it must be equal to the primitive's vertex count
     std::vector<BuilderDetails::Entry>& entries = mImpl->mEntries;
@@ -340,17 +339,17 @@ RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level,
 }
 
 RenderableManager::Builder& RenderableManager::Builder::blendOrder(
-        size_t const index, uint16_t const blendOrder) noexcept {
-    if (index < mImpl->mEntries.size()) {
-        mImpl->mEntries[index].blendOrder = blendOrder;
+        size_t const primitiveIndex, uint16_t const blendOrder) noexcept {
+    if (primitiveIndex < mImpl->mEntries.size()) {
+        mImpl->mEntries[primitiveIndex].blendOrder = blendOrder;
     }
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::globalBlendOrderEnabled(
-        size_t const index, bool const enabled) noexcept {
-    if (index < mImpl->mEntries.size()) {
-        mImpl->mEntries[index].globalBlendOrderEnabled = enabled;
+        size_t const primitiveIndex, bool const enabled) noexcept {
+    if (primitiveIndex < mImpl->mEntries.size()) {
+        mImpl->mEntries[primitiveIndex].globalBlendOrderEnabled = enabled;
     }
     return *this;
 }
@@ -415,11 +414,11 @@ void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engi
                     if (boneWeight > 0.0f) {
                         FILAMENT_CHECK_PRECONDITION(boneIndex >= 0)
                                 << "[entity=" << entity.getId() << ", primitive @ "
-                                << primitiveIndex << "] bone index (" << (int)boneIndex
+                                << primitiveIndex << "] bone index (" << int(boneIndex)
                                 << ") of vertex=" << iVertex << " is negative";
                         FILAMENT_CHECK_PRECONDITION(boneIndex < mSkinningBoneCount)
                                 << "[entity=" << entity.getId() << ", primitive @ "
-                                << primitiveIndex << "] bone index (" << (int)boneIndex
+                                << primitiveIndex << "] bone index (" << int(boneIndex)
                                 << ") of vertex=" << iVertex << " is bigger then bone count ("
                                 << mSkinningBoneCount << ")";
                         boneWeightsSum += boneWeight;
@@ -452,14 +451,14 @@ void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engi
                 // prepare data for vertex attributes
                 auto const offset = iVertex * 4;
                 // set attributes, indices and weights, for <= 4 pairs
-                for (size_t j = 0, c = std::min((int)tempPairCount, 4); j < c; j++) {
+                for (size_t j = 0, c = std::min(int(tempPairCount), 4); j < c; j++) {
                     skinJoints[j + offset] = uint16_t(tempPairs[j][0]);
                     skinWeights[j + offset] = tempPairs[j][1] / float(boneWeightsSum);
                 }
                 // prepare data for texture
                 if (tempPairCount > 4) { // set attributes, indices and weights, for > 4 pairs
                     // number pairs per vertex in texture
-                    skinJoints[3 + offset] = (uint16_t)tempPairCount;
+                    skinJoints[3 + offset] = uint16_t(tempPairCount);
                     // negative offset to texture 0..-1, 1..-2
                     skinWeights[3 + offset] = -float(pairsCount + 1);
                     for (size_t j = 3; j < tempPairCount; j++) {
@@ -479,18 +478,18 @@ void RenderableManager::BuilderDetails::processBoneIndicesAndWights(Engine& engi
 }
 
 RenderableManager::Builder& RenderableManager::Builder::instances(size_t const instanceCount) noexcept {
-    mImpl->mInstanceCount = clamp((unsigned int)instanceCount, 1u, 32767u);
+    mImpl->mInstanceCount = clamp(static_cast<unsigned int>(instanceCount), 1u, 32767u);
     return *this;
 }
 
 RenderableManager::Builder& RenderableManager::Builder::instances(
         size_t const instanceCount, InstanceBuffer* instanceBuffer) noexcept {
-    mImpl->mInstanceCount = clamp(instanceCount, (size_t)1, CONFIG_MAX_INSTANCES);
+    mImpl->mInstanceCount = clamp(instanceCount, size_t(1), CONFIG_MAX_INSTANCES);
     mImpl->mInstanceBuffer = downcast(instanceBuffer);
     return *this;
 }
 
-RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity const entity) {
+RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity const entity) const {
     bool isEmpty = true;
 
     FILAMENT_CHECK_PRECONDITION(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT)
@@ -603,7 +602,8 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
 
 // ------------------------------------------------------------------------------------------------
 
-FRenderableManager::FRenderableManager(FEngine& engine) noexcept : mEngine(engine) {
+FRenderableManager::FRenderableManager(FEngine& engine) noexcept
+        : mManager(engine.getEntityManager()), mEngine(engine) {
     // DON'T use engine here in the ctor, because it's not fully constructed yet.
 }
 
@@ -618,6 +618,11 @@ void FRenderableManager::create(
     FEngine& engine = mEngine;
     auto& manager = mManager;
     FEngine::DriverApi& driver = engine.getDriverApi();
+
+    Entity zombie;
+    if (UTILS_UNLIKELY(manager.popPendingZombie(entity, zombie))) {
+        destroy(zombie, driver);
+    }
 
     if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
         destroy(entity, driver);
@@ -665,8 +670,8 @@ void FRenderableManager::create(
                 Bones& bones = manager[ci].bones;
                 bones = Bones{
                         .handle = builder->mSkinningBuffer->getHwHandle(),
-                        .count = (uint16_t)boneCount,
-                        .offset = (uint16_t)builder->mSkinningBufferOffset,
+                        .count = uint16_t(boneCount),
+                        .offset = uint16_t(builder->mSkinningBufferOffset),
                         .skinningBufferMode = true };
             }
         } else {
@@ -690,7 +695,7 @@ void FRenderableManager::create(
                                 sizeof(PerRenderableBoneUib),
                                 BufferObjectBinding::UNIFORM,
                                 BufferUsage::DYNAMIC),
-                        .count = (uint16_t)boneCount,
+                        .count = uint16_t(boneCount),
                         .offset = 0,
                         .skinningBufferMode = false };
 
@@ -758,8 +763,8 @@ void FRenderableManager::create(
             mManager[ci].morphTargetBuffer = morphTargetBuffer;
             if (builder->mMorphTargetBuffer) {
                 for (size_t i = 0; i < entryCount; ++i) {
-                    const auto& morphing = builder->mEntries[i].morphing;
-                    primitives[i].setMorphingBufferOffset(morphing.offset);
+                    auto const& [offset] = builder->mEntries[i].morphing;
+                    primitives[i].setMorphingBufferOffset(offset);
                 }
             }
 
@@ -776,16 +781,19 @@ void FRenderableManager::create(
 }
 
 // this destroys a single component from an entity
-void FRenderableManager::destroy(Entity const e, DriverApi& driver) noexcept {
-    Instance const ci = getInstance(e);
-    if (ci) {
-        destroyComponent(ci, driver);
-        mManager.removeComponent(e);
+void FRenderableManager::destroyComponents(Entity const* entities, size_t const count, DriverApi& driver) noexcept {
+    auto& manager = mManager;
+    for (size_t k = 0; k < count; ++k) {
+        Entity const e = entities[k];
+        if (Instance const ci = getInstance(e)) {
+            destroyComponent(ci, driver);
+            manager.removeComponent(e);
+        }
     }
 }
 
-void FRenderableManager::clientDestroy(Entity e) noexcept {
-    destroy(e, mEngine.getDriverApi());
+void FRenderableManager::clientDestroy(Entity const e) noexcept {
+    destroyComponents(&e, 1, mEngine.getDriverApi());
 }
 
 // this destroys all components in this manager
@@ -803,10 +811,8 @@ void FRenderableManager::terminate(DriverApi& driver) noexcept {
     mHwRenderPrimitiveFactory.terminate(driver);
 }
 
-void FRenderableManager::gc(EntityManager& em, DriverApi& driver) noexcept {
-    mManager.gc(em, [this, &driver](Entity const e) {
-        destroy(e, driver);
-    });
+void FRenderableManager::gc(DriverApi& driver) noexcept {
+    mManager.gc(this, &FRenderableManager::destroyComponents, driver);
 }
 
 // This is basically a Renderable's destructor.
@@ -857,13 +863,13 @@ void FRenderableManager::setMaterialInstanceAt(Instance const instance, uint8_t 
             // we want a feature level violation to be a hard error (exception if enabled, or crash)
             FILAMENT_CHECK_PRECONDITION(mEngine.hasFeatureLevel(material->getFeatureLevel()))
                     << "Material \"" << material->getName().c_str_safe() << "\" has feature level "
-                    << (uint8_t)material->getFeatureLevel()
+                    << uint8_t(material->getFeatureLevel())
                     << " which is not supported by this Engine";
 
             primitives[primitiveIndex].setMaterialInstance(mi);
             AttributeBitset const required = material->getRequiredAttributes();
             AttributeBitset const declared = primitives[primitiveIndex].getEnabledAttributes();
-            // Print the warning only when the handle is available. Otherwise this may end up
+            // Print the warning only when the handle is available. Otherwise, this may end up
             // emitting many invalid warnings as the `declared` bitset is not populated yet.
             bool const isPrimitiveInitialized = !!primitives[primitiveIndex].getHwHandle();
             if (UTILS_UNLIKELY(isPrimitiveInitialized && (declared & required) != required)) {
@@ -875,8 +881,8 @@ void FRenderableManager::setMaterialInstanceAt(Instance const instance, uint8_t 
     }
 }
 
-void FRenderableManager::clearMaterialInstanceAt(Instance instance, uint8_t level,
-        size_t primitiveIndex) {
+void FRenderableManager::clearMaterialInstanceAt(Instance const instance, uint8_t const level,
+        size_t const primitiveIndex) {
     if (instance) {
         Slice<FRenderPrimitive> const primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
@@ -899,11 +905,11 @@ MaterialInstance* FRenderableManager::getMaterialInstanceAt(
 }
 
 void FRenderableManager::setBlendOrderAt(Instance const instance, uint8_t const level,
-        size_t const primitiveIndex, uint16_t const order) noexcept {
+        size_t const primitiveIndex, uint16_t const blendOrder) noexcept {
     if (instance) {
         Slice<FRenderPrimitive> const primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
-            primitives[primitiveIndex].setBlendOrder(order);
+            primitives[primitiveIndex].setBlendOrder(blendOrder);
         }
     }
 }
@@ -952,7 +958,7 @@ AttributeBitset FRenderableManager::getEnabledAttributesAt(
 }
 
 void FRenderableManager::setGeometryAt(Instance const instance, uint8_t const level, size_t const primitiveIndex,
-        PrimitiveType const type, FVertexBuffer* vertices, FIndexBuffer* indices,
+        PrimitiveType const type, FVertexBuffer const* vertices, FIndexBuffer const* indices,
         size_t const offset, size_t const count) noexcept {
     if (instance) {
         Slice<FRenderPrimitive> const primitives = getRenderPrimitives(instance, level);
@@ -964,7 +970,7 @@ void FRenderableManager::setGeometryAt(Instance const instance, uint8_t const le
 }
 
 void FRenderableManager::setGeometryAt(Instance const instance, uint8_t const level, size_t const primitiveIndex,
-        PrimitiveType const type, FVertexBuffer* vertices,
+        PrimitiveType const type, FVertexBuffer const* vertices,
         size_t const offset, size_t const count) noexcept {
     if (instance) {
         Slice<FRenderPrimitive> const primitives = getRenderPrimitives(instance, level);
@@ -1021,7 +1027,7 @@ void FRenderableManager::setBones(Instance const ci,
 }
 
 void FRenderableManager::setSkinningBuffer(Instance const ci,
-        FSkinningBuffer* skinningBuffer, size_t count, size_t const offset) {
+        FSkinningBuffer const* skinningBuffer, size_t count, size_t const offset) {
 
     Bones& bones = mManager[ci].bones;
 
@@ -1054,7 +1060,7 @@ static void updateMorphWeights(FEngine& engine, Handle<HwBufferObject> handle,
         float const* weights, size_t const count, size_t const offset) noexcept {
     auto& driver = engine.getDriverApi();
     auto size = sizeof(float4) * count;
-    auto* UTILS_RESTRICT out = (float4*)driver.allocate(size);
+    auto* UTILS_RESTRICT out = static_cast<float4*>(driver.allocate(size));
     std::transform(weights, weights + count, out,
             [](float const value) { return float4(value, 0, 0, 0); });
     driver.updateBufferObject(handle, { out, size }, sizeof(float4) * offset);

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -92,7 +92,7 @@ public:
     // free-up all resources
     void terminate(backend::DriverApi& driver) noexcept;
 
-    void gc(utils::EntityManager& em, backend::DriverApi& driver) noexcept;
+    void gc(backend::DriverApi& driver) noexcept;
 
     /*
      * Component Manager APIs
@@ -128,7 +128,11 @@ public:
 
     void create(const Builder& builder, utils::Entity entity);
 
-    void destroy(utils::Entity e, backend::DriverApi& driver) noexcept;
+    void destroyComponents(utils::Entity const* entities, size_t count, backend::DriverApi& driver) noexcept;
+
+    void destroy(utils::Entity e, backend::DriverApi& driver) noexcept {
+        destroyComponents(&e, 1, driver);
+    }
 
     // The client API should have taken an Engine&, but it doesn't, so that's a workaround
     // so we can keep the API as it is.
@@ -169,7 +173,7 @@ public:
     }
     void setBones(Instance instance, Bone const* transforms, size_t boneCount, size_t offset = 0);
     void setBones(Instance instance, math::mat4f const* transforms, size_t boneCount, size_t offset = 0);
-    void setSkinningBuffer(Instance instance, FSkinningBuffer* skinningBuffer,
+    void setSkinningBuffer(Instance instance, FSkinningBuffer const* skinningBuffer,
             size_t count, size_t offset);
 
     inline void setMorphing(Instance instance, MorphType type);
@@ -227,14 +231,14 @@ public:
     size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;
     size_t getInstanceCount(Instance instance) const noexcept;
     void setMaterialInstanceAt(Instance instance, uint8_t level,
-            size_t primitiveIndex, FMaterialInstance const* materialInstance);
+            size_t primitiveIndex, FMaterialInstance const* mi);
     void clearMaterialInstanceAt(Instance instance, uint8_t level, size_t primitiveIndex);
     MaterialInstance* getMaterialInstanceAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
-            PrimitiveType type, FVertexBuffer* vertices, FIndexBuffer* indices,
+            PrimitiveType type, FVertexBuffer const* vertices, FIndexBuffer const* indices,
             size_t offset, size_t count) noexcept;
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
-            PrimitiveType type, FVertexBuffer* vertices,
+            PrimitiveType type, FVertexBuffer const* vertices,
             size_t offset, size_t count) noexcept;
     void setBlendOrderAt(Instance instance, uint8_t level, size_t primitiveIndex, uint16_t blendOrder) noexcept;
     uint16_t getBlendOrderAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
@@ -308,6 +312,7 @@ private:
     >;
 
     struct Sim : public Base {
+        explicit Sim(utils::EntityManager& em) noexcept : Base(em, "RenderableManager") {}
         using Base::gc;
         using Base::swap;
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -19,6 +19,7 @@
 #include <filament/TransformManager.h>
 
 #include <utils/debug.h>
+#include <utils/PagedArenaBitsetPool.h>
 
 #include <math/mat4.h>
 
@@ -28,7 +29,9 @@ using namespace filament::math;
 
 namespace filament {
 
-FTransformManager::FTransformManager() noexcept = default;
+FTransformManager::FTransformManager(EntityManager& em) noexcept
+        : mManager(em) {
+}
 
 FTransformManager::~FTransformManager() noexcept = default;
 
@@ -45,52 +48,46 @@ void FTransformManager::setAccurateTranslationsEnabled(bool const enable) noexce
     }
 }
 
+inline void FTransformManager::createImpl(Entity const entity, Instance const parent,
+        std::variant<mat4, mat4f> localTransform) {
+    // this always adds at the end, so all existing instances stay valid
+    auto& manager = mManager;
+
+    Entity zombie;
+    if (UTILS_UNLIKELY(manager.popPendingZombie(entity, zombie))) {
+        destroy(zombie);
+    }
+
+    // TODO: try to keep entries sorted with their siblings/parents to improve cache access
+    if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
+        destroy(entity);
+    }
+    Instance const i = manager.addComponent(entity);
+    assert_invariant(i);
+    assert_invariant(i != parent);
+
+    if (i && i != parent) {
+        manager[i].parent = 0;
+        manager[i].next = 0;
+        manager[i].prev = 0;
+        manager[i].firstChild = 0;
+        insertNode(i, parent);
+        std::visit([this, i](auto&& arg) {
+            setTransform(i, arg);
+        }, localTransform);
+    }
+}
+
 void FTransformManager::create(Entity const entity) {
-    create(entity, 0, mat4f{});
+    createImpl(entity, 0, mat4f{});
 }
 
 void FTransformManager::create(Entity const entity, Instance const parent, const mat4f& localTransform) {
-    // this always adds at the end, so all existing instances stay valid
-    auto& manager = mManager;
-
-    // TODO: try to keep entries sorted with their siblings/parents to improve cache access
-    if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
-        destroy(entity);
-    }
-    Instance const i = manager.addComponent(entity);
-    assert_invariant(i);
-    assert_invariant(i != parent);
-
-    if (i && i != parent) {
-        manager[i].parent = 0;
-        manager[i].next = 0;
-        manager[i].prev = 0;
-        manager[i].firstChild = 0;
-        insertNode(i, parent);
-        setTransform(i, localTransform);
-    }
+    createImpl(entity, parent, localTransform);
 }
 
 void FTransformManager::create(Entity const entity, Instance const parent, const mat4& localTransform) {
-    // this always adds at the end, so all existing instances stay valid
-    auto& manager = mManager;
-
-    // TODO: try to keep entries sorted with their siblings/parents to improve cache access
-    if (UTILS_UNLIKELY(manager.hasComponent(entity))) {
-        destroy(entity);
-    }
-    Instance const i = manager.addComponent(entity);
-    assert_invariant(i);
-    assert_invariant(i != parent);
-
-    if (i && i != parent) {
-        manager[i].parent = 0;
-        manager[i].next = 0;
-        manager[i].prev = 0;
-        manager[i].firstChild = 0;
-        insertNode(i, parent);
-        setTransform(i, localTransform);
-    }
+    createImpl(entity, parent, localTransform);
 }
 
 void FTransformManager::setParent(Instance const i, Instance const parent) noexcept {
@@ -147,28 +144,23 @@ TransformManager::children_range FTransformManager::getChildrenRange(
     return { { *this, mManager[parent].firstChild } };
 }
 
-void FTransformManager::destroy(Entity const e) noexcept {
-    // update the reference of the element we're removing
+void FTransformManager::destroyComponents(Entity const* entities, size_t const count) noexcept {
     auto& manager = mManager;
-    Instance const i = manager.getInstance(e);
-    validateNode(i);
-    if (i) {
-        // 1) remove the entry from the linked lists
-        removeNode(i);
-
-        // our children don't have parents anymore
-        Instance child = manager[i].firstChild;
-        while (child) {
-            manager[child].parent = 0;
-            child = manager[child].next;
-        }
-
-        // 2) remove the component
-        Instance const moved = manager.removeComponent(e);
-
-        // 3) update the references to the entry now with Instance i
-        if (moved != i) {
-            updateNode(i);
+    for (size_t k = 0; k < count; ++k) {
+        Entity const e = entities[k];
+        Instance const i = manager.getInstance(e);
+        validateNode(i);
+        if (i) {
+            removeNode(i);
+            Instance child = manager[i].firstChild;
+            while (child) {
+                manager[child].parent = 0;
+                child = manager[child].next;
+            }
+            Instance const moved = manager.removeComponent(e);
+            if (moved != i) {
+                updateNode(i);
+            }
         }
     }
 }
@@ -439,7 +431,6 @@ void FTransformManager::computeWorldTransform(
     }
 }
 
-
 void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance const i) noexcept {
 #ifndef NDEBUG
     auto& manager = mManager;
@@ -482,12 +473,9 @@ void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance const i) n
 #endif
 }
 
-void FTransformManager::gc(EntityManager& em) noexcept {
-    mManager.gc(em, [this](Entity const e) {
-                destroy(e);
-            });
+void FTransformManager::gc() noexcept {
+    mManager.gc(this, &FTransformManager::destroyComponents);
 }
-
 TransformManager::children_iterator& TransformManager::children_iterator::operator++() noexcept {
     FTransformManager const& that = downcast(*mManager);
     mInstance = that.mManager[mInstance].next;

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -28,13 +28,16 @@
 
 #include <math/mat4.h>
 
+#include <utility>
+#include <variant>
+
 namespace filament {
 
 class UTILS_PRIVATE FTransformManager : public TransformManager {
 public:
     using Instance = Instance;
 
-    FTransformManager() noexcept;
+    explicit FTransformManager(utils::EntityManager& em) noexcept;
     ~FTransformManager() noexcept;
 
     // free-up all resources
@@ -85,7 +88,11 @@ public:
 
     void create(utils::Entity entity, Instance parent, const math::mat4& localTransform);
 
-    void destroy(utils::Entity e) noexcept;
+    void destroyComponents(utils::Entity const* entities, size_t count) noexcept;
+
+    void destroy(utils::Entity e) noexcept {
+        destroyComponents(&e, 1);
+    }
 
     void setParent(Instance i, Instance newParent) noexcept;
 
@@ -105,7 +112,7 @@ public:
 
     void commitLocalTransformTransaction() noexcept;
 
-    void gc(utils::EntityManager& em) noexcept;
+    void gc() noexcept;
 
     void registerChangeCallback(void const* token, utils::SingleInstanceComponentManagerBase::ChangeCallback callback) noexcept {
         mManager.registerChangeCallback(token, std::move(callback));
@@ -152,6 +159,8 @@ public:
 private:
     struct Sim;
 
+    void createImpl(utils::Entity entity, Instance parent, std::variant<math::mat4, math::mat4f> localTransform);
+
     void validateNode(Instance i) noexcept;
     void removeNode(Instance i) noexcept;
     void updateNode(Instance i) noexcept;
@@ -192,6 +201,7 @@ private:
     >;
 
     struct Sim : public Base {
+        explicit Sim(utils::EntityManager& em) noexcept : Base(em, "TransformManager") {}
         using Base::gc;
         using Base::swap;
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -300,6 +300,7 @@ FEngine::FEngine(Builder const& builder) :
         mPostProcessManager(*this),
         mEntityManager(EntityManager::get()),
         mRenderableManager(*this),
+        mTransformManager(mEntityManager),
         mLightManager(*this),
         mCameraManager(*this),
         mMaterialCache(builder->mConfig.materialCacheCapacity, builder->mConfig.programCacheCapacity),
@@ -796,28 +797,26 @@ void FEngine::prepare(DriverApi& driver) {
 
 void FEngine::gc() {
     JobSystem& js = getJobSystem();
-    auto *rootJob = js.createJob();
-
-    js.run(
-            jobs::createJob(js, rootJob, [this] {
-                // These are safe to GC *sequentially* from a worker thread.
-                // The JobSystem acts as a release/acquire operation.
-                mLightManager.gc(mEntityManager);
-                mTransformManager.gc(mEntityManager);
-                mCameraManager.gc(*this, mEntityManager);
-            }));
+    JobSystem::Job* asyncJob = nullptr;
 
     if (isAsynchronousModeEnabled()) {
-        // gcDeferredAsyncObjectDestruction() is thread-safe in this context because
-        // 1. JobSystem provides the release/acquire operation
-        // 2. it's only used from the main thread, which we are blocking during the gc
-        js.run(jobs::createJob(js, rootJob, &FEngine::gcDeferredAsyncObjectDestruction, this));
+        asyncJob = js.createJob();
+        js.run(jobs::createJob(js, asyncJob, &FEngine::gcDeferredAsyncObjectDestruction, this));
     }
 
-    // RenderableManager cannot be gc'ed from a different thread, because it needs the DriverAPI
-    mRenderableManager.gc(mEntityManager, getDriverApi());
+    mLightManager.gc();
+    mTransformManager.gc();
+    mCameraManager.gc(*this);
+    mRenderableManager.gc(getDriverApi());
 
-    js.runAndWait(rootJob);
+    // Because the managers just updated their watermarks to the current epoch,
+    // advanceEpoch() will see the highest possible safe threshold, allowing
+    // it to reclaim the maximum amount of global IDs this frame.
+    mEntityManager.advanceEpoch();
+
+    if (asyncJob) {
+        js.runAndWait(asyncJob);
+    }
 }
 
 void FEngine::gcDeferredAsyncObjectDestruction() {
@@ -1170,7 +1169,7 @@ FCamera* FEngine::getCameraComponent(Entity const entity) noexcept {
 }
 
 void FEngine::destroyCameraComponent(Entity const entity) noexcept {
-    mCameraManager.destroy(*this, entity);
+    mCameraManager.destroy(entity, *this);
 }
 
 
@@ -1428,7 +1427,7 @@ void FEngine::destroy(Entity const e) {
     mRenderableManager.destroy(e, getDriverApi());
     mLightManager.destroy(e);
     mTransformManager.destroy(e);
-    mCameraManager.destroy(*this, e);
+    mCameraManager.destroy(e, *this);
 }
 
 bool FEngine::isValid(const FBufferObject* p) const {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -78,6 +78,7 @@
 #include <utils/JobSystem.h>
 #include <utils/memalign.h>
 #include <utils/Slice.h>
+#include <utils/PagedArenaBitsetPool.h>
 #include <utils/tribool.h>
 
 #include <cstddef>

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -35,13 +35,13 @@
 #include <filament/Engine.h>
 #include <filament/FrameHistoryStream.h>
 #include <filament/Frustum.h>
-#include <filament/Material.h>
 #include <filament/ToneMapper.h>
 
 #include <private/backend/BackendUtils.h>
 
 #include <backend/DriverEnums.h>
 
+#include <utils/NameComponentManager.h>
 #include <utils/Slice.h>
 
 #include <math/half.h>
@@ -55,10 +55,8 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <cmath>
+#include <chrono>
 #include <cstddef>
-#include <cstdint>
-#include <cstring>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -201,8 +199,8 @@ TEST(FilamentTest, SkinningMath) {
 }
 
 TEST(FilamentTest, TransformManagerSimple) {
-    FTransformManager tcm;
     EntityManager& em = EntityManager::get();
+    FTransformManager tcm(em);
     Entity const root = em.create();
     tcm.create(root);
 
@@ -218,9 +216,9 @@ TEST(FilamentTest, TransformManagerSimple) {
 }
 
 TEST(FilamentTest, TransformManager) {
-    FTransformManager tcm;
-    tcm.setAccurateTranslationsEnabled(true);
     EntityManager& em = EntityManager::get();
+    FTransformManager tcm(em);
+    tcm.setAccurateTranslationsEnabled(true);
     std::array<Entity, 3> entities;
     em.create(entities.size(), entities.data());
 
@@ -340,8 +338,8 @@ TEST(FilamentTest, TransformManager) {
 }
 
 TEST(FilamentTest, TransformManagerChildrenIteration) {
-    FTransformManager tcm;
     EntityManager& em = EntityManager::get();
+    FTransformManager tcm(em);
 
     std::array<Entity, 5> entities;
     em.create(entities.size(), entities.data());
@@ -445,34 +443,34 @@ TEST(FilamentTest, RenderableManagerCallback) {
     auto& rm = engine->getRenderableManager();
     EntityManager& em = EntityManager::get();
     Entity const e = em.create();
-    
+
     int callbackCount = 0;
     auto callback = [&](Slice<const Entity> entities) {
         callbackCount += entities.size();
     };
-    
+
     rm.registerChangeCallback(&rm, std::move(callback));
-    
+
     // Test addComponent
     RenderableManager::Builder(1).boundingBox({{0,0,0},{1,1,1}}).build(*engine, e);
     rm.flushNotifications();
     EXPECT_GT(callbackCount, 0);
-    
+
     callbackCount = 0;
-    
+
     // Test modify
     auto const instance = rm.getInstance(e);
     rm.setLayerMask(instance, 0x2);
     rm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     callbackCount = 0;
-    
+
     // Test removeComponent
     rm.destroy(e, engine->getDriverApi());
     rm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     rm.unregisterChangeCallback(&rm);
     em.destroy(e);
     Engine::destroy((Engine**)&engine);
@@ -483,34 +481,34 @@ TEST(FilamentTest, LightManagerCallback) {
     auto& lm = engine->getLightManager();
     EntityManager& em = EntityManager::get();
     Entity const e = em.create();
-    
+
     int callbackCount = 0;
     auto callback = [&](Slice<const Entity> entities) {
         callbackCount += entities.size();
     };
-    
+
     lm.registerChangeCallback(&lm, std::move(callback));
-    
+
     // Test addComponent
     LightManager::Builder(LightManager::Type::POINT).build(*engine, e);
     lm.flushNotifications();
     EXPECT_GT(callbackCount, 0);
-    
+
     callbackCount = 0;
-    
+
     // Test modify
     auto const instance = lm.getInstance(e);
     lm.setIntensity(instance, 2000.0f, FLightManager::IntensityUnit::LUMEN_LUX);
     lm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     callbackCount = 0;
-    
+
     // Test removeComponent
     lm.destroy(e);
     lm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     lm.unregisterChangeCallback(&lm);
     em.destroy(e);
     Engine::destroy((Engine**)&engine);
@@ -521,40 +519,40 @@ TEST(FilamentTest, TransformManagerCallback) {
     auto& tcm = engine->getTransformManager();
     EntityManager& em = EntityManager::get();
     Entity const e = em.create();
-    
+
     int callbackCount = 0;
     auto callback = [&](Slice<const Entity> entities) {
         callbackCount += entities.size();
     };
-    
+
     tcm.registerChangeCallback(&tcm, std::move(callback));
-    
+
     // Test addComponent
     tcm.create(e);
     tcm.flushNotifications();
     EXPECT_GT(callbackCount, 0);
-    
+
     callbackCount = 0;
-    
+
     // Test modify without transaction
     auto const instance = tcm.getInstance(e);
     constexpr auto t = mat4f::translation(float3{ 1, 2, 3 });
     tcm.setTransform(instance, t);
     tcm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     callbackCount = 0;
-    
+
     // Test transaction
     tcm.openLocalTransformTransaction();
     tcm.setTransform(instance, mat4f::translation(float3{ 4, 5, 6 }));
     tcm.flushNotifications();
     EXPECT_EQ(callbackCount, 0);
-    
+
     tcm.commitLocalTransformTransaction();
     tcm.flushNotifications();
     EXPECT_EQ(callbackCount, 1);
-    
+
     tcm.unregisterChangeCallback(&tcm);
     tcm.destroy(e);
     em.destroy(e);
@@ -1111,7 +1109,7 @@ TEST(FilamentTest, GridSnapping) {
     // Test case 6: Automatic grid size (Perspective)
     view->setGridSize(0.0); // Enable auto
     static_cast<Camera*>(camera)->setProjection(90.0, 1.0, 0.1, 100.0, Camera::Fov::VERTICAL); // Set far plane to 100
-    
+
     // FOV 90, aspect 1.0 -> baseScale = 2.0. Width at far plane = 200.
     // Auto grid size should be 2.0 * 100 * 0.1 = 20.
     camera->setModelMatrix(mat4::translation(double3{0.0, 0.0, 0.0}));
@@ -1765,6 +1763,76 @@ TEST(FilamentTest, FrameHistoryStreamTest) {
     engine->destroy(renderer);
     Engine::destroy(&engine);
 }
+
+TEST(FilamentTest, ECREpochBasedReclamationManagers) {
+    Engine* engine = Engine::Builder().backend(Engine::Backend::NOOP).build();
+    auto& em = engine->getEntityManager();
+    auto& tcm = engine->getTransformManager();
+    auto& lcm = engine->getLightManager();
+    auto& rcm = engine->getRenderableManager();
+
+    NameComponentManager ncm(em);
+
+    Entity e1 = em.create();
+    Entity e2 = em.create();
+
+    // Add components
+    tcm.create(e1, 0, mat4f());
+    LightManager::Builder(LightManager::Type::POINT).build(*engine, e1);
+    RenderableManager::Builder(1).boundingBox({{0,0,0},{1,1,1}}).build(*engine, e1);
+    ncm.addComponent(e1);
+    engine->createCamera(e1);
+
+    tcm.create(e2, 0, mat4f());
+    LightManager::Builder(LightManager::Type::POINT).build(*engine, e2);
+    RenderableManager::Builder(1).boundingBox({{0,0,0},{1,1,1}}).build(*engine, e2);
+    ncm.addComponent(e2);
+    engine->createCamera(e2);
+
+    EXPECT_TRUE(tcm.hasComponent(e1));
+    EXPECT_TRUE(lcm.hasComponent(e1));
+    EXPECT_TRUE(rcm.hasComponent(e1));
+    EXPECT_TRUE(ncm.hasComponent(e1));
+    EXPECT_NE(engine->getCameraComponent(e1), nullptr);
+
+    EXPECT_TRUE(tcm.hasComponent(e2));
+    EXPECT_TRUE(lcm.hasComponent(e2));
+    EXPECT_TRUE(rcm.hasComponent(e2));
+    EXPECT_TRUE(ncm.hasComponent(e2));
+    EXPECT_NE(engine->getCameraComponent(e2), nullptr);
+
+    em.advanceEpoch();
+
+    em.destroy(e1);
+
+    EXPECT_FALSE(em.isAlive(e1));
+    EXPECT_TRUE(em.isAlive(e2));
+
+    em.advanceEpoch();
+
+    downcast(engine)->gc();
+    ncm.gc();
+
+    EXPECT_FALSE(tcm.hasComponent(e1));
+    EXPECT_FALSE(lcm.hasComponent(e1));
+    EXPECT_FALSE(rcm.hasComponent(e1));
+    EXPECT_FALSE(ncm.hasComponent(e1));
+    EXPECT_EQ(engine->getCameraComponent(e1), nullptr);
+
+    EXPECT_TRUE(tcm.hasComponent(e2));
+    EXPECT_TRUE(lcm.hasComponent(e2));
+    EXPECT_TRUE(rcm.hasComponent(e2));
+    EXPECT_TRUE(ncm.hasComponent(e2));
+    EXPECT_NE(engine->getCameraComponent(e2), nullptr);
+
+    em.destroy(e2);
+    downcast(engine)->gc();
+    ncm.gc();
+
+    Engine::destroy(&engine);
+}
+
+
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -236,6 +236,11 @@ public:
     void destroyAsset(const FilamentAsset* asset);
 
     /**
+     * @brief Performs a Garbage Collection sweep over all internal component managers.
+     */
+    void gc() noexcept;
+
+    /**
      * Gets a weak reference to an array of cached materials, used internally to create material
      * instances for assets.
      */

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -260,6 +260,8 @@ struct FAssetLoader : public AssetLoader {
             mTransformManager(config.engine->getTransformManager()),
             mMaterials(*config.materials),
             mEngine(*config.engine),
+            mNodeManager(mEntityManager),
+            mTrsTransformManager(mEntityManager),
             mDefaultNodeName(config.defaultNodeName) {
         if (config.ext) {
             FILAMENT_CHECK_POSTCONDITION(AssetConfigurationExtended::isSupported())
@@ -281,6 +283,11 @@ struct FAssetLoader : public AssetLoader {
 
     void destroyAsset(const FFilamentAsset* asset) {
         delete asset;
+    }
+
+    void gc() noexcept {
+        mNodeManager.gc();
+        mTrsTransformManager.gc();
     }
 
     size_t getMaterialsCount() const noexcept {
@@ -1836,6 +1843,10 @@ void AssetLoader::enableDiagnostics(bool enable) {
 
 void AssetLoader::destroyAsset(const FilamentAsset* asset) {
     downcast(this)->destroyAsset(downcast(asset));
+}
+
+void AssetLoader::gc() noexcept {
+    downcast(this)->gc();
 }
 
 size_t AssetLoader::getMaterialsCount() const noexcept {

--- a/libs/gltfio/src/FNodeManager.h
+++ b/libs/gltfio/src/FNodeManager.h
@@ -24,6 +24,7 @@
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Entity.h>
+#include <utils/PagedArenaBitsetPool.h>
 #include <utils/SingleInstanceComponentManager.h>
 #include <utils/Slice.h>
 
@@ -33,7 +34,7 @@ class UTILS_PRIVATE FNodeManager : public NodeManager {
 public:
     using Instance = NodeManager::Instance;
 
-    FNodeManager() noexcept {}
+    explicit FNodeManager(utils::EntityManager& em) noexcept : mManager(em) {}
 
     ~FNodeManager() noexcept {
         assert_invariant(mManager.getComponentCount() == 0);
@@ -50,6 +51,10 @@ public:
     }
 
     void create(utils::Entity entity) {
+        utils::Entity zombie;
+        if (UTILS_UNLIKELY(mManager.popPendingZombie(entity, zombie))) {
+            destroy(zombie);
+        }
         if (UTILS_UNLIKELY(mManager.hasComponent(entity))) {
             destroy(entity);
         }
@@ -57,16 +62,16 @@ public:
         assert_invariant(ci);
     }
 
-    void destroy(utils::Entity e) noexcept {
-        if (Instance const ci = mManager.getInstance(e); ci) {
-            mManager.removeComponent(e);
-        }
+    void destroyComponents(utils::Entity const* entities, size_t const count) noexcept {
+        mManager.removeComponents(entities, count);
     }
 
-    void gc(utils::EntityManager& em) noexcept {
-        mManager.gc(em, [this](Entity e) {
-            destroy(e);
-        });
+    void destroy(utils::Entity e) noexcept {
+        destroyComponents(&e, 1);
+    }
+
+    void gc() noexcept {
+        mManager.gc(this, &FNodeManager::destroyComponents);
     }
 
     void setMorphTargetNames(Instance ci, utils::FixedCapacityVector<CString> names) noexcept {
@@ -107,6 +112,7 @@ private:
             SceneMask>;                           // 4
 
     struct Sim : public Base {
+        explicit Sim(utils::EntityManager& em) noexcept : Base(em, "NodeManager") {}
         using Base::gc;
         using Base::swap;
 

--- a/libs/gltfio/src/FTrsTransformManager.h
+++ b/libs/gltfio/src/FTrsTransformManager.h
@@ -26,6 +26,7 @@
 #include <utils/debug.h>
 #include <utils/Entity.h>
 #include <utils/FixedCapacityVector.h>
+#include <utils/PagedArenaBitsetPool.h>
 #include <utils/SingleInstanceComponentManager.h>
 #include <utils/Slice.h>
 
@@ -37,7 +38,7 @@ class UTILS_PRIVATE FTrsTransformManager : public TrsTransformManager {
 public:
     using Instance = TrsTransformManager::Instance;
 
-    FTrsTransformManager() noexcept {}
+    explicit FTrsTransformManager(utils::EntityManager& em) noexcept : mManager(em) {}
 
     ~FTrsTransformManager() noexcept {
         assert_invariant(mManager.getComponentCount() == 0);
@@ -59,6 +60,10 @@ public:
 
     void create(utils::Entity entity, const float3& translation,
                 const quatf& rotation, const float3& scale) {
+        utils::Entity zombie;
+        if (UTILS_UNLIKELY(mManager.popPendingZombie(entity, zombie))) {
+            destroy(zombie);
+        }
         if (UTILS_UNLIKELY(mManager.hasComponent(entity))) {
             destroy(entity);
         }
@@ -70,16 +75,16 @@ public:
         }
     }
 
-    void destroy(utils::Entity e) noexcept {
-        if (Instance const ci = mManager.getInstance(e); ci) {
-            mManager.removeComponent(e);
-        }
+    void destroyComponents(utils::Entity const* entities, size_t const count) noexcept {
+        mManager.removeComponents(entities, count);
     }
 
-    void gc(utils::EntityManager& em) noexcept {
-        mManager.gc(em, [this](Entity e) {
-            destroy(e);
-        });
+    void destroy(utils::Entity e) noexcept {
+        destroyComponents(&e, 1);
+    }
+
+    void gc() noexcept {
+        mManager.gc(this, &FTrsTransformManager::destroyComponents);
     }
 
     void setTranslation(Instance ci, const float3& translation) noexcept {
@@ -133,6 +138,7 @@ private:
             float3>;
 
     struct Sim : public Base {
+        explicit Sim(utils::EntityManager& em) noexcept : Base(em, "TrsTransformManager") {}
         using Base::gc;
         using Base::swap;
 

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -211,6 +211,7 @@ public:
         delete mKtxDecoder;
         delete mWebpDecoder;
 
+        mAssetLoader->gc();
         AssetLoader::destroy(&mAssetLoader);
     }
 
@@ -253,6 +254,8 @@ protected:
         Engine::destroy(&mEngine);
 
         delete mMaterialProvider;
+
+        mNameManager->gc();
         delete mNameManager;
     }
 };
@@ -378,7 +381,7 @@ TEST_F(glTFIOTest, DamagedHelmetWebpMaterials) {
 #else
     EXPECT_FALSE(isWebpSupported());
     EXPECT_TRUE(mData[DAMAGED_HELMET_WEBP_GLB]->mWebpDecoder == nullptr);
-    EXPECT_EQ(mEngine->getTextureCount(), 3);    
+    EXPECT_EQ(mEngine->getTextureCount(), 3);
 #endif
 }
 

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -253,7 +253,8 @@ if (FILAMENT_BUILD_TESTING AND NOT WASM)
             benchmark/benchmark_JobSystem.cpp
             benchmark/benchmark_mutex.cpp
             benchmark/benchmark_memcpy.cpp
-            benchmark/benchmark_EntitySet.cpp)
+            benchmark/benchmark_EntitySet.cpp
+            benchmark/benchmark_EntityManager.cpp)
 
 
     add_executable(benchmark_${TARGET} ${BENCHMARK_SRCS})

--- a/libs/utils/benchmark/benchmark_EntityManager.cpp
+++ b/libs/utils/benchmark/benchmark_EntityManager.cpp
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../src/EntityManagerImpl.h"
+
+#include <utils/SingleInstanceComponentManager.h>
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <vector>
+
+using namespace utils;
+template <typename T>
+class TestManagerBase : public SingleInstanceComponentManager<T> {
+public:
+    explicit TestManagerBase(EntityManager& em) noexcept
+            : SingleInstanceComponentManager<T>(em, "TestManager", false) {}
+
+    using SingleInstanceComponentManager<T>::gc;
+
+    void removeComponents(Entity const* entities, size_t const count) noexcept {
+        for (size_t i = 0; i < count; ++i) {
+            SingleInstanceComponentManager<T>::removeComponent(entities[i]);
+        }
+    }
+};
+// ==================================================================================================
+// Part 1: Core Entity Lifecycle (Single-Threaded)
+// ==================================================================================================
+
+static void BM_EntityManager_CreateSingular(benchmark::State& state) {
+    EntityManagerImpl em;
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+
+        for (size_t i = 0; i < count; ++i) {
+            entities[i] = em.create();
+        }
+
+        state.PauseTiming();
+        em.destroy(count, entities.data());
+        em.flushNotifications();
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_EntityManager_CreateSingular)->Range(8, 8192);
+
+static void BM_EntityManager_CreateBatched(benchmark::State& state) {
+    EntityManagerImpl em;
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+
+        em.create(count, entities.data());
+
+        state.PauseTiming();
+        em.destroy(count, entities.data());
+        em.flushNotifications();
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_EntityManager_CreateBatched)->Range(8, 8192);
+
+static void BM_EntityManager_DestroySingular(benchmark::State& state) {
+    EntityManagerImpl em;
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        em.create(count, entities.data());
+        state.ResumeTiming();
+
+        for (size_t i = 0; i < count; ++i) {
+            em.destroy(entities[i]);
+        }
+        em.flushNotifications();
+
+        state.PauseTiming();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_EntityManager_DestroySingular)->Range(8, 8192);
+
+static void BM_EntityManager_DestroyBatched(benchmark::State& state) {
+    EntityManagerImpl em;
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        em.create(count, entities.data());
+        state.ResumeTiming();
+
+        em.destroy(count, entities.data());
+        em.flushNotifications();
+
+        state.PauseTiming();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_EntityManager_DestroyBatched)->Range(8, 8192);
+
+// ==================================================================================================
+// Part 2: Component Management & JIT Synchronization (Single-Threaded)
+// ==================================================================================================
+
+static void BM_ComponentManager_AddComponent(benchmark::State& state) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+    em.create(count, entities.data());
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        TestManager cm(em);
+        state.ResumeTiming();
+
+        for (size_t i = 0; i < count; ++i) {
+            cm.addComponent(entities[i]);
+        }
+
+        state.PauseTiming();
+        cm.suspend();
+        state.ResumeTiming();
+    }
+
+    em.destroy(count, entities.data());
+}
+BENCHMARK(BM_ComponentManager_AddComponent)->Range(8, 8192);
+
+static void BM_ComponentManager_CatchupGarbage(benchmark::State& state) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+    em.create(count, entities.data());
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        TestManager cm(em);
+        for (size_t i = 0; i < count; ++i) {
+            cm.addComponent(entities[i]);
+        }
+        for (size_t i = 0; i < count; i += 2) {
+            em.destroy(entities[i]);
+        }
+        em.flushNotifications();
+        em.advanceEpoch();
+        state.ResumeTiming();
+
+        cm.gc(&cm, &TestManager::removeComponent);
+
+        state.PauseTiming();
+        cm.suspend();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+
+    em.destroy(count, entities.data());
+}
+BENCHMARK(BM_ComponentManager_CatchupGarbage)->Range(8, 8192);
+
+static void BM_ComponentManager_GCLargeScale(benchmark::State& state) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        em.create(count, entities.data());
+        TestManager cm(em);
+        for (size_t i = 0; i < count; ++i) {
+            cm.addComponent(entities[i]);
+        }
+        em.destroy(count, entities.data());
+        em.flushNotifications();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+
+        cm.gc(&cm, &TestManager::removeComponents);
+    }
+}
+BENCHMARK(BM_ComponentManager_GCLargeScale)->Range(64, 8192);
+
+static void BM_ComponentManager_Defragmentation(benchmark::State& state) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+    em.create(count, entities.data());
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        TestManager cm(em);
+        for (size_t i = 0; i < count; ++i) {
+            cm.addComponent(entities[i]);
+        }
+        std::default_random_engine rng(1337);
+        std::vector<Entity> toDestroy;
+        for (size_t i = 0; i < count; ++i) {
+            if (rng() % 4 == 0) {
+                toDestroy.push_back(entities[i]);
+            }
+        }
+        em.destroy(toDestroy.size(), toDestroy.data());
+        em.flushNotifications();
+        em.advanceEpoch();
+        state.ResumeTiming();
+
+        cm.gc(&cm, &TestManager::removeComponent);
+
+        state.PauseTiming();
+        cm.suspend();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+
+    em.destroy(count, entities.data());
+}
+BENCHMARK(BM_ComponentManager_Defragmentation)->Range(8, 8192);
+
+// ==================================================================================================
+// Part 3: The Garbage Collector Orchestrator (Single-Threaded)
+// ==================================================================================================
+
+static void BM_EBR_AdvanceAndReclaim(benchmark::State& state) {
+    size_t const count = state.range(0);
+    std::vector<Entity> entities(count);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        EntityManagerImpl em;
+        std::atomic<uint64_t> dummyWatermark{em.getLatestEpochID()};
+        em.registerWatermark(&dummyWatermark, "DummyWatermark");
+
+        em.create(count, entities.data());
+        em.destroy(count, entities.data());
+        em.flushNotifications();
+        state.ResumeTiming();
+
+        em.advanceEpoch();
+        dummyWatermark.store(em.getLatestEpochID(), std::memory_order_release);
+        em.reclaimSafeEpochs();
+
+        state.PauseTiming();
+        em.unregisterWatermark(&dummyWatermark);
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_EBR_AdvanceAndReclaim)->Range(8, 8192);
+
+// ==================================================================================================
+// Part 4: Multithreaded Contention Provers
+// ==================================================================================================
+
+static void BM_MT_Contention_Create_Vs_Destroy(benchmark::State& state) {
+    EntityManagerImpl em;
+    constexpr size_t NUM = 10000;
+    std::vector<Entity> preallocated(NUM);
+    em.create(NUM, preallocated.data());
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        std::atomic<bool> active{true};
+        state.ResumeTiming();
+
+        std::thread t1([&em, &active]() {
+            constexpr size_t BATCH = 128;
+            std::vector<Entity> local(BATCH);
+            while (active.load(std::memory_order_relaxed)) {
+                em.create(BATCH, local.data());
+                for (auto e : local) {
+                    if (e) em.destroy(e);
+                }
+            }
+        });
+
+        std::thread t2([&em, &preallocated, &active]() {
+            constexpr size_t BATCH = 128;
+            while (active.load(std::memory_order_relaxed)) {
+                for (size_t i = 0; i < NUM; i += BATCH) {
+                    Entity localBatch[BATCH];
+                    std::copy_n(&preallocated[i], BATCH, localBatch);
+                    em.destroy(BATCH, localBatch);
+                    em.create(BATCH, &preallocated[i]);
+                }
+            }
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        active.store(false, std::memory_order_relaxed);
+
+        t1.join();
+        t2.join();
+
+        state.PauseTiming();
+        em.advanceEpoch();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+
+    em.destroy(NUM, preallocated.data());
+}
+BENCHMARK(BM_MT_Contention_Create_Vs_Destroy);
+
+static void BM_MT_Contention_Systems_Vs_GC(benchmark::State& state) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        TestManager cm(em);
+        std::atomic<bool> active{true};
+        state.ResumeTiming();
+
+        std::thread t1([&em, &cm, &active]() {
+            constexpr size_t BATCH = 128;
+            std::vector<Entity> local(BATCH);
+            while (active.load(std::memory_order_relaxed)) {
+                em.create(BATCH, local.data());
+                for (auto e : local) {
+                    cm.addComponent(e);
+                }
+                em.destroy(BATCH, local.data());
+                em.flushNotifications();
+                cm.gc(&cm, &TestManager::removeComponent);
+            }
+        });
+
+        std::thread t2([&em, &active]() {
+            while (active.load(std::memory_order_relaxed)) {
+                em.advanceEpoch();
+                std::this_thread::sleep_for(std::chrono::microseconds(500));
+            }
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        active.store(false, std::memory_order_relaxed);
+
+        t1.join();
+        t2.join();
+
+        state.PauseTiming();
+        cm.suspend();
+        em.reclaimSafeEpochs();
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_MT_Contention_Systems_Vs_GC);
+
+static void BM_PagedArenaBitset_PopSetBits(benchmark::State& state) {
+    size_t const count = state.range(0);
+    for (auto _ : state) {
+        state.PauseTiming();
+        PagedArenaBitset bitset;
+        for (uint32_t i = 0; i < count; ++i) {
+            bitset.add(i * 10);
+        }
+        state.ResumeTiming();
+
+        uint32_t processedCount = 0;
+        bitset.popSetBits([&](uint32_t bit) {
+            processedCount++;
+            if (processedCount == count / 2) {
+                return false; // Stop halfway
+            }
+            return true; // Pop
+        });
+
+        state.PauseTiming();
+        uint32_t remainderCount = 0;
+        bitset.popSetBits([&](uint32_t bit) {
+            remainderCount++;
+            return true;
+        });
+        state.ResumeTiming();
+    }
+}
+BENCHMARK(BM_PagedArenaBitset_PopSetBits)->Range(8, 8192);
+

--- a/libs/utils/benchmark/benchmark_EntitySet.cpp
+++ b/libs/utils/benchmark/benchmark_EntitySet.cpp
@@ -801,6 +801,51 @@ BENCHMARK_TEMPLATE(BM_bitset_Merge6, PagedArenaBitset)->Range(10, 100000);
 BENCHMARK_TEMPLATE(BM_bitset_IntersectSize6, PagedArenaBitset)->Range(10, 100000);
 BENCHMARK_TEMPLATE(BM_bitset_MergeSize6, PagedArenaBitset)->Range(10, 100000);
 
+template<typename Policy>
+void BM_bitset_PopSetBits(benchmark::State& state) {
+    size_t const count = state.range(0);
+    std::default_random_engine gen{123};
+    std::uniform_int_distribution<uint32_t> ndBase{0, 100000};
+    std::uniform_int_distribution<uint32_t> ndGen{0, 0};
+
+    Policy set;
+    size_t idx = 0;
+    while (idx < count) {
+        uint32_t const base = ndBase(gen);
+        uint32_t const g = ndGen(gen);
+        size_t const batchSize = std::min<size_t>(count - idx, 100);
+        for (size_t j = 0; j < batchSize; ++j) {
+            set.add((g << 17) | ((base + j) & 0x1FFFF));
+        }
+        idx += batchSize;
+    }
+
+    std::vector<Policy> temps(kInPlaceBatchSize);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        for (auto& t : temps) {
+            t.copyFrom(set);
+        }
+        state.ResumeTiming();
+
+        for (auto& t : temps) {
+            uint32_t processed = 0;
+            t.popSetBits([&](uint32_t bit) {
+                processed++;
+                if (processed == count / 2) {
+                    return false; // Stop halfway
+                }
+                return true;
+            });
+            benchmark::DoNotOptimize(t);
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * kInPlaceBatchSize);
+}
+
+BENCHMARK_TEMPLATE(BM_bitset_PopSetBits, PagedArenaBitset)->Range(10, 100000)->Iterations(10);
+
 BENCHMARK_TEMPLATE(BM_bitset_IntersectMulti2, PagedArenaBitset)->Range(10, 100000);
 BENCHMARK_TEMPLATE(BM_bitset_IntersectMulti6, PagedArenaBitset)->Range(10, 100000);
 BENCHMARK_TEMPLATE(BM_bitset_IntersectChained6, PagedArenaBitset)->Range(10, 100000);

--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -21,6 +21,7 @@
 #include <utils/compiler.h>
 #include <utils/Slice.h>
 #include <utils/PagedArenaBitset.h>
+#include <utils/ImmutableCString.h>
 
 #include <assert.h>
 #include <stddef.h>
@@ -35,18 +36,65 @@
 #include <vector>
 #endif
 
-#include <functional>
+#include <atomic>
+#include <vector>
 
 namespace utils {
 
+class SingleInstanceComponentManagerBase;
+
+/**
+ * @class EntityManager
+ * @brief Thread-safe coordinator managing the lifecycle, indices, and generation tracking for all Entity instances.
+ *
+ * @details The EntityManager is the core source-of-truth for Entity identities in Filament. It coordinates the
+ * creation, recycling, and safe reclamation of 32-bit Entity IDs. Due to the highly multithreaded nature of the
+ * engine, the EntityManager provides **two distinct groups of APIs**:
+ *
+ * ---
+ *
+ * ### 1. Public API (Gameplay & Application Layer)
+ * This group is aimed at standard usage for applications, renderers, and game systems.
+ * - **Entity Creation**: Methods like @p create() and @p create(size_t, Entity*) allocate new or recycled Entity
+ *   identities.
+ * - **Entity Destruction**: Methods like @p destroy(Entity) and @p destroy(size_t, Entity*) logically kill entities,
+ *   instantly advancing the active timeline.
+ * - **Queries & Hooks**: Mechanisms to query logical presence (@p isAlive()) or subscribe to global destruction
+ *   notifications via @p registerChangeCallback().
+ *
+ * ---
+ *
+ * ### 2. Internal Component API (ECS Integration & Component Managers)
+ * This group supports the underlying asynchronous **Epoch-Based Reclamation (EBR)** garbage collector. Designed
+ * exclusively for subclasses of @p SingleInstanceComponentManagerBase (e.g. @p FCameraManager, @p FTransformManager),
+ * these methods govern thread-consensus and physical payload purging budgets:
+ * - **Consensus Registration**: Methods like @p registerWatermark() and @p unregisterWatermark() allow components to
+ *   join or vacate the global timeline consensus.
+ * - **Timeline Sweeps**: Methods like @p advanceEpoch() and @p reclaimSafeEpochs() seal completed frames and process
+ *   physical reclaiming boundaries.
+ * - **Missed Garbage Harvests**: APIs like @p getMissedGarbage() enable Component Managers to retrieve logically dead
+ *   Entity bitsets precisely synced against their local watermarks in atomic, collision-free transaction blocks.
+ */
 class UTILS_PUBLIC EntityManager {
 public:
-    // Get the global EntityManager. It is recommended to cache this value.
-    // Thread Safe.
+    /**
+     * @brief Gets a reference to the global EntityManager singleton.
+     * @note It is recommended to cache this reference locally to bypass lookups.
+     * @return Reference to the thread-safe global EntityManager.
+     */
     static EntityManager& get() noexcept;
 
+    /**
+     * @class Listener
+     * @brief Abstract base class for receiving global entity lifecycle notifications.
+     */
     class Listener {
     public:
+        /**
+         * @brief Invoked asynchronously after a batch of entities has been globally destroyed.
+         * @param[in] n The number of entities contained in the destruction batch.
+         * @param[in] entities Pointer to the contiguous array of destroyed Entity identities.
+         */
         virtual void onEntitiesDestroyed(size_t n, Entity const* entities) noexcept = 0;
     protected:
         virtual ~Listener() noexcept;
@@ -55,69 +103,192 @@ public:
     using ChangeCallback = std::function<void(Slice<const Entity>)>;
 
     /**
-     * Registers a callback to be triggered when entities are destroyed.
-     * The callback receives a batch of destroyed entities.
-     * Thread safe.
-     * @param token A unique identifier for the listener (e.g., 'this' pointer).
-     * @param callback The callback to invoke.
+     * @brief Registers a callback to be triggered when entities are destroyed.
+     * @param[in] token Unique identifier key for the listener (e.g., 'this' pointer).
+     * @param[in] callback The invocable target function to execute.
      */
     void registerChangeCallback(void const* token, ChangeCallback callback) noexcept;
 
     /**
-     * Unregisters a callback.
-     * Thread safe.
-     * @param token The token used during registration.
+     * @brief Unregisters a pre-existing change notification callback.
+     * @param[in] token The unique identifier key used during registration.
      */
     void unregisterChangeCallback(void const* token) noexcept;
 
     /**
-     * Flushes any pending notifications to listeners.
-     * Thread safe.
+     * @brief Flushes all pending entity lifecycle change notifications to registered callbacks.
+     * @details Invoked automatically upon internal queue thresholds, or manually per frame.
      */
     void flushNotifications() noexcept;
 
-    // maximum number of entities that can exist at the same time
+    /**
+     * @brief Retrieves the maximum theoretical upper bound of entities that can exist concurrently.
+     * @details Factored around reserved index slots and 2^GENERATION_SHIFT limits.
+     * @return The maximum available 32-bit Entity identity limit.
+     */
     static size_t getMaxEntityCount() noexcept {
-        // because index 0 is reserved, we only have 2^GENERATION_SHIFT - 1 valid indices
         return RAW_INDEX_COUNT - 1;
     }
 
-    // number of active Entities
+    /**
+     * @brief Returns the total number of currently active/alive Entities.
+     * @return Count of logical entities currently populated in the system.
+     */
     size_t getEntityCount() const noexcept;
 
-    // Create n entities. Thread safe.
+    /**
+     * @brief Allocates and creates a batch of 'n' new or recycled Entities.
+     * @param[in] n The number of Entity identities to generate.
+     * @param[out] entities Pointer to the output array receiving the populated Entity IDs.
+     */
     void create(size_t n, Entity* entities);
 
-    // destroys n entities. Thread safe.
+    /**
+     * @brief Globally and logically destroys a batch of 'n' Entities.
+     * @param[in] n The number of Entity identities to destroy.
+     * @param[in] entities Pointer to the contiguous array of Entities to logically kill.
+     */
     void destroy(size_t n, Entity* entities) noexcept;
 
-    // Create a new Entity. Thread safe.
-    // Return Entity.isNull() if the entity cannot be allocated.
+    /**
+     * @brief Allocates and creates a single new or recycled Entity.
+     * @return The populated Entity ID, or Entity.isNull() upon allocation failure.
+     */
     Entity create() {
         Entity e;
         create(1, &e);
         return e;
     }
 
-    // Destroys an Entity. Thread safe.
+    /**
+     * @brief Globally and logically destroys a single Entity identity.
+     * @param[in] e The Entity to logically kill.
+     */
     void destroy(Entity e) noexcept {
         destroy(1, &e);
     }
 
-    // Return whether the given Entity has been destroyed (false) or not (true).
-    // Thread safe.
+    /**
+     * @brief Queries the logical lifecycle state of a given Entity.
+     * @param[in] e The Entity to test for presence.
+     * @return True if the Entity is active and logically alive, false if dead/destroyed.
+     */
     bool isAlive(Entity e) const noexcept;
 
-    // Registers a listener to be called when an entity is destroyed. Thread safe.
-    // If the listener is already registered, this method has no effect.
+    /**
+     * @brief Subscribes an abstract Listener to global entity destruction notifications.
+     * @param[in] l Pointer to the abstract Listener subclass.
+     */
     void registerListener(Listener* l) noexcept;
 
-    // unregisters a listener.
+    /**
+     * @brief Unregisters a pre-existing abstract Listener from the system.
+     * @param[in] l Pointer to the Listener instance to remove.
+     */
     void unregisterListener(Listener* l) noexcept;
 
-    // Returns the bitset of alive entities.
+    /**
+     * @brief Extracts the complete tracking bitset representing all logically alive Entities.
+     * @return PagedArenaBitset containing bits for every active 32-bit Entity index.
+     */
     PagedArenaBitset getAliveEntities() const noexcept;
 
+    /**
+     * @brief Registers a reader's watermark with the Epoch-Based Reclamation (EBR) system.
+     *
+     * @details Registering a watermark prevents the orchestrator from reclaiming/recycling
+     * any Entity indices destroyed in epochs greater than or equal to this watermark.
+     * Readers must update their watermarks during their GC phase.
+     * Thread-safe.
+     *
+     * @param watermark Pointer to the reader's atomic watermark.
+     */
+    void registerWatermark(std::atomic<uint64_t>* watermark, utils::ImmutableCString name = "Unknown") noexcept;
+
+    /**
+     * @brief Unregisters a reader's watermark from the EBR system.
+     *
+     * @details Unregistering a watermark allows the orchestrator to reclaim epochs without
+     * being blocked by this reader. Automatically triggers reclaimSafeEpochs() to recycle
+     * any pending garbage that was blocked by this reader.
+     * Thread-safe.
+     *
+     * @param watermark Pointer to the reader's atomic watermark.
+     */
+    void unregisterWatermark(std::atomic<uint64_t>* watermark) noexcept;
+
+    /**
+     * @brief Atomically rebinds a component manager's EBR watermark to a new memory address.
+     *
+     * @details
+     * This method is strictly required to maintain Epoch-Based Reclamation (EBR) consensus
+     * during Component Manager lifecycle events, specifically Move Construction and Move Assignment.
+     *
+     * When a Component Manager is moved, the physical memory address of its internal
+     * `std::atomic<uint64_t>` watermark changes. If the manager were to simply call
+     * `unregisterWatermark()` followed by `registerWatermark()`, it would create a microscopic
+     * race condition where the manager temporarily drops out of the global timeline consensus.
+     * * If a background thread calls `advanceEpoch()` during that unlocked window, the
+     * EntityManager could miscalculate the `safeThreshold` and prematurely recycle Entity IDs
+     * that the moving manager still expects to be safely held in purgatory, leading to
+     * Stale State Resurrection bugs.
+     *
+     * `rebindWatermark` prevents this by acquiring the timeline lock and swapping the pointers
+     * atomically. This guarantees that the manager's watermark is continuously tracked and
+     * its protection over dead entities is never interrupted.
+     *
+     * @param oldW Pointer to the watermark's previous memory address.
+     * @param newW Pointer to the watermark's new memory address.
+     * @param newName The diagnostic name of the component manager, used for tracking EBR stalls.
+     *
+     * @warning Never substitute this method with an unregister/register pair when moving
+     * a Component Manager.
+     */
+    void rebindWatermark(std::atomic<uint64_t> const* oldW, std::atomic<uint64_t>* newW,
+            ImmutableCString newName) noexcept;
+
+    /**
+     * @brief Advances the timeline to the next epoch.
+     *
+     * @details Increments the current epoch ID and seals the current epoch. All subsequent
+     * entity destructions will be recorded in the new epoch. Automatically triggers
+     * reclaimSafeEpochs() to recycle safe, completed epochs.
+     * Thread-safe.
+     */
+    void advanceEpoch() noexcept;
+
+    /**
+     * @brief Retrieves all completed, sealed garbage epochs missed by a reader.
+     *
+     * @details Returns pointers to the PagedArenaBitsets of all epochs in the timeline
+     * where `epoch.id > readerWatermark && epoch.id < currentEpochID`.
+     * Thread-safe.
+     *
+     * @note **Important Allocation/Memory Contract**:
+     * 1. The vector passed as @p out is explicitly cleared at the start of the query.
+     * 2. It reserves necessary capacity and appends all harvested missed epochs directly,
+     *    completely avoiding dynamic heap allocation overhead inside the culling/rendering hot paths.
+     *
+     * @param out The pre-allocated target vector to collect the missed garbage epochs.
+     * @param readerWatermark The current watermark of the requesting reader.
+     * @return Reference to the populated target vector @p out.
+     */
+    uint64_t getMissedGarbage(
+            std::vector<const PagedArenaBitset*>& out, uint64_t readerWatermark) noexcept;
+
+    // Reclaims and recycles all indices from epochs that are safe to reclaim.
+    // Note: This method is intended EXCLUSIVELY for testing, unit test harnesses, and micro-benchmarks 
+    // to trigger harvesting sweeps in isolation. In production, Filament NEVER needs to call this method, 
+    // as advanceEpoch() automatically and synchronously invokes the identical recycling sweep.
+    void reclaimSafeEpochs() noexcept;
+
+    /**
+     * @brief Returns the current active (unsealed) epoch ID.
+     * Thread-safe.
+     *
+     * @return The current epoch ID.
+     */
+    uint64_t getLatestEpochID() const noexcept;
 
     /* no user serviceable parts below */
 
@@ -137,6 +308,7 @@ public:
 
 private:
     friend class EntityManagerImpl;
+    friend class SingleInstanceComponentManagerBase;
     EntityManager();
     ~EntityManager();
 

--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -21,6 +21,7 @@
 #include <utils/CString.h>
 #include <utils/Entity.h>
 #include <utils/EntityInstance.h>
+#include <utils/PagedArenaBitsetPool.h>
 #include <utils/SingleInstanceComponentManager.h>
 
 #include <stddef.h>
@@ -70,7 +71,7 @@ public:
      *
      * @return Non-zero handle if the entity has a name component, 0 otherwise.
      */
-    Instance getInstance(Entity e) const noexcept {
+    Instance getInstance(Entity const e) const noexcept {
         return { SingleInstanceComponentManager::getInstance(e) };
     }
 
@@ -85,6 +86,15 @@ public:
     void removeComponent(Entity e);
 
     /**
+     * Destroys the name component of the given entity.
+     */
+    void destroyComponents(Entity const* entities, size_t count) noexcept;
+
+    void destroy(Entity e) noexcept {
+        destroyComponents(&e, 1);
+    }
+
+    /**
      * Stores a copy of the given string and associates it with the given instance.
      */
     void setName(Instance instance, const char* name) noexcept;
@@ -96,10 +106,8 @@ public:
      */
     const char* getName(Instance instance) const noexcept;
 
-    void gc(EntityManager& em) noexcept {
-        SingleInstanceComponentManager<CString>::gc(em, [this](Entity e) {
-            removeComponent(e);
-        });
+    void gc() noexcept {
+        SingleInstanceComponentManager<CString>::gc(this, &NameComponentManager::destroyComponents);
     }
 };
 

--- a/libs/utils/include/utils/PagedArenaBitset.h
+++ b/libs/utils/include/utils/PagedArenaBitset.h
@@ -365,6 +365,9 @@ public:
 
     static PagedArenaBitset merge(const PagedArenaBitset& a, const PagedArenaBitset& b);
 
+    static PagedArenaBitset& mergeSpan(PagedArenaBitset* UTILS_RESTRICT UTILS_NONNULL out,
+            Slice<const PagedArenaBitset* const> inputs);
+
     // ----------------------------------------------------------------------------------------------------------------
     // difference
     // ----------------------------------------------------------------------------------------------------------------
@@ -546,9 +549,9 @@ private:
     static_assert(WORDS_PER_PAGE == 64, "WORDS_PER_PAGE must be 64 to match the 64-bit activeWordsMask!");
 
     // Do NOT pad or align this struct to 64 bytes (576) or 512 bytes.
-    // Maintaining a non-cache-line-multiple size (520) creates a natural 
-    // memory stagger. In Multi-Way operations (Merge6, Intersect6), this stagger 
-    // prevents 4K Cache Set Aliasing and L1 Cache Thrashing, resulting in 
+    // Maintaining a non-cache-line-multiple size (520) creates a natural
+    // memory stagger. In Multi-Way operations (Merge6, Intersect6), this stagger
+    // prevents 4K Cache Set Aliasing and L1 Cache Thrashing, resulting in
     // up to an 8x performance increase.
     struct Page {
         uint64_t activeWordsMask = 0;
@@ -582,9 +585,6 @@ private:
     template<typename Collection>
     static PagedArenaBitset& mergeInternal(PagedArenaBitset* UTILS_RESTRICT UTILS_NONNULL out,
             const Collection& inputs);
-
-    static PagedArenaBitset& mergeSpan(PagedArenaBitset* UTILS_RESTRICT UTILS_NONNULL
-            out, Slice<const PagedArenaBitset* const> inputs);
 
     template<typename Collection>
     static uint32_t mergeSizeInternal(const Collection& inputs);

--- a/libs/utils/include/utils/PagedArenaBitset.h
+++ b/libs/utils/include/utils/PagedArenaBitset.h
@@ -401,6 +401,24 @@ public:
      */
     template <typename Func>
     void forEachSetBit(Func&& callback) const {
+        const_cast<PagedArenaBitset*>(this)->traverseSetBits<false>(std::forward<Func>(callback));
+    }
+
+    /**
+     * @brief Traverses set bits in ascending order, popping (clearing) each bit upon successful processing.
+     * @tparam Func A callable taking `uint32_t` and returning `bool` (or convertible to `bool`).
+     * @param callback Invoked for each set bit. Return `true` to consume/pop the bit; `false` to STOP and leave the bit set.
+     * @return The number of bits successfully popped.
+     */
+    template <typename Func>
+    uint32_t popSetBits(Func&& callback) {
+        return traverseSetBits<true>(std::forward<Func>(callback));
+    }
+
+private:
+    template <bool Destructive, typename Func>
+    uint32_t traverseSetBits(Func&& callback) {
+        uint32_t count = 0;
         for (uint32_t m = 0; m < MASTER_WORDS; ++m) {
             uint64_t masterMask = mMasterMask[m];
             while (masterMask) {
@@ -418,7 +436,7 @@ public:
                     uint16_t const physicalIdx = mDirectory[dirIdx];
 
                     assert(physicalIdx != INVALID_PAGE && "Summary mask desynchronized");
-                    auto const& [activeWordsMask, words] = mArena[physicalIdx];
+                    auto& [activeWordsMask, words] = mArena[physicalIdx];
                     uint64_t activeMask = activeWordsMask;
 
                     while (activeMask != 0) {
@@ -431,10 +449,29 @@ public:
                             // Calculate the unique Entity ID from the hierarchy indices
                             uint32_t const id = (dirIdx << FILAMENT_PAGE_SHIFT) | (w << WORD_SHIFT) | wBit;
 
+                            bool proceed = true;
                             if constexpr (std::is_convertible_v<std::invoke_result_t<Func, uint32_t>, bool>) {
-                                if (!callback(id)) return;
+                                proceed = callback(id);
                             } else {
                                 callback(id);
+                            }
+
+                            if constexpr (Destructive) {
+                                if (UTILS_LIKELY(proceed)) {
+                                    words[w] &= ~(1ULL << wBit);
+                                    if (words[w] == 0) {
+                                        activeWordsMask &= ~(1ULL << w);
+                                    }
+                                    mSize--;
+                                    count++;
+                                } else {
+                                    return count;
+                                }
+                            } else {
+                                if (UTILS_UNLIKELY(!proceed)) {
+                                    return count;
+                                }
+                                count++;
                             }
                         }
                         activeMask &= (activeMask - 1);
@@ -442,8 +479,10 @@ public:
                 }
             }
         }
+        return count;
     }
 
+public:
     // ----------------------------------------------------------------------------------------------------------------
     // subset / superset queries
     // ----------------------------------------------------------------------------------------------------------------

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -28,6 +28,7 @@
 
 #include <tsl/robin_map.h>
 
+#include <atomic>
 #include <utility>
 #include <vector>
 
@@ -38,7 +39,6 @@
 namespace utils {
 
 class EntityManager;
-class PagedArenaBitset;
 
 /**
  * Base class for SingleInstanceComponentManager to handle callbacks without template bloat.
@@ -46,6 +46,7 @@ class PagedArenaBitset;
 class UTILS_PUBLIC SingleInstanceComponentManagerBase {
 public:
     using ChangeCallback = Invocable<void(Slice<const Entity>)>;
+    using Instance = EntityInstanceBase::Type;
 
     static constexpr bool USE_SORTED_DIRTY_ARRAY = false;
 
@@ -86,21 +87,158 @@ public:
     void unregisterBitset(PagedArenaBitset const* bitset);
 
     /**
+     * @brief Checks if a newly allocated/recycled Entity collides with an active but logically-dead component payload (a pending zombie).
+     *
+     * @details Under Filament's asynchronous Epoch-Based Reclamation (EBR) system, when an entity is globally destroyed,
+     * its corresponding component payload is immediately cilled logically (e.g., removed from the active bitset) inside
+     * @p catchupGarbage(), but its physical slot inside the dense payload array is not freed until the next @p gc() call.
+     *
+     * If the central EntityManager recycles the dead entity's index and reallocates it to a brand new entity
+     * (@p newEntity, which inherits the same index but with a higher generation number) *before* this component
+     * manager has physically run its garbage collector, the old "zombie" component payload will still be residing at
+     * that exact index slot inside the dense payload array, creating a catastrophic collision.
+     *
+     * To resolve this, concrete component managers MUST call @p popPendingZombie() inside their component allocation paths.
+     * If a collision is detected:
+     * 1. The old zombie's identity is extracted in @p outZombie.
+     * 2. The zombie's bit is immediately popped and removed from @p mPendingDestruction.
+     * 3. The caller MUST immediately and synchronously invoke the C++ payload destructor and array swap-and-pop
+     *    compaction logic on @p outZombie (e.g., by calling @p removeComponent(outZombie)) before allocating
+     *    the component for @p newEntity.
+     *
+     * @param[in] newEntity The newly created Entity to check for recycled index collisions.
+     * @param[out] outZombie Reference to store the pre-existing logically dead Entity that was collided with.
+     * @return True if a pending zombie component was found and popped (requiring immediate destruction), false otherwise.
+     */
+    bool popPendingZombie(Entity newEntity, Entity& outZombie) noexcept;
+
+    /**
      * Records a change for the given entity.
      * Flushes notifications if the internal buffer becomes full.
      */
     void notifyChange(Entity e) noexcept;
 
+    // Non-templated Presence & Instance queries
+    bool hasComponent(Entity const e) const noexcept {
+        return getInstance(e) != 0;
+    }
+
+    Instance getInstance(Entity const e) const noexcept {
+        auto const pos = mInstanceMap.find(e);
+        return pos != mInstanceMap.end() ? pos->second : 0;
+    }
+
+    PagedArenaBitset const& getEntityBitset() const noexcept {
+        return mEntities;
+    }
+
+    /**
+     * @brief Returns true if this component manager supports deferred/amortized physical array compactions.
+     */
+    bool isAmortizationSupported() const noexcept { return mAmortizationSupported; }
+
+    /**
+     * @brief Temporarily suspends (sleeps) this component manager, unregistering its watermark.
+     *
+     * @details When a manager is suspended, it no longer participates in the EBR system, allowing
+     * the central EntityManager to safely reclaim/recycle epochs without being blocked by this manager.
+     *
+     * @warning **Strict Rules in Suspended State:**
+     * 1. **NO Component Operations**: While suspended, you MUST NOT call any component operations
+     *    (e.g. @p addComponent, @p removeComponent, @p getInstance, @p gc, etc.) or access elements in the component arrays.
+     * 2. **Entity Destruction Risk**: Because the manager's watermark is unregistered, any entities managed
+     *    by this component manager that are destroyed while the manager is suspended can have their
+     *    underlying indices recycled and completely reused for newly created entities *before* the manager
+     *    has a chance to garbage collect them. This will lead to severe data corruption if accessed!
+     * 3. **Precondition for Suspend**: A manager should ideally be completely empty (having 0 components)
+     *    or guarantee that no entities it currently holds components for can be destroyed during its suspension.
+     *    Typically, @p suspend() is called when the associated scene, world, or render context is inactive or shutdown.
+     */
+    void suspend() noexcept {
+        mEntityManager.unregisterWatermark(&mWatermark);
+    }
+
+    /**
+     * @brief Resumes this component manager from a suspended state, re-registering its watermark.
+     *
+     * @details Re-registers the manager's watermark with the EBR system.
+     * Upon resuming, the manager will automatically participate in the next GC cycle and catch up
+     * on all missed garbage epochs that are still present on the timeline.
+     */
+    void resume() noexcept {
+        mEntityManager.registerWatermark(&mWatermark);
+    }
+
+    ImmutableCString const& getName() const noexcept { return mName; }
+
+    uint64_t getWatermark() const noexcept { return mWatermark.load(std::memory_order_relaxed); }
+
+    void checkZombieCollisionPanic(Entity newEntity) noexcept;
+
 protected:
-    SingleInstanceComponentManagerBase() noexcept = default;
-    ~SingleInstanceComponentManagerBase() noexcept = default;
+    struct CompactionResult {
+        size_t lastIndex;
+        Entity swappedEntity;
+    };
+
+    using SoaAllocator = Instance (*)(void* context, Entity e);
+    using SoaDeallocator = CompactionResult (*)(void* context, size_t index);
+    using EvictionDispatcher = void (*)(void* ctx, void* extra, Entity const* entities, size_t count);
+
+    /**
+     * @brief Constructs a new SingleInstanceComponentManagerBase.
+     *
+     * @param[in] em Reference to the global EntityManager timeline coordinator.
+     * @param[in] name Descriptive diagnostic name for this component manager.
+     * @param[in] amortizationSupported Set to true to opt-in to multi-frame physical destruction amortization.
+     *
+     * @note **CRITICAL CONCURRENCY CONTRACT**:
+     * If @p amortizationSupported is set to **true**, the physical component payload array is no longer guaranteed
+     * to be purged synchronously inside the current frame. This exposes the manager to Just-In-Time (JIT)
+     * recycled index collisions.
+     *
+     * **IT BECOMES THE STRICT RESPONSIBILITY** of the concrete Component Manager implementation to invoke
+     * @p popPendingZombie() and synchronously purge any colliding zombie component payloads inside their
+     * @p create() allocation paths BEFORE assigning the new component.
+     *
+     * If @p amortizationSupported is **false** (the default), physical payloads are purged synchronously per frame,
+     * relaxing this implementation requirement (suitable for test harnesses and micro-benchmarks).
+     */
+    explicit SingleInstanceComponentManagerBase(EntityManager& em, ImmutableCString name,
+            bool amortizationSupported = false) noexcept;
+    ~SingleInstanceComponentManagerBase() noexcept;
 
     SingleInstanceComponentManagerBase(const SingleInstanceComponentManagerBase&) = delete;
     SingleInstanceComponentManagerBase& operator=(const SingleInstanceComponentManagerBase&) = delete;
-    SingleInstanceComponentManagerBase(SingleInstanceComponentManagerBase&&) noexcept = default;
-    SingleInstanceComponentManagerBase& operator=(SingleInstanceComponentManagerBase&&) noexcept = default;
+
+    SingleInstanceComponentManagerBase(SingleInstanceComponentManagerBase&& rhs) noexcept;
+    SingleInstanceComponentManagerBase& operator=(SingleInstanceComponentManagerBase&& rhs) noexcept;
+
+    Instance addComponentImpl(Entity e, void* context, SoaAllocator allocator) noexcept;
+
+    void removeComponentsImpl(Entity const* entities, size_t count, void* context, SoaDeallocator deallocator) noexcept;
+
+    void gcImpl(uint32_t maxDestructions,
+            void* context, void* extraArg, EvictionDispatcher dispatcher) noexcept;
+
+    /*
+     * EBR GC: Periodically queries missed garbage from the global EntityManager
+     * and marks dead entities logically dead in mPendingDestruction without moving memory.
+     */
+    void catchupGarbage() noexcept;
+
+    tsl::robin_map<Entity, Instance, Entity::Hasher> mInstanceMap;
+    PagedArenaBitset mEntities;
+    PagedArenaBitset mPendingDestruction;
 
 private:
+    EntityManager& mEntityManager;
+    ImmutableCString mName;
+    bool mAmortizationSupported = false;
+    PagedArenaBitset mCollapsedGarbage;
+    std::atomic<uint64_t> mWatermark{0};
+    std::vector<const PagedArenaBitset*> mMissedGarbage;
+
     struct CallbackInfo {
         void const* token;
         ChangeCallback callback;
@@ -143,10 +281,9 @@ public:
     using Structure = typename SoA::Structure;
     using Instance = EntityInstanceBase::Type;
 
-    SingleInstanceComponentManager() noexcept {
-        // We always start with a dummy entry because index=0 is reserved. The component
-        // at index = 0, is guaranteed to be default-initialized.
-        // Subclasses can use this to their advantage.
+    explicit SingleInstanceComponentManager(EntityManager& em, ImmutableCString name,
+            bool const amortizationSupported = false) noexcept
+            : SingleInstanceComponentManagerBase(em, std::move(name), amortizationSupported) {
         mData.push_back(Structure{});
     }
 
@@ -154,21 +291,18 @@ public:
 
     SingleInstanceComponentManager(SingleInstanceComponentManager const& rhs) = delete;
     SingleInstanceComponentManager& operator=(SingleInstanceComponentManager const& rhs) = delete;
-    SingleInstanceComponentManager(SingleInstanceComponentManager&&) noexcept = default;
-    SingleInstanceComponentManager& operator=(SingleInstanceComponentManager&&) = default;
 
-    // returns true if the given Entity has a component of this Manager
-    bool hasComponent(Entity const e) const noexcept {
-        return getInstance(e) != 0;
+    SingleInstanceComponentManager(SingleInstanceComponentManager&& rhs) noexcept
+            : SingleInstanceComponentManagerBase(std::move(rhs)),
+              mData(std::move(rhs.mData)) {
     }
 
-    // Get instance of this Entity to be used to retrieve components
-    UTILS_NOINLINE
-    Instance getInstance(Entity const e) const noexcept {
-        auto const& map = mInstanceMap;
-        // find() generates quite a bit of code
-        auto const pos = map.find(e);
-        return pos != map.end() ? pos->second : 0;
+    SingleInstanceComponentManager& operator=(SingleInstanceComponentManager&& rhs) noexcept {
+        if (UTILS_LIKELY(this != &rhs)) {
+            SingleInstanceComponentManagerBase::operator=(std::move(rhs));
+            mData = std::move(rhs.mData);
+        }
+        return *this;
     }
 
     // Returns the number of components (i.e. size of each array)
@@ -197,6 +331,13 @@ public:
     // Removes a component from the given entity.
     // This invalidates all pointers components.
     Instance removeComponent(Entity e);
+    void removeComponents(Entity const* entities, size_t count) noexcept;
+
+    // return the first instance
+    Instance begin() noexcept {
+        catchupGarbage();
+        return 1u;
+    }
 
     // return the first instance
     Instance begin() const noexcept { return 1u; }
@@ -300,97 +441,168 @@ protected:
         }
     }
 
-    template<typename REMOVE>
-    void gc(const EntityManager& em,
-            REMOVE&& removeComponent) noexcept {
-        gc(em, 4, std::forward<REMOVE>(removeComponent));
+    template<typename MFClass, typename ReturnType>
+    using BatchDestroyFunc = ReturnType (MFClass::*)(Entity const*, size_t);
+
+    template<typename MFClass, typename ReturnType, typename Arg>
+    using BatchDestroyArgFunc = ReturnType (MFClass::*)(Entity const*, size_t, Arg);
+
+    template<typename MFClass, typename ReturnType>
+    using SingleDestroyFunc = ReturnType (MFClass::*)(Entity);
+
+    template<typename MFClass, typename ReturnType, typename Arg>
+    using SingleDestroyArgFunc = ReturnType (MFClass::*)(Entity, Arg);
+
+    template<typename Class, typename MFClass, typename ReturnType>
+    void gc(Class* outerInstance, uint32_t const maxDestructions,
+            BatchDestroyFunc<MFClass, ReturnType> const destroyFunc) noexcept {
+        auto pmf = destroyFunc;
+
+        auto dispatcher = [](void* ctx, void* ext, Entity const* entities, size_t const count) noexcept {
+            auto outer = static_cast<Class*>(ctx);
+            auto funcPtr = static_cast<BatchDestroyFunc<MFClass, ReturnType>*>(ext);
+            (outer->**funcPtr)(entities, count);
+        };
+
+        gcImpl(maxDestructions, outerInstance, &pmf, dispatcher);
     }
 
-    template<typename REMOVE>
-    void gc(const EntityManager& em, size_t const ratio,
-            REMOVE&& removeComponent) noexcept {
-        Entity const* const pEntities = begin<ENTITY_INDEX>();
-        size_t count = getComponentCount();
-        size_t aliveInARow = 0;
-        default_random_engine& rng = mRng;
-        UTILS_NOUNROLL
-        while (count && aliveInARow < ratio) {
-            assert(count == getComponentCount());
-            // note: using the modulo favorizes lower number
-            size_t const i = rng() % count;
-            Entity const entity = pEntities[i];
-            assert(entity);
-            if (UTILS_LIKELY(em.isAlive(entity))) {
-                ++aliveInARow;
-                continue;
+    template<typename Class, typename MFClass, typename ReturnType, typename Arg>
+    void gc(Class* outerInstance, uint32_t const maxDestructions,
+            BatchDestroyArgFunc<MFClass, ReturnType, Arg> const destroyFunc,
+            std::remove_reference_t<Arg>& extra) noexcept {
+        struct Context {
+            BatchDestroyArgFunc<MFClass, ReturnType, Arg> pmf;
+            std::remove_reference_t<Arg>* arg;
+        } ctxStruct { destroyFunc, &extra };
+
+        auto dispatcher = [](void* ctx, void* ext, Entity const* entities, size_t const count) noexcept {
+            auto outer = static_cast<Class*>(ctx);
+            auto context = static_cast<Context*>(ext);
+            (outer->*(context->pmf))(entities, count, *(context->arg));
+        };
+
+        gcImpl(maxDestructions, outerInstance, &ctxStruct, dispatcher);
+    }
+
+    static constexpr uint32_t DEFAULT_AMORTIZED_DESTRUCTIONS = 50;
+
+    template<typename Class, typename MFClass, typename ReturnType>
+    void gc(Class* outerInstance, BatchDestroyFunc<MFClass, ReturnType> destroyFunc) noexcept {
+        gc(outerInstance, DEFAULT_AMORTIZED_DESTRUCTIONS, destroyFunc);
+    }
+
+    template<typename Class, typename MFClass, typename ReturnType, typename Arg>
+    void gc(Class* outerInstance, BatchDestroyArgFunc<MFClass, ReturnType, Arg> destroyFunc,
+            std::remove_reference_t<Arg>& extra) noexcept {
+        gc(outerInstance, DEFAULT_AMORTIZED_DESTRUCTIONS, destroyFunc, extra);
+    }
+
+    template<typename Class, typename MFClass, typename ReturnType>
+    void gc(Class* outerInstance, uint32_t const maxDestructions,
+            SingleDestroyFunc<MFClass, ReturnType> const destroyFunc) noexcept {
+        auto pmf = destroyFunc;
+
+        auto dispatcher = [](void* ctx, void* ext, Entity const* entities, size_t const count) noexcept {
+            auto outer = static_cast<Class*>(ctx);
+            auto funcPtr = static_cast<SingleDestroyFunc<MFClass, ReturnType>*>(ext);
+            for (size_t i = 0; i < count; ++i) {
+                (outer->**funcPtr)(entities[i]);
             }
-            removeComponent(entity);
-            aliveInARow = 0;
-            --count;
-        }
+        };
+
+        gcImpl(maxDestructions, outerInstance, &pmf, dispatcher);
+    }
+
+    template<typename Class, typename MFClass, typename ReturnType, typename Arg>
+    void gc(Class* outerInstance, uint32_t const maxDestructions,
+            SingleDestroyArgFunc<MFClass, ReturnType, Arg> const destroyFunc,
+            std::remove_reference_t<Arg>& extra) noexcept {
+        struct Context {
+            SingleDestroyArgFunc<MFClass, ReturnType, Arg> pmf;
+            std::remove_reference_t<Arg>* arg;
+        } ctxStruct { destroyFunc, &extra };
+
+        auto dispatcher = [](void* ctx, void* ext, Entity const* entities, size_t const count) noexcept {
+            auto outer = static_cast<Class*>(ctx);
+            auto context = static_cast<Context*>(ext);
+            for (size_t i = 0; i < count; ++i) {
+                (outer->*(context->pmf))(entities[i], *(context->arg));
+            }
+        };
+
+        gcImpl(maxDestructions, outerInstance, &ctxStruct, dispatcher);
+    }
+
+    template<typename Class, typename MFClass, typename ReturnType>
+    void gc(Class* outerInstance, SingleDestroyFunc<MFClass, ReturnType> destroyFunc) noexcept {
+        gc(outerInstance, DEFAULT_AMORTIZED_DESTRUCTIONS, destroyFunc);
+    }
+
+    template<typename Class, typename MFClass, typename ReturnType, typename Arg>
+    void gc(Class* outerInstance, SingleDestroyArgFunc<MFClass, ReturnType, Arg> destroyFunc,
+            std::remove_reference_t<Arg>& extra) noexcept {
+        gc(outerInstance, DEFAULT_AMORTIZED_DESTRUCTIONS, destroyFunc, extra);
     }
 
     SoA mData;
 
 private:
-    // maps an entity to an instance index
-    tsl::robin_map<Entity, Instance, Entity::Hasher> mInstanceMap;
-    default_random_engine mRng;
-    PagedArenaBitset mEntities;
+    Instance removeComponentsHelper(Entity const* entities, size_t count) noexcept;
 };
 
 // Keep these outside of the class because CLion has trouble parsing them
 template<typename ... Elements>
 typename SingleInstanceComponentManager<Elements ...>::Instance
 SingleInstanceComponentManager<Elements ...>::addComponent(Entity e) {
-    Instance ci = 0;
-    if (!e.isNull()) {
-        if (!hasComponent(e)) {
-            // this is like a push_back(e);
-            mData.push_back(Structure{}).template back<ENTITY_INDEX>() = e;
-            // index 0 is used when the component doesn't exist
-            ci = Instance(mData.size() - 1);
-            mInstanceMap[e] = ci;
-            mEntities.add(e.getId());
-            notifyChange(e);
-        } else {
-            // if the entity already has this component, just return its instance
-            ci = mInstanceMap[e];
-        }
-    }
-    assert(ci != 0);
-    return ci;
+    auto allocator = [](void* ctx, Entity ent) noexcept -> Instance {
+        auto self = static_cast<SingleInstanceComponentManager*>(ctx);
+        self->mData.push_back(Structure{}).template back<ENTITY_INDEX>() = ent;
+        return Instance(self->mData.size() - 1);
+    };
+    return addComponentImpl(e, this, allocator);
 }
 
-// Keep these outside of the class because CLion has trouble parsing them
+template <typename ... Elements>
+typename SingleInstanceComponentManager<Elements ...>::Instance
+SingleInstanceComponentManager<Elements ... >::removeComponentsHelper(Entity const* entities, size_t const count) noexcept {
+    Instance lastIndex = 0;
+    struct Context {
+        SingleInstanceComponentManager* self;
+        Instance* pLastIndex;
+    } ctx { this, &lastIndex };
+
+    auto deallocator = [](void* context, size_t index) noexcept -> CompactionResult {
+        auto ctxPtr = static_cast<Context*>(context);
+        auto self = ctxPtr->self;
+        size_t last = self->mData.size() - 1;
+        *(ctxPtr->pLastIndex) = last;
+
+        Entity swappedEntity;
+        if (last != index) {
+            self->mData.forEach([index, last](auto* p) {
+                p[index] = std::move(p[last]);
+            });
+            swappedEntity = self->mData.template elementAt<ENTITY_INDEX>(index);
+        }
+        self->mData.pop_back();
+        return { last, swappedEntity };
+    };
+
+    removeComponentsImpl(entities, count, &ctx, deallocator);
+    return lastIndex;
+}
+
 template <typename ... Elements>
 typename SingleInstanceComponentManager<Elements ...>::Instance
 SingleInstanceComponentManager<Elements ... >::removeComponent(Entity const e) {
-    auto& map = mInstanceMap;
-    auto const pos = map.find(e);
-    if (UTILS_LIKELY(pos != map.end())) {
-        size_t index = pos->second;
-        assert(index != 0);
-        size_t last = mData.size() - 1;
-        if (last != index) {
-            // move the last item to where we removed this component, as to keep
-            // the array tightly packed.
-            mData.forEach([index, last](auto* p) {
-                p[index] = std::move(p[last]);
-            });
-
-            Entity const lastEntity = mData.template elementAt<ENTITY_INDEX>(index);
-            map[lastEntity] = index;
-        }
-        mData.pop_back();
-        map.erase(pos);
-        mEntities.remove(e.getId());
-        notifyChange(e);
-        return last;
-    }
-    return 0;
+    return removeComponentsHelper(&e, 1);
 }
 
+template <typename ... Elements>
+void SingleInstanceComponentManager<Elements ... >::removeComponents(Entity const* entities, size_t const count) noexcept {
+    removeComponentsHelper(entities, count);
+}
 
 } // namespace filament
 

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -91,8 +91,38 @@ bool EntityManager::isAlive(Entity const e) const noexcept {
 
 PagedArenaBitset EntityManager::getAliveEntities() const noexcept {
     auto const* impl = static_cast<EntityManagerImpl const*>(this);
-    utils::LockGuard const lock(impl->mFreeListLock);
+    LockGuard const lock(impl->mDestructionLock);
     return impl->mAliveEntities.clone();
+}
+
+void EntityManager::registerWatermark(std::atomic<uint64_t>* watermark, ImmutableCString name) noexcept {
+    static_cast<EntityManagerImpl *>(this)->registerWatermark(watermark, std::move(name));
+}
+
+void EntityManager::unregisterWatermark(std::atomic<uint64_t>* watermark) noexcept {
+    static_cast<EntityManagerImpl *>(this)->unregisterWatermark(watermark);
+}
+
+void EntityManager::rebindWatermark(std::atomic<uint64_t> const* oldW, std::atomic<uint64_t>* newW,
+        ImmutableCString newName) noexcept {
+    static_cast<EntityManagerImpl *>(this)->rebindWatermark(oldW, newW, std::move(newName));
+}
+
+void EntityManager::advanceEpoch() noexcept {
+    static_cast<EntityManagerImpl *>(this)->advanceEpoch();
+}
+
+uint64_t EntityManager::getMissedGarbage(
+        std::vector<const PagedArenaBitset*>& out, uint64_t readerWatermark) noexcept {
+    return static_cast<EntityManagerImpl *>(this)->getMissedGarbage(out, readerWatermark);
+}
+
+void EntityManager::reclaimSafeEpochs() noexcept {
+    static_cast<EntityManagerImpl *>(this)->reclaimSafeEpochs();
+}
+
+uint64_t EntityManager::getLatestEpochID() const noexcept {
+    return static_cast<EntityManagerImpl const *>(this)->getLatestEpochID();
 }
 
 } // namespace utils

--- a/libs/utils/src/EntityManager.md
+++ b/libs/utils/src/EntityManager.md
@@ -1,0 +1,75 @@
+# Filament Epoch-Based Reclamation (EBR) Architecture
+
+This document details the concurrent architectural data flows, timelines, and memory layout boundaries of Filament's asynchronous Epoch-Based Reclamation (EBR) garbage collector.
+
+```
+=================================================================================================
+                          FILAMENT MULTITHREADED EBR ARCHITECTURE
+=================================================================================================
+
+ [ GLOBAL TIMELINE LAYER ] (EntityManagerImpl)
+ 
+   Epoch ID:          ... [ Epoch 2 ]         [ Epoch 3 ]         [ Epoch 4 (ACTIVE) ]
+   Status:                 (SEALED)            (SEALED)            (OPEN / UNSEALED)
+                        +-------------+     +-------------+     +--------------------+
+   Dead Entity Bitset:  | PagedArena  |     | PagedArena  |     | PagedArenaBitset   |
+                        | Bitset(E2)  |     | Bitset(E3)  |     | (Active Deletions) |
+                        +-------------+     +-------------+     +--------------------+
+                               |                   |                      |
+                               v                   v                      v
+                             [---------------- STAGED GARBAGE ----------------]
+                                                   |
+                                                   | getMissedGarbage(Watermark = 2)
+                                                   | Returns { E3 bitset }
+                                                   v
+-------------------------------------------------------------------------------------------------
+ [ LOGICAL EXTRACTION LAYER ] (SingleInstanceComponentManagerBase)
+ 
+   1. catchupGarbage() Execution Window:
+   
+      mMyWatermark (E2) -----------------------------------------------> Advance to E3
+      
+      PagedArenaBitset::intersect( Live Components (mEntities) , E3 Bitset )
+                               |
+                               +---> [ Logical Zombies Extracted ]
+                                               |
+                                               v
+                                    mPendingDestruction.merge()
+                                    mEntities.difference()
+                                               |
+                                               v
+-------------------------------------------------------------------------------------------------
+ [ PHYSICAL EVICTION LAYER ] (SingleInstanceComponentManager<T>)
+ 
+   2. gc() Eviction Execution Window:
+   
+      mPendingDestruction.swap( readyToDestruct )
+      
+      readyToDestruct.forEachSetBit( ... )
+             |
+             +---> Index Collides with recycled Active Entity?
+             |            |
+             |            +- (Yes) -> JIT Zombie Purge (popPendingZombie) -> Compaction
+             |            +- (No)  -> Invoke Concrete C++ Destructor (~Component)
+             v
+      StructureOfArrays (Dense Payload Mapping)
+      +--------+--------+--------+--------+
+      | Comp 0 | Comp 1 | Comp 2 | Comp 3 |  <--- Physical Payload Defragmentation
+      +--------+--------+--------+--------+       (Swap-and-Pop on Destruction)
+         [A]      [B]      [C]      [D]
+=================================================================================================
+```
+
+## Architectural Key Concepts
+
+### 1. The Global Epoch Boundaries
+`EntityManagerImpl` maintains a growing array of sealed epoch bitsets. Only epochs that have been sealed via `advanceEpoch()` are processed by the managers.
+
+### 2. Logical Deletion (O(1) Intersect)
+In `catchupGarbage()`, dead entity IDs for sealed frames are bitwise intersected into `mPendingDestruction` and subtracted from `mEntities` instantly. Live rendering and game-loop queries immediately hide these components before their physical destructors have even been scheduled.
+
+### 3. Physical Array Defragmentation
+When `gc()` executes, it isolates the queue via an O(1) swap and processes each payload, utilizing `removeComponent()` to perform a swap-and-pop move to keep the underlying `StructureOfArrays` tightly packed in memory for maximum cache performance.
+
+### 4. JIT Eviction (popPendingZombie)
+Acts as an emergency safety net. If a recycled Entity ID index reallocates a payload spot before `gc()` has cleared the old frame's garbage, the implementation JIT-extracts the pending zombie from `mPendingDestruction` and safely purges the stale component to maintain layout integrity.

--- a/libs/utils/src/EntityManagerImpl.h
+++ b/libs/utils/src/EntityManagerImpl.h
@@ -19,15 +19,12 @@
 
 #include <utils/CallStack.h>
 #include <utils/compiler.h>
-#include <utils/compiler.h>
-#include <utils/debug.h>
 #include <utils/debug.h>
 #include <utils/Entity.h>
 #include <utils/EntityManager.h>
-#include <utils/EntityManager.h>
 #include <utils/FixedCapacityVector.h>
+#include <utils/Logger.h>
 #include <utils/Mutex.h>
-#include <utils/PagedArenaBitset.h>
 #include <utils/PagedArenaBitset.h>
 #include <utils/Slice.h>
 
@@ -37,12 +34,12 @@
 #include <tsl/robin_set.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
-#include <cstddef>
-#include <cstdint>
 #include <deque>
+#include <limits>
 #include <memory>
-#include <mutex> // for std::lock_guard
+#include <mutex> // for LockGuard
 #include <new>
 #include <utility>
 #include <vector>
@@ -50,6 +47,16 @@
 namespace utils {
 
 static constexpr size_t MIN_FREE_INDICES = 1024;
+
+struct GarbageEpoch {
+    uint64_t id;
+    std::unique_ptr<PagedArenaBitset> garbageBits;
+};
+
+struct WatermarkInfo {
+    std::atomic<uint64_t>* watermark;
+    ImmutableCString name;
+};
 
 class UTILS_PRIVATE EntityManagerImpl : public EntityManager {
 public:
@@ -65,6 +72,7 @@ public:
             : mGens(new(std::nothrow) uint8_t[RAW_INDEX_COUNT]) {
         // initialize all the generations to 0
         std::fill_n(mGens, RAW_INDEX_COUNT, 0);
+        mTimeline.push_back({mCurrentEpochID.load(std::memory_order_relaxed), std::make_unique<PagedArenaBitset>()});
     }
 
     ~EntityManagerImpl() noexcept {
@@ -77,103 +85,178 @@ public:
             return false;
         }
 
-        LockGuard const lock(mFreeListLock);
-        bool const alive = (getGeneration(e) == mGens[getIndex(e)]);
+        LockGuard const lock(mDestructionLock);
+        uint32_t const index = getIndex(e);
+
+        // Is this entity the current tenant of this memory slot?
+        bool const alive = (getGeneration(e) == mGens[index]);
         assert(alive == mAliveEntities[e.getId()]);
         return alive;
     }
 
     UTILS_NOINLINE
     size_t getEntityCount() const noexcept {
-        LockGuard const lock(mFreeListLock);
-        if (mCurrentIndex < RAW_INDEX_COUNT) {
-            return (mCurrentIndex - 1) - mFreeList.size();
-        } else {
-            return getMaxEntityCount() - mFreeList.size();
-        }
+        LockGuard const lock(mDestructionLock);
+        return mAliveEntities.size();
     }
 
     UTILS_NOINLINE
     void create(size_t const n, Entity* entities) {
-        Entity::Type index{};
         auto& freeList = mFreeList;
-        uint8_t const* const gens = mGens;
 
-        // this must be thread-safe, acquire the free-list mutex
-        LockGuard const lock(mFreeListLock);
-        Entity::Type currentIndex = mCurrentIndex;
-        for (size_t i = 0; i < n; i++) {
-            if (UTILS_UNLIKELY(currentIndex >= RAW_INDEX_COUNT || freeList.size() >= MIN_FREE_INDICES)) {
+        size_t processed = 0;
 
-                // this could only happen if we had gone through all the indices at least once
-                if (UTILS_UNLIKELY(freeList.empty())) {
-                    // return the null entity
-                    entities[i] = {};
-                    continue;
+        while (processed < n) {
+            constexpr size_t BATCH_SIZE = 128;
+            // Determine how many entities to process in this iteration
+            size_t const chunk = std::min(n - processed, BATCH_SIZE);
+
+            Entity::Type localCreated[BATCH_SIZE];
+            size_t validCount = 0;
+
+            // -------------------------------------------------------------
+            // Phase 1: Lock the Free List and allocate IDs
+            // -------------------------------------------------------------
+            {
+                LockGuard const lock(mCreationLock);
+                Entity::Type currentIndex = mCurrentIndex;
+
+                for (size_t i = 0; i < chunk; i++) {
+                    Entity::Type index{};
+
+                    if (UTILS_UNLIKELY(currentIndex >= RAW_INDEX_COUNT || freeList.size() >= MIN_FREE_INDICES)) {
+                        // Out of indices check
+                        if (UTILS_UNLIKELY(freeList.empty())) {
+                            entities[processed + i] = {}; // Return Null Entity
+                            continue; // Do NOT increment validCount
+                        }
+                        index = freeList.front();
+                        freeList.pop_front();
+                    } else {
+                        index = currentIndex++;
+                    }
+
+                    // Read mGens lock-free because this index is mathematically sterile
+                    uint8_t const gen = [this, index]() UTILS_NO_THREAD_SAFETY_ANALYSIS noexcept {
+                        return mGens[index];
+                    }();
+                    Entity e = Entity{makeIdentity(gen, index)};
+                    entities[processed + i] = e;
+                    localCreated[validCount++] = e.getId();
                 }
+                mCurrentIndex = currentIndex;
+            } // mCreationLock dropped!
 
-                index = freeList.front();
-                freeList.pop_front();
-            } else {
-                index = currentIndex++;
-            }
-            entities[i] = Entity{ makeIdentity(gens[index], index) };
-            mAliveEntities.add(entities[i].getId());
+            // -------------------------------------------------------------
+            // Phase 2: Lock the Global State to register active entities
+            // -------------------------------------------------------------
+            if (UTILS_LIKELY(validCount > 0)) {
+                LockGuard const stateLock(mDestructionLock);
+                for (size_t i = 0; i < validCount; i++) {
+                    mAliveEntities.add(localCreated[i]);
+                }
+            } // mDestructionLock dropped!
+
 #if FILAMENT_UTILS_TRACK_ENTITIES
-            mDebugActiveEntities.emplace(entities[i], CallStack::unwind(5));
+            {
+                LockGuard const stateLock(mDestructionLock);
+                for (size_t i = 0; i < chunk; i++) {
+                    if (!entities[processed + i].isNull()) {
+                        mDebugActiveEntities.emplace(entities[processed + i], CallStack::unwind(5));
+                    }
+                }
+            }
 #endif
+
+            processed += chunk;
         }
-        mCurrentIndex = currentIndex;
     }
 
     UTILS_NOINLINE
     void destroy(size_t const n, Entity* entities) noexcept {
-        auto& freeList = mFreeList;
+        UniqueLock stateLock(mDestructionLock);
         uint8_t* const gens = mGens;
-
-        UniqueLock lock(mFreeListLock);
         for (size_t i = 0; i < n; i++) {
             if (!entities[i]) {
-                // behave like free(), ok to free null Entity.
-                continue;
+                continue; // behave like free(), ok to free null Entity.
             }
 
-            // it's an error to delete an Entity twice...
             bool const isAlive = getGeneration(entities[i]) == mGens[getIndex(entities[i])];
             assert(isAlive);
 
-            // ... deleting a dead Entity will corrupt the internal state, so we protect ourselves
-            // against it. We don't guarantee anything about external state -- e.g. the listeners
-            // will be called.
             if (UTILS_LIKELY(isAlive)) {
                 Entity::Type const index = getIndex(entities[i]);
-                freeList.push_back(index);
+
                 gens[index]++;
                 mAliveEntities.remove(entities[i].getId());
 
 #if FILAMENT_UTILS_TRACK_ENTITIES
+                // MUST be protected by mDestructionLock
                 mDebugActiveEntities.erase(entities[i]);
 #endif
+
+                // Safely write to the shared member buffer
                 mDirtyEntities[mDirtyCount++] = entities[i];
+
+                // Batch Process when buffer is full
                 if (mDirtyCount == MAX_DIRTY_COUNT) {
+                    // 1. Extract the shared data to a private stack buffer
                     Entity localBuffer[MAX_DIRTY_COUNT];
-                    std::copy(mDirtyEntities, mDirtyEntities + MAX_DIRTY_COUNT, localBuffer);
+                    std::copy_n(mDirtyEntities, MAX_DIRTY_COUNT, localBuffer);
+
+                    // 2. Reset the global state for other threads
                     mDirtyCount = 0;
-                    lock.unlock();
 
-                    triggerChangeCallbacks(localBuffer, MAX_DIRTY_COUNT);
+                    // 3. Drop the state lock NOW, safely
+                    stateLock.unlock();
 
-                    lock.lock();
+                    // 4. Process the heavy timeline append + callbacks
+                    flushDestroyBuffer(localBuffer, MAX_DIRTY_COUNT);
+
+                    // 5. Re-acquire for the next loop iteration
+                    stateLock.lock();
                 }
             }
         }
-        lock.unlock();
+
+        // Handle any remaining entities in the buffer
+        if (mDirtyCount > 0) {
+            Entity localBuffer[MAX_DIRTY_COUNT];
+            uint32_t const remainder = mDirtyCount;
+            std::copy_n(mDirtyEntities, remainder, localBuffer);
+            mDirtyCount = 0;
+
+            stateLock.unlock();
+            flushDestroyBuffer(localBuffer, remainder);
+        } else {
+            stateLock.unlock(); // Ensure lock is dropped before listeners
+        }
 
         // notify our listeners that some entities are being destroyed
         auto listeners = getListeners();
         for (auto const& l : listeners) {
             l->onEntitiesDestroyed(n, entities);
         }
+    }
+
+    void flushDestroyBuffer(Entity const* localEntities, uint32_t const count) noexcept {
+        // Lock the timeline EXACTLY ONCE for the entire batch
+        {
+            LockGuard timelineLock(mTimelineLock);
+            auto& currentGarbage = *mTimeline.back().garbageBits;
+
+            for (size_t i = 0; i < count; ++i) {
+                Entity::Type const fullId = localEntities[i].getId();
+#ifndef NDEBUG
+                assert(!mDebugGlobalPurgatory[fullId] && "EBR: Double-Destroy caught!");
+                mDebugGlobalPurgatory.add(fullId);
+#endif
+                currentGarbage.add(fullId);
+            }
+        } // mTimelineLock dropped!
+
+        // Trigger Callbacks outside ALL locks
+        triggerChangeCallbacks(localEntities, count);
     }
 
     void registerListener(Listener* l) noexcept {
@@ -186,6 +269,114 @@ public:
         mListeners.erase(l);
     }
 
+    void registerWatermark(std::atomic<uint64_t>* const watermark, ImmutableCString name) noexcept {
+        LockGuard const lock(mTimelineLock);
+        mActiveWatermarks.push_back({watermark, std::move(name)});
+    }
+
+    void unregisterWatermark(std::atomic<uint64_t>* const watermark) noexcept {
+        constexpr size_t BATCH_SIZE = RECLAMATION_EPOCH_BATCH_SIZE;
+        std::array<GarbageEpoch, BATCH_SIZE> batch;
+        size_t count = 0;
+        {
+            LockGuard const lock(mTimelineLock);
+            mActiveWatermarks.erase(
+                std::ranges::remove_if(mActiveWatermarks,
+                        [watermark](auto const& info) noexcept { return info.watermark == watermark; }).begin(),
+                mActiveWatermarks.end());
+            count = getExpiredEpochsLocked(batch.data(), BATCH_SIZE);
+        }
+        if (count > 0) {
+            recycleGarbageEpochs(batch.data(), count);
+        }
+    }
+
+    void rebindWatermark(std::atomic<uint64_t> const* oldW, std::atomic<uint64_t>* newW,
+            ImmutableCString newName) noexcept {
+        LockGuard const lock(mTimelineLock);
+        for (auto& [watermark, name] : mActiveWatermarks) {
+            if (watermark == oldW) {
+                watermark = newW;
+                name = std::move(newName);
+                return;
+            }
+        }
+    }
+
+    void advanceEpoch() noexcept {
+        std::unique_ptr<PagedArenaBitset> newBitset;
+        {
+            LockGuard const lock(mCreationLock);
+            if (UTILS_LIKELY(!mBitsetPool.empty())) {
+                newBitset = std::move(mBitsetPool.back());
+                mBitsetPool.pop_back();
+            } else {
+                newBitset = std::make_unique<PagedArenaBitset>();
+            }
+        }
+
+        constexpr size_t BATCH_SIZE = RECLAMATION_EPOCH_BATCH_SIZE;
+        std::array<GarbageEpoch, BATCH_SIZE> batch;
+        size_t count = 0;
+        {
+            LockGuard const lock(mTimelineLock);
+            
+            // Read the current epoch (relaxed is safe because we hold the exclusive lock)
+            uint64_t const nextEpoch = mCurrentEpochID.load(std::memory_order_relaxed) + 1;
+            
+            // Mutate the heavy data structures
+            mTimeline.push_back({nextEpoch, std::move(newBitset)});
+
+            // mCurrentEpochID is not publishing data, the lock is, but we keep it at the end -- even if not required for
+            // correctness.
+            mCurrentEpochID.store(nextEpoch, std::memory_order_relaxed);
+
+            // this must be done after we write mCurrentEpochID 
+            count = getExpiredEpochsLocked(batch.data(), BATCH_SIZE);
+        }
+
+        // Do the heavy lifting outside the lock
+        if (count > 0) {
+            recycleGarbageEpochs(batch.data(), count);
+        }
+    }
+
+    uint64_t getMissedGarbage(
+            std::vector<const PagedArenaBitset*>& out, uint64_t const readerWatermark) noexcept {
+        LockGuard const lock(mTimelineLock);
+        out.clear();
+        out.reserve(mTimeline.size());
+        // Relaxed is fine here. The mutex acts as our memory barrier.
+        uint64_t const currentEpoch = mCurrentEpochID.load(std::memory_order_relaxed);
+        for (auto const& [id, garbageBits] : mTimeline) {
+            if (id > readerWatermark && id < currentEpoch) {
+                out.push_back(garbageBits.get());
+            }
+        }
+        // Return the logical fence. Because we scanned everything < currentEpoch,
+        // the reader is guaranteed to be fully caught up to currentEpoch - 1.
+        return currentEpoch - 1;
+    }
+
+    void reclaimSafeEpochs() noexcept {
+        constexpr size_t BATCH_SIZE = RECLAMATION_EPOCH_BATCH_SIZE;
+        std::array<GarbageEpoch, BATCH_SIZE> batch;
+        size_t count = 0;
+        {
+            LockGuard const lock(mTimelineLock);
+            count = getExpiredEpochsLocked(batch.data(), BATCH_SIZE);
+        }
+        // Do the heavy lifting outside the lock
+        if (count > 0) {
+            recycleGarbageEpochs(batch.data(), count);
+        }
+    }
+
+    uint64_t getLatestEpochID() const noexcept UTILS_NO_THREAD_SAFETY_ANALYSIS {
+        // this cannot be used to acquire data (mCurrentEpochID is not releasing data)
+        return mCurrentEpochID.load(std::memory_order_relaxed);
+    }
+
     void registerChangeCallback(void const* token, ChangeCallback callback) noexcept {
         LockGuard const lock(mListenerLock);
         mChangeCallbacks.push_back({token, std::move(callback)});
@@ -193,26 +384,22 @@ public:
 
     void unregisterChangeCallback(void const* token) noexcept {
         LockGuard const lock(mListenerLock);
-        mChangeCallbacks.erase(
-                std::remove_if(mChangeCallbacks.begin(), mChangeCallbacks.end(),
-                        [token](auto const& info) { return info.token == token; }),
-                mChangeCallbacks.end());
+        std::erase_if(mChangeCallbacks,
+                [token](auto const& info) { return info.token == token; });
     }
 
     void flushNotifications() noexcept {
-        Entity localBuffer[MAX_DIRTY_COUNT];
-        size_t count = 0;
-        {
-            LockGuard const lock(mFreeListLock);
-            if (mDirtyCount > 0) {
-                assert_invariant(mDirtyCount <= MAX_DIRTY_COUNT);
-                std::copy(mDirtyEntities, mDirtyEntities + mDirtyCount, localBuffer);
-                count = mDirtyCount;
-                mDirtyCount = 0;
-            }
-        }
-        if (count > 0) {
-            triggerChangeCallbacks(localBuffer, count);
+        UniqueLock lock(mDestructionLock);
+        if (mDirtyCount > 0) {
+            Entity localBuffer[MAX_DIRTY_COUNT];
+            assert_invariant(mDirtyCount <= MAX_DIRTY_COUNT);
+            std::copy_n(mDirtyEntities, mDirtyCount, localBuffer);
+            size_t const count = mDirtyCount;
+            mDirtyCount = 0;
+            lock.unlock();
+
+            // Safely appends to timeline and triggers callbacks
+            flushDestroyBuffer(localBuffer, count);
         }
     }
 
@@ -220,7 +407,7 @@ public:
     std::vector<Entity> getActiveEntities() const {
         std::vector<Entity> result;
         {
-            LockGuard const lock(mFreeListLock);
+            LockGuard const lock(mDestructionLock);
             result.reserve(mDebugActiveEntities.size());
             for (auto const& i : mDebugActiveEntities) {
                 result.push_back(i.first);
@@ -229,10 +416,10 @@ public:
         return result;
     }
 
-    void dumpActiveEntities(utils::io::ostream& out) const {
+    void dumpActiveEntities(io::ostream& out) const {
         std::vector<std::pair<Entity, CallStack>> activeEntities;
         {
-            LockGuard const lock(mFreeListLock);
+            LockGuard const lock(mDestructionLock);
             activeEntities.reserve(mDebugActiveEntities.size());
             for (auto const& i : mDebugActiveEntities) {
                 activeEntities.push_back(i);
@@ -252,8 +439,8 @@ private:
         LockGuard const lock(mListenerLock);
         std::vector<ChangeCallback> result;
         result.reserve(mChangeCallbacks.size());
-        for (auto const& info : mChangeCallbacks) {
-            result.push_back(info.callback);
+        for (auto const& [token, callback] : mChangeCallbacks) {
+            result.push_back(callback);
         }
         return result;
     }
@@ -266,36 +453,141 @@ private:
         }
     }
 
+    void recycleGarbageEpochs(GarbageEpoch* batch, size_t const count) noexcept {
+        // Only lock the free-list. Never blocks destroy().
+        LockGuard const lock(mCreationLock);
+
+        for (size_t i = 0; i < count; ++i) {
+            auto& garbageBits = batch[i].garbageBits;
+            garbageBits->forEachSetBit([this](uint32_t const bit) UTILS_NO_THREAD_SAFETY_ANALYSIS noexcept {
+                // STRIP THE GENERATION: Convert the ID back to a pure index
+                // before pushing it to the available free-list.
+                Entity::Type const index = getIndex(Entity::import(bit));
+                mFreeList.push_back(index); // FIXME: this will heap allocate (std::deque)
+            });
+            garbageBits->clear();
+            mBitsetPool.push_back(std::move(garbageBits));
+        }
+    }
+
+    size_t getExpiredEpochsLocked(GarbageEpoch* out, size_t const capacity) noexcept UTILS_REQUIRES(mTimelineLock) {
+        size_t count = 0;
+        uint64_t safeThreshold = std::numeric_limits<uint64_t>::max();
+        // Relaxed is fine here. The mutex acts as our memory barrier.
+        uint64_t const currentEpoch = mCurrentEpochID.load(std::memory_order_relaxed);
+        if (UTILS_LIKELY(!mActiveWatermarks.empty())) {
+            for (auto const& [watermark, name] : mActiveWatermarks) {
+                safeThreshold = std::min(safeThreshold, watermark->load(std::memory_order_acquire));
+            }
+        } else {
+            safeThreshold = currentEpoch;
+        }
+
+        // EBR Stall Diagnostics
+        // Only print the warning when it crosses a 64-epoch threshold to prevent I/O freezing
+        if (UTILS_UNLIKELY(mTimeline.size() > 128 && (mTimeline.size() % 64 == 0))) {
+            for (auto const& [watermark, name] : mActiveWatermarks) {
+                uint64_t const wm = watermark->load(std::memory_order_relaxed);
+                if (wm < currentEpoch - 1) {
+                    LOG(WARNING)
+                            << "EBR Stall Warning: Component Manager '" << name.c_str()
+                            << "' is stalling reclamation! Its watermark is stuck at epoch "
+                            << wm << ", blocking the recycling of "
+                            << mTimeline.front().garbageBits->size() << " dead entities.";
+                }
+            }
+        }
+
+        auto it = mTimeline.begin();
+        while (it != mTimeline.end() && it->id < safeThreshold && count < capacity) {
+            out[count++] = std::move(*it);
+            ++it;
+        }
+
+        if (UTILS_LIKELY(it != mTimeline.begin())) {
+            mTimeline.erase(mTimeline.begin(), it);
+
+#ifndef NDEBUG
+            // We already hold mTimelineLock here!
+            // Validate and update the global purgatory tracker mathematically.
+            for (size_t i = 0; i < count; ++i) {
+                auto const& garbageBits = out[i].garbageBits;
+                // Prove Invariant: The dying epoch MUST be a strict subset of our tracker
+                assert(garbageBits->isSubsetOf(mDebugGlobalPurgatory) &&
+                        "EBR: Attempted to recycle an untracked ID!");
+                // Safely remove these bits from purgatory before they hit the free list
+                mDebugGlobalPurgatory.difference(*garbageBits);
+            }
+#endif
+        }
+        return count;
+    }
+
     FixedCapacityVector<Listener*> getListeners() const noexcept {
         LockGuard const lock(mListenerLock);
         tsl::robin_set<Listener*> const& listeners = mListeners;
         FixedCapacityVector<Listener*> result(listeners.size());
         result.resize(result.capacity()); // unfortunately this memset()
-        std::copy(listeners.begin(), listeners.end(), result.begin());
+        std::ranges::copy(listeners, result.begin());
         return result; // the c++ standard guarantees a move
     }
 
+    /**
+     * @brief The Bounded Stack-Batch Size for Epoch-Based Reclamation (EBR) Timeline Drains.
+     *
+     * @details
+     * ARCHITECTURAL TRADEOFF ANALYSIS:
+     * -------------------------------
+     * 1. 8x Drain-to-Input Ratio: Since advanceEpoch() produces exactly ONE new epoch
+     *    per rendering frame, a batch size of 8 delivers a mathematically guaranteed
+     *    8x output reclamation rate. Stalled timeline backlogs automatically drain and
+     *    catch up to steady-state within a handful of frame intervals.
+     *
+     * 2. CPU Spike Amortization: Hard-bounding the extraction limit to 8 epochs prevents
+     *    massive synchronizations during Level/Scene unloads from flushing thousands of
+     *    dead components in a single frame, perfectly protecting the 60 FPS frame time from stutter.
+     *
+     * 3. Forward Progress & Multithread Liveness: Because the extraction loop executes bounded,
+     *    single-pass extractions within EXACTLY ONE lock acquisition, the engine eliminates all
+     *    livelock vulnerabilities and indefinite thread spinning under heavy concurrent Engine contention.
+     *
+     * 4. Zero Heap Allocations: Matches the array capacity to exactly fit on the executing thread's
+     *    local stack frame inside std::array<GarbageEpoch, N>, guaranteeing zero dynamic heap Footprint.
+     */
+    static constexpr size_t RECLAMATION_EPOCH_BATCH_SIZE = 8;
     static constexpr size_t MAX_DIRTY_COUNT = 16;
     struct CallbackInfo {
         void const* token;
         ChangeCallback callback;
     };
 
-    mutable Mutex mFreeListLock;
-    uint32_t mCurrentIndex UTILS_GUARDED_BY(mFreeListLock) = 1;
-    std::deque<Entity::Type> mFreeList UTILS_GUARDED_BY(mFreeListLock); // stores indices that got freed
-    uint8_t* const mGens UTILS_PT_GUARDED_BY(mFreeListLock);            // stores the generation of each index.
-    PagedArenaBitset mAliveEntities UTILS_GUARDED_BY(mFreeListLock);    // stores entities that are alive
+    mutable Mutex mCreationLock;
+    uint32_t mCurrentIndex UTILS_GUARDED_BY(mCreationLock) = 1;
+    std::deque<Entity::Type> mFreeList UTILS_GUARDED_BY(mCreationLock);     // stores indices that got freed
+    std::vector<std::unique_ptr<PagedArenaBitset>> mBitsetPool UTILS_GUARDED_BY(mCreationLock);
+
+    mutable Mutex mDestructionLock;
+    uint8_t* const mGens UTILS_GUARDED_BY(mDestructionLock);                   // stores the generation of each index.
+    PagedArenaBitset mAliveEntities UTILS_GUARDED_BY(mDestructionLock);        // stores entities that are alive
+    Entity mDirtyEntities[MAX_DIRTY_COUNT] UTILS_GUARDED_BY(mDestructionLock);
+    size_t mDirtyCount UTILS_GUARDED_BY(mDestructionLock) = 0;
+#if FILAMENT_UTILS_TRACK_ENTITIES
+    tsl::robin_map<Entity, CallStack, Entity::Hasher> mDebugActiveEntities UTILS_GUARDED_BY(mDestructionLock);
+#endif
+
+    mutable std::mutex mTimelineLock;
+    // EBR timeline state
+    std::atomic<uint64_t> mCurrentEpochID UTILS_GUARDED_BY(mTimelineLock){1}; // doesn't publish data, the mutex does
+    std::vector<GarbageEpoch> mTimeline UTILS_GUARDED_BY(mTimelineLock);
+    std::vector<WatermarkInfo> mActiveWatermarks UTILS_GUARDED_BY(mTimelineLock);
+#ifndef NDEBUG
+    // Tracks every bit that is dead but not yet recycled
+    PagedArenaBitset UTILS_GUARDED_BY(mTimelineLock) mDebugGlobalPurgatory;
+#endif
 
     mutable Mutex mListenerLock;
     tsl::robin_set<Listener*> mListeners UTILS_GUARDED_BY(mListenerLock);
     std::vector<CallbackInfo> mChangeCallbacks UTILS_GUARDED_BY(mListenerLock);
-    Entity mDirtyEntities[MAX_DIRTY_COUNT] UTILS_GUARDED_BY(mFreeListLock);
-    size_t mDirtyCount UTILS_GUARDED_BY(mFreeListLock) = 0;
-
-#if FILAMENT_UTILS_TRACK_ENTITIES
-    tsl::robin_map<Entity, CallStack, Entity::Hasher> mDebugActiveEntities UTILS_GUARDED_BY(mFreeListLock);
-#endif
 };
 
 } // namespace utils

--- a/libs/utils/src/NameComponentManager.cpp
+++ b/libs/utils/src/NameComponentManager.cpp
@@ -21,27 +21,36 @@ namespace utils {
 
 static constexpr size_t NAME = 0;
 
-NameComponentManager::NameComponentManager(EntityManager&) {
+NameComponentManager::NameComponentManager(EntityManager& em)
+        : SingleInstanceComponentManager<CString>(em, "NameComponentManager") {
 }
 
 NameComponentManager::~NameComponentManager() = default;
 
-void NameComponentManager::setName(Instance instance, const char* name) noexcept {
+void NameComponentManager::setName(Instance const instance, const char* name) noexcept {
     if (instance) {
         elementAt<NAME>(instance) = CString{ name };
     }
 }
 
-const char* NameComponentManager::getName(Instance instance) const noexcept {
+const char* NameComponentManager::getName(Instance const instance) const noexcept {
     return elementAt<NAME>(instance).c_str();
 }
 
-void NameComponentManager::addComponent(Entity e) {
+void NameComponentManager::addComponent(Entity const e) {
+    Entity zombie;
+    if (UTILS_UNLIKELY(popPendingZombie(e, zombie))) {
+        destroy(zombie);
+    }
     SingleInstanceComponentManager::addComponent(e);
 }
 
-void NameComponentManager::removeComponent(Entity e) {
+void NameComponentManager::removeComponent(Entity const e) {
     SingleInstanceComponentManager::removeComponent(e);
+}
+
+void NameComponentManager::destroyComponents(Entity const* entities, size_t const count) noexcept {
+    SingleInstanceComponentManager::removeComponents(entities, count);
 }
 
 } // namespace utils

--- a/libs/utils/src/SingleInstanceComponentManager.cpp
+++ b/libs/utils/src/SingleInstanceComponentManager.cpp
@@ -15,12 +15,13 @@
  */
 
 #include <utils/Entity.h>
+#include <utils/EntityManager.h>
 #include <utils/PagedArenaBitset.h>
+#include <utils/Panic.h>
 #include <utils/SingleInstanceComponentManager.h>
 #include <utils/Slice.h>
 
 #include <algorithm>
-#include <cstddef>
 #include <utility>
 
 namespace utils {
@@ -33,8 +34,8 @@ void SingleInstanceComponentManagerBase::registerChangeCallback(
 void SingleInstanceComponentManagerBase::unregisterChangeCallback(
         void const* token) noexcept {
     mChangeCallbacks.erase(
-            std::remove_if(mChangeCallbacks.begin(), mChangeCallbacks.end(),
-                    [token](auto const& info) { return info.token == token; }),
+            std::ranges::remove_if(mChangeCallbacks,
+                    [token](auto const& info) { return info.token == token; }).begin(),
             mChangeCallbacks.end());
 }
 
@@ -82,6 +83,194 @@ void SingleInstanceComponentManagerBase::registerBitset(PagedArenaBitset* bitset
 }
 
 void SingleInstanceComponentManagerBase::unregisterBitset(PagedArenaBitset const* bitset) {
-    mBitsets.erase(std::remove(mBitsets.begin(), mBitsets.end(), bitset), mBitsets.end());
+    mBitsets.erase(std::ranges::remove(mBitsets, bitset).begin(), mBitsets.end());
 }
+
+void SingleInstanceComponentManagerBase::catchupGarbage() noexcept {
+    uint64_t const currentWatermark = mWatermark.load(std::memory_order_relaxed);
+
+    // Transact with the source of truth
+    uint64_t const syncedFence = mEntityManager.getMissedGarbage(mMissedGarbage, currentWatermark);
+
+    // O(1) Fast-Path Early Exit: Ceiling hasn't moved
+    if (syncedFence == currentWatermark) {
+        return;
+    }
+
+    // Process bitsets if any were returned (Clean frames will simply skip this loop)
+    if (UTILS_LIKELY(!mMissedGarbage.empty())) {
+        mCollapsedGarbage.clear();
+        for (auto const* garbageBits : mMissedGarbage) {
+            PagedArenaBitset::intersect(&mCollapsedGarbage, mEntities, *garbageBits);
+            if (!mCollapsedGarbage.empty()) {
+                mPendingDestruction.merge(mCollapsedGarbage);
+                mEntities.difference(mCollapsedGarbage);
+            }
+        }
+    }
+
+    // Commit our watermark. It will match currentEpoch - 1,
+    mWatermark.store(syncedFence, std::memory_order_release);
+}
+
+bool SingleInstanceComponentManagerBase::popPendingZombie(Entity const newEntity, Entity& outZombie) noexcept {
+    uint32_t const index = EntityManager::getIndex(newEntity);
+    // TODO: this loop will disappear once we only store the indices
+    constexpr int32_t kGenerationCount = 1 << EntityManager::GENERATION_BITS;
+    for (int32_t g = 0; g < kGenerationCount; ++g) {
+        int32_t const potentialZombie = EntityManager::makeIdentity(g, index);
+        if (mPendingDestruction[potentialZombie]) {
+            mPendingDestruction.remove(potentialZombie);
+            outZombie = Entity::import(potentialZombie);
+            return true;
+        }
+    }
+    return false;
+}
+
+void SingleInstanceComponentManagerBase::checkZombieCollisionPanic(Entity const newEntity) noexcept {
+    Entity zombie;
+    if (UTILS_UNLIKELY(popPendingZombie(newEntity, zombie))) {
+        FILAMENT_CHECK_PRECONDITION(false)
+                << "In " << mName.c_str_safe() << ", new component with entity " << newEntity.getId()
+                << " collides with a logically-dead component with entity = " << zombie.getId()
+                << " (component manager implementation bug)";
+    }
+}
+
+void SingleInstanceComponentManagerBase::gcImpl(uint32_t const maxDestructions,
+        void* context, void* extraArg, EvictionDispatcher const dispatcher) noexcept {
+
+    catchupGarbage();
+
+    if (UTILS_UNLIKELY(mPendingDestruction.empty())) {
+        return;
+    }
+
+    uint32_t const actualLimit = isAmortizationSupported() ?
+            maxDestructions : std::numeric_limits<uint32_t>::max();
+
+    uint32_t destroyedCount = 0;
+
+    constexpr size_t BATCH_SIZE = 64;
+    Entity buffer[BATCH_SIZE];
+    size_t count = 0;
+
+    auto flush = [&]() noexcept {
+        if (count > 0) {
+            dispatcher(context, extraArg, buffer, count);
+            destroyedCount += count;
+            count = 0;
+        }
+    };
+
+    mPendingDestruction.popSetBits([&](uint32_t const bit) noexcept {
+        if (destroyedCount + count < actualLimit) {
+            buffer[count++] = Entity::import(bit);
+            if (count == BATCH_SIZE) {
+                flush();
+            }
+            return true;
+        }
+        return false;
+    });
+
+    flush();
+}
+
+SingleInstanceComponentManagerBase::Instance
+SingleInstanceComponentManagerBase::addComponentImpl(Entity const e, void* context,
+        SoaAllocator const allocator) noexcept {
+    Instance ci = 0;
+    if (!e.isNull()) {
+        if (isAmortizationSupported()) {
+            checkZombieCollisionPanic(e);
+        }
+
+        if (!hasComponent(e)) {
+            ci = allocator(context, e);
+            mInstanceMap[e] = ci;
+            mEntities.add(e.getId());
+            notifyChange(e);
+        } else {
+            ci = mInstanceMap[e];
+        }
+    }
+    assert(ci != 0);
+    return ci;
+}
+
+
+
+void SingleInstanceComponentManagerBase::removeComponentsImpl(Entity const* entities, size_t const count,
+        void* context, SoaDeallocator deallocator) noexcept {
+    auto& map = mInstanceMap;
+    for (size_t k = 0; k < count; ++k) {
+        Entity const e = entities[k];
+        auto const pos = map.find(e);
+        if (UTILS_LIKELY(pos != map.end())) {
+            size_t const index = pos->second;
+            assert(index != 0);
+
+            auto const [lastIndex, swappedEntity] = deallocator(context, index);
+
+            if (!swappedEntity.isNull()) {
+                map[swappedEntity] = index;
+            }
+
+            map.erase(pos);
+            mEntities.remove(e.getId());
+            notifyChange(e);
+        }
+    }
+}
+
+SingleInstanceComponentManagerBase::SingleInstanceComponentManagerBase(EntityManager& em, ImmutableCString name,
+        bool const amortizationSupported) noexcept
+        : mEntityManager(em), mName(std::move(name)), mAmortizationSupported(amortizationSupported) {
+    mEntityManager.registerWatermark(&mWatermark, mName);
+}
+
+SingleInstanceComponentManagerBase::~SingleInstanceComponentManagerBase() noexcept {
+    mEntityManager.unregisterWatermark(&mWatermark);
+}
+
+SingleInstanceComponentManagerBase::SingleInstanceComponentManagerBase(SingleInstanceComponentManagerBase&& rhs) noexcept
+        : mInstanceMap(std::move(rhs.mInstanceMap)),
+          mEntities(std::move(rhs.mEntities)),
+          mPendingDestruction(std::move(rhs.mPendingDestruction)),
+          mEntityManager(rhs.mEntityManager),
+          mName(std::move(rhs.mName)),
+          mAmortizationSupported(rhs.mAmortizationSupported),
+          mCollapsedGarbage(std::move(rhs.mCollapsedGarbage)),
+          mMissedGarbage(std::move(rhs.mMissedGarbage)),
+          mDirtyCount(rhs.mDirtyCount),
+          mChangeCallbacks(std::move(rhs.mChangeCallbacks)),
+          mBitsets(std::move(rhs.mBitsets)) {
+    std::copy_n(rhs.mDirtyEntities, rhs.mDirtyCount, mDirtyEntities);
+    mWatermark.store(rhs.mWatermark.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    mEntityManager.rebindWatermark(&rhs.mWatermark, &mWatermark, mName);
+}
+
+SingleInstanceComponentManagerBase& SingleInstanceComponentManagerBase::operator=(SingleInstanceComponentManagerBase&& rhs) noexcept {
+    if (UTILS_LIKELY(this != &rhs)) {
+        mEntityManager.unregisterWatermark(&mWatermark);
+
+        mEntities = std::move(rhs.mEntities);
+        mPendingDestruction = std::move(rhs.mPendingDestruction);
+        mName = std::move(rhs.mName);
+        mAmortizationSupported = rhs.mAmortizationSupported;
+        mInstanceMap = std::move(rhs.mInstanceMap);
+        mCollapsedGarbage = std::move(rhs.mCollapsedGarbage);
+        mMissedGarbage = std::move(rhs.mMissedGarbage);
+        mDirtyCount = rhs.mDirtyCount;
+        mChangeCallbacks = std::move(rhs.mChangeCallbacks);
+        mBitsets = std::move(rhs.mBitsets);
+        std::copy_n(rhs.mDirtyEntities, rhs.mDirtyCount, mDirtyEntities);
+        mWatermark.store(rhs.mWatermark.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        mEntityManager.rebindWatermark(&rhs.mWatermark, &mWatermark, mName);
+    }
+    return *this;
+}
+
 } // namespace utils

--- a/libs/utils/test/test_Entity.cpp
+++ b/libs/utils/test/test_Entity.cpp
@@ -14,15 +14,34 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
-#include <memory>
-
 #include "../src/EntityManagerImpl.h"
+
 #include <utils/NameComponentManager.h>
 
-using namespace utils;
+#include <gtest/gtest.h>
 
+#include <chrono>
+#include <memory>
+#include <thread>
+
+using namespace utils;
+template <typename T>
+class TestManagerBase : public SingleInstanceComponentManager<T> {
+public:
+    explicit TestManagerBase(EntityManager& em) noexcept
+            : SingleInstanceComponentManager<T>(em, "TestManager", false) {}
+
+    PagedArenaBitset const& getEntities() const noexcept { return this->mEntities; }
+    PagedArenaBitset const& getPendingDestruction() const noexcept { return this->mPendingDestruction; }
+
+    using SingleInstanceComponentManager<T>::gc;
+
+    void removeComponents(Entity const* entities, size_t const count) noexcept {
+        for (size_t i = 0; i < count; ++i) {
+            SingleInstanceComponentManager<T>::removeComponent(entities[i]);
+        }
+    }
+};
 
 TEST(EntityTest, Simple) {
 
@@ -88,6 +107,7 @@ TEST(EntityTest, Free) {
     Entity entities[1024];
     em.create(1024, entities);
     em.destroy(1024, entities);
+    em.advanceEpoch();
 
     // now we have 1024 entities in the free list, we're going to start reusing them
     // using a new generation
@@ -109,6 +129,7 @@ TEST(EntityTest, Lots) {
 
     // see that we can free and allocate
     em.destroy(entities[0]);
+    em.advanceEpoch();
     e = em.create();
     EXPECT_FALSE(e.isNull());
     EXPECT_TRUE(em.isAlive(e));
@@ -121,6 +142,7 @@ TEST(EntityTest, Lots) {
 
     // and free everything
     em.destroy(n, entities.get());
+    em.advanceEpoch();
     for (size_t i = 0; i < EntityManager::getMaxEntityCount(); i++) {
         EXPECT_FALSE(em.isAlive(entities[i]));
     }
@@ -174,23 +196,23 @@ TEST(EntityTest, NameComponent) {
 
     em.destroy(8, entities);
 
-    cm.gc(em);
+    cm.gc();
 }
 
 TEST(EntityTest, Callback) {
     EntityManagerImpl em;
     Entity entities[20];
     em.create(20, entities);
-    
+
     std::vector<Entity> notifiedEntities;
     auto callback = [&](Slice<const Entity> slice) {
         for (auto e : slice) {
             notifiedEntities.push_back(e);
         }
     };
-    
+
     em.registerChangeCallback(&em, std::move(callback));
-    
+
     // Test small batch (<= 16)
     em.destroy(10, entities);
     em.flushNotifications();
@@ -198,9 +220,9 @@ TEST(EntityTest, Callback) {
     for (int i = 0; i < 10; ++i) {
         EXPECT_EQ(notifiedEntities[i], entities[i]);
     }
-    
+
     notifiedEntities.clear();
-    
+
     // Test large batch (> 16)
     Entity largeBatch[17];
     em.create(17, largeBatch);
@@ -210,9 +232,702 @@ TEST(EntityTest, Callback) {
     for (int i = 0; i < 17; ++i) {
         EXPECT_EQ(notifiedEntities[i], largeBatch[i]);
     }
-    
+
     em.unregisterChangeCallback(&em);
-    
+
     // Cleanup remaining
     em.destroy(10, entities + 10);
+}
+
+TEST(EntityTest, EpochBasedReclamation) {
+    auto& em = static_cast<EntityManagerImpl&>(EntityManager::get());
+
+    struct DummyComponent {
+        float x;
+    };
+
+    struct TestComponentManager : public SingleInstanceComponentManager<DummyComponent> {
+        explicit TestComponentManager(EntityManager& em) noexcept : SingleInstanceComponentManager<DummyComponent>(em, "TestComponentManager") {}
+        using SingleInstanceComponentManager::gc;
+    };
+
+    TestComponentManager cm(em);
+
+    constexpr size_t NUM_ENTITIES = 1024;
+    std::vector<Entity> entities(NUM_ENTITIES);
+    em.create(NUM_ENTITIES, entities.data());
+
+    for (auto e : entities) {
+        cm.addComponent(e);
+    }
+
+    em.advanceEpoch();
+
+    for (auto e : entities) {
+        em.destroy(e);
+    }
+
+    em.advanceEpoch();
+
+    cm.gc(&cm, &TestComponentManager::removeComponent);
+
+    for (auto e : entities) {
+        EXPECT_FALSE(cm.hasComponent(e));
+    }
+
+    cm.suspend();
+
+    em.reclaimSafeEpochs();
+
+    Entity reused = em.create();
+    EXPECT_EQ(EntityManagerImpl::getIndex(reused), 1);
+
+    // Cleanup
+    em.destroy(reused);
+}
+
+TEST(EntityTest, EntityManager_DoubleDestroyIsSafelyIgnored) {
+    EntityManagerImpl em;
+    Entity A = em.create();
+
+    em.destroy(A);
+    EXPECT_FALSE(em.isAlive(A));
+
+#ifndef NDEBUG
+    // Under Debug, the second destroy triggers an assertion failure (death test)
+    EXPECT_DEATH(em.destroy(A), ".*");
+#else
+    // Under Release, the second destroy is silently and safely ignored
+    em.destroy(A);
+    em.advanceEpoch();
+    em.reclaimSafeEpochs();
+
+    // Allocate again: expects a fresh Index 2 (Generation 0) due to MIN_FREE_INDICES threshold
+    Entity B = em.create();
+    EXPECT_EQ(EntityManagerImpl::getIndex(B), 2);
+    EXPECT_EQ(EntityManagerImpl::getGeneration(B), 0);
+    em.destroy(B);
+#endif
+}
+
+TEST(EntityTest, EntityManager_EBR_DelaysRecyclingUntilSafe) {
+    EntityManagerImpl em;
+    std::atomic<uint64_t> w1{1};
+    em.registerWatermark(&w1, "DummyWatermark");
+
+    constexpr size_t NUM = 1024;
+    std::vector<Entity> A(NUM);
+    em.create(NUM, A.data());
+
+    for (size_t i = 0; i < NUM; ++i) {
+        EXPECT_EQ(EntityManagerImpl::getIndex(A[i]), i + 1);
+    }
+
+    em.destroy(NUM, A.data());
+    em.flushNotifications();
+    em.advanceEpoch(); // Current epoch becomes 2, A is sealed in epoch 1
+
+    em.reclaimSafeEpochs(); // Reclaim safe epochs. w1 is still 1, so epoch 1 is NOT safe!
+
+    std::vector<Entity> B(NUM);
+    em.create(NUM, B.data());
+    // None of the new ones should be index 1, because it's held hostage!
+    for (size_t i = 0; i < NUM; ++i) {
+        EXPECT_NE(EntityManagerImpl::getIndex(B[i]), 1);
+    }
+
+    w1.store(2, std::memory_order_release); // Update watermark past epoch 1
+    em.reclaimSafeEpochs(); // Reclaim safe epochs. w1 is now 2, so epoch 1 is safe!
+
+    std::vector<Entity> C(NUM);
+    em.create(NUM, C.data());
+    // Now index 1 should be reused with bumped generation 1!
+    EXPECT_EQ(EntityManagerImpl::getIndex(C[0]), 1);
+    EXPECT_EQ(EntityManagerImpl::getGeneration(C[0]), 1);
+
+    em.unregisterWatermark(&w1);
+    em.destroy(NUM, B.data());
+    em.destroy(NUM, C.data());
+}
+
+TEST(EntityTest, EntityManager_ConcurrentCreateAndDestroy) {
+    EntityManagerImpl em;
+    constexpr size_t NUM_ENTITIES = 5000;
+    std::vector<Entity> preallocated(NUM_ENTITIES);
+    em.create(NUM_ENTITIES, preallocated.data());
+
+    std::atomic<bool> active{true};
+
+    std::thread t1([&em, &active]() {
+        std::vector<Entity> localCreated(NUM_ENTITIES);
+        while (active.load(std::memory_order_relaxed)) {
+            em.create(NUM_ENTITIES, localCreated.data());
+            for (auto e : localCreated) {
+                if (e) {
+                    em.destroy(e);
+                }
+            }
+        }
+    });
+
+    std::thread t2([&em, &preallocated, &active]() {
+        while (active.load(std::memory_order_relaxed)) {
+            for (size_t i = 0; i < NUM_ENTITIES; i += 10) {
+                Entity localBatch[10];
+                for (size_t j = 0; j < 10; ++j) {
+                    localBatch[j] = preallocated[i + j];
+                }
+                // destroy them concurrently
+                em.destroy(10, localBatch);
+                // recreate them immediately to keep the slots populated
+                em.create(10, &preallocated[i]);
+            }
+        }
+    });
+
+    std::thread t3([&em, &active]() {
+        for (size_t i = 0; i < 100; ++i) {
+            em.advanceEpoch();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        active.store(false, std::memory_order_relaxed);
+    });
+
+    t1.join();
+    t2.join();
+    t3.join();
+
+    // Final cleanup to unblock EBR
+    em.advanceEpoch();
+    em.reclaimSafeEpochs();
+
+    // Verify we can still successfully allocate
+    Entity finalCheck = em.create();
+    EXPECT_TRUE(finalCheck);
+    em.destroy(finalCheck);
+}
+
+TEST(EntityTest, EntityManager_EBR_ConcurrentTimelineStress) {
+    EntityManagerImpl em;
+    std::atomic<bool> active{true};
+
+    // Thread 1: Generates garbage rapidly
+    std::thread t1([&em, &active]() {
+        std::vector<Entity> ents(128);
+        while (active.load(std::memory_order_relaxed)) {
+            em.create(128, ents.data());
+            em.destroy(128, ents.data());
+            std::this_thread::yield();
+        }
+    });
+
+    // Thread 2: Advances the timeline (Allocates from bitset pool)
+    std::thread t2([&em, &active]() {
+        while (active.load(std::memory_order_relaxed)) {
+            em.advanceEpoch();
+            std::this_thread::yield();
+        }
+    });
+
+    // Thread 3: Reclaims safe epochs (Returns to bitset pool)
+    std::thread t3([&em, &active]() {
+        while (active.load(std::memory_order_relaxed)) {
+            em.reclaimSafeEpochs();
+            std::this_thread::yield();
+        }
+    });
+
+    // Thread 4: Registers/Unregisters watermarks (Also returns to pool and moves safe threshold)
+    std::thread t4([&em, &active]() {
+        std::atomic<uint64_t> watermark{0};
+        while (active.load(std::memory_order_relaxed)) {
+            em.registerWatermark(&watermark, "StressWatermark");
+            watermark.store(em.getLatestEpochID(), std::memory_order_relaxed);
+            em.unregisterWatermark(&watermark);
+            std::this_thread::yield();
+        }
+    });
+
+    // Let them hammer the pools and locks for a brief moment
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    active.store(false, std::memory_order_relaxed);
+
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+
+    // Final cleanup
+    em.advanceEpoch();
+    em.reclaimSafeEpochs();
+}
+
+TEST(EntityTest, ComponentManager_ZombieSafelyMovedDuringDefragmentation) {
+    EntityManagerImpl em;
+    struct DummyComponent {
+        int payload;
+    };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    TestManager cm(em);
+    Entity A = em.create();
+    Entity B = em.create();
+    Entity C = em.create();
+
+    auto iA = cm.addComponent(A);
+    auto iB = cm.addComponent(B);
+    auto iC = cm.addComponent(C);
+
+    cm.elementAt<0>(iA).payload = 100;
+    cm.elementAt<0>(iB).payload = 200;
+    cm.elementAt<0>(iC).payload = 300;
+
+    // Logically destroy C. It's now a Zombie inside cm's active array!
+    em.destroy(C);
+
+    // Manually remove component A. This will trigger a swap-and-pop compaction,
+    // swapping C (the last element at index 3) into C's new home at index 1!
+    cm.removeComponent(A);
+
+    // C should be swapped into index 1 (which was A's index)
+    EXPECT_EQ(cm.getInstance(C), 1);
+    EXPECT_EQ(cm.elementAt<0>(1).payload, 300); // C's payload should be at index 1!
+
+    cm.suspend();
+    em.destroy(A);
+    em.destroy(B);
+}
+
+TEST(EntityTest, ComponentManager_CatchupGarbageRemovesDeadEntities) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    TestManager cm(em);
+    Entity A = em.create();
+    cm.addComponent(A);
+
+    EXPECT_TRUE(cm.hasComponent(A));
+
+    em.destroy(A);
+    // State hasn't been swept yet, so it's still theoretically alive in the component manager!
+    EXPECT_TRUE(cm.hasComponent(A));
+
+    em.advanceEpoch();
+    // Trigger GC sweep
+    cm.gc(&cm, &TestManager::removeComponent);
+
+    // State is now cleanly caught up!
+    EXPECT_FALSE(cm.hasComponent(A));
+
+    cm.suspend();
+}
+
+TEST(EntityTest, ComponentManager_MoveSemanticsRebindWatermark) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    TestManager M1(em);
+    constexpr size_t NUM = 1024;
+    std::vector<Entity> A(NUM);
+    em.create(NUM, A.data());
+    for (auto e : A) {
+        M1.addComponent(e);
+    }
+
+    em.destroy(NUM, A.data());
+    em.flushNotifications();
+    em.advanceEpoch(); // A is sealed in epoch 1
+
+    // Move construct M2 from M1. This atomically rebinds the watermark!
+    TestManager M2(std::move(M1));
+
+    em.reclaimSafeEpochs(); // Reclaim safe epochs. M2's watermark is still at 1, holding it hostage!
+
+    std::vector<Entity> B(NUM);
+    em.create(NUM, B.data());
+    for (size_t i = 0; i < NUM; ++i) {
+        EXPECT_NE(EntityManagerImpl::getIndex(B[i]), 1);
+    }
+
+    M2.suspend(); // Suspend M2 (unregisters watermark)
+    em.reclaimSafeEpochs(); // Reclaim safe epochs again.
+
+    std::vector<Entity> C(NUM);
+    em.create(NUM, C.data());
+    // Now A[0]'s index 1 should be successfully recycled!
+    EXPECT_EQ(EntityManagerImpl::getIndex(C[0]), 1);
+
+    em.destroy(NUM, B.data());
+    em.destroy(NUM, C.data());
+}
+
+TEST(EntityTest, Legacy_AliveEntitiesReturns32BitIDs) {
+    EntityManagerImpl em;
+    constexpr size_t NUM = 1024;
+    std::vector<Entity> A(NUM);
+    em.create(NUM, A.data());
+    auto const firstId = A[0].getId();
+    EXPECT_EQ(EntityManagerImpl::getIndex(A[0]), 1);
+    EXPECT_EQ(EntityManagerImpl::getGeneration(A[0]), 0);
+
+    em.destroy(NUM, A.data());
+    em.flushNotifications();
+    em.advanceEpoch();
+    em.reclaimSafeEpochs(); // A is recycled
+
+    std::vector<Entity> B(NUM);
+    em.create(NUM, B.data());
+    // The first element of B inherits A[0]'s index but has generation 1
+    EXPECT_EQ(EntityManagerImpl::getIndex(B[0]), 1);
+    EXPECT_EQ(EntityManagerImpl::getGeneration(B[0]), 1);
+
+    PagedArenaBitset alive = em.getAliveEntities();
+
+    EXPECT_TRUE(alive[B[0].getId()]);
+    EXPECT_FALSE(alive[firstId]);
+
+    em.destroy(NUM, B.data());
+}
+
+TEST(EntityTest, LegacyManager_LogicalDeathIsImmediateDespiteEBR) {
+    EntityManagerImpl em;
+    std::atomic<uint64_t> w1{1};
+    em.registerWatermark(&w1, "DummyWatermark");
+
+    Entity A = em.create();
+    EXPECT_TRUE(em.isAlive(A));
+    size_t const initialCount = em.getEntityCount();
+
+    em.destroy(A);
+    em.flushNotifications();
+
+    // Even though A is stuck in the timeline (EBR holds it hostage),
+    // it MUST be logically dead to observers immediately!
+    EXPECT_FALSE(em.isAlive(A));
+    EXPECT_EQ(em.getEntityCount(), initialCount - 1);
+
+    em.unregisterWatermark(&w1);
+}
+
+TEST(EntityTest, LegacyManager_ImmuneToRecycledIndexCollisions) {
+    EntityManagerImpl em;
+    constexpr size_t NUM = 1024;
+    std::vector<Entity> entities(NUM);
+    em.create(NUM, entities.data());
+
+    Entity A = entities[0];
+    auto const indexA = EntityManagerImpl::getIndex(A);
+    auto const genA = EntityManagerImpl::getGeneration(A);
+    EXPECT_EQ(indexA, 1);
+    EXPECT_EQ(genA, 0);
+
+    // Simulate legacy manager storing A
+    Entity storedA = A;
+
+    em.destroy(NUM, entities.data());
+    em.flushNotifications();
+    em.advanceEpoch();
+    em.reclaimSafeEpochs(); // Recycled!
+
+    std::vector<Entity> entities2(NUM);
+    em.create(NUM, entities2.data());
+    Entity B = entities2[0];
+
+    // B reuses index 1 but has generation 1
+    EXPECT_EQ(EntityManagerImpl::getIndex(B), 1);
+    EXPECT_EQ(EntityManagerImpl::getGeneration(B), 1);
+
+    // The legacy manager wakes up and queries storedA
+    EXPECT_FALSE(em.isAlive(storedA)); // Immune! Stored pointer is dead!
+    EXPECT_NE(storedA.getId(), B.getId()); // Mathematically isolated!
+
+    em.destroy(NUM, entities2.data());
+}
+
+TEST(EntityTest, ComponentManager_DestructorReleasesWatermark) {
+    EntityManagerImpl em;
+    constexpr size_t NUM = 1024;
+    auto const firstIndex = [&em]() -> uint32_t {
+        struct DummyComponent { float x; };
+        struct TestManager : public TestManagerBase<DummyComponent> {
+            using TestManagerBase::TestManagerBase;
+        };
+
+        std::vector<Entity> A(NUM);
+        em.create(NUM, A.data());
+        auto const index = EntityManagerImpl::getIndex(A[0]);
+        EXPECT_EQ(index, 1);
+
+        {
+            TestManager cm(em);
+            cm.addComponent(A[0]);
+
+            em.destroy(NUM, A.data());
+            em.flushNotifications();
+        } // Scope closed! TestManager's destructor runs, unregistering its watermark!
+
+        return index;
+    }();
+
+    em.advanceEpoch();
+    em.reclaimSafeEpochs(); // Reclaim safe epochs. Since the manager is destroyed, nothing should block it!
+
+    std::vector<Entity> B(NUM);
+    em.create(NUM, B.data());
+
+    // Index 1 should be successfully recycled!
+    EXPECT_EQ(EntityManagerImpl::getIndex(B[0]), firstIndex);
+
+    em.destroy(NUM, B.data());
+}
+
+TEST(EntityTest, ComponentManager_TOCTOU_WatermarkRaceCondition) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+
+        struct CustomDestroyContext {
+            EntityManagerImpl* pEm;
+            Entity entityB;
+        };
+
+        void customDestroy(Entity const* entities, size_t const count, CustomDestroyContext& ctx) noexcept {
+            for (size_t i = 0; i < count; ++i) {
+                ctx.pEm->destroy(ctx.entityB);
+                ctx.pEm->flushNotifications();
+                ctx.pEm->advanceEpoch(); // Global epoch advances from 1 to 2! Seals B in epoch 1.
+            }
+        }
+    };
+
+    TestManager cm(em);
+    Entity A = em.create();
+    Entity B = em.create();
+    cm.addComponent(A);
+    cm.addComponent(B);
+
+    // A is destroyed in epoch 0
+    em.destroy(A);
+    em.flushNotifications();
+
+    // Advance epoch so A is sealed in epoch 0. Active epoch is 1.
+    em.advanceEpoch();
+
+    // Call gc to clean up A.
+    // Inside the custom destructor callback, we simulate the TOCTOU race by advancing the epoch to 2
+    // and destroying B in epoch 1!
+    TestManager::CustomDestroyContext ctx { &em, B };
+    cm.gc(&cm, &TestManager::customDestroy, ctx);
+
+    // Now B has been destroyed in epoch 1, and the global epoch is 2.
+    // Due to the TOCTOU race, gc() stored 2 in mMyWatermark at the end of A's sweep.
+    // In the next gc sweep, B's destruction in epoch 1 will be completely skipped!
+
+    // Let's trigger GC again
+    em.advanceEpoch(); // global epoch = 3
+    em.reclaimSafeEpochs();
+    cm.gc(&cm, &TestManager::removeComponent);
+
+    // If the TOCTOU race bug is present, B was skipped and is still active in mEntities (a ghost object!)
+    // This assertion will FAIL under the bug, proving the existence of the race!
+    EXPECT_FALSE(cm.hasComponent(B));
+}
+
+TEST(EntityTest, ComponentManager_CatchupGarbageExtractsDeadEntities) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+        using TestManagerBase::catchupGarbage;
+    };
+
+    TestManager cm(em);
+    Entity A = em.create();
+    Entity B = em.create();
+    cm.addComponent(A);
+    cm.addComponent(B);
+
+    em.destroy(A);
+    em.flushNotifications();
+    em.advanceEpoch(); // seals Epoch 0 containing A
+
+    EXPECT_TRUE(cm.hasComponent(A));
+    EXPECT_TRUE(cm.getPendingDestruction().empty());
+
+    cm.catchupGarbage();
+
+    EXPECT_FALSE(cm.getEntities()[A.getId()]);
+    EXPECT_TRUE(cm.getEntities()[B.getId()]);
+    EXPECT_TRUE(cm.getPendingDestruction()[A.getId()]);
+    EXPECT_EQ(cm.getWatermark(), em.getLatestEpochID() - 1);
+
+    em.destroy(B);
+}
+
+TEST(EntityTest, ComponentManager_CatchupGarbageLeapsOverCleanFrames) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+        using TestManagerBase::catchupGarbage;
+    };
+
+    TestManager cm(em);
+    Entity dummy = em.create();
+    cm.addComponent(dummy);
+
+    // Loop 5 times calling em.advanceEpoch() without destroying anything
+    for (size_t i = 0; i < 5; ++i) {
+        em.advanceEpoch();
+    }
+
+    cm.catchupGarbage();
+
+    EXPECT_TRUE(cm.getPendingDestruction().empty());
+    EXPECT_EQ(cm.getWatermark(), 5); // leaps forward to currentEpoch - 1 (which is 5)
+
+    em.destroy(dummy);
+}
+
+TEST(EntityTest, ComponentManager_CatchupGarbageNeverSkipsActiveEpoch) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+        using TestManagerBase::catchupGarbage;
+    };
+
+    TestManager cm(em);
+    Entity dummy = em.create();
+    cm.addComponent(dummy);
+
+    em.destroy(dummy);
+    em.flushNotifications();
+    // Crucial: Do NOT call em.advanceEpoch(). Dummy's destruction is unsealed in Epoch 1.
+
+    cm.catchupGarbage();
+
+    EXPECT_TRUE(cm.getPendingDestruction().empty());
+    EXPECT_EQ(cm.getWatermark(), 0); // Watermark stays behind at 0!
+
+    em.advanceEpoch();
+}
+
+TEST(EntityTest, ComponentManager_GCLargeScaleEviction) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public TestManagerBase<DummyComponent> {
+        using TestManagerBase::TestManagerBase;
+    };
+
+    TestManager cm(em);
+    constexpr size_t NUM = 1024;
+    std::vector<Entity> entities(NUM);
+    em.create(NUM, entities.data());
+
+    for (auto e : entities) {
+        cm.addComponent(e);
+    }
+
+    em.destroy(NUM, entities.data());
+    em.flushNotifications();
+    em.advanceEpoch();
+    em.reclaimSafeEpochs();
+
+    // Verify all components are physically active prior to gc()
+    EXPECT_EQ(cm.getComponentCount(), NUM);
+
+    cm.gc(&cm, &TestManager::removeComponents);
+
+    // Verify all components were cleanly and physically purged
+    EXPECT_EQ(cm.getComponentCount(), 0);
+}
+
+
+TEST(EntityTest, PagedArenaBitset_PopSetBits) {
+    PagedArenaBitset bitset;
+    for (uint32_t i = 0; i < 10; ++i) {
+        bitset.add(i * 10);
+    }
+    EXPECT_EQ(bitset.size(), 10);
+
+    uint32_t processedCount = 0;
+    bitset.popSetBits([&](uint32_t bit) {
+        processedCount++;
+        if (processedCount == 5) {
+            return false; // Stop!
+        }
+        return true; // Pop
+    });
+
+    EXPECT_EQ(processedCount, 5);
+    EXPECT_EQ(bitset.size(), 6); // 10 originally - 4 popped successfully = 6 remaining!
+
+    // Process the remainder
+    uint32_t remainderCount = 0;
+    bitset.popSetBits([&](uint32_t bit) {
+        remainderCount++;
+        return true;
+    });
+
+    EXPECT_EQ(remainderCount, 6);
+    EXPECT_TRUE(bitset.empty());
+}
+
+TEST(EntityTest, ComponentManager_AmortizedGC) {
+    EntityManagerImpl em;
+    struct DummyComponent { float x; };
+    struct TestManager : public SingleInstanceComponentManager<DummyComponent> {
+        explicit TestManager(EntityManager& em) noexcept
+                : SingleInstanceComponentManager<DummyComponent>(em, "TestManager", true) {}
+        using SingleInstanceComponentManager<DummyComponent>::gc;
+    };
+
+    TestManager cm(em);
+
+    std::vector<Entity> entities(10);
+    em.create(10, entities.data());
+
+    for (auto e : entities) {
+        cm.addComponent(e);
+    }
+
+    em.advanceEpoch();
+
+    for (auto e : entities) {
+        em.destroy(e);
+    }
+
+    em.advanceEpoch();
+
+    // GC exactly 3 components this frame
+    cm.gc(&cm, 3, &TestManager::removeComponent);
+
+    uint32_t aliveCount = 0;
+    for (auto e : entities) {
+        if (cm.hasComponent(e)) {
+            aliveCount++;
+        }
+    }
+    EXPECT_EQ(aliveCount, 7);
+
+    // GC the remaining 7
+    cm.gc(&cm, 10, &TestManager::removeComponent);
+
+    aliveCount = 0;
+    for (auto e : entities) {
+        if (cm.hasComponent(e)) {
+            aliveCount++;
+        }
+    }
+    EXPECT_EQ(aliveCount, 0);
 }

--- a/libs/utils/test/test_EntitySet.cpp
+++ b/libs/utils/test/test_EntitySet.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include <utils/PagedArenaBitset.h>
+
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/utils/test/test_EntitySet.cpp
+++ b/libs/utils/test/test_EntitySet.cpp
@@ -761,3 +761,32 @@ TEST(PagedArenaBitsetTest, CopyFrom) {
     EXPECT_TRUE(target[5000]);
 }
 
+TEST(PagedArenaBitsetTest, PopSetBits) {
+    PagedArenaBitset bitset;
+    for (uint32_t i = 0; i < 10; ++i) {
+        bitset.add(i * 10);
+    }
+    EXPECT_EQ(bitset.size(), 10);
+
+    uint32_t processedCount = 0;
+    bitset.popSetBits([&](uint32_t bit) {
+        processedCount++;
+        if (processedCount == 5) {
+            return false; // Stop
+        }
+        return true; // Pop
+    });
+
+    EXPECT_EQ(processedCount, 5);
+    EXPECT_EQ(bitset.size(), 6);
+
+    uint32_t remainderCount = 0;
+    bitset.popSetBits([&](uint32_t bit) {
+        remainderCount++;
+        return true;
+    });
+
+    EXPECT_EQ(remainderCount, 6);
+    EXPECT_TRUE(bitset.empty());
+}
+

--- a/libs/utils/test/test_SingleInstanceComponentManager.cpp
+++ b/libs/utils/test/test_SingleInstanceComponentManager.cpp
@@ -16,8 +16,8 @@ struct DummyComponent {
 
 class TestManager : public SingleInstanceComponentManager<DummyComponent> {
 public:
-    using SingleInstanceComponentManager::SingleInstanceComponentManager;
-    
+    explicit TestManager(EntityManager& em) noexcept : SingleInstanceComponentManager<DummyComponent>(em, "TestManager", false) {}
+
     void setValue(Instance i, int v) {
         if (elementAt<0>(i).value != v) {
             elementAt<0>(i).value = v;
@@ -28,31 +28,31 @@ public:
 
 TEST(SingleInstanceComponentManagerTest, BatchCallbackTest) {
     EntityManager& em = EntityManager::get();
-    TestManager manager;
-    
+    TestManager manager(em);
+
     std::vector<Entity> notifiedEntities;
-    
+
     auto callback = [&](Slice<const Entity> entities) {
         for (auto e : entities) {
             notifiedEntities.push_back(e);
         }
     };
-    
+
     manager.registerChangeCallback(&manager, std::move(callback));
-    
+
     // Test addComponent (should be batched, not flushed yet)
     Entity e1 = em.create();
     manager.addComponent(e1);
 
     EXPECT_TRUE(notifiedEntities.empty());
-    
+
     // Manual flush
     manager.flushNotifications();
     EXPECT_EQ(notifiedEntities.size(), 1);
     EXPECT_EQ(notifiedEntities[0], e1);
-    
+
     notifiedEntities.clear();
-    
+
     // Test auto-flush when full (16 elements)
     std::vector<Entity> entities;
     for (int i = 0; i < 16; ++i) {
@@ -60,7 +60,7 @@ TEST(SingleInstanceComponentManagerTest, BatchCallbackTest) {
         entities.push_back(e);
         manager.addComponent(e);
     }
-    
+
     // The 16th add should have triggered a flush!
     EXPECT_EQ(notifiedEntities.size(), 16);
     if constexpr (SingleInstanceComponentManagerBase::USE_SORTED_DIRTY_ARRAY) {
@@ -69,32 +69,32 @@ TEST(SingleInstanceComponentManagerTest, BatchCallbackTest) {
     for (int i = 0; i < 16; ++i) {
         EXPECT_EQ(notifiedEntities[i], entities[i]);
     }
-    
+
     notifiedEntities.clear();
-    
+
     // Test change check in setValue
     auto i_last = manager.getInstance(entities.back());
     manager.setValue(i_last, 42); // Value changed
     manager.flushNotifications();
     EXPECT_EQ(notifiedEntities.size(), 1);
     EXPECT_EQ(notifiedEntities[0], entities.back());
-    
+
     notifiedEntities.clear();
-    
+
     manager.setValue(i_last, 42); // Value not changed
     manager.flushNotifications();
     EXPECT_TRUE(notifiedEntities.empty()); // Should not notify
-    
+
     notifiedEntities.clear();
-    
+
     // Test de-duplication in notifyChange
     manager.setValue(i_last, 43);
     manager.setValue(i_last, 44); // Modifying same entity again!
     manager.flushNotifications();
     EXPECT_EQ(notifiedEntities.size(), 1); // Should only appear ONCE in the batch!
-    
+
     manager.unregisterChangeCallback(&manager);
-    
+
     // Cleanup
     for (auto e : entities) {
         manager.removeComponent(e);
@@ -106,68 +106,68 @@ TEST(SingleInstanceComponentManagerTest, BatchCallbackTest) {
 
 TEST(SingleInstanceComponentManagerTest, MultiCallbackTest) {
     EntityManager& em = EntityManager::get();
-    TestManager manager;
-    
+    TestManager manager(em);
+
     int count1 = 0;
     int count2 = 0;
     auto cb1 = [&](Slice<const Entity>) { count1++; };
     auto cb2 = [&](Slice<const Entity>) { count2++; };
-    
+
     int token1 = 1;
     int token2 = 2;
     manager.registerChangeCallback(&token1, std::move(cb1));
     manager.registerChangeCallback(&token2, std::move(cb2));
-    
+
     Entity e1 = em.create();
     manager.addComponent(e1);
     manager.flushNotifications();
-    
+
     EXPECT_EQ(count1, 1);
     EXPECT_EQ(count2, 1);
-    
+
     manager.unregisterChangeCallback(&token1);
-    
+
     Entity e2 = em.create();
     manager.addComponent(e2);
     manager.flushNotifications();
-    
+
     EXPECT_EQ(count1, 1); // Should not increase
     EXPECT_EQ(count2, 2); // Should increase
-    
+
     manager.unregisterChangeCallback(&token2);
-    
+
     em.destroy(e1);
     em.destroy(e2);
 }
 
 TEST(SingleInstanceComponentManagerTest, DuplicateCallbackTest) {
     EntityManager& em = EntityManager::get();
-    TestManager manager;
-    
+    TestManager manager(em);
+
     int count = 0;
-    
+
     // We must create two separate lambdas because Invocable is move-only
     auto cb1 = [&](Slice<const Entity>) { count++; };
     auto cb2 = [&](Slice<const Entity>) { count++; };
-    
+
     int token = 1;
     manager.registerChangeCallback(&token, std::move(cb1));
     manager.registerChangeCallback(&token, std::move(cb2));
-    
+
     Entity e = em.create();
     manager.addComponent(e);
     manager.flushNotifications();
-    
+
     EXPECT_EQ(count, 2); // Both should be called
-    
+
     manager.unregisterChangeCallback(&token);
-    
+
     Entity e2 = em.create();
     manager.addComponent(e2);
     manager.flushNotifications();
-    
+
     EXPECT_EQ(count, 2); // Should not increase after unregister
-    
+
     em.destroy(e);
     em.destroy(e2);
 }

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -16,6 +16,17 @@
 
 #include "common/arguments.h"
 
+#include "generated/resources/gltf_demo.h"
+
+#include "materials/uberarchive.h"
+
+#include <viewer/ViewerGui.h>
+
+#include <gltfio/AssetLoader.h>
+#include <gltfio/FilamentAsset.h>
+#include <gltfio/ResourceLoader.h>
+#include <gltfio/TextureProvider.h>
+
 #include <filamentapp/Config.h>
 #include <filamentapp/FilamentApp.h>
 #include <filamentapp/IBL.h>
@@ -26,27 +37,16 @@
 #include <filament/TransformManager.h>
 #include <filament/View.h>
 
-#include <gltfio/AssetLoader.h>
-#include <gltfio/FilamentAsset.h>
-#include <gltfio/ResourceLoader.h>
-#include <gltfio/TextureProvider.h>
-
-#include <viewer/ViewerGui.h>
-
 #include <camutils/Manipulator.h>
 
 #include <utils/getopt.h>
-
 #include <utils/NameComponentManager.h>
-
-#include <iostream>
-#include <fstream>
-#include <string>
 
 #include <math/mat4.h>
 
-#include "generated/resources/gltf_demo.h"
-#include "materials/uberarchive.h"
+#include <fstream>
+#include <iostream>
+#include <string>
 
 using namespace filament;
 using namespace filament::math;
@@ -295,6 +295,9 @@ int main(int argc, char** argv) {
         app.resourceLoader->asyncUpdateLoad();
         app.viewer->updateRootTransform();
         app.viewer->populateScene();
+
+        app.names->gc();
+        app.loader->gc();
 
         if (app.instanceToAnimate == -1) {
             for (FilamentInstance* instance : app.instances) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -1087,6 +1087,9 @@ int main(int argc, char** argv) {
     auto animate = [&app](Engine*, View*, double now) {
         app.resourceLoader->asyncUpdateLoad();
 
+        app.names->gc();
+        app.assetLoader->gc();
+
         // Optionally fit the model into a unit cube at the origin.
         app.viewer->updateRootTransform();
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1742,10 +1742,11 @@ class_<utils::EntityManager>("EntityManager")
     }), allow_raw_pointers())
 #endif
 
-    /// create ::method::
-    /// ::retval:: an [Entity] without any components
     .function("create", select_overload<utils::Entity()>(&utils::EntityManager::create))
-    .function("destroy", select_overload<void(utils::Entity)>(&utils::EntityManager::destroy));
+    .function("destroy", select_overload<void(utils::Entity)>(&utils::EntityManager::destroy))
+    .function("advanceEpoch", &utils::EntityManager::advanceEpoch)
+    .class_function("getMaxEntityCount", &utils::EntityManager::getMaxEntityCount)
+    .function("getEntityCount", &utils::EntityManager::getEntityCount);
 
 // DRIVER TYPES
 // ------------


### PR DESCRIPTION
This major architectural update introduces an Epoch-Based Reclamation (EBR)
system to the EntityManager. It delays the recycling of destroyed Entity IDs
until all active readers and component managers have advanced past the epoch
in which the destruction occurred.

The primary motivation for EBR is to decouple the lifecycle of the 32-bit
Entity ID from the dense tracking structures. By guaranteeing that an entity's
physical index is never safely recycled while any subsystem is still processing
its destruction, component managers can safely transition to tracking entities
purely by their raw index, dropping the generation count from their internal
bitsets. This paves the way for drastically shrinking the memory footprint
of structures like PagedArenaBitset (e.g., from 16KB down to 256B) in future
updates.

Key changes:
- Implement `advanceEpoch()`, `registerWatermark()`, and `reclaimSafeEpochs()`
  in EntityManager to orchestrate the global timeline.
- Introduce `catchupGarbage()` in SingleInstanceComponentManager to
  periodically query the central timeline for missed garbage and mark
  entities logically dead.
- Amortize the physical destruction of component data into a `gc()` phase,
  safely holding zombie components in dense arrays until they can be cleaned up.
- Prevent use-after-free ID collisions by keeping destroyed Entity indices
  in a purgatory epoch until the global safe threshold clears them.
- Introduce exhaustive concurrent stress tests to ensure thread-safety of
  the timeline and bitset pools.