### PR TITLE
fix(filaflat): bounds-check material-chunk offset in getDictionaryOccurrences (OOB read)

### DIFF
--- a/libs/filaflat/include/filaflat/Unflattener.h
+++ b/libs/filaflat/include/filaflat/Unflattener.h
@@ -52,6 +52,9 @@ public:
     bool willOverflow(size_t const size) const noexcept {
         // Evaluate the remaining valid buffer size instead of using pointer arithmetic,
         // preventing arbitrary integer size overflows from pointer wrapping.
+        if (UTILS_UNLIKELY(mCursor > mEnd)) {
+            return true;   // cursor was constructed/advanced past the end
+        }
         return size > size_t(mEnd - mCursor);
     }
 

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -387,7 +387,13 @@ size_t MaterialChunk::getDictionaryOccurrences(std::vector<uint32_t>& outOccurre
         ShaderStage stage;
         decodeKey(chunk.first, &model, &variant, &stage);
 
-        Unflattener unflattener(mBase + chunk.second, mContainer.getChunkRange(mMaterialTag).second);
+        auto const matRange = mContainer.getChunkRange(mMaterialTag);
+        // chunk.second (offsetValue) is attacker-controlled; reject offsets that would place
+        // the cursor outside the material chunk before forming the pointer (parity with setCursor()).
+        if (chunk.second >= size_t(matRange.second - mBase)) {
+            continue;
+        }
+        Unflattener unflattener(mBase + chunk.second, matRange.second);
 
         uint32_t shaderSize = 0;
         if (!unflattener.read(&shaderSize)) {


### PR DESCRIPTION
## Summary

`MaterialChunk::getDictionaryOccurrences()` builds an `Unflattener` at `mBase + chunk.second`, where `chunk.second` is a `uint32_t` offset read from the material package in `initialize()` and stored **without bounds-checking**. Because the `Unflattener(src, end)` constructor never enforces `src <= end`, and `willOverflow()` computes `size > size_t(mEnd - mCursor)` — which underflows to a huge value when `mCursor > mEnd` — an out-of-range offset defeats the bounds check and reads out of bounds.

This is reachable from **`matinfo`** (`tools/matinfo/src/main.cpp:653`, the `--print-dic*` flags) when it parses an untrusted `.filamat`. The runtime `getTextShader()` path is **unaffected** — it routes the same offset through the clamping `Unflattener::setCursor()`.

Tracked privately as **GHSA-v4hr-2wf7-fhpj**.

## Reproduction

A crafted 91-byte `.filamat` makes `matinfo`'s dictionary-occurrence pass read at `mBase + 0xFFFFFFBF` → out-of-bounds read (SEGV under ASan). The input was found with an AddressSanitizer + libFuzzer harness driving the real parse path (`ChunkContainer::parse → MaterialChunk::initialize → getDictionaryOccurrences`); it is deterministic and minimal.

## Fix

1. **`getDictionaryOccurrences()`** — reject offsets that fall outside the material chunk *before* forming the pointer, mirroring the existing `setCursor()` guard.
2. **`Unflattener::willOverflow()`** — treat `mCursor > mEnd` as overflow (defense-in-depth: protects every caller, not only this one).

Verified: the original build SEGVs on the crashing input; the patched build parses it cleanly and exits 0. No behavior change for valid material packages — only out-of-range offsets are skipped, matching how the runtime path already handles them.

## Notes

Found via automated fuzzing tooling; happy to provide the harness or the regression input on request.
