### PR TITLE
gltfio: bound createSkins inverse bind matrix copies to bufferView

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -247,31 +247,39 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
                 continue;
             }
 
-            cgltf_size bufferSize = 0;
-            cgltf_size totalOffset = 0;
-            uint8_t* bytes = nullptr;
-            uint8_t* srcBuffer = nullptr;
+            if (srcMatrices->type != cgltf_type_mat4 ||
+                    srcMatrices->component_type != cgltf_component_type_r_32f) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, unsupported accessor type.";
+                continue;
+            }
+            if (srcMatrices->count < srcSkin.joints_count) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor count is too small.";
+                continue;
+            }
 
+            const cgltf_size requiredBytes = srcSkin.joints_count * sizeof(mat4f);
+            const cgltf_size viewSize = srcMatrices->buffer_view->size;
+            const cgltf_size offsetInView = srcMatrices->offset;
+            if (offsetInView > viewSize || requiredBytes > viewSize - offsetInView) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer view bounds.";
+                continue;
+            }
+
+            uint8_t* srcBuffer = nullptr;
             if (srcMatrices->buffer_view->has_meshopt_compression) {
                 if (!srcMatrices->buffer_view->data) {
                     LOG(WARNING) << "Cannot copy inverse bind matrices, compressed buffer data is null.";
                     continue;
                 }
-                bufferSize = srcMatrices->buffer_view->size;
-                totalOffset = srcMatrices->offset;
-                bytes = (uint8_t*) srcMatrices->buffer_view->data;
-                srcBuffer = bytes + totalOffset;
+                srcBuffer = (uint8_t*) srcMatrices->buffer_view->data + offsetInView;
             } else {
-                bufferSize = srcMatrices->buffer_view->buffer->size;
-                totalOffset = srcMatrices->offset + srcMatrices->buffer_view->offset;
-                bytes = (uint8_t*) srcMatrices->buffer_view->buffer->data;
-                srcBuffer = bytes + totalOffset;
-            }
-
-            const cgltf_size requiredBytes = srcSkin.joints_count * sizeof(mat4f);
-            if (totalOffset > bufferSize || requiredBytes > bufferSize - totalOffset) {
-                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer bounds.";
-                continue;
+                const cgltf_size bufferSize = srcMatrices->buffer_view->buffer->size;
+                const cgltf_size totalOffset = srcMatrices->buffer_view->offset + offsetInView;
+                if (totalOffset > bufferSize || requiredBytes > bufferSize - totalOffset) {
+                    LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer bounds.";
+                    continue;
+                }
+                srcBuffer = (uint8_t*) srcMatrices->buffer_view->buffer->data + totalOffset;
             }
 
             memcpy((uint8_t*) inverseBindMatrices.data(), (const void*) srcBuffer, requiredBytes);

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gltfio/AssetLoader.h>
 #include <gltfio/FilamentAsset.h>
+#include <gltfio/FilamentInstance.h>
 #include <gltfio/math.h>
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
@@ -31,6 +32,7 @@
 
 #include <utils/EntityManager.h>
 #include <utils/NameComponentManager.h>
+#include <utils/Panic.h>
 #include <utils/Path.h>
 
 #include <math/mathfwd.h>
@@ -38,8 +40,10 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <unordered_map>
+#include <unistd.h>
 
 using namespace filament;
 using namespace backend;
@@ -287,6 +291,73 @@ TEST_F(glTFIOTest, DamagedHelmetWebpMaterials) {
     EXPECT_TRUE(mData[DAMAGED_HELMET_WEBP_GLB]->mWebpDecoder == nullptr);
     EXPECT_EQ(mEngine->getTextureCount(), 3);    
 #endif
+}
+
+TEST_F(glTFIOTest, SkipsInverseBindMatricesOutsideBufferView) {
+    namespace fs = std::filesystem;
+    const fs::path root = fs::temp_directory_path() / ("gltfio_m7_" + std::to_string(getpid()));
+    const fs::path attackerDir = root / "attacker";
+    fs::create_directories(attackerDir);
+
+    const fs::path secretPath = root / "secret.bin";
+    {
+        std::ofstream out(secretPath, std::ios::binary);
+        ASSERT_TRUE(out.good());
+        const float identity[16] = {
+                1.0f, 0.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 1.0f, 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f,
+        };
+        const float secret[16] = {
+                1337.0f, 1338.0f, 1339.0f, 1340.0f,
+                1341.0f, 1342.0f, 1343.0f, 1344.0f,
+                1345.0f, 1346.0f, 1347.0f, 1348.0f,
+                1349.0f, 1350.0f, 1351.0f, 1352.0f,
+        };
+        out.write(reinterpret_cast<const char*>(identity), sizeof(identity));
+        out.write(reinterpret_cast<const char*>(secret), sizeof(secret));
+    }
+
+    const fs::path gltfPath = attackerDir / "evil.gltf";
+    {
+        std::ofstream out(gltfPath);
+        ASSERT_TRUE(out.good());
+        out << R"({"asset":{"version":"2.0"},"scene":0,"scenes":[{"nodes":[0]}],)"
+               R"("nodes":[{"name":"root","skin":0,"children":[1,2]},{"name":"joint0"},{"name":"joint1"}],)"
+               R"("skins":[{"joints":[1,2],"inverseBindMatrices":0}],)"
+               R"("buffers":[{"uri":"../secret.bin","byteLength":128}],)"
+               R"("bufferViews":[{"buffer":0,"byteOffset":0,"byteLength":64}],)"
+               R"("accessors":[{"bufferView":0,"byteOffset":0,"componentType":5126,"count":1,"type":"MAT4"}]})";
+    }
+
+    std::ifstream in(gltfPath, std::ifstream::binary | std::ifstream::ate);
+    ASSERT_TRUE(in.good());
+    const auto contentSize = in.tellg();
+    in.seekg(0, std::ifstream::beg);
+    std::vector<uint8_t> buffer(static_cast<size_t>(contentSize));
+    ASSERT_TRUE(in.read(reinterpret_cast<char*>(buffer.data()), contentSize));
+
+    AssetLoader* assetLoader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    ResourceLoader* resourceLoader = new ResourceLoader({
+            mEngine, gltfPath.string().c_str(), false,
+    });
+
+    FilamentAsset* asset = assetLoader->createAsset(buffer.data(), buffer.size());
+    ASSERT_NE(asset, nullptr);
+    EXPECT_TRUE(resourceLoader->loadResources(asset));
+
+    FilamentInstance* instance = asset->getInstance();
+    ASSERT_NE(instance, nullptr);
+    EXPECT_EQ(instance->getSkinCount(), 1u);
+    EXPECT_EQ(instance->getJointCountAt(0), 2u);
+    EXPECT_THROW((void) instance->getInverseBindMatricesAt(0), utils::PreconditionPanic);
+
+    assetLoader->destroyAsset(asset);
+    delete resourceLoader;
+    AssetLoader::destroy(&assetLoader);
+
+    fs::remove_all(root);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- validate inverse bind matrix copies against the declared accessor count and `bufferView` span in `ResourceLoader::createSkins()`
- keep the whole-buffer bounds check for uncompressed buffers as a second line of defense
- add a regression test for malformed external-buffer glTF skins that previously disclosed bytes outside the declared view

## Testing

- `cmake --build out/cmake-debug --target test_gltfio`
- `./out/cmake-debug/libs/gltfio/test_gltfio`
- `./out/cmake-debug/libs/gltfio/test_gltfio --gtest_filter=glTFIOTest.SkipsInverseBindMatricesOutsideBufferView`

Issue: [issu.ee/523503237](https://issuetracker.google.com/issues/523503237)