### PR TITLE
Fix the broken amortization mode for async ops

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -316,6 +316,10 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfi
 
     mShaderCompilerService.init();
 
+    // Create the backend thread's state after mContext is fully initialized
+    mBackendState = mContext.createState();
+    assert_invariant(mBackendState);
+
     if (driverConfig.asynchronousMode != AsynchronousMode::NONE) {
         mJobQueue = JobQueue::create();
 
@@ -340,13 +344,12 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfi
             };
             mJobWorker = ThreadWorker::create(mJobQueue, std::move(threadWorkerConfig));
         } else {
+            // The worker operates on the same backend (engine) thread for the Amortization mode,
+            // so use the same state.
+            mWorkerState = mBackendState;
             mJobWorker = AmortizationWorker::create(mJobQueue);
         }
     }
-
-    // Create the backend thread's state after mContext is fully initialized
-    mBackendState = mContext.createState();
-    assert_invariant(mBackendState);
 }
 
 OpenGLDriver::~OpenGLDriver() noexcept { // NOLINT(modernize-use-equals-default)


### PR DESCRIPTION
The amortization async mode has been broken since the OpenGL state refactor.

`mWorkerState` in OpenGlDriver class was not properly initialized for the amortization mode.