### PR TITLE
Gate filament material instance in-use check with feature flag

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1391,24 +1391,24 @@ bool FEngine::destroy(const FMaterialInstance* p) {
 
     // Check that the material instance we're destroying is not in use in the RenderableManager
     // To do this, we currently need to inspect all render primitives in the RenderableManager
-    EntityManager const& em = mEntityManager;
-    FRenderableManager const& rcm = mRenderableManager;
-    Entity const* entities = rcm.getEntities();
-    size_t const count = rcm.getComponentCount();
-    for (size_t i = 0; i < count; i++) {
-        Entity const entity = entities[i];
-        RenderableManager::Instance const ri = rcm.getInstance(entity);
-        size_t const primitiveCount = rcm.getPrimitiveCount(ri, 0);
-        for (size_t j = 0; j < primitiveCount; j++) {
-            auto const* const mi = rcm.getMaterialInstanceAt(ri, 0, j);
-            if (UTILS_VERY_UNLIKELY(mi == p)) {
-                // if we have a match, we check again with the liveness of the entity
-                FILAMENT_FLAG_GUARDED_CHECK_PRECONDITION(
-                        ((mi != p) || !em.isAlive(entity)),
-                        features.engine.debug.assert_material_instance_in_use)
-                        << "destroying MaterialInstance \"" << mi->getName()
-                        << "\" which is still in use by Renderable (entity=" << entity.getId()
-                        << ", instance=" << ri.asValue() << ", index=" << j << ")";
+    if (features.engine.debug.assert_material_instance_in_use) {
+        EntityManager const& em = mEntityManager;
+        FRenderableManager const& rcm = mRenderableManager;
+        Entity const* entities = rcm.getEntities();
+        size_t const count = rcm.getComponentCount();
+        for (size_t i = 0; i < count; i++) {
+            Entity const entity = entities[i];
+            RenderableManager::Instance const ri = rcm.getInstance(entity);
+            size_t const primitiveCount = rcm.getPrimitiveCount(ri, 0);
+            for (size_t j = 0; j < primitiveCount; j++) {
+                auto const* const mi = rcm.getMaterialInstanceAt(ri, 0, j);
+                if (UTILS_VERY_UNLIKELY(mi == p)) {
+                    // if we have a match, we check again with the liveness of the entity
+                    FILAMENT_CHECK_PRECONDITION(mi != p || !em.isAlive(entity))
+                            << "destroying MaterialInstance \"" << mi->getName()
+                            << "\" which is still in use by Renderable (entity=" << entity.getId()
+                            << ", instance=" << ri.asValue() << ", index=" << j << ")";
+                }
             }
         }
     }


### PR DESCRIPTION
Avoid running the expensive loop that scans all renderables to check if a material instance is in use when the assertion is disabled. This improves performance during material destruction.

Fixes #10124