### PR TITLE
gltfio: fix header organization in test and extended loader

### DIFF
--- a/libs/gltfio/src/extended/AssetLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.cpp
@@ -16,11 +16,12 @@
 
 #include "AssetLoaderExtended.h"
 
+#include "TangentsJobExtended.h"
+
 #include "../DracoCache.h"
 #include "../FFilamentAsset.h"
 #include "../GltfEnums.h"
 #include "../Utility.h"
-#include "TangentsJobExtended.h"
 
 #include <filament/BufferObject.h>
 

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -35,9 +35,8 @@
 
 #include <math/mathfwd.h>
 
-#include <meshoptimizer.h>
-
 #include <gtest/gtest.h>
+#include <meshoptimizer.h>
 
 #include <cstdint>
 #include <fstream>


### PR DESCRIPTION
## Summary
- Run reorganize-headers on files flagged by test-code-correctness CI in #10123

## Test plan
- [x] `bash test/code-correctness/check-headers.sh libs/gltfio/test/gltfio_test.cpp libs/gltfio/src/extended/AssetLoaderExtended.cpp`

Made with [Cursor](https://cursor.com)