### PR TITLE
gltfio/uberz: handle archive decompression failures safely

### DIFF
--- a/libs/gltfio/src/ArchiveCache.cpp
+++ b/libs/gltfio/src/ArchiveCache.cpp
@@ -16,24 +16,24 @@
 
 #include "ArchiveCache.h"
 
-#include <filament/Material.h>
-
 #include <uberz/ArchiveEnums.h>
 #include <uberz/ReadableArchive.h>
 
+#include <filament/Material.h>
+
 #include <utils/compiler.h>
 #include <utils/CString.h>
+#include <utils/debug.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
-#include <utils/Panic.h>
-#include <utils/debug.h>
 #include <utils/memalign.h>
 #include <utils/ostream.h>
+#include <utils/Panic.h>
 
 #include <zstd.h>
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 using namespace utils;

--- a/libs/gltfio/src/ArchiveCache.cpp
+++ b/libs/gltfio/src/ArchiveCache.cpp
@@ -73,7 +73,19 @@ void ArchiveCache::load(const void* archiveData, uint64_t archiveByteCount) {
         return;
     }
     uint64_t* basePointer = (uint64_t*) utils::aligned_alloc(decompSize, 8);
-    ZSTD_decompress(basePointer, decompSize, archiveData, archiveByteCount);
+    if (UTILS_UNLIKELY(basePointer == nullptr)) {
+        utils::slog.e << "ArchiveCache: failed to allocate decompression buffer ("
+                      << decompSize << " bytes)" << utils::io::endl;
+        return;
+    }
+    const size_t decompressed = ZSTD_decompress(basePointer, decompSize, archiveData,
+            archiveByteCount);
+    if (UTILS_UNLIKELY(ZSTD_isError(decompressed))) {
+        utils::slog.e << "ArchiveCache: decompression failed: " << ZSTD_getErrorName(decompressed)
+                      << utils::io::endl;
+        utils::aligned_free(basePointer);
+        return;
+    }
     mArchive = (ReadableArchive*) basePointer;
     if (!convertOffsetsToPointers(mArchive, decompSize)) {
         utils::aligned_free(basePointer);

--- a/libs/uberz/src/ReadableArchive.cpp
+++ b/libs/uberz/src/ReadableArchive.cpp
@@ -67,6 +67,10 @@ const char* checkedCString(ReadableArchive* archive, size_t archiveSize,
 } // namespace
 
 bool convertOffsetsToPointers(ReadableArchive* archive, size_t archiveSize) {
+    if (!archive) {
+        LOG(ERROR) << "Uberz archive pointer is null";
+        return false;
+    }
     if (archiveSize < sizeof(ReadableArchive)) {
         LOG(ERROR) << "Uberz archive header is truncated";
         return false;

--- a/libs/uberz/tests/test_ReadableArchive.cpp
+++ b/libs/uberz/tests/test_ReadableArchive.cpp
@@ -29,6 +29,10 @@ using filament::uberz::convertOffsetsToPointers;
 
 namespace {
 
+TEST(ReadableArchiveTest, RejectsNullArchivePointer) {
+    EXPECT_FALSE(convertOffsetsToPointers(nullptr, 64));
+}
+
 TEST(ReadableArchiveTest, RejectsSpecsOffsetOutsideBuffer) {
     alignas(8) std::array<uint8_t, 64> storage {};
     auto* archive = reinterpret_cast<ReadableArchive*>(storage.data());

--- a/tools/uberz/src/main.cpp
+++ b/tools/uberz/src/main.cpp
@@ -189,7 +189,17 @@ int main(int argc, char* argv[]) {
             PANIC_POSTCONDITION("Decompression error.");
         }
         uint64_t* basePointer = (uint64_t*) utils::aligned_alloc(decompSize, 8);
-        ZSTD_decompress(basePointer, decompSize, archiveData, archiveSize);
+        if (UTILS_UNLIKELY(basePointer == nullptr)) {
+            cerr << "Failed to allocate decompression buffer" << endl;
+            exit(1);
+        }
+        const size_t decompressed = ZSTD_decompress(basePointer, decompSize, archiveData,
+                archiveSize);
+        if (UTILS_UNLIKELY(ZSTD_isError(decompressed))) {
+            utils::aligned_free(basePointer);
+            cerr << "Decompression failed: " << ZSTD_getErrorName(decompressed) << endl;
+            exit(1);
+        }
         existingArchive = (ReadableArchive*) basePointer;
         if (!convertOffsetsToPointers(existingArchive, decompSize)) {
             cerr << "Failed to parse existing uberz archive" << endl;


### PR DESCRIPTION
## Summary

Hi! This PR adds a few safety checks around uberz archive loading:

- `ArchiveCache::load()` now verifies `aligned_alloc` and `ZSTD_decompress` before calling `convertOffsetsToPointers()`
- The same checks are applied in the `uberz` tool's append path
- `convertOffsetsToPointers()` gets a small null-pointer guard, plus a regression test

The goal is to avoid a crash when a `.uberz` archive declares a large decompressed size (up to the 256 MiB limit) but allocation fails under memory pressure.

## Test plan

- [x] `./out/cmake-debug/libs/uberz/test_uberzlib --gtest_filter=ReadableArchiveTest.RejectsNullArchivePointer`
- [x] `./out/cmake-debug/libs/uberz/test_uberzlib --gtest_filter='ReadableArchiveTest.*'`
- [x] Incremental desktop debug build of `gltfio`, `uberz`, and `test_uberzlib`

Thanks for taking a look!

Issue: https://issuetracker.google.com/issues/523622762