### PR TITLE
engine: guard colored penumbra divisor against divide-by-zero

### DIFF
--- a/shaders/src/surface_shading_model_cloth.fs
+++ b/shaders/src/surface_shading_model_cloth.fs
@@ -49,7 +49,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
     color *= light.colorIntensity.rgb * (light.colorIntensity.w * light.attenuation * occlusion);
 #else
 #if defined(HAS_COLORED_PENUMBRA)
-    vec3 penumbraColor = min(vec3(1.0 / PI), Fd / (2.0 * (1.0 - pixel.diffuseColor)));
+    vec3 penumbraColor = min(vec3(1.0 / PI), Fd / max(2.0 * (1.0 - pixel.diffuseColor), vec3(FLT_EPS)));
     Fd = mix(penumbraColor, Fd, pow4(occlusion));
 #endif
 

--- a/shaders/src/surface_shading_model_standard.fs
+++ b/shaders/src/surface_shading_model_standard.fs
@@ -119,7 +119,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
 
 #if defined(HAS_COLORED_PENUMBRA)
     // Saturate the diffuse color to simulate subsurface scattering
-    vec3 penumbraColor = min(vec3(1.0 / PI), Fd / (2.0 * (1.0 - pixel.diffuseColor)));
+    vec3 penumbraColor = min(vec3(1.0 / PI), Fd / max(2.0 * (1.0 - pixel.diffuseColor), vec3(FLT_EPS)));
     Fd = mix(penumbraColor, Fd, pow4(occlusion));
 #endif
 


### PR DESCRIPTION
The colored penumbra term in the standard and cloth surface shading models divides by 2.0 * (1.0 - diffuseColor), which is zero for white/near-white diffuse colors and yields Inf/NaN. min(1.0 / PI, NaN) is undefined in GLSL: most drivers return the finite operand, but ANGLE-D3D11 (Chromium/Firefox on Windows, including WebGL) propagates the NaN and renders the affected fragments black in shadow penumbra.

Clamp the divisor with a small epsilon. The division only fed the min(1.0 / PI, ...) energy-conserving cap, so results are unchanged for valid inputs and simply reach the cap as diffuseColor approaches 1.