### PR TITLE
utils: Improve Slice compatibility with std::span

### DIFF
--- a/libs/utils/include/utils/Slice.h
+++ b/libs/utils/include/utils/Slice.h
@@ -21,13 +21,31 @@
 #include <utils/Hash.h>
 
 #include <algorithm>
+#include <array>
+#include <iterator>
 #include <type_traits>
 #include <utility>
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 
 namespace utils {
+
+template<typename T>
+class Slice;
+
+constexpr size_t dynamic_extent = static_cast<size_t>(-1);
+
+namespace details {
+
+template<typename T>
+struct is_slice : std::false_type {};
+
+template<typename T>
+struct is_slice<Slice<T>> : std::true_type {};
+
+} // namespace details
 
 /** A fixed-size slice of a container.
  *
@@ -39,25 +57,44 @@ public:
     using element_type = T;
     using value_type = std::remove_cv_t<T>;
     using size_type = size_t;
+    using difference_type = ptrdiff_t;
     using pointer = T*;
     using const_pointer = const T*;
     using reference = T&;
     using const_reference = const T&;
     using iterator = T*;
     using const_iterator = T const*;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static constexpr size_type extent = dynamic_extent;
 
     Slice() = default;
-    Slice(iterator begin, iterator end) noexcept : mBegin(begin), mEnd(end) {}
+    Slice(iterator const begin, iterator const end) noexcept : mBegin(begin), mEnd(end) {}
     Slice(pointer begin, size_type count) noexcept : mBegin(begin), mEnd(begin + count) {}
 
-    Slice(Slice<T> const& rhs) : mBegin(rhs.begin()), mEnd(rhs.end()) {}
+    template<size_t N>
+    Slice(element_type (&arr)[N]) noexcept : mBegin(arr), mEnd(arr + N) {}
+
+    template<typename Cont>
+    using IsConvertibleToSlice = std::enable_if_t<
+            !details::is_slice<std::remove_cv_t<std::remove_reference_t<Cont>>>::value &&
+            !std::is_array_v<std::remove_cv_t<std::remove_reference_t<Cont>>> &&
+            std::is_convertible_v<decltype(std::declval<Cont&>().data()), pointer> &&
+            std::is_convertible_v<decltype(std::declval<Cont&>().size()), size_type>>;
+
+    template<typename Cont,
+            typename = IsConvertibleToSlice<Cont>>
+    Slice(Cont&& cont) noexcept : Slice(cont.data(), cont.size()) {}
+
+    Slice(Slice const& rhs) : mBegin(rhs.begin()), mEnd(rhs.end()) {}
 
     // If Slice<T> is Slice<const U>, define coercive copy constructor from Slice<U>.
     template<typename U = T>
     Slice(std::enable_if_t<std::is_const_v<U>, Slice<value_type> const&> rhs)
         : mBegin(rhs.begin()), mEnd(rhs.end()) {}
 
-    Slice& operator=(Slice<T> const& rhs) noexcept {
+    Slice& operator=(Slice const& rhs) noexcept {
         mBegin = rhs.begin();
         mEnd = rhs.end();
         return *this;
@@ -82,7 +119,7 @@ public:
         mEnd = end;
     }
 
-    void swap(Slice<T>& rhs) noexcept {
+    void swap(Slice& rhs) noexcept {
         std::swap(mBegin, rhs.mBegin);
         std::swap(mEnd, rhs.mEnd);
     }
@@ -106,9 +143,30 @@ public:
         return *this == Slice<const value_type>(rhs);
     }
 
+    // subviews
+    Slice first(size_type count) const noexcept {
+        assert(count <= size());
+        return Slice(data(), count);
+    }
+
+    Slice last(size_type count) const noexcept {
+        assert(count <= size());
+        return Slice(data() + size() - count, count);
+    }
+
+    Slice subspan(size_type offset, size_type count = dynamic_extent) const noexcept {
+        assert(offset <= size());
+        if (count == dynamic_extent) {
+            count = size() - offset;
+        }
+        assert(count <= size() - offset);
+        return Slice(data() + offset, count);
+    }
+
     // size
     size_t size() const noexcept { return mEnd - mBegin; }
     size_t sizeInBytes() const noexcept { return size() * sizeof(T); }
+    size_type size_bytes() const noexcept { return this->sizeInBytes(); }
     bool empty() const noexcept { return size() == 0; }
 
     // iterators
@@ -117,13 +175,18 @@ public:
     iterator end() const noexcept { return mEnd; }
     const_iterator cend() const noexcept { return this->end(); }
 
+    reverse_iterator rbegin() const noexcept { return reverse_iterator(this->end()); }
+    const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(this->end()); }
+    reverse_iterator rend() const noexcept { return reverse_iterator(this->begin()); }
+    const_reverse_iterator crend() const noexcept { return const_reverse_iterator(this->begin()); }
+
     // data access
     reference operator[](size_t n) const noexcept {
         assert(n < size());
         return mBegin[n];
     }
 
-    reference at(size_t n) const noexcept {
+    reference at(size_t const n) const noexcept {
         return operator[](n);
     }
 
@@ -146,7 +209,7 @@ public:
         Hash hasher;
         size_t seed = size();
         for (auto const& it : *this) {
-            utils::hash::combine_fast(seed, hasher(it));
+            hash::combine_fast(seed, hasher(it));
         }
         return seed;
     }
@@ -156,15 +219,29 @@ protected:
     iterator mEnd = nullptr;
 };
 
+template<typename T>
+Slice<const uint8_t> as_bytes(Slice<T> s) noexcept {
+    return Slice<const uint8_t>(reinterpret_cast<const uint8_t*>(s.data()), s.sizeInBytes());
+}
+
+template<typename T, typename = std::enable_if_t<!std::is_const_v<T>>>
+Slice<uint8_t> as_writable_bytes(Slice<T> s) noexcept {
+    return Slice<uint8_t>(reinterpret_cast<uint8_t*>(s.data()), s.sizeInBytes());
+}
+
+#if __cplusplus >= 201703L
+template<typename Cont>
+Slice(Cont&) -> Slice<typename Cont::value_type>;
+
+template<typename Cont>
+Slice(Cont const&) -> Slice<const typename Cont::value_type>;
+#endif
+
 } // namespace utils
 
-namespace std {
-
 template<typename T>
-struct hash<utils::Slice<T>> {
-    inline size_t operator()(utils::Slice<T> const& lhs) const noexcept { return lhs.hash(); }
-};
-
-} // namespace std
+struct std::hash<utils::Slice<T>> {
+    size_t operator()(utils::Slice<T> const& lhs) const noexcept { return lhs.hash(); }
+}; // namespace std
 
 #endif // TNT_UTILS_SLICE_H

--- a/libs/utils/test/test_Slice.cpp
+++ b/libs/utils/test/test_Slice.cpp
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+#include <utils/FixedCapacityVector.h>
+#include <utils/Slice.h>
+
 #include <gtest/gtest.h>
 
-#include <utils/Slice.h>
-#include <utils/FixedCapacityVector.h>
+#include <array>
+#include <vector>
 
 using namespace utils;
 
@@ -81,3 +84,87 @@ TEST(SliceTest, CanCompareConstWithMutable) {
 
     EXPECT_TRUE(slice1.hash() == slice2.hash());
 }
+
+TEST(SliceTest, ConstructFromCArray) {
+    int arr[] = {10, 20, 30};
+    Slice<int> s = arr;
+    EXPECT_EQ(s.size(), 3);
+    EXPECT_EQ(s[0], 10);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[2], 30);
+}
+
+TEST(SliceTest, ConstructFromStdArray) {
+    std::array<int, 3> arr = {10, 20, 30};
+    Slice<int> s = arr;
+    EXPECT_EQ(s.size(), 3);
+    EXPECT_EQ(s[0], 10);
+    EXPECT_EQ(s[1], 20);
+    EXPECT_EQ(s[2], 30);
+
+    Slice<const int> sConst = arr;
+    EXPECT_EQ(sConst.size(), 3);
+}
+
+TEST(SliceTest, ConstructFromContainer) {
+    std::vector<int> vec = {1, 2, 3, 4};
+    Slice<int> s = vec;
+    EXPECT_EQ(s.size(), 4);
+    EXPECT_EQ(s[3], 4);
+}
+
+TEST(SliceTest, Subviews) {
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+    Slice<int> s = vec;
+
+    Slice<int> sFirst = s.first(2);
+    EXPECT_EQ(sFirst.size(), 2);
+    EXPECT_EQ(sFirst[0], 1);
+    EXPECT_EQ(sFirst[1], 2);
+
+    Slice<int> sLast = s.last(2);
+    EXPECT_EQ(sLast.size(), 2);
+    EXPECT_EQ(sLast[0], 4);
+    EXPECT_EQ(sLast[1], 5);
+
+    Slice<int> sSub = s.subspan(1, 3);
+    EXPECT_EQ(sSub.size(), 3);
+    EXPECT_EQ(sSub[0], 2);
+    EXPECT_EQ(sSub[1], 3);
+    EXPECT_EQ(sSub[2], 4);
+}
+
+TEST(SliceTest, ReverseIterators) {
+    std::vector<int> vec = {1, 2, 3};
+    Slice<int> s = vec;
+
+    std::vector<int> reversed;
+    for (auto it = s.rbegin(); it != s.rend(); ++it) {
+        reversed.push_back(*it);
+    }
+    EXPECT_EQ(reversed.size(), 3);
+    EXPECT_EQ(reversed[0], 3);
+    EXPECT_EQ(reversed[1], 2);
+    EXPECT_EQ(reversed[2], 1);
+}
+
+TEST(SliceTest, AsBytes) {
+    int val = 0x12345678;
+    Slice<int> s(&val, 1);
+
+    Slice<const uint8_t> bytes = as_bytes(s);
+    EXPECT_EQ(bytes.size(), sizeof(int));
+    EXPECT_EQ(bytes.size_bytes(), sizeof(int));
+
+    Slice<uint8_t> writableBytes = as_writable_bytes(s);
+    EXPECT_EQ(writableBytes.size(), sizeof(int));
+    writableBytes[0] = 0xAA;
+}
+
+#if __cplusplus >= 201703L
+TEST(SliceTest, DeductionGuides) {
+    std::vector<int> vec = {5, 6, 7};
+    Slice s = vec;
+    EXPECT_EQ(s.size(), 3);
+}
+#endif


### PR DESCRIPTION
Enhance utils::Slice by adding missing std::span features and APIs, improving interoperability across the engine.

Key improvements:
- Add non-explicit constructors from C-arrays, std::array, and any contiguous container (like std::vector or FixedCapacityVector).
- Implement subview operations: first(), last(), and subspan().
- Add standard type aliases (difference_type, reverse_iterator) and reverse iterator accessors (rbegin(), rend(), etc.).
- Provide as_bytes() and as_writable_bytes() non-member helpers alongside a size_bytes() alias.
- Add C++17 deduction guides for container ranges.

Fully verified with new unit tests in test_Slice.cpp.