### PR TITLE
backend: Protect Platform::Foo dtor against UB

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -48,10 +48,25 @@ class Driver;
  */
 class UTILS_PUBLIC Platform {
 public:
-    struct SwapChain {};
-    struct Fence {};
-    struct Stream {};
-    struct Sync {};
+    struct SwapChain {
+    protected:
+        ~SwapChain() = default;
+    };
+
+    struct Fence {
+    protected:
+        ~Fence() = default;
+    };
+
+    struct Stream {
+    protected:
+        ~Stream() = default;
+    };
+
+    struct Sync {
+    protected:
+        ~Sync() = default;
+    };
 
     using SyncCallback = void(*)(Sync* UTILS_NONNULL sync, void* UTILS_NULLABLE userData);
 

--- a/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/include/backend/platforms/PlatformEGLAndroid.h
@@ -109,6 +109,8 @@ protected:
     // OpenGLPlatform Interface
 
     struct SyncEGLAndroid : public Sync {
+        explicit SyncEGLAndroid(EGLSyncKHR sync) noexcept
+            : sync(sync) {}
         EGLSyncKHR sync;
     };
 

--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -480,7 +480,9 @@ public:
     }
 
 protected:
-    struct VulkanSync : public Platform::Sync {
+    struct VulkanSync : public Sync {
+        explicit VulkanSync(std::shared_ptr<VulkanCmdFence> fence) noexcept
+            : fenceStatus(std::move(fence)) {}
         std::shared_ptr<VulkanCmdFence> fenceStatus;
     };
 

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -154,13 +154,10 @@ FenceStatus OpenGLPlatform::waitFence(
 }
 
 Platform::Sync* OpenGLPlatform::createSync() noexcept {
-    return new Platform::Sync();
+    return nullptr;
 }
 
 void OpenGLPlatform::destroySync(Platform::Sync* sync) noexcept {
-    // sync must be a Platform::Sync, since it was created by this platform
-    // object.
-    delete sync;
 }
 
 Platform::Stream* OpenGLPlatform::createStream(

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -623,7 +623,7 @@ Platform::Sync* PlatformEGLAndroid::createSync() noexcept {
     } else {
         LOG(WARNING) << "Native fences not supported on this device.";
     }
-    return new(std::nothrow) SyncEGLAndroid{ .sync = sync };
+    return new(std::nothrow) SyncEGLAndroid(sync);
 }
 
 bool PlatformEGLAndroid::convertSyncToFd(Sync* sync, int* fd) noexcept {

--- a/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatform.cpp
@@ -786,10 +786,10 @@ SwapChainPtr VulkanPlatform::createSwapChain(void* nativeWindow, uint64_t flags,
 
 Platform::Sync* VulkanPlatform::createSync(
         std::shared_ptr<VulkanCmdFence> fenceStatus) noexcept {
-    return new VulkanSync{.fenceStatus = fenceStatus};
+    return new(std::nothrow) VulkanSync(std::move(fenceStatus));
 }
 
-void VulkanPlatform::destroySync(Platform::Sync* sync) noexcept {
+void VulkanPlatform::destroySync(Sync* sync) noexcept {
     // Sync must be a VulkanSync*, since it was created by VulkanPlatform's
     // createSync object.
     // Note: the cast is required, as Platform::Sync does not have a virtual


### PR DESCRIPTION
Making Platform objects's destructor protected prevents accidental raw deletion through non-virtual base pointers.

Because protected base destructors disable aggregate initialization in derived classes, an explicit constructor is added to VulkanSync and PlatformEGLAndroid to enable direct construction in createSync.