### PR TITLE
Fix unbound types error in JS shadowOptions

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -60,11 +60,14 @@ Filament.shadowOptions = function(overrides) {
         shadowNearHint: 1.0,
         shadowFarHint: 100.0,
         stable: false,
+        lispsm: true,
         polygonOffsetConstant: 0.5,
         polygonOffsetSlope: 2.0,
         screenSpaceContactShadows: false,
         stepCount: 8,
-        maxShadowDistance: 0.3
+        maxShadowDistance: 0.3,
+        shadowBulbRadius: 0.02,
+        transform: [0, 0, 0, 1]
     };
     return Object.assign(options, overrides);
 };

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -297,6 +297,12 @@ value_array<filament::math::quat>("quat")
     .element(&filament::math::quat::z)
     .element(&filament::math::quat::w);
 
+value_array<filament::math::quatf>("quatf")
+    .element(&filament::math::quatf::x)
+    .element(&filament::math::quatf::y)
+    .element(&filament::math::quatf::z)
+    .element(&filament::math::quatf::w);
+
 value_array<Viewport>("Viewport")
     .element(&Viewport::left)
     .element(&Viewport::bottom)


### PR DESCRIPTION
Bind filament::math::quatf in Embind and add missing default fields

(lispsm, shadowBulbRadius, transform) to Filament.shadowOptions in

extensions.js so runtime resolution succeeds.

Fixes: #10043