### PR TITLE
gltfio: Always validate glTF buffers and check load status

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -711,7 +711,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     cgltf_data const* gltf = asset->mSourceAsset->hierarchy;
 
     if (!isExtendedAlgo) {
-        utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache);
+        if (!utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache)) {
+            return false;
+        }
 
         // Decompress Draco meshes early on, which allows us to exploit subsequent processing such
         // as tangent generation.

--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -286,12 +286,10 @@ bool loadCgltfBuffers(cgltf_data const* gltf, char const* gltfPath,
 
     FILAMENT_TRACING_NAME_END(FILAMENT_TRACING_CATEGORY_GLTFIO);
 
-#ifndef NDEBUG
     if (cgltf_validate((cgltf_data*) gltf) != cgltf_result_success) {
         slog.e << "Failed cgltf validation." << io::endl;
         return false;
     }
-#endif
     return true;
 }
 


### PR DESCRIPTION
### Summary
This PR fixes a heap out-of-bounds read vulnerability in the glTF loader by ensuring structural validation always runs and is correctly handled.

### Details
1. **Enable Validation in Release Builds:** In `libs/gltfio/src/Utility.cpp`, the validator wrapper `cgltf_validate` was compiled out under release configurations (`#ifndef NDEBUG`). This allowed malformed glTF models specifying invalid accessor elements/bounds to bypass verification, triggering out-of-bounds heap memory access during unpacking (e.g., in `TangentsJob::run` via `cgltf_accessor_unpack_floats`). I removed the debug guard to ensure validation is always performed.
2. **Handle Validation Failure:** In `libs/gltfio/src/ResourceLoader.cpp`, I updated the call to `loadCgltfBuffers` to check its return status and return `false` (aborted load) if validation or buffer loading fails.

Fixes #10134
Security Report Reference: https://issuetracker.google.com/issues/525730913
