### PR TITLE
fix FrameInfo::presentDeadline

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -114,11 +114,10 @@ public:
         duration_ns compositeInterval;
 
         /**
-         * The timestamp [ns] since epoch of the next time the compositor will begin composition.
-         * This is effectively the deadline for when the compositor must receive a newly queued
-         * frame.
+         * The time delta [ns] between the start of composition and the next time the compositor will begin composition.
+         * This is effectively the deadline for when the compositor must receive a newly queued frame.
          */
-        time_point_ns compositeDeadline;
+        duration_ns compositeDeadlineLatency;
 
         /**
          * The time delta [ns] between the start of composition and the expected present time of

--- a/filament/backend/src/AndroidFrameCallback.cpp
+++ b/filament/backend/src/AndroidFrameCallback.cpp
@@ -128,8 +128,12 @@ void AndroidFrameCallback::vsyncCallback(const AChoreographerFrameCallbackData* 
                 AChoreographerFrameCallbackData_getFrameTimelineDeadlineNanos(
                         callbackData, preferredIndex);
 
+        int64_t const frameId = AChoreographerFrameCallbackData_getFrameTimelineVsyncId(
+                callbackData, preferredIndex);
+
         LockGuard const l(mLock);
         mPreferredTimeline = {
+            .frameId = frameId,
             .frameTime = frameTime,
             .expectedPresentTime = expectedPresentTime,
             .frameTimelineDeadline = frameTimelineDeadline

--- a/filament/backend/src/AndroidFrameCallback.h
+++ b/filament/backend/src/AndroidFrameCallback.h
@@ -42,6 +42,7 @@ public:
     struct Timeline {
         using timepoint_ns = int64_t;
         static constexpr timepoint_ns INVALID = -1;
+        int64_t frameId{ INVALID };
         timepoint_ns frameTime{ INVALID };
         timepoint_ns expectedPresentTime{ INVALID };
         timepoint_ns frameTimelineDeadline{ INVALID };

--- a/filament/backend/src/AndroidNativeWindow.cpp
+++ b/filament/backend/src/AndroidNativeWindow.cpp
@@ -73,10 +73,10 @@ int NativeWindow::frameTimestampsSupportsPresent(ANativeWindow* anw, bool* outSu
 
 int NativeWindow::getCompositorTiming(ANativeWindow* anw,
         int64_t* compositeDeadline, int64_t* compositeInterval,
-        int64_t* compositeToPresentLatency) {
+        int64_t* compositeToPresent) {
     NativeWindow const* pWindow = reinterpret_cast<NativeWindow const*>(anw);
     return pWindow->perform(anw, GET_COMPOSITOR_TIMING,
-            compositeDeadline, compositeInterval, compositeToPresentLatency);
+            compositeDeadline, compositeInterval, compositeToPresent);
 }
 
 int NativeWindow::getFrameTimestamps(ANativeWindow* anw,

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -296,19 +296,13 @@ bool PlatformEGLAndroid::queryCompositorTiming(SwapChain const* swapchain,
 
     AndroidFrameCallback::Timeline const preferredTimeline{
             mAndroidDetails.androidFrameCallback.getPreferredTimeline() };
-    // FIXME: expectedPresentLatency might reflect the previous frame's value because
-    //        the choreographer's callback can happen before (good) or after (bad) us.
-    //        This problem is mitigated by storing the latency instead of the deadline,
-    //        because it generally is constant frame to frame.
-    if (UTILS_LIKELY(preferredTimeline.expectedPresentTime > preferredTimeline.frameTime)) {
-        // latency can never be negative, let's be safe
-        outCompositorTiming->expectedPresentLatency =
-                preferredTimeline.expectedPresentTime - preferredTimeline.frameTime;
-    } else {
-        // fake a reasonable value (33ms)
-        outCompositorTiming->expectedPresentLatency = 33'000'000;
-    }
-    outCompositorTiming->compositeDeadline = CompositorTiming::INVALID;
+
+    outCompositorTiming->expectedPresentLatency =
+        preferredTimeline.expectedPresentTime - preferredTimeline.frameTime;
+
+    outCompositorTiming->compositeDeadlineLatency =
+        preferredTimeline.frameTimelineDeadline - preferredTimeline.frameTime;
+
     outCompositorTiming->compositeInterval = CompositorTiming::INVALID;
     outCompositorTiming->compositeToPresentLatency = CompositorTiming::INVALID;
 
@@ -325,9 +319,8 @@ bool PlatformEGLAndroid::queryCompositorTiming(SwapChain const* swapchain,
             return true;
         }
 
-        std::array<EGLnsecsANDROID, 3> values;
-        constexpr std::array<EGLint, 3> names{
-            EGL_COMPOSITE_DEADLINE_ANDROID,
+        std::array<EGLnsecsANDROID, 2> values;
+        constexpr std::array names{
             EGL_COMPOSITE_INTERVAL_ANDROID,
             EGL_COMPOSITE_TO_PRESENT_LATENCY_ANDROID
         };
@@ -337,9 +330,8 @@ bool PlatformEGLAndroid::queryCompositorTiming(SwapChain const* swapchain,
             // reset current error to EGL_SUCCESS
             eglGetError();
         } else {
-            outCompositorTiming->compositeDeadline = values[0];
-            outCompositorTiming->compositeInterval = values[1];
-            outCompositorTiming->compositeToPresentLatency = values[2];
+            outCompositorTiming->compositeInterval = values[0];
+            outCompositorTiming->compositeToPresentLatency = values[1];
         }
     }
     return true;
@@ -415,8 +407,6 @@ Platform::SwapChain* PlatformEGLAndroid::createSwapChain(void* nativeWindow, uin
     if (UTILS_LIKELY(ext.egl.ANDROID_get_frame_timestamps)) {
         EGLDisplay const dpy = getEglDisplay();
         sc->compositorTimingSupported =
-                eglGetCompositorTimingSupportedANDROID(dpy, sc->sur,
-                        EGL_COMPOSITE_DEADLINE_ANDROID) &&
                 eglGetCompositorTimingSupportedANDROID(dpy, sc->sur,
                         EGL_COMPOSITE_INTERVAL_ANDROID) &&
                 eglGetCompositorTimingSupportedANDROID(dpy, sc->sur,

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -709,26 +709,23 @@ bool VulkanPlatformAndroid::queryCompositorTiming(SwapChain const* swapchain,
 
     AndroidFrameCallback::Timeline const preferredTimeline{
         mAndroidDetails.androidFrameCallback.getPreferredTimeline() };
-    // FIXME: expectedPresentLatency might reflect the previous frame's value because
-    //        the choreographer's callback can happen before (good) or after (bad) us.
-    //        This problem is mitigated by storing the latency instead of the deadline,
-    //        because it generally is constant frame to frame.
-    if (UTILS_LIKELY(preferredTimeline.expectedPresentTime > preferredTimeline.frameTime)) {
-        // latency can never be negative, let's be safe
-        outCompositorTiming->expectedPresentLatency =
-                preferredTimeline.expectedPresentTime - preferredTimeline.frameTime;
-    } else {
-        // fake a reasonable value (33ms)
-        outCompositorTiming->expectedPresentLatency = 33'000'000;
-    }
-    outCompositorTiming->compositeDeadline = CompositorTiming::INVALID;
+
+    outCompositorTiming->expectedPresentLatency =
+        preferredTimeline.expectedPresentTime - preferredTimeline.frameTime;
+
+    outCompositorTiming->compositeDeadlineLatency =
+        preferredTimeline.frameTimelineDeadline - preferredTimeline.frameTime;
+
     outCompositorTiming->compositeInterval = CompositorTiming::INVALID;
     outCompositorTiming->compositeToPresentLatency = CompositorTiming::INVALID;
 
     // From this point on, we always return "success" because some timings were returned.
 
+    CompositorTiming result{};
     auto vulkanSwapchain = static_cast<VulkanPlatformSwapChainBase const *>(swapchain);
-    vulkanSwapchain->queryCompositorTiming(outCompositorTiming);
+    vulkanSwapchain->queryCompositorTiming(&result);
+    outCompositorTiming->compositeInterval = result.compositeInterval;
+    outCompositorTiming->compositeToPresentLatency = result.compositeToPresentLatency;
     return true;
 }
 

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -362,9 +362,10 @@ bool VulkanPlatformSurfaceSwapChain::queryCompositorTiming(
 #ifdef __ANDROID__
     // fallback to private APIs
     if (UTILS_VERY_LIKELY(mNativeWindow)) {
+        CompositorTiming::duration_ns dummyCompositeDeadlineLatency;
         int const status = NativeWindow::getCompositorTiming(
                 static_cast<ANativeWindow*>(mNativeWindow),
-                &outCompositorTiming->compositeDeadline,
+                &dummyCompositeDeadlineLatency,
                 &outCompositorTiming->compositeInterval,
                 &outCompositorTiming->compositeToPresentLatency);
         if (status == 0) {

--- a/filament/src/FrameInfo.cpp
+++ b/filament/src/FrameInfo.cpp
@@ -132,7 +132,7 @@ void FrameInfoManager::beginFrame(FSwapChain* swapChain, DriverApi& driver,
     CompositorTiming compositorTiming{};
     if (driver.isCompositorTimingSupported() &&
         driver.queryCompositorTiming(swapChain->getHwHandle(), &compositorTiming)) {
-        front.presentDeadline = compositorTiming.compositeDeadline;
+        front.presentDeadlineLatency = compositorTiming.compositeDeadlineLatency;
         front.displayPresentInterval = compositorTiming.compositeInterval;
         front.compositionToPresentLatency = compositorTiming.compositeToPresentLatency;
         front.expectedPresentLatency = compositorTiming.expectedPresentLatency;
@@ -359,7 +359,7 @@ void FrameInfoManager::updateUserHistory(FSwapChain* swapChain, DriverApi& drive
                 .gpuFrameComplete               = toTimepoint(entry.gpuFrameComplete),
                 .vsync                          = toTimepoint(entry.vsync),
                 .displayPresent                 = entry.displayPresent,
-                .presentDeadline                = entry.presentDeadline,
+                .presentDeadline                = toTimepoint(entry.vsync) + entry.presentDeadlineLatency,
                 .displayPresentInterval         = entry.displayPresentInterval,
                 .compositionToPresentLatency    = entry.compositionToPresentLatency,
                 .expectedPresentLatency         = entry.expectedPresentLatency

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -75,7 +75,7 @@ struct FrameInfoImpl : public details::FrameInfo {
     // Actual presentation time of this frame
     FrameTimestamps::time_point_ns displayPresent{ FrameTimestamps::PENDING };
     // deadline for queuing a frame [ns]
-    CompositorTiming::time_point_ns presentDeadline{ FrameTimestamps::INVALID };
+    CompositorTiming::time_point_ns presentDeadlineLatency{ FrameTimestamps::INVALID };
     // display refresh rate [ns]
     CompositorTiming::duration_ns displayPresentInterval{ FrameTimestamps::INVALID };
     // time between the start of composition and the expected present time [ns]


### PR DESCRIPTION
There was two related issues. First, we got the present-deadline from ANativeWindow / EGL instead of from Choreographer. It's unclear how they differ, but the Choreographer one is the modern way of getting that information.

The next problem is that we can't use timepoints because we can't correlate them to the user's view of the vsync time.  So instead we record deltas from the Choregrapher's vsync (normally it will match the user's, but it could be off by one frame), and we later recalculate the timepoint from the duration relative the user's vsync.