### PR TITLE
Refactor: Simplify Scene cache ownership and lifecycle

### DIFF
--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -119,7 +119,8 @@ public:
      *
      * @note
      *  There is no reference-counting.
-     *  Make sure to dissociate a Scene from all Views before destroying it.
+     *  If a Scene is destroyed before it is dissociated from a View, it will be automatically
+     *  dissociated from that View (setting the View's Scene to nullptr).
      */
     void setScene(Scene* UTILS_NULLABLE scene);
 

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -22,8 +22,8 @@
 #include "components/RenderableManager.h"
 #include "components/TransformManager.h"
 
-#include "details/Engine.h"
 #include "details/Camera.h"
+#include "details/Engine.h"
 #include "details/Skybox.h"
 #include "details/View.h"
 
@@ -413,9 +413,10 @@ void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables, FScen
 }
 
 void FScene::terminate(FEngine&) {
-    while (!mViewCaches.empty()) {
-        mViewCaches.begin()->first->invalidateCache(this);
+    for (FView* view : mRegisteredViews) {
+        view->detachScene(this);
     }
+    mRegisteredViews.clear();
 }
 
 void FScene::prepareDynamicLights(const CameraInfo& camera,
@@ -579,17 +580,20 @@ void FScene::setSkybox(FSkybox* skybox) noexcept {
     }
 }
 
-FScene::SceneCacheData* FScene::registerView(FView const* view) noexcept {
-    auto [it, inserted] = mViewCaches.try_emplace(view, nullptr);
-    assert_invariant(inserted);
-    if (inserted) {
-        it->second = std::make_unique<SceneCacheData>();
+void FScene::registerView(FView* view) noexcept {
+    auto it = std::find(mRegisteredViews.begin(), mRegisteredViews.end(), view);
+    assert_invariant(it == mRegisteredViews.end());
+    if (it == mRegisteredViews.end()) {
+        mRegisteredViews.push_back(view);
     }
-    return it->second.get();
 }
 
-void FScene::unregisterView(FView const* view) noexcept {
-    mViewCaches.erase(view);
+void FScene::unregisterView(FView* view) noexcept {
+    auto it = std::find(mRegisteredViews.begin(), mRegisteredViews.end(), view);
+    assert_invariant(it != mRegisteredViews.end());
+    if (it != mRegisteredViews.end()) {
+        mRegisteredViews.erase(it);
+    }
 }
 
 UTILS_NOINLINE

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -34,7 +34,7 @@
 #include <utils/Slice.h>
 #include <utils/StructureOfArrays.h>
 
-#include <tsl/robin_set.h>
+#include <vector>
 
 #include <stddef.h>
 
@@ -218,9 +218,9 @@ private:
      * we store it here.
      */
     friend class FView;
-    SceneCacheData* registerView(FView const* view) noexcept;
-    void unregisterView(FView const* view) noexcept;
-    std::unordered_map<FView const*, std::unique_ptr<SceneCacheData>> mViewCaches;
+    void registerView(FView* view) noexcept;
+    void unregisterView(FView* view) noexcept;
+    std::vector<FView*> mRegisteredViews;
     EntitySet mEntities;
 };
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -205,19 +205,26 @@ FView::~FView() noexcept = default;
 void FView::setScene(FScene* scene) {
     if (mScene != scene) {
         if (mScene) {
-            invalidateCache(mScene);
+            mScene->unregisterView(this);
         }
         mScene = scene;
         if (scene) {
-            mCurrentViewCache = scene->registerView(this);
+            scene->registerView(this);
+            if (!mSceneCache) {
+                mSceneCache = std::make_unique<FScene::SceneCacheData>();
+            }
+        } else {
+            mSceneCache.reset();
         }
     }
 }
 
 void FView::terminate(FEngine& engine) {
     if (mScene) {
-        invalidateCache(mScene);
+        mScene->unregisterView(this);
+        mScene = nullptr;
     }
+    mSceneCache.reset();
 
     // Here we would cleanly free resources we've allocated, or we own (currently none).
 
@@ -504,14 +511,14 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
     FILAMENT_TRACING_CONTEXT(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     FScene* const scene = mScene;
-    auto const& lightData = mCurrentViewCache->lightData;
+    auto const& lightData = mSceneCache->lightData;
 
     /*
      * Dynamic lights
      */
 
     if (hasDynamicLighting()) {
-        scene->prepareDynamicLights(cameraInfo, mLightUbh, *mCurrentViewCache);
+        scene->prepareDynamicLights(cameraInfo, mLightUbh, *mSceneCache);
     }
 
     // here the array of visible lights has been shrunk to CONFIG_MAX_LIGHT_COUNT
@@ -730,7 +737,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
      */
     scene->prepare(js, rootArenaScope,
             cameraInfo.worldTransform,
-            hasVSM(), *mCurrentViewCache);
+            hasVSM(), *mSceneCache);
 
     /*
      * Light culling: runs in parallel with Renderable culling (below)
@@ -738,7 +745,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
     JobSystem::Job* froxelizeLightsJob = nullptr;
     JobSystem::Job* prepareVisibleLightsJob = nullptr;
-    size_t const lightCount = mCurrentViewCache->lightData.size();
+    size_t const lightCount = mSceneCache->lightData.size();
     if (lightCount > FScene::DIRECTIONAL_LIGHTS_COUNT) {
         // create and start the prepareVisibleLights job
         // note: this job updates LightData (non const)
@@ -750,7 +757,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         prepareVisibleLightsJob = js.runAndRetain(js.createJob(nullptr,
                 [&engine, distances, positionalLightCount, &viewMatrix = cameraInfo.view, &cullingFrustum,
-                 &lightData = mCurrentViewCache->lightData]
+                 &lightData = mSceneCache->lightData]
                         (JobSystem&, JobSystem::Job*) {
                     prepareVisibleLights(engine.getLightManager(),
                             { distances, distances + positionalLightCount },
@@ -764,7 +771,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
     Range merged;
 
     { // all the operations in this scope must happen sequentially
-        FScene::RenderableSoa& renderableData = mCurrentViewCache->renderableData;
+        FScene::RenderableSoa& renderableData = mSceneCache->renderableData;
 
         Slice<Culler::result_type> cullingMask = renderableData.slice<FScene::VISIBLE_MASK>();
         std::uninitialized_fill(cullingMask.begin(), cullingMask.end(), 0);
@@ -788,7 +795,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
         }
 
         // lightData is const from this point on (can only happen after prepareVisibleLightsJob)
-        auto const& lightData = mCurrentViewCache->lightData;
+        auto const& lightData = mSceneCache->lightData;
 
         // now we know if we have dynamic lighting (i.e.: dynamic lights are visible)
         mHasDynamicLighting = lightData.size() > FScene::DIRECTIONAL_LIGHTS_COUNT;
@@ -892,7 +899,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
         // TODO: when any spotlight is used, `merged` ends-up being the whole list. However,
         //       some of the items will end-up not being visible by any light. Can we do better?
         //       e.g. could we deffer some of the prepareVisibleRenderables() to later?
-        scene->prepareVisibleRenderables(merged, *mCurrentViewCache);
+        scene->prepareVisibleRenderables(merged, *mSceneCache);
 
         // update those UBOs
         if (!merged.empty()) {
@@ -910,7 +917,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
     { // this must happen after mRenderableUbh is created/updated
         // prepare skinning, morphing and hybrid instancing
-        auto& sceneData = mCurrentViewCache->renderableData;
+        auto& sceneData = mSceneCache->renderableData;
         for (uint32_t const i : merged) {
             auto const& skinning = sceneData.elementAt<FScene::SKINNING_BUFFER>(i);
             auto const& morphing = sceneData.elementAt<FScene::MORPHING_BUFFER>(i);
@@ -1685,19 +1692,17 @@ float4 FView::getMaterialGlobal(uint32_t const index) const {
 }
 
 bool FView::hasContactShadows() const noexcept {
-    if (mCurrentViewCache) {
+    if (mSceneCache) {
         assert_invariant(mScene);
-        return mScene->hasContactShadows(*mCurrentViewCache);
+        return mScene->hasContactShadows(*mSceneCache);
     }
     return false;
 }
 
-void FView::invalidateCache(FScene* scene) const noexcept {
-    assert_invariant(scene);
-    if (mCurrentViewCache && mScene == scene) {
-        scene->unregisterView(this);
-        mCurrentViewCache = nullptr;
+void FView::detachScene(FScene const* scene) noexcept {
+    if (mScene == scene) {
         mScene = nullptr;
+        mSceneCache.reset();
     }
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -104,12 +104,12 @@ public:
     ~FView() noexcept;
 
     FScene::RenderableSoa& getRenderableData() const noexcept {
-        assert_invariant(mCurrentViewCache);
-        return mCurrentViewCache->renderableData;
+        assert_invariant(mSceneCache);
+        return mSceneCache->renderableData;
     }
     FScene::LightSoa& getLightData() const noexcept {
-        assert_invariant(mCurrentViewCache);
-        return mCurrentViewCache->lightData;
+        assert_invariant(mSceneCache);
+        return mSceneCache->lightData;
     }
 
     void terminate(FEngine& engine);
@@ -127,7 +127,7 @@ public:
     FScene* getScene() noexcept { return mScene; }
 
     bool hasContactShadows() const noexcept;
-    void invalidateCache(FScene* scene) const noexcept;
+    void detachScene(FScene const* scene) noexcept;
 
     void setCullingCamera(FCamera* camera) noexcept { mCullingCamera = camera; }
     void setViewingCamera(FCamera* camera) noexcept { mViewingCamera = camera; }
@@ -590,8 +590,8 @@ private:
     backend::Handle<backend::HwBufferObject> mRenderableUbh;
     DescriptorSet mCommonRenderableDescriptorSet;
 
-    mutable FScene* mScene = nullptr;
-    mutable FScene::SceneCacheData* mCurrentViewCache = nullptr;
+    FScene* mScene = nullptr;
+    std::unique_ptr<FScene::SceneCacheData> mSceneCache;
     // The camera set by the user, used for culling and viewing
     FCamera* mCullingCamera = nullptr;
     // The optional (debug) camera, used only for viewing


### PR DESCRIPTION
Move FScene::SceneCacheData ownership to FView, simplifying the circular dependency and cleanup callbacks between FScene and FView.

Previously, FScene owned the SceneCacheData map keyed by FView, requiring complex and messy invalidateCache() and unregisterView() callbacks to tear down state. FView also had to use mutable qualifiers on mScene and mCurrentViewCache.

With this change:
- FView owns its SceneCacheData directly via a std::unique_ptr.
- FScene tracks referencing views using a simple std::vector<FView*> since the set of views rendering a scene is expected to be small.
- FView::detachScene() is introduced to allow FScene to safely nullify referencing views and clear their caches during scene destruction.
- Public View::setScene() documentation is updated to specify that scenes are automatically dissociated from the view when destroyed.
- mScene and mSceneCache are now const-correct (non-mutable).