### PR TITLE
Fix memory leak in vulkan fence pool

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -658,7 +658,11 @@ void PlatformEGLAndroid::destroySync(Sync* sync) noexcept {
             eglDestroySyncKHR(getEglDisplay(), eglSync.sync);
         }
     }
-    delete sync;
+
+    // Cast to SyncEGLAndroid, as Platform::Sync does not have a virtual
+    // destructor, and therefore, it is undefined behavior to delete
+    // the base class.
+    delete static_cast<SyncEGLAndroid*>(sync);
 }
 
 void PlatformEGLAndroid::attach(Stream* stream, intptr_t const tname) noexcept {

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -792,7 +792,10 @@ Platform::Sync* VulkanPlatform::createSync(
 void VulkanPlatform::destroySync(Platform::Sync* sync) noexcept {
     // Sync must be a VulkanSync*, since it was created by VulkanPlatform's
     // createSync object.
-    delete sync;
+    // Note: the cast is required, as Platform::Sync does not have a virtual
+    // destructor, and therefore it is undefined behavior to delete the base
+    // class.
+    delete static_cast<VulkanSync*>(sync);
 }
 
 VkInstance VulkanPlatform::getInstance() const noexcept {


### PR DESCRIPTION
Right now, if you create a sync, the sync's fenceStatus object will live forever. Platform::Sync does not have a virtual destructor, so calling delete on the base class is undefined behavior. We decided not to use virtual destructors for that class to avoid a vtable, so we can simply use a cast with the delete in these cases.