### PR TITLE
utils: Implement PagedArenaBitsetPool transient resource pool

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/NameComponentManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/ostream.h
         ${PUBLIC_HDR_DIR}/${TARGET}/PagedArenaBitset.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/PagedArenaBitsetPool.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Panic.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Path.h
         ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation.h
@@ -94,6 +95,7 @@ set(SRCS
         src/ThreadUtils.cpp
         src/Status.cpp
         src/PagedArenaBitset.cpp
+        src/PagedArenaBitsetPool.cpp
 )
 
 if (WIN32)
@@ -188,6 +190,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_Allocators.cpp
             test/test_bitset.cpp
             test/test_EntitySet.cpp
+            test/test_PagedArenaBitsetPool.cpp
             test/test_tribool.cpp
             test/test_CountDownLatch.cpp
             test/test_CString.cpp

--- a/libs/utils/include/utils/PagedArenaBitsetPool.h
+++ b/libs/utils/include/utils/PagedArenaBitsetPool.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_PAGEDARENABITSETPOOL_H
+#define TNT_UTILS_PAGEDARENABITSETPOOL_H
+
+#include <utils/PagedArenaBitset.h>
+
+#include <memory>
+#include <vector>
+
+namespace utils {
+
+/**
+ * @class PagedArenaBitsetPool
+ * @brief A zero-allocation, RAII-driven transient resource pool for PagedArenaBitset.
+ *
+ * @details
+ * Frequently allocating and freeing temporary PagedArenaBitsets inside engine hot loops causes
+ * heavy L2/L3 cache misses and allocator overhead due to randomized heap placements on Android.
+ * This pool acts as a thread-local/thread-isolated high-water mark allocator.
+ *
+ * Outstanding allocations are checked out as move-only ScopedBitset RAII wrappers, which are
+ * automatically cleaned and returned back to the pool's free-list on destruction.
+ *
+ * ### Usage Example
+ * @code
+ * PagedArenaBitsetPool pool;
+ *
+ * void processIntersection(const PagedArenaBitset& inputA, const PagedArenaBitset& inputB) {
+ *     // Checkout a temporary bitset
+ *     PagedArenaBitsetPool::ScopedBitset temp = pool.get();
+ *
+ *     // Perform fast boolean math (implicitly converts ScopedBitset to PagedArenaBitset&)
+ *     PagedArenaBitset::intersect(&temp, inputA, inputB);
+ *
+ *     // Iterate the results using ergonomic -> operator
+ *     temp->forEachSetBit([](uint32_t index) {
+ *         // ...
+ *     });
+ *
+ *     // At the end of scope, 'temp' automatically clears the bitset
+ *     // and returns it back to the pool without any heap deallocations!
+ * }
+ * @endcode
+ *
+ * @note **Thread Safety:** This pool is intentionally NOT thread-safe to avoid mutex lock contention.
+ */
+class PagedArenaBitsetPool {
+    std::vector<std::unique_ptr<PagedArenaBitset>> mFreeList;
+
+public:
+    /**
+     * @brief Constructs an empty PagedArenaBitsetPool.
+     */
+    PagedArenaBitsetPool() noexcept;
+
+    /**
+     * @brief Destroys the pool, freeing all cached PagedArenaBitset resources.
+     */
+    ~PagedArenaBitsetPool() noexcept;
+
+    // Delete copy/move to prevent accidental invalidation of internal pointers
+    // (specifically: outstanding ScopedBitsets hold a raw pointer to this pool)
+    PagedArenaBitsetPool(const PagedArenaBitsetPool&) = delete;
+    PagedArenaBitsetPool& operator=(const PagedArenaBitsetPool&) = delete;
+    PagedArenaBitsetPool(PagedArenaBitsetPool&&) = delete;
+    PagedArenaBitsetPool& operator=(PagedArenaBitsetPool&&) = delete;
+
+    /**
+     * @class ScopedBitset
+     * @brief Move-only RAII wrapper that manages checkout/cleanup lifecycle of a pooled PagedArenaBitset.
+     */
+    class ScopedBitset {
+        PagedArenaBitset* mBitset = nullptr;
+        PagedArenaBitsetPool* mPool = nullptr;
+
+        /**
+         * @brief Constructs a ScopedBitset wrapping a checked-out PagedArenaBitset.
+         * @param bitset Reference to the checked-out bitset.
+         * @param pool Reference to the parent pool.
+         */
+        ScopedBitset(PagedArenaBitset& bitset, PagedArenaBitsetPool& pool) noexcept
+                : mBitset(&bitset), mPool(&pool) {}
+
+        friend class PagedArenaBitsetPool;
+
+    public:
+        /**
+         * @brief Constructs an empty, null ScopedBitset wrapper in a moved-from state.
+         */
+        ScopedBitset() noexcept = default;
+
+        /**
+         * @brief Destructs the wrapper, automatically clearing the bitset and returning it to the pool.
+         */
+        ~ScopedBitset() noexcept;
+
+        /**
+         * @brief Move constructor. Transfers ownership of the pooled bitset.
+         * @param other The wrapper to move from.
+         */
+        ScopedBitset(ScopedBitset&& other) noexcept
+                : mBitset(other.mBitset), mPool(other.mPool) {
+            other.mBitset = nullptr;
+            other.mPool = nullptr;
+        }
+
+        /**
+         * @brief Move assignment operator. Releases any currently owned bitset and transfers ownership from @p other.
+         * @param other The wrapper to move from.
+         * @return Reference to this wrapper.
+         */
+        ScopedBitset& operator=(ScopedBitset&& other) noexcept;
+
+        // Deleted Copy Semantics
+        ScopedBitset(const ScopedBitset&) = delete;
+        ScopedBitset& operator=(const ScopedBitset&) = delete;
+
+        /**
+         * @brief Returns a pointer to the underlying PagedArenaBitset.
+         */
+        PagedArenaBitset* get() const noexcept { return mBitset; }
+
+        /**
+         * @brief Dereferences the underlying PagedArenaBitset.
+         */
+        PagedArenaBitset& operator*() const noexcept { return *mBitset; }
+
+        /**
+         * @brief Provides member access to the underlying PagedArenaBitset.
+         */
+        PagedArenaBitset* operator->() const noexcept { return mBitset; }
+        
+        /**
+         * @brief Transparent conversion to reference for API boundary interoperability.
+         */
+        operator PagedArenaBitset&() const noexcept { return *mBitset; }
+
+        /**
+         * @brief Returns true if this wrapper holds a valid, active PagedArenaBitset checkout.
+         */
+        explicit operator bool() const noexcept { return mBitset != nullptr; }
+    };
+
+    /**
+     * @brief Checks out a clean, sterile PagedArenaBitset from the pool.
+     * @details If the free-list is empty, a new PagedArenaBitset is allocated and its ownership is retained.
+     * @return A ScopedBitset RAII wrapper managing the checked-out bitset.
+     */
+    [[nodiscard]] ScopedBitset get();
+
+    /**
+     * @brief Clears the pool, freeing all internally cached PagedArenaBitset resources back to the OS.
+     * @details Call this during low-activity states, epoch transitions, or garbage collection
+     * to shrink the high-water mark memory footprint when the pool goes unused.
+     *
+     * @note **Active Allocations Safety:** Calling clear() while ScopedBitsets are currently checked out
+     * is completely safe and defined. Only the idle bitsets currently in the free-list are destroyed.
+     * Outstanding ScopedBitsets will continue to function normally and will be cleanly recycled
+     * back to the pool upon their destruction.
+     */
+    void clear() noexcept;
+
+    /**
+     * @brief Returns the number of idle PagedArenaBitset resources currently cached in the pool.
+     * @return The size of the internal free-list.
+     */
+    size_t size() const noexcept {
+        return mFreeList.size();
+    }
+
+private:
+    friend class ScopedBitset;
+    
+    // The Return Function (Called exclusively by ScopedBitset::~ScopedBitset)
+    void release(PagedArenaBitset& bitset);
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_PAGEDARENABITSETPOOL_H

--- a/libs/utils/src/PagedArenaBitsetPool.cpp
+++ b/libs/utils/src/PagedArenaBitsetPool.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/compiler.h>
+#include <utils/PagedArenaBitset.h>
+#include <utils/PagedArenaBitsetPool.h>
+
+#include <memory>
+
+namespace utils {
+
+// ============================================================================
+// PagedArenaBitsetPool
+// ============================================================================
+
+PagedArenaBitsetPool::PagedArenaBitsetPool() noexcept = default;
+
+PagedArenaBitsetPool::~PagedArenaBitsetPool() noexcept = default;
+
+PagedArenaBitsetPool::ScopedBitset PagedArenaBitsetPool::get() {
+    if (UTILS_UNLIKELY(mFreeList.empty())) {
+        mFreeList.push_back(std::make_unique<PagedArenaBitset>());
+    }
+    PagedArenaBitset* bitset = mFreeList.back().release();
+    mFreeList.pop_back();
+    return ScopedBitset(*bitset, *this);
+}
+
+void PagedArenaBitsetPool::release(PagedArenaBitset& bitset) {
+    bitset.clear();
+    mFreeList.push_back(std::unique_ptr<PagedArenaBitset>(&bitset));
+}
+
+void PagedArenaBitsetPool::clear() noexcept {
+    mFreeList.clear();
+}
+
+// ============================================================================
+// PagedArenaBitsetPool::ScopedBitset
+// ============================================================================
+
+PagedArenaBitsetPool::ScopedBitset::~ScopedBitset() noexcept {
+    if (UTILS_LIKELY(mBitset && mPool)) {
+        mPool->release(*mBitset);
+    }
+}
+
+PagedArenaBitsetPool::ScopedBitset& PagedArenaBitsetPool::ScopedBitset::operator=(ScopedBitset&& other) noexcept {
+    if (UTILS_LIKELY(this != &other)) {
+        if (UTILS_LIKELY(mBitset && mPool)) {
+            mPool->release(*mBitset);
+        }
+        mBitset = other.mBitset;
+        mPool = other.mPool;
+        other.mBitset = nullptr;
+        other.mPool = nullptr;
+    }
+    return *this;
+}
+
+} // namespace utils

--- a/libs/utils/test/test_PagedArenaBitsetPool.cpp
+++ b/libs/utils/test/test_PagedArenaBitsetPool.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/PagedArenaBitsetPool.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+using namespace utils;
+
+TEST(PagedArenaBitsetPoolTest, BasicCheckoutAndReturn) {
+    PagedArenaBitsetPool pool;
+
+    PagedArenaBitset* address = nullptr;
+
+    {
+        PagedArenaBitsetPool::ScopedBitset bs = pool.get();
+        EXPECT_NE(bs.get(), nullptr);
+        address = bs.get();
+
+        // Modify the bitset
+        bs->add(10);
+        bs->add(20);
+        EXPECT_EQ(bs->size(), 2);
+        EXPECT_TRUE((*bs)[10]);
+        EXPECT_TRUE((*bs)[20]);
+    } // bs goes out of scope, should clear and return to pool
+
+    {
+        PagedArenaBitsetPool::ScopedBitset bs2 = pool.get();
+        // Verify we got the exact same physical bitset back
+        EXPECT_EQ(bs2.get(), address);
+
+        // Verify it was sterile/cleared automatically
+        EXPECT_TRUE(bs2->empty());
+        EXPECT_EQ(bs2->size(), 0);
+        EXPECT_FALSE((*bs2)[10]);
+        EXPECT_FALSE((*bs2)[20]);
+    }
+}
+
+TEST(PagedArenaBitsetPoolTest, MoveSemantics) {
+    PagedArenaBitsetPool pool;
+
+    PagedArenaBitsetPool::ScopedBitset bs1 = pool.get();
+    PagedArenaBitset* address = bs1.get();
+    bs1->add(42);
+
+    // Move constructor
+    PagedArenaBitsetPool::ScopedBitset bs2 = std::move(bs1);
+    EXPECT_EQ(bs1.get(), nullptr);
+    EXPECT_EQ(bs2.get(), address);
+    EXPECT_TRUE((*bs2)[42]);
+
+    // Move assignment
+    PagedArenaBitsetPool::ScopedBitset bs3 = pool.get();
+    PagedArenaBitset* address3 = bs3.get();
+    
+    bs3 = std::move(bs2);
+    // bs3's original bitset (address3) should be returned to the pool
+    // bs2 should be null, bs3 should own bs1's bitset
+    EXPECT_EQ(bs2.get(), nullptr);
+    EXPECT_EQ(bs3.get(), address);
+
+    // Let's verify address3 was returned to the pool and is sterile
+    PagedArenaBitsetPool::ScopedBitset bs4 = pool.get();
+    EXPECT_EQ(bs4.get(), address3);
+    EXPECT_TRUE(bs4->empty());
+}
+
+TEST(PagedArenaBitsetPoolTest, ConversionOperator) {
+    PagedArenaBitsetPool pool;
+    PagedArenaBitsetPool::ScopedBitset scoped = pool.get();
+    scoped->add(100);
+
+    // Transparent conversion operator to PagedArenaBitset&
+    PagedArenaBitset& ref = scoped;
+    EXPECT_TRUE(ref[100]);
+    EXPECT_EQ(ref.size(), 1);
+}
+
+TEST(PagedArenaBitsetPoolTest, HighWaterMarkScaling) {
+    PagedArenaBitsetPool pool;
+
+    PagedArenaBitset* addr1 = nullptr;
+    PagedArenaBitset* addr2 = nullptr;
+    PagedArenaBitset* addr3 = nullptr;
+
+    {
+        PagedArenaBitsetPool::ScopedBitset bs1 = pool.get();
+        PagedArenaBitsetPool::ScopedBitset bs2 = pool.get();
+        PagedArenaBitsetPool::ScopedBitset bs3 = pool.get();
+
+        addr1 = bs1.get();
+        addr2 = bs2.get();
+        addr3 = bs3.get();
+
+        EXPECT_NE(addr1, addr2);
+        EXPECT_NE(addr2, addr3);
+        EXPECT_NE(addr1, addr3);
+    } // All returned
+
+    // Now check them out again, they should be returned in LIFO order (LIFO or FIFO depending on vector pop_back/push_back)
+    // push_back/pop_back is LIFO
+    {
+        PagedArenaBitsetPool::ScopedBitset bsA = pool.get();
+        PagedArenaBitsetPool::ScopedBitset bsB = pool.get();
+        PagedArenaBitsetPool::ScopedBitset bsC = pool.get();
+
+        EXPECT_EQ(bsA.get(), addr1);
+        EXPECT_EQ(bsB.get(), addr2);
+        EXPECT_EQ(bsC.get(), addr3);
+    }
+}
+
+TEST(PagedArenaBitsetPoolTest, ClearPool) {
+    PagedArenaBitsetPool pool;
+
+    PagedArenaBitset* address1 = nullptr;
+    PagedArenaBitset* address2 = nullptr;
+
+    {
+        PagedArenaBitsetPool::ScopedBitset bs1 = pool.get();
+        PagedArenaBitsetPool::ScopedBitset bs2 = pool.get();
+        address1 = bs1.get();
+        address2 = bs2.get();
+    } // Both returned to pool's free-list
+
+    // Clear the pool to free all resources
+    pool.clear();
+
+    // Checkout one bitset. Since the pool was cleared, this will allocate a new one.
+    PagedArenaBitsetPool::ScopedBitset bs3 = pool.get();
+    // Checkout a second one. This will also allocate a new one.
+    PagedArenaBitsetPool::ScopedBitset bs4 = pool.get();
+
+    // Verify they are distinct from each other
+    EXPECT_NE(bs3.get(), bs4.get());
+}
+
+TEST(PagedArenaBitsetPoolTest, PoolSize) {
+    PagedArenaBitsetPool pool;
+    EXPECT_EQ(pool.size(), 0);
+
+    {
+        PagedArenaBitsetPool::ScopedBitset bs1 = pool.get();
+        EXPECT_EQ(pool.size(), 0); // Active, not in free-list
+
+        {
+            PagedArenaBitsetPool::ScopedBitset bs2 = pool.get();
+            EXPECT_EQ(pool.size(), 0);
+        } // bs2 returned
+
+        EXPECT_EQ(pool.size(), 1);
+    } // bs1 returned
+
+    EXPECT_EQ(pool.size(), 2);
+
+    pool.clear();
+    EXPECT_EQ(pool.size(), 0);
+}
+
+TEST(PagedArenaBitsetPoolTest, DefaultConstructor) {
+    PagedArenaBitsetPool pool;
+    
+    // Default constructed empty wrapper
+    PagedArenaBitsetPool::ScopedBitset empty_wrapper;
+    EXPECT_EQ(empty_wrapper.get(), nullptr);
+    EXPECT_FALSE(static_cast<bool>(empty_wrapper));
+
+    // Assign a valid checked-out wrapper to it
+    empty_wrapper = pool.get();
+    EXPECT_NE(empty_wrapper.get(), nullptr);
+    EXPECT_TRUE(static_cast<bool>(empty_wrapper));
+}


### PR DESCRIPTION
Introduce utils::PagedArenaBitsetPool, a zero-allocation, RAII-driven transient resource pool for PagedArenaBitset. This pool optimizes steady-state execution in hot rendering and ECS loops by caching bitsets, avoiding randomized OS heap allocator placements.

- Implement ScopedBitset RAII wrapper with C++ reference constructors.
- Add clear() and size() for pool size tracking and garbage sweeps.
- Add comprehensive Doxygen documentation and unit test coverage.