### PR TITLE
docs: add code style and commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,9 @@ AI agents **must** consult and strictly follow the corresponding skill files for
 *   [skills/filament_build_clean/SKILL.md](skills/filament_build_clean/SKILL.md): Clean commands, debug desktop compilation, and release desktop compilation protocols.
 *   [skills/filament_desktop_testing/SKILL.md](skills/filament_desktop_testing/SKILL.md): Instructions for executing and filtering tests and benchmarks on desktop.
 *   [skills/filament_android_development/SKILL.md](skills/filament_android_development/SKILL.md): Android development, compilation with Perfetto, binary deployment, shell invocation, and formatted benchmarking.
+
+### 3. Code Style
+*   **Code Formatting**: Code formatting in Filament code (not `third_party/`) should follow the formatting convention in [CODE_STYLE.md](CODE_STYLE.md).
+
+### 4. Commit Conventions
+*   **Commit Messages**: Commit messages should be formatted with the 50/72 rule: 50 is the maximum number of characters of the commit title, and 72 is the maximum character length of the commit body.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -19,6 +19,7 @@ The guiding principles of the filament code style and code formatting can be res
 - spaces around operators and after `;`
 - class access modifiers are not indented
 - last line of `.cpp` or `.h` file must be an empty line
+- there should be no trailing white spaces on any line
 
 ```c++
 for (int i = 0; i < max; i++) {

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add dedicated code style and commit message formatting sections (50/72 rule) to AGENTS.md to enforce consistent AI assistant behavior. Also create a GEMINI.md symlink pointing to AGENTS.md for compatibility with tools that default to GEMINI.md.