### PR TITLE
Add getVisibleRenderableCount() to View

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-#include <jni.h>
+#include "common/CallbackUtils.h"
 
 #include <filament/Color.h>
 #include <filament/View.h>
 #include <filament/Viewport.h>
 
-#include "common/CallbackUtils.h"
-#include <common/JniUtils.h>
+#include <private/backend/VirtualMachineEnv.h>
 
-#include "private/backend/VirtualMachineEnv.h"
+#include <common/JniUtils.h>
+#include <jni.h>
 
 using namespace filament;
 using namespace filament::android;
@@ -600,6 +600,14 @@ Java_com_google_android_filament_View_nGetFogEntity(JNIEnv *env, jclass clazz,
         jlong nativeView) {
     View *view = (View *) nativeView;
     return (jint)view->getFogEntity().getId();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_google_android_filament_View_nGetVisibleRenderableCount(JNIEnv *env, jclass clazz,
+        jlong nativeView) {
+    View *view = (View *) nativeView;
+    return (jint)view->getVisibleRenderableCount();
 }
 
 extern "C"

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1357,6 +1357,19 @@ public class View {
     }
 
     /**
+     * Returns the most recent number of visible renderables for the current Scene as calculated
+     * the last time Renderer::render() was called with this View and Scene.
+     *
+     * Returns -1 if the cache is invalid (e.g. before the first render call, or if the scene
+     * was detached).
+     *
+     * @return the number of visible renderables, or -1 if no value is available.
+     */
+    public int getVisibleRenderableCount() {
+        return nGetVisibleRenderableCount(getNativeObject());
+    }
+
+    /**
      * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view
      * keeps a history of previous frame renders associated with the Renderer the view was last
      * used with. When switching Renderer, it may be necessary to clear that history by calling
@@ -1440,6 +1453,7 @@ public class View {
     private static native void nSetMaterialGlobal(long nativeView, int index, float x, float y, float z, float w);
     private static native void nGetMaterialGlobal(long nativeView, int index, float[] out);
     private static native int nGetFogEntity(long nativeView);
+    private static native int nGetVisibleRenderableCount(long nativeView);
     private static native void nClearFrameHistory(long nativeView, long nativeEngine);
 
     /**

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -992,6 +992,17 @@ public:
      */
     utils::Entity getFogEntity() const noexcept;
 
+    /**
+     * Returns the most recent number of visible renderables for the current Scene as calculated
+     * the last time Renderer::render() was called with this View and Scene.
+     *
+     * Returns -1 if the cache is invalid (e.g. before the first render call, or if the scene
+     * was detached).
+     *
+     * @return the number of visible renderables, or -1 if no value is available.
+     */
+    int32_t getVisibleRenderableCount() const noexcept;
+
 
     /**
      * When certain temporal features are used (e.g.: TAA or Screen-space reflections), the view

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -360,6 +360,10 @@ utils::Entity View::getFogEntity() const noexcept {
     return downcast(this)->getFogEntity();
 }
 
+int32_t View::getVisibleRenderableCount() const noexcept {
+    return downcast(this)->getVisibleRenderableCount();
+}
+
 void View::clearFrameHistory(Engine& engine) noexcept {
     downcast(this)->clearFrameHistory(downcast(engine));
 }

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -24,9 +24,9 @@
 #include "FrameInfo.h"
 #include "Froxelizer.h"
 #include "RenderPrimitive.h"
-#include "TextureCache.h"
 #include "ShadowMap.h"
 #include "ShadowMapManager.h"
+#include "TextureCache.h"
 
 #include "components/TransformManager.h"
 
@@ -34,24 +34,27 @@
 #include "details/IndirectLight.h"
 #include "details/InstanceBuffer.h"
 #include "details/MorphTargetBuffer.h"
-#include "details/RenderTarget.h"
 #include "details/Renderer.h"
+#include "details/RenderTarget.h"
 #include "details/Scene.h"
 #include "details/Skybox.h"
 
-#include <backend/DriverEnums.h>
-#include <backend/Handle.h>
+#if FILAMENT_ENABLE_FGVIEWER
+#include "fg/FgviewerManager.h"
+#endif
+#include "fg/FrameGraphId.h"
+#include "fg/FrameGraphTexture.h"
 
-#include <fg/FrameGraphTexture.h>
-#include <fg/FrameGraphId.h>
+#include <private/filament/EngineEnums.h>
+#include <private/filament/UibStructs.h>
 
+#include <filament/DebugRegistry.h>
 #include <filament/Exposure.h>
 #include <filament/Frustum.h>
-#include <filament/DebugRegistry.h>
 #include <filament/View.h>
 
-#include <private/filament/UibStructs.h>
-#include <private/filament/EngineEnums.h>
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
 
 #include <private/utils/Tracing.h>
 
@@ -65,16 +68,14 @@
 
 #include <math/mat3.h>
 #include <math/mat4.h>
+#include <math/scalar.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
-#include <math/scalar.h>
 
-#include <assert.h>
-
-#include <array>
 #include <algorithm>
-#include <cmath>
+#include <array>
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -82,11 +83,9 @@
 #include <ratio>
 #include <utility>
 
-using namespace utils;
+#include <assert.h>
 
-#if FILAMENT_ENABLE_FGVIEWER
-#include "fg/FgviewerManager.h"
-#endif
+using namespace utils;
 
 namespace filament {
 
@@ -202,29 +201,31 @@ FView::FView(FEngine& engine)
 
 FView::~FView() noexcept = default;
 
+void FView::invalidateSceneCache() noexcept {
+    if (!mScene) {
+        mSceneCache.reset();
+    }
+    mVisibleRenderableCount = -1;
+}
+
 void FView::setScene(FScene* scene) {
     if (mScene != scene) {
         if (mScene) {
             mScene->unregisterView(this);
         }
         mScene = scene;
+        invalidateSceneCache();
         if (scene) {
             scene->registerView(this);
             if (!mSceneCache) {
                 mSceneCache = std::make_unique<FScene::SceneCacheData>();
             }
-        } else {
-            mSceneCache.reset();
         }
     }
 }
 
 void FView::terminate(FEngine& engine) {
-    if (mScene) {
-        mScene->unregisterView(this);
-        mScene = nullptr;
-    }
-    mSceneCache.reset();
+    setScene(nullptr);
 
     // Here we would cleanly free resources we've allocated, or we own (currently none).
 
@@ -880,6 +881,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         // convert to indices
         mVisibleRenderables = { 0, uint32_t(beginDirCastersOnly - beginRenderables) };
+        mVisibleRenderableCount = int32_t(mVisibleRenderables.size());
 
         mVisibleDirectionalShadowCasters = {
                 uint32_t(beginDirCasters - beginRenderables),
@@ -1702,7 +1704,7 @@ bool FView::hasContactShadows() const noexcept {
 void FView::detachScene(FScene const* scene) noexcept {
     if (mScene == scene) {
         mScene = nullptr;
-        mSceneCache.reset();
+        invalidateSceneCache();
     }
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -445,6 +445,10 @@ public:
         return mVisibleRenderables;
     }
 
+    int32_t getVisibleRenderableCount() const noexcept {
+        return mVisibleRenderableCount;
+    }
+
     Range const& getVisibleDirectionalShadowCasters() const noexcept {
         return mVisibleDirectionalShadowCasters;
     }
@@ -554,6 +558,8 @@ private:
         PickingQueryResult result{};
     };
 
+    void invalidateSceneCache() noexcept;
+
     void prepareVisibleRenderables(utils::JobSystem& js,
             Frustum const& frustum, FScene::RenderableSoa& renderableData) const noexcept;
 
@@ -662,6 +668,7 @@ private:
     Range mVisibleRenderables;
     Range mVisibleDirectionalShadowCasters;
     Range mSpotLightShadowCasters;
+    int32_t mVisibleRenderableCount = -1;
     uint32_t mRenderableUBOElementCount = 0;
     mutable bool mHasDirectionalLighting = false;
     mutable bool mHasDynamicLighting = false;

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include <filament/Engine.h>
 #include <filament/Renderer.h>
-#include <filament/Skybox.h>
 #include <filament/Scene.h>
+#include <filament/Skybox.h>
 #include <filament/View.h>
 #include <filament/Viewport.h>
 
+#include <backend/PixelBufferDescriptor.h>
+
 #include <utils/EntityManager.h>
 
-#include <backend/PixelBufferDescriptor.h>
+#include <gtest/gtest.h>
 
 using namespace filament;
 using namespace backend;
@@ -131,4 +131,29 @@ TEST_F(RenderingTest, ClearGreen) {
         callbackCalled = true;
     });
     EXPECT_TRUE(callbackCalled);
+}
+
+TEST_F(RenderingTest, VisibleRenderableCount) {
+    EXPECT_EQ(mView->getVisibleRenderableCount(), -1);
+
+    View* viewB = mEngine->createView();
+    viewB->setViewport({0, 0, 16, 16});
+    viewB->setScene(mScene);
+    viewB->setCamera(mCamera);
+    viewB->setPostProcessingEnabled(false);
+
+    EXPECT_EQ(viewB->getVisibleRenderableCount(), -1);
+
+    bool callbackCalled = false;
+    runTest([this, viewB, &callbackCalled](uint8_t const*, uint32_t, uint32_t) {
+        EXPECT_EQ(mView->getVisibleRenderableCount(), 1);
+        EXPECT_EQ(viewB->getVisibleRenderableCount(), -1);
+        callbackCalled = true;
+    });
+    EXPECT_TRUE(callbackCalled);
+
+    mView->setScene(nullptr);
+    EXPECT_EQ(mView->getVisibleRenderableCount(), -1);
+
+    mEngine->destroy(viewB);
 }

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -32,6 +32,24 @@
  * this explicit rather than mysterious.
  */
 
+#include <viewer/AutomationEngine.h>
+#include <viewer/AutomationSpec.h>
+#include <viewer/Settings.h>
+#include <viewer/ViewerGui.h>
+
+#include <ktxreader/Ktx1Reader.h>
+#include <ktxreader/Ktx2Reader.h>
+
+#include <gltfio/Animator.h>
+#include <gltfio/AssetLoader.h>
+#include <gltfio/FilamentAsset.h>
+#include <gltfio/FilamentInstance.h>
+#include <gltfio/MaterialProvider.h>
+#include <gltfio/ResourceLoader.h>
+#include <gltfio/TextureProvider.h>
+
+#include <geometry/SurfaceOrientation.h>
+
 #include <filameshio/MeshReader.h>
 
 #include <filament/BufferObject.h>
@@ -56,42 +74,22 @@
 #include <filament/View.h>
 #include <filament/Viewport.h>
 
-#include <geometry/SurfaceOrientation.h>
-
-#include <viewer/AutomationEngine.h>
-#include <viewer/AutomationSpec.h>
-#include <viewer/Settings.h>
-#include <viewer/ViewerGui.h>
-
 #include <camutils/Bookmark.h>
 #include <camutils/Manipulator.h>
 
-#include <gltfio/Animator.h>
-#include <gltfio/AssetLoader.h>
-#include <gltfio/FilamentAsset.h>
-#include <gltfio/FilamentInstance.h>
-#include <gltfio/MaterialProvider.h>
-#include <gltfio/ResourceLoader.h>
-#include <gltfio/TextureProvider.h>
+#include <utils/EntityManager.h>
+#include <utils/Log.h>
+#include <utils/NameComponentManager.h>
 
-#include <materials/uberarchive.h>
-
-#include <ktxreader/Ktx1Reader.h>
-#include <ktxreader/Ktx2Reader.h>
-
+#include <math/mat4.h>
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
-#include <math/mat4.h>
-
-#include <utils/EntityManager.h>
-#include <utils/NameComponentManager.h>
-#include <utils/Log.h>
-
-#include <stb_image.h>
 
 #include <emscripten.h>
 #include <emscripten/bind.h>
+#include <materials/uberarchive.h>
+#include <stb_image.h>
 
 // Avoid warnings for deprecated Filament APIs.
 #pragma clang diagnostic push
@@ -772,6 +770,7 @@ class_<View>("View")
     .function("getAntiAliasing", &View::getAntiAliasing)
     .function("setSampleCount", &View::setSampleCount)
     .function("getSampleCount", &View::getSampleCount)
+    .function("getVisibleRenderableCount", &View::getVisibleRenderableCount)
     .function("setRenderTarget", EMBIND_LAMBDA(void, (View* self, RenderTarget* renderTarget), {
         self->setRenderTarget(renderTarget);
     }), allow_raw_pointers())


### PR DESCRIPTION
Introduce getVisibleRenderableCount() to View, returning the frame-local number of visible renderables as calculated during frustum culling and partitioning in Renderer::render().

Returns -1 as a sentinel when no value is available (e.g., before rendering or after detaching the scene). Provides full multi-view independence by storing the counter directly in FView.

Includes complete Doxygen documentation, Javadoc with zero-allocation JNI wrappers, Emscripten Embind JavaScript bindings, and validation via GTest.