### PR TITLE
TextureCache: Recycle texture resources when discarded from history

### DIFF
--- a/filament/src/TextureCache.cpp
+++ b/filament/src/TextureCache.cpp
@@ -140,6 +140,7 @@ TextureCache::TextureCache(std::shared_ptr<TextureCacheDisposer> disposer,
 }
 
 TextureCache::~TextureCache() noexcept {
+    mDisposer->removeTextureCache(this);
     assert_invariant(mTextureCache.empty());
 }
 
@@ -231,7 +232,7 @@ TextureHandle TextureCache::createTexture(StaticString const name,
             handle = swizzledHandle;
         }
     }
-    mDisposer->checkout(handle, key);
+    mDisposer->checkout(this, handle, key);
     return handle;
 }
 
@@ -247,10 +248,6 @@ void TextureCache::destroyTexture(TextureHandle const h) noexcept {
     } else {
         mBackend.destroyTexture(h);
     }
-}
-
-TextureCacheDisposerInterface& TextureCache::getDisposer() noexcept {
-    return *mDisposer;
 }
 
 void TextureCache::gc(bool const skippedFrame) noexcept {
@@ -372,15 +369,22 @@ void TextureCacheDisposer::terminate() noexcept {
 
 void TextureCacheDisposer::destroy(TextureHandle const handle) noexcept {
     if (handle) {
-        auto r = checkin(handle);
-        if (r.has_value()) {
+        auto it = mInUseTextures.find(handle);
+        if (it != mInUseTextures.end()) {
+            if (it->second.cache) {
+                it->second.cache->destroyTexture(handle);
+            } else {
+                mBackend.destroyTexture(handle);
+                mInUseTextures.erase(it);
+            }
+        } else {
             mBackend.destroyTexture(handle);
         }
     }
 }
 
-void TextureCacheDisposer::checkout(TextureHandle handle, TextureCache::TextureKey key) {
-    mInUseTextures.emplace(handle, key);
+void TextureCacheDisposer::checkout(TextureCacheInterface* cache, TextureHandle handle, TextureCache::TextureKey key) {
+    mInUseTextures.emplace(handle, InUseRecord{key, cache});
 }
 
 std::optional<TextureCache::TextureKey> TextureCacheDisposer::checkin(TextureHandle handle) {
@@ -390,10 +394,18 @@ std::optional<TextureCache::TextureKey> TextureCacheDisposer::checkin(TextureHan
     if (it == mInUseTextures.end()) {
         return std::nullopt;
     }
-    TextureKey const key = it->second;
+    TextureKey const key = it->second.key;
     // remove it from the in-use list
     mInUseTextures.erase(it);
     return key;
+}
+
+void TextureCacheDisposer::removeTextureCache(TextureCacheInterface* cache) noexcept {
+    for (auto& entry : mInUseTextures) {
+        if (entry.second.cache == cache) {
+            entry.second.cache = nullptr;
+        }
+    }
 }
 
 void TextureCache::Debugger::recordEviction(TextureKey const& key,

--- a/filament/src/TextureCache.h
+++ b/filament/src/TextureCache.h
@@ -52,6 +52,7 @@ class TextureCacheInterface;
 class TextureCacheDisposerInterface {
 public:
     virtual void destroy(backend::TextureHandle handle) noexcept = 0;
+    virtual void removeTextureCache(TextureCacheInterface* cache) noexcept = 0;
 protected:
     virtual ~TextureCacheDisposerInterface();
 };
@@ -77,8 +78,6 @@ public:
             backend::TextureUsage usage) noexcept = 0;
 
     virtual void destroyTexture(backend::TextureHandle h) noexcept = 0;
-
-    virtual TextureCacheDisposerInterface& getDisposer() noexcept = 0;
 
 protected:
     virtual ~TextureCacheInterface();
@@ -121,8 +120,6 @@ public:
             backend::TextureUsage usage) noexcept override;
 
     void destroyTexture(backend::TextureHandle h) noexcept override;
-
-    TextureCacheDisposerInterface& getDisposer() noexcept override;
 
     void gc(bool skippedFrame = false) noexcept;
 
@@ -281,13 +278,18 @@ public:
     ~TextureCacheDisposer() noexcept override;
     void terminate() noexcept;
     void destroy(backend::TextureHandle handle) noexcept override;
+    void removeTextureCache(TextureCacheInterface* cache) noexcept override;
 
 private:
     friend class TextureCache;
-    void checkout(backend::TextureHandle handle, TextureKey key);
+    void checkout(TextureCacheInterface* cache, backend::TextureHandle handle, TextureKey key);
     std::optional<TextureKey> checkin(backend::TextureHandle handle);
 
-    using InUseContainer = TextureCache::AssociativeContainer<backend::TextureHandle, TextureKey>;
+    struct InUseRecord {
+        TextureKey key;
+        TextureCacheInterface* cache;
+    };
+    using InUseContainer = TextureCache::AssociativeContainer<backend::TextureHandle, InUseRecord>;
     backend::DriverApi& mBackend;
     InUseContainer mInUseTextures;
 };

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include "TextureCache.h"
 
 #include "details/Texture.h"
 
+#include "fg/details/DependencyGraph.h"
 #include "fg/FrameGraph.h"
 #include "fg/FrameGraphId.h"
 #include "fg/FrameGraphResources.h"
 #include "fg/FrameGraphTexture.h"
-#include "fg/details/DependencyGraph.h"
 
-#include <private/backend/CommandStream.h>
 #include <private/backend/CircularBuffer.h>
+#include <private/backend/CommandStream.h>
 #include <private/backend/PlatformFactory.h>
 
 #include <backend/DriverEnums.h>
@@ -36,6 +34,8 @@
 
 #include <utils/Logger.h>
 #include <utils/StaticString.h>
+
+#include <gtest/gtest.h>
 
 #include <array>
 #include <cstdint>
@@ -47,6 +47,7 @@ class MockResourceAllocator final : public TextureCacheInterface {
     uint32_t handle = 0;
     struct MockDisposer final : public TextureCacheDisposerInterface {
         void destroy(TextureHandle) noexcept override {}
+        void removeTextureCache(TextureCacheInterface*) noexcept override {}
     } disposer;
 
 public:
@@ -74,10 +75,6 @@ public:
     }
 
     void destroyTexture(TextureHandle h) noexcept override {
-    }
-
-    TextureCacheDisposerInterface& getDisposer() noexcept override {
-        return disposer;
     }
 };
 


### PR DESCRIPTION
When TAA or SSR history textures were popped from the frame history FIFO, they were destroyed directly through the driver via the disposer, deleting them permanently from the GPU. By registering the active TextureCache with the TextureCacheDisposer, we redirect these discard events back to the cache, allowing them to be successfully recycled and reused next frame instead of being recreated from scratch.