### PR TITLE
fix(gltfio): reject oversized 8-bit index accessors

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -284,7 +284,29 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
     }
 }
 
-inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
+static bool indexAccessorFitsBuffer(cgltf_accessor const* accessor, uint32_t bindingSize) {
+    if (!accessor->buffer_view) {
+        return false;
+    }
+    cgltf_size capacity = 0;
+    cgltf_size totalOffset = 0;
+    if (accessor->buffer_view->has_meshopt_compression) {
+        capacity = accessor->buffer_view->size;
+        totalOffset = accessor->offset;
+    } else {
+        if (!accessor->buffer_view->buffer) {
+            return false;
+        }
+        capacity = accessor->buffer_view->buffer->size;
+        totalOffset = accessor->buffer_view->offset + accessor->offset;
+    }
+    if (totalOffset >= capacity) {
+        return false;
+    }
+    return bindingSize <= capacity - totalOffset;
+}
+
+inline bool uploadBuffers(FFilamentAsset* asset, Engine& engine,
         UriDataCacheHandle uriDataCache) {
     const cgltf_accessor* kGenerateTangents = &asset->mGenerateTangents;
     const cgltf_accessor* kGenerateNormals = &asset->mGenerateNormals;
@@ -502,6 +524,11 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                 continue;
             }
 
+            if (!indexAccessorFitsBuffer(accessor, size)) {
+                LOG(ERROR) << "Index accessor size exceeds buffer capacity.";
+                return false;
+            }
+
             if (accessor->component_type == cgltf_component_type_r_8u) {
                 if (size_t(size) > std::numeric_limits<size_t>::max() / 2) {
                     LOG(WARNING) << "Index buffer size would overflow on conversion, skipping.";
@@ -597,6 +624,7 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                     slot.morphTargetOffset);
         }
     }
+    return true;
 }
 
 } // anonymous namespace
@@ -711,7 +739,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     cgltf_data const* gltf = asset->mSourceAsset->hierarchy;
 
     if (!isExtendedAlgo) {
-        utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache);
+        if (!utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache)) {
+            return false;
+        }
 
         // Decompress Draco meshes early on, which allows us to exploit subsequent processing such
         // as tangent generation.
@@ -728,7 +758,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
             return false;
         }
 
-        uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache);
+        if (!uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache)) {
+            return false;
+        }
 
         // Compute surface orientation quaternions if necessary. This is similar to sparse data in
         // that we need to generate the contents of a GPU buffer by processing one or more CPU

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -39,7 +39,9 @@
 
 #include <cstdint>
 #include <fstream>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 using namespace filament;
 using namespace backend;
@@ -287,6 +289,117 @@ TEST_F(glTFIOTest, DamagedHelmetWebpMaterials) {
     EXPECT_TRUE(mData[DAMAGED_HELMET_WEBP_GLB]->mWebpDecoder == nullptr);
     EXPECT_EQ(mEngine->getTextureCount(), 3);    
 #endif
+}
+
+namespace {
+
+static void appendU32LE(std::vector<uint8_t>& dst, uint32_t value) {
+    dst.push_back(uint8_t(value & 0xffu));
+    dst.push_back(uint8_t((value >> 8u) & 0xffu));
+    dst.push_back(uint8_t((value >> 16u) & 0xffu));
+    dst.push_back(uint8_t((value >> 24u) & 0xffu));
+}
+
+static std::vector<uint8_t> makeMalformedEightBitIndexGlb(uint32_t indexCount) {
+    std::string json = std::string(R"({
+  "asset": { "version": "2.0" },
+  "extensionsUsed": ["KHR_materials_unlit"],
+  "buffers": [
+    { "byteLength": 13 }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 12 },
+    { "buffer": 0, "byteOffset": 12, "byteLength": 1 }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 1,
+      "type": "VEC3",
+      "min": [0, 0, 0],
+      "max": [0, 0, 0]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5121,
+      "count": )") +
+            std::to_string(indexCount) +
+            R"(,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": { "POSITION": 0 },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    { "mesh": 0 }
+  ],
+  "scenes": [
+    { "nodes": [0] }
+  ],
+  "scene": 0
+})";
+
+    while ((json.size() % 4u) != 0u) {
+        json.push_back(' ');
+    }
+
+    std::vector<uint8_t> bin(13, 0);
+    while ((bin.size() % 4u) != 0u) {
+        bin.push_back(0);
+    }
+
+    const uint32_t jsonSize = uint32_t(json.size());
+    const uint32_t binSize = uint32_t(bin.size());
+    const uint32_t totalSize = 12u + 8u + jsonSize + 8u + binSize;
+
+    std::vector<uint8_t> glb;
+    glb.reserve(totalSize);
+
+    appendU32LE(glb, 0x46546c67u);
+    appendU32LE(glb, 2u);
+    appendU32LE(glb, totalSize);
+    appendU32LE(glb, jsonSize);
+    appendU32LE(glb, 0x4e4f534au);
+    glb.insert(glb.end(), json.begin(), json.end());
+    appendU32LE(glb, binSize);
+    appendU32LE(glb, 0x004e4942u);
+    glb.insert(glb.end(), bin.begin(), bin.end());
+
+    return glb;
+}
+
+} // namespace
+
+TEST_F(glTFIOTest, RejectsOversizedEightBitIndexAccessor) {
+    AssetLoader* loader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    ASSERT_NE(loader, nullptr);
+
+    std::vector<uint8_t> glb = makeMalformedEightBitIndexGlb(100000000u);
+    FilamentAsset* asset = loader->createAsset(glb.data(), uint32_t(glb.size()));
+    ASSERT_NE(asset, nullptr);
+
+    ResourceLoader resourceLoader({ mEngine, ".", false });
+    EXPECT_FALSE(resourceLoader.loadResources(asset));
+
+    loader->destroyAsset(asset);
+    AssetLoader::destroy(&loader);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

This fixes an out-of-bounds read when loading glTF assets with 8-bit index accessors whose declared size exceeds the backing buffer.

- Return `false` from `loadResources()` when `loadCgltfBuffers()` fails (including debug `cgltf_validate` failures)
- Reject index accessors whose binding size is larger than the available buffer bytes before 8-bit index expansion
- Add a regression test with a crafted GLB that previously triggered the crash

## Test plan

- [x] `./out/cmake-debug/libs/gltfio/test_gltfio` (all 6 tests pass)
- [x] New test `RejectsOversizedEightBitIndexAccessor` confirms `loadResources()` returns `false` without crashing


Made with [Cursor](https://cursor.com)

Issue: [issu.ee/523642979](https://issuetracker.google.com/issues/523642979)