### PR TITLE
utils: use k prefix for tribool enum values

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-#include <jni.h>
-
-#include <exception>
+#include "common/CallbackUtils.h"
+#include "common/JniUtils.h"
 
 #include <filament/Camera.h>
 #include <filament/ColorGrading.h>
 #include <filament/Engine.h>
+#include <filament/Material.h>
 #include <filament/MorphTargetBuffer.h>
+#include <filament/View.h>
 
 #include <utils/Entity.h>
 #include <utils/EntityManager.h>
 #include <utils/tribool.h>
 
-#include <filament/Material.h>
-#include <filament/View.h>
+#include <jni.h>
 
-#include "common/CallbackUtils.h"
-#include "common/JniUtils.h"
+#include <exception>
 
 using namespace filament;
 using namespace utils;
@@ -499,8 +498,8 @@ Java_com_google_android_filament_Engine_nCompile(JNIEnv *env, jclass,
             engine->compile(
                     (backend::CompilerPriorityQueue) priority,
                     material, view,
-                    (utils::tribool::value_t) shadowReceiver,
-                    (utils::tribool::value_t) skinning,
+                    (utils::tribool::Value) shadowReceiver,
+                    (utils::tribool::Value) skinning,
                     jniCallback->getHandler(), [jniCallback](Material*){
                         JniCallback::postToJavaAndDestroy(jniCallback);
                     });

--- a/libs/utils/include/utils/tribool.h
+++ b/libs/utils/include/utils/tribool.h
@@ -21,43 +21,57 @@
 
 namespace utils {
 
+/**
+ * A 3-state boolean type representing true, false, or indeterminate.
+ *
+ * This class provides standard logical operators (!, &&, ||) and observer methods
+ * that correctly implement Kleene three-valued logic.
+ */
 class tribool {
 public:
-    enum value_t : uint8_t {
-        False = 0,
-        True = 1,
-        Indeterminate = 2
+    enum class Value : uint8_t {
+        kFalse = 0,
+        kTrue = 1,
+        kIndeterminate = 2
     };
 
-    constexpr tribool() noexcept : mValue(Indeterminate) {}
-    constexpr tribool(bool v) noexcept : mValue(v ? True : False) {}
-    constexpr tribool(value_t v) noexcept : mValue(v) {}
+    using value_t = Value;
 
-    constexpr bool is_true() const noexcept { return mValue == True; }
-    constexpr bool is_false() const noexcept { return mValue == False; }
-    constexpr bool is_indeterminate() const noexcept { return mValue == Indeterminate; }
+    static constexpr Value kFalse = Value::kFalse;
+    static constexpr Value kTrue = Value::kTrue;
+    static constexpr Value kIndeterminate = Value::kIndeterminate;
+
+    constexpr tribool() noexcept : mValue(Value::kIndeterminate) {}
+    constexpr tribool(bool const v) noexcept : mValue(v ? Value::kTrue : Value::kFalse) {}
+    constexpr tribool(Value const v) noexcept : mValue(v) {}
+
+    constexpr bool is_true() const noexcept { return mValue == Value::kTrue; }
+    constexpr bool is_false() const noexcept { return mValue == Value::kFalse; }
+    constexpr bool is_indeterminate() const noexcept { return mValue == Value::kIndeterminate; }
 
     constexpr tribool operator!() const noexcept {
-        return mValue == Indeterminate ? Indeterminate : (mValue == True ? False : True);
+        return mValue == Value::kIndeterminate
+                       ? Value::kIndeterminate
+                       : (mValue == Value::kTrue ? Value::kFalse : Value::kTrue);
     }
 
-    constexpr tribool operator&&(tribool rhs) const noexcept {
-        if (mValue == False || rhs.mValue == False) return False;
-        if (mValue == True) return rhs;
-        return Indeterminate;
+    constexpr tribool operator&&(tribool const rhs) const noexcept {
+        if (mValue == Value::kFalse || rhs.mValue == Value::kFalse) return Value::kFalse;
+        if (mValue == Value::kTrue) return rhs;
+        return Value::kIndeterminate;
     }
 
-    constexpr tribool operator||(tribool rhs) const noexcept {
-        if (mValue == True || rhs.mValue == True) return True;
-        if (mValue == False) return rhs;
-        return Indeterminate;
+    constexpr tribool operator||(tribool const rhs) const noexcept {
+        if (mValue == Value::kTrue || rhs.mValue == Value::kTrue) return Value::kTrue;
+        if (mValue == Value::kFalse) return rhs;
+        return Value::kIndeterminate;
     }
 
-    constexpr bool operator==(tribool rhs) const noexcept { return mValue == rhs.mValue; }
-    constexpr bool operator!=(tribool rhs) const noexcept { return mValue != rhs.mValue; }
+    constexpr bool operator==(tribool const rhs) const noexcept { return mValue == rhs.mValue; }
+    constexpr bool operator!=(tribool const rhs) const noexcept { return mValue != rhs.mValue; }
 
 private:
-    value_t mValue;
+    Value mValue;
 };
 
 } // namespace utils

--- a/libs/utils/test/test_tribool.cpp
+++ b/libs/utils/test/test_tribool.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include <utils/tribool.h>
+
+#include <gtest/gtest.h>
 
 using namespace utils;
 
@@ -36,26 +36,26 @@ TEST(TriboolTest, ConstructorsAndObservers) {
     EXPECT_FALSE(t3.is_true());
     EXPECT_FALSE(t3.is_indeterminate());
 
-    tribool t4(tribool::True);
+    tribool t4(tribool::kTrue);
     EXPECT_TRUE(t4.is_true());
 
-    tribool t5(tribool::False);
+    tribool t5(tribool::kFalse);
     EXPECT_TRUE(t5.is_false());
 
-    tribool t6(tribool::Indeterminate);
+    tribool t6(tribool::kIndeterminate);
     EXPECT_TRUE(t6.is_indeterminate());
 }
 
 TEST(TriboolTest, LogicalNot) {
     EXPECT_TRUE((!tribool(true)).is_false());
     EXPECT_TRUE((!tribool(false)).is_true());
-    EXPECT_TRUE((!tribool(tribool::Indeterminate)).is_indeterminate());
+    EXPECT_TRUE((!tribool(tribool::kIndeterminate)).is_indeterminate());
 }
 
 TEST(TriboolTest, LogicalAnd) {
     tribool T(true);
     tribool F(false);
-    tribool I(tribool::Indeterminate);
+    tribool I(tribool::kIndeterminate);
 
     EXPECT_TRUE((T && T).is_true());
     EXPECT_TRUE((T && F).is_false());
@@ -74,7 +74,7 @@ TEST(TriboolTest, LogicalAnd) {
 TEST(TriboolTest, LogicalOr) {
     tribool T(true);
     tribool F(false);
-    tribool I(tribool::Indeterminate);
+    tribool I(tribool::kIndeterminate);
 
     EXPECT_TRUE((T || T).is_true());
     EXPECT_TRUE((T || F).is_true());
@@ -93,11 +93,11 @@ TEST(TriboolTest, LogicalOr) {
 TEST(TriboolTest, Equality) {
     tribool T(true);
     tribool F(false);
-    tribool I(tribool::Indeterminate);
+    tribool I(tribool::kIndeterminate);
 
     EXPECT_TRUE(T == tribool(true));
     EXPECT_TRUE(F == tribool(false));
-    EXPECT_TRUE(I == tribool(tribool::Indeterminate));
+    EXPECT_TRUE(I == tribool(tribool::kIndeterminate));
 
     EXPECT_TRUE(T != F);
     EXPECT_TRUE(T != I);


### PR DESCRIPTION
System headers such as <X11/Xlib.h> define legacy preprocessor macros for True and False. When included alongside <utils/tribool.h>, these macros rewrite the enum identifiers and cause compilation failures.

This change renames the value_t enum members in utils::tribool from False, True, and Indeterminate to kFalse, kTrue, and kIndeterminate. It also adds a static constexpr helper `indeterminate` for convenience.