### PR TITLE
Fix reorganize-headers root path discovery and test suite imports 

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -24,7 +24,6 @@
 #include <bluevk/BlueVK.h>
 
 #include <utils/compiler.h>
-
 #include <utils/CString.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Hash.h>

--- a/filament/backend/src/AndroidFrameCallback.h
+++ b/filament/backend/src/AndroidFrameCallback.h
@@ -19,7 +19,6 @@
 
 #include <utils/compiler.h>
 #include <utils/CountDownLatch.h>
-#include <utils/CountDownLatch.h>
 #include <utils/Mutex.h>
 
 #include <android/choreographer.h>

--- a/filament/backend/src/AndroidSwapChainHelper.cpp
+++ b/filament/backend/src/AndroidSwapChainHelper.cpp
@@ -22,13 +22,12 @@
 #include <utils/Logger.h>
 #include <utils/Mutex.h>
 
-#include <limits>
-#include <mutex>
-
 #include <android/native_window.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <mutex>
 
 namespace filament::backend {
 

--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -21,13 +21,10 @@
 #include <utils/Allocator.h>
 #include <utils/compiler.h>
 #include <utils/CString.h>
-#include <utils/CString.h>
 #include <utils/debug.h>
-#include <utils/Logger.h>
 #include <utils/Logger.h>
 #include <utils/Mutex.h>
 #include <utils/ostream.h>
-#include <utils/Panic.h>
 #include <utils/Panic.h>
 
 #include <algorithm>

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -16,8 +16,8 @@
 
 #include <backend/Platform.h>
 
-#include <utils/Mutex.h>
 #include <utils/compiler.h>
+#include <utils/Mutex.h>
 #include <utils/ostream.h>
 
 #include <atomic>

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -74,7 +74,6 @@
 #include <mutex>
 #include <new>
 #include <type_traits>
-#include <type_traits>
 #include <utility>
 #include <variant>
 

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -34,7 +34,6 @@
 #include <utils/Log.h>
 
 #include <algorithm>
-#include <algorithm>
 #include <array>
 #include <new>
 #include <string_view>

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -23,7 +23,6 @@
 #include "OpenGLDriver.h"
 
 #include <private/backend/BackendUtils.h>
-#include <private/backend/BackendUtils.h>
 
 #include <backend/DriverEnums.h>
 #include <backend/Program.h>
@@ -44,15 +43,12 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <atomic>
 #include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <iterator>
-#include <iterator>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <optional>
 #include <string_view>
 #include <thread>

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -28,12 +28,13 @@
 
 #include <bluevk/BlueVK.h>
 
+#include <utils/Mutex.h>
+
 #include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <utils/Mutex.h>
 #include <shared_mutex>
 #include <utility>
 #include <vector>

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -15,6 +15,9 @@
  */
 #include "webgpu/WebGPUDriver.h"
 
+#include "CommandStreamDispatcher.h"
+#include "DriverBase.h"
+#include "SystraceProfile.h"
 #include "WebGPUBufferObject.h"
 #include "WebGPUConstants.h"
 #include "WebGPUDescriptorSet.h"
@@ -33,25 +36,25 @@
 #include "WebGPUTextureHelpers.h"
 #include "WebGPUVertexBuffer.h"
 #include "WebGPUVertexBufferInfo.h"
-#include "webgpu/utils/AsyncTaskCounter.h"
-#include <backend/platforms/WebGPUPlatform.h>
 
-#include "CommandStreamDispatcher.h"
-#include "DriverBase.h"
-#include "SystraceProfile.h"
-#include "private/backend/Dispatcher.h"
+#include "webgpu/utils/AsyncTaskCounter.h"
+
+#include <private/backend/BackendUtils.h>
+#include <private/backend/Dispatcher.h>
+
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
+#include <backend/platforms/WebGPUPlatform.h>
 #include <backend/TargetBufferInfo.h>
-#include <private/backend/BackendUtils.h>
+
+#include <utils/compiler.h>
+#include <utils/CString.h>
+#include <utils/debug.h>
+#include <utils/Hash.h>
+#include <utils/ImmutableCString.h>
+#include <utils/Panic.h>
 
 #include <math/mat3.h>
-#include <utils/debug.h>
-#include <utils/CString.h>
-#include <utils/ImmutableCString.h>
-#include <utils/Hash.h>
-#include <utils/Panic.h>
-#include <utils/compiler.h>
 
 #include <webgpu/webgpu_cpp.h>
 

--- a/filament/backend/src/webgpu/WebGPUProgram.h
+++ b/filament/backend/src/webgpu/WebGPUProgram.h
@@ -17,9 +17,9 @@
 #ifndef TNT_FILAMENT_BACKEND_WEBGPUPROGRAM_H
 #define TNT_FILAMENT_BACKEND_WEBGPUPROGRAM_H
 
-#include "webgpu/WebGPUPushConstantDescription.h"
-
 #include "DriverBase.h"
+
+#include "webgpu/WebGPUPushConstantDescription.h"
 
 #include <webgpu/webgpu_cpp.h>
 

--- a/filament/backend/src/webgpu/WebGPUPushConstantDescription.h
+++ b/filament/backend/src/webgpu/WebGPUPushConstantDescription.h
@@ -17,8 +17,8 @@
 #ifndef TNT_FILAMENT_BACKEND_WEBGPUPUSHCONSTANTDESCRIPTION_H
 #define TNT_FILAMENT_BACKEND_WEBGPUPUSHCONSTANTDESCRIPTION_H
 
-#include <backend/Program.h>
 #include <backend/DriverEnums.h>
+#include <backend/Program.h>
 
 #include <utils/FixedCapacityVector.h>
 

--- a/filament/backend/src/webgpu/WebGPURenderTarget.cpp
+++ b/filament/backend/src/webgpu/WebGPURenderTarget.cpp
@@ -28,6 +28,7 @@
 #include <utils/BitmaskEnum.h>
 #include <utils/debug.h>
 #include <utils/Panic.h>
+
 #include <webgpu/webgpu_cpp.h>
 
 #include <algorithm>

--- a/filament/src/details/DebugRegistry.cpp
+++ b/filament/src/details/DebugRegistry.cpp
@@ -16,11 +16,11 @@
 
 #include "details/DebugRegistry.h"
 
+#include <utils/compiler.h>
 #include <utils/CString.h>
 #include <utils/Invocable.h>
 #include <utils/Logger.h>
 #include <utils/Panic.h>
-#include <utils/compiler.h>
 
 #include <math/vec2.h>
 #include <math/vec3.h>
@@ -32,13 +32,13 @@
 #include <string_view>
 #include <utility>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #ifdef __ANDROID__
 #include <sys/system_properties.h>
 #endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 using namespace filament::math;
 using namespace utils;

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -68,9 +68,7 @@
 #include <utils/Allocator.h>
 #include <utils/CallStack.h>
 #include <utils/compiler.h>
-#include <utils/compiler.h>
 #include <utils/CString.h>
-#include <utils/debug.h>
 #include <utils/debug.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Invocable.h>

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -34,9 +34,8 @@
 #include <utils/Slice.h>
 #include <utils/StructureOfArrays.h>
 
-#include <vector>
-
 #include <unordered_map>
+#include <vector>
 
 #include <stddef.h>
 

--- a/skills/cpp_header_inclusion/SKILL.md
+++ b/skills/cpp_header_inclusion/SKILL.md
@@ -36,7 +36,7 @@ Includes must be grouped and separated by **exactly one blank line** in the foll
 AI agents **must never manually sort includes** or guess target dependencies. Always run the repository's dynamic topological include formatter after modifying C++ files:
 
 ```bash
-./tools/reorganize_headers/run.py <file_or_directory>
+./tools/reorganize-headers/run.py <file_or_directory>
 ```
 
 *Note: The tool dynamically parses `CMakeLists.txt` files to topologically sort proprietary libraries and includes preprocessor safety checks to avoid breaking platform-conditional include guards.*

--- a/tools/reorganize-headers/run.py
+++ b/tools/reorganize-headers/run.py
@@ -361,7 +361,7 @@ def reorganize_file(filepath, dry_run=False):
 if __name__ == "__main__":
     # Setup workspace root and build the topological dependency list dynamically
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    workspace = os.path.dirname(script_dir)
+    workspace = os.path.dirname(os.path.dirname(script_dir))
     
     try:
         deps = analyze_dependencies(workspace)

--- a/tools/reorganize-headers/test.py
+++ b/tools/reorganize-headers/test.py
@@ -4,12 +4,11 @@ import sys
 import unittest
 import tempfile
 
-# Ensure the tools/ directory is in the Python path to import reorganize_headers
+# Ensure the script directory is in the Python path to import run as reorganize_headers
 script_dir = os.path.dirname(os.path.abspath(__file__))
-workspace_root = os.path.dirname(os.path.dirname(script_dir))
-sys.path.insert(0, os.path.join(workspace_root, "tools"))
+sys.path.insert(0, script_dir)
 
-import reorganize_headers
+import run as reorganize_headers
 
 class TestHeaderReorganizer(unittest.TestCase):
 


### PR DESCRIPTION
When reorganize_headers.py was moved to tools/reorganize-headers/run.py,
the workspace root calculation evaluated to tools/ rather than the
repository root. This caused analyze_dependencies() to miss internal
libraries (treating math and utils as third-party dependencies).

- Updated run.py to correctly resolve the repository root.
- Corrected test.py import path to load run.py as reorganize_headers.
- Marked test.py executable.
- Updated SKILL.md documentation with the correct script path.
