### PR TITLE
gltfio: import security and stability fixes

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -17,12 +17,12 @@
 #ifndef GLTFIO_ASSETLOADER_H
 #define GLTFIO_ASSETLOADER_H
 
-#include <filament/Engine.h>
-#include <filament/Material.h>
-
 #include <gltfio/FilamentAsset.h>
 #include <gltfio/FilamentInstance.h>
 #include <gltfio/MaterialProvider.h>
+
+#include <filament/Engine.h>
+#include <filament/Material.h>
 
 #include <utils/compiler.h>
 

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -17,10 +17,10 @@
 #ifndef GLTFIO_FILAMENTASSET_H
 #define GLTFIO_FILAMENTASSET_H
 
+#include <gltfio/NodeManager.h>
+
 #include <filament/Box.h>
 #include <filament/TextureSampler.h>
-
-#include <gltfio/NodeManager.h>
 
 #include <utils/compiler.h>
 #include <utils/Entity.h>

--- a/libs/gltfio/include/gltfio/FilamentInstance.h
+++ b/libs/gltfio/include/gltfio/FilamentInstance.h
@@ -17,10 +17,10 @@
 #ifndef GLTFIO_FILAMENTINSTANCE_H
 #define GLTFIO_FILAMENTINSTANCE_H
 
+#include <filament/Box.h>
+
 #include <utils/compiler.h>
 #include <utils/Entity.h>
-
-#include <filament/Box.h>
 
 namespace filament {
 class MaterialInstance;

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -21,8 +21,8 @@
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 
-#include <utils/FixedCapacityVector.h>
 #include <utils/compiler.h>
+#include <utils/FixedCapacityVector.h>
 
 #include <array>
 #include <string>

--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -17,11 +17,11 @@
 #ifndef GLTFIO_TEXTUREPROVIDER_H
 #define GLTFIO_TEXTUREPROVIDER_H
 
+#include <utils/BitmaskEnum.h>
+#include <utils/compiler.h>
+
 #include <stddef.h>
 #include <stdint.h>
-
-#include <utils/compiler.h>
-#include <utils/BitmaskEnum.h>
 
 namespace filament {
     class Engine;

--- a/libs/gltfio/include/gltfio/TrsTransformManager.h
+++ b/libs/gltfio/include/gltfio/TrsTransformManager.h
@@ -21,9 +21,10 @@
 
 #include <utils/compiler.h>
 #include <utils/EntityInstance.h>
+
+#include <math/mat4.h>
 #include <math/quat.h>
 #include <math/vec3.h>
-#include <math/mat4.h>
 
 using namespace filament::math;
 

--- a/libs/gltfio/include/gltfio/math.h
+++ b/libs/gltfio/include/gltfio/math.h
@@ -17,13 +17,13 @@
 #ifndef GLTFIO_MATH_H
 #define GLTFIO_MATH_H
 
-#include <math/quat.h>
-#include <math/vec3.h>
+#include <utils/compiler.h>
+
 #include <math/mat3.h>
 #include <math/mat4.h>
+#include <math/quat.h>
 #include <math/TVecHelpers.h>
-
-#include <utils/compiler.h>
+#include <math/vec3.h>
 
 namespace filament::gltfio {
 

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include <gltfio/Animator.h>
-#include <gltfio/math.h>
-
+#include "downcast.h"
 #include "FFilamentAsset.h"
 #include "FFilamentInstance.h"
 #include "FTrsTransformManager.h"
-#include "downcast.h"
 
-#include <filament/VertexBuffer.h>
+#include <gltfio/Animator.h>
+#include <gltfio/math.h>
+
 #include <filament/RenderableManager.h>
 #include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
 
 #include <utils/Log.h>
 
@@ -160,7 +160,40 @@ static void setTransformType(const cgltf_animation_channel& src, Channel& dst) {
     }
 }
 
+static bool accessorFitsView(const cgltf_accessor* accessor) {
+    const cgltf_buffer_view* view = accessor->buffer_view;
+    if (!view || accessor->is_sparse || accessor->count == 0) {
+        return false;
+    }
+    const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
+    const cgltf_size stride = accessor->stride ? accessor->stride : elementSize;
+    if (elementSize == 0 || stride == 0 || accessor->offset > view->size) {
+        return false;
+    }
+    const cgltf_size available = view->size - accessor->offset;
+    if (elementSize > available) {
+        return false;
+    }
+    return accessor->count <= (available - elementSize) / stride + 1;
+}
+
+static bool validateSampler(const cgltf_animation_sampler& sampler) {
+    if (!sampler.input || !sampler.output) {
+        return false;
+    }
+    if (sampler.input->type != cgltf_type_scalar ||
+            sampler.input->component_type != cgltf_component_type_r_32f) {
+        return false;
+    }
+    return accessorFitsView(sampler.input) && accessorFitsView(sampler.output);
+}
+
 static bool validateAnimation(const cgltf_animation& anim) {
+    for (cgltf_size j = 0; j < anim.samplers_count; ++j) {
+        if (!validateSampler(anim.samplers[j])) {
+            return false;
+        }
+    }
     for (cgltf_size j = 0; j < anim.channels_count; ++j) {
         const cgltf_animation_channel& channel = anim.channels[j];
         const cgltf_animation_sampler* sampler = channel.sampler;
@@ -177,8 +210,32 @@ static bool validateAnimation(const cgltf_animation& anim) {
             }
             components = channel.target_node->mesh->primitives[0].targets_count;
         }
+        cgltf_type expectedType;
+        switch (channel.target_path) {
+            case cgltf_animation_path_type_translation:
+            case cgltf_animation_path_type_scale:
+                expectedType = cgltf_type_vec3;
+                break;
+            case cgltf_animation_path_type_rotation:
+                expectedType = cgltf_type_vec4;
+                break;
+            case cgltf_animation_path_type_weights:
+                expectedType = cgltf_type_scalar;
+                break;
+            case cgltf_animation_path_type_invalid:
+            case cgltf_animation_path_type_max_enum:
+                return false;
+        }
+        if (sampler->output->type != expectedType) {
+            return false;
+        }
+
         cgltf_size values = sampler->interpolation == cgltf_interpolation_type_cubic_spline ? 3 : 1;
-        if (sampler->input->count * components * values != sampler->output->count) {
+        if (components == 0 || sampler->output->count % values != 0) {
+            return false;
+        }
+        cgltf_size outputCount = sampler->output->count / values;
+        if (outputCount % components != 0 || outputCount / components != sampler->input->count) {
             return false;
         }
     }
@@ -263,6 +320,9 @@ size_t Animator::getAnimationCount() const {
 }
 
 void Animator::applyAnimation(size_t animationIndex, float time) const {
+    if (animationIndex >= mImpl->animations.size()) {
+        return;
+    }
     const Animation& anim = mImpl->animations[animationIndex];
     time = time == anim.duration ? time : fmod(time, anim.duration);
     TransformManager& transformManager = *mImpl->transformManager;

--- a/libs/gltfio/src/ArchiveCache.h
+++ b/libs/gltfio/src/ArchiveCache.h
@@ -17,17 +17,17 @@
 #ifndef GLTFIO_ARCHIVE_CACHE_H
 #define GLTFIO_ARCHIVE_CACHE_H
 
+#include <uberz/ReadableArchive.h>
+
 #include <filament/Engine.h>
 #include <filament/Material.h>
+
+#include <utils/CString.h>
+#include <utils/FixedCapacityVector.h>
 
 #include <tsl/robin_map.h>
 
 #include <string_view>
-
-#include <uberz/ReadableArchive.h>
-
-#include <utils/CString.h>
-#include <utils/FixedCapacityVector.h>
 
 namespace filament::gltfio {
 

--- a/libs/gltfio/src/DracoCache.h
+++ b/libs/gltfio/src/DracoCache.h
@@ -18,7 +18,6 @@
 #define GLTFIO_DRACO_CACHE_H
 
 #include <cgltf.h>
-
 #include <tsl/robin_map.h>
 
 #include <memory>

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -17,8 +17,16 @@
 #ifndef GLTFIO_FFILAMENTASSET_H
 #define GLTFIO_FFILAMENTASSET_H
 
+#include "DependencyGraph.h"
+#include "downcast.h"
+#include "DracoCache.h"
+#include "FFilamentInstance.h"
+#include "Utility.h"
+
 #include <gltfio/FilamentAsset.h>
+#include <gltfio/MaterialProvider.h>
 #include <gltfio/NodeManager.h>
+#include <gltfio/TextureProvider.h>
 #include <gltfio/TrsTransformManager.h>
 
 #include <filament/Engine.h>
@@ -30,23 +38,14 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 
-#include <gltfio/MaterialProvider.h>
-#include <gltfio/TextureProvider.h>
-
-#include <math/mat4.h>
-
 #include <utils/CString.h>
 #include <utils/Entity.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Hash.h>
 
-#include <cgltf.h>
+#include <math/mat4.h>
 
-#include "downcast.h"
-#include "DependencyGraph.h"
-#include "DracoCache.h"
-#include "FFilamentInstance.h"
-#include "Utility.h"
+#include <cgltf.h>
 
 #include <string>
 #include <unordered_map>

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -17,6 +17,8 @@
 #ifndef GLTFIO_FFILAMENTINSTANCE_H
 #define GLTFIO_FFILAMENTINSTANCE_H
 
+#include "downcast.h"
+
 #include <gltfio/FilamentInstance.h>
 
 #include <utils/CString.h>
@@ -28,8 +30,6 @@
 #include <tsl/robin_set.h>
 
 #include <vector>
-
-#include "downcast.h"
 
 struct cgltf_node;
 

--- a/libs/gltfio/src/FNodeManager.h
+++ b/libs/gltfio/src/FNodeManager.h
@@ -23,8 +23,8 @@
 
 #include <utils/compiler.h>
 #include <utils/debug.h>
-#include <utils/SingleInstanceComponentManager.h>
 #include <utils/Entity.h>
+#include <utils/SingleInstanceComponentManager.h>
 #include <utils/Slice.h>
 
 namespace filament::gltfio {

--- a/libs/gltfio/src/FTrsTransformManager.h
+++ b/libs/gltfio/src/FTrsTransformManager.h
@@ -18,17 +18,18 @@
 #define GLTFIO_FTRSTRANSFORMMANAGER_H
 
 #include "downcast.h"
-#include "gltfio/math.h"
-#include "math/quat.h"
-#include "utils/debug.h"
 
+#include <gltfio/math.h>
 #include <gltfio/TrsTransformManager.h>
 
 #include <utils/compiler.h>
-#include <utils/SingleInstanceComponentManager.h>
+#include <utils/debug.h>
 #include <utils/Entity.h>
 #include <utils/FixedCapacityVector.h>
+#include <utils/SingleInstanceComponentManager.h>
 #include <utils/Slice.h>
+
+#include <math/quat.h>
 
 namespace filament::gltfio {
 

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "FFilamentAsset.h"
+#include "GltfEnums.h"
+#include "Wireframe.h"
 
 #include <gltfio/Animator.h>
 
@@ -24,9 +26,6 @@
 #include <utils/EntityManager.h>
 #include <utils/Log.h>
 #include <utils/NameComponentManager.h>
-
-#include "GltfEnums.h"
-#include "Wireframe.h"
 
 using namespace filament;
 using namespace utils;

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "FFilamentInstance.h"
 #include "FFilamentAsset.h"
+#include "FFilamentInstance.h"
 
 #include <gltfio/Animator.h>
 

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -17,6 +17,7 @@
 #include <gltfio/MaterialProvider.h>
 
 #include <filament/MaterialEnums.h>
+
 #include <filamat/MaterialBuilder.h>
 
 #include <utils/Hash.h>

--- a/libs/gltfio/src/Ktx2Provider.cpp
+++ b/libs/gltfio/src/Ktx2Provider.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
+#include <ktxreader/Ktx2Reader.h>
+
 #include <gltfio/TextureProvider.h>
-
-#include <string>
-#include <vector>
-
-#include <utils/JobSystem.h>
 
 #include <filament/Engine.h>
 #include <filament/Texture.h>
 
-#include <ktxreader/Ktx2Reader.h>
+#include <utils/JobSystem.h>
+
+#include <string>
+#include <vector>
 
 using namespace filament;
 using namespace utils;

--- a/libs/gltfio/src/NodeManager.cpp
+++ b/libs/gltfio/src/NodeManager.cpp
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
+#include "downcast.h"
 #include "FNodeManager.h"
 
 #include <utils/Log.h>
-
-#include "downcast.h"
 
 using namespace utils;
 

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
+#include "downcast.h"
+#include "FFilamentAsset.h"
+#include "GltfEnums.h"
+#include "TangentsJob.h"
+#include "Utility.h"
+
+#include "extended/ResourceLoaderExtended.h"
+
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
 
-#include "GltfEnums.h"
-#include "FFilamentAsset.h"
-#include "TangentsJob.h"
-#include "downcast.h"
-#include "Utility.h"
-#include "extended/ResourceLoaderExtended.h"
+#include <geometry/Transcoder.h>
 
-#include <limits>
 #include <filament/BufferObject.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
+#include <filament/MorphTargetBuffer.h>
 #include <filament/Texture.h>
 #include <filament/VertexBuffer.h>
-#include <filament/MorphTargetBuffer.h>
-
-#include <geometry/Transcoder.h>
 
 #include <private/utils/Tracing.h>
 
@@ -41,16 +41,16 @@
 #include <utils/Logger.h>
 #include <utils/Path.h>
 
-#include <cgltf.h>
-#include <meshoptimizer.h>
-
 #include <math/quat.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
 
+#include <cgltf.h>
+#include <meshoptimizer.h>
 #include <tsl/robin_map.h>
 
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -240,6 +240,16 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
         const cgltf_accessor* srcMatrices = srcSkin.inverse_bind_matrices;
         FixedCapacityVector<mat4f> inverseBindMatrices(srcSkin.joints_count);
         if (srcMatrices) {
+            if (srcMatrices->type != cgltf_type_mat4 ||
+                    srcMatrices->component_type != cgltf_component_type_r_32f) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, unsupported accessor type.";
+                continue;
+            }
+            if (srcMatrices->count < srcSkin.joints_count) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor count is too small.";
+                continue;
+            }
+
             if (!srcMatrices->buffer_view ||
                 (!srcMatrices->buffer_view->has_meshopt_compression &&
                  (!srcMatrices->buffer_view->buffer || !srcMatrices->buffer_view->buffer->data))) {
@@ -247,31 +257,29 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
                 continue;
             }
 
-            cgltf_size bufferSize = 0;
-            cgltf_size totalOffset = 0;
-            uint8_t* bytes = nullptr;
-            uint8_t* srcBuffer = nullptr;
+            const cgltf_size requiredBytes = srcSkin.joints_count * sizeof(mat4f);
+            const cgltf_size viewSize = srcMatrices->buffer_view->size;
+            const cgltf_size offsetInView = srcMatrices->offset;
+            if (offsetInView > viewSize || requiredBytes > viewSize - offsetInView) {
+                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer view bounds.";
+                continue;
+            }
 
+            uint8_t* srcBuffer = nullptr;
             if (srcMatrices->buffer_view->has_meshopt_compression) {
                 if (!srcMatrices->buffer_view->data) {
                     LOG(WARNING) << "Cannot copy inverse bind matrices, compressed buffer data is null.";
                     continue;
                 }
-                bufferSize = srcMatrices->buffer_view->size;
-                totalOffset = srcMatrices->offset;
-                bytes = (uint8_t*) srcMatrices->buffer_view->data;
-                srcBuffer = bytes + totalOffset;
+                srcBuffer = (uint8_t*) srcMatrices->buffer_view->data + offsetInView;
             } else {
-                bufferSize = srcMatrices->buffer_view->buffer->size;
-                totalOffset = srcMatrices->offset + srcMatrices->buffer_view->offset;
-                bytes = (uint8_t*) srcMatrices->buffer_view->buffer->data;
-                srcBuffer = bytes + totalOffset;
-            }
-
-            const cgltf_size requiredBytes = srcSkin.joints_count * sizeof(mat4f);
-            if (totalOffset > bufferSize || requiredBytes > bufferSize - totalOffset) {
-                LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer bounds.";
-                continue;
+                const cgltf_size bufferSize = srcMatrices->buffer_view->buffer->size;
+                const cgltf_size totalOffset = srcMatrices->buffer_view->offset + offsetInView;
+                if (totalOffset > bufferSize || requiredBytes > bufferSize - totalOffset) {
+                    LOG(WARNING) << "Cannot copy inverse bind matrices, accessor data exceeds buffer bounds.";
+                    continue;
+                }
+                srcBuffer = (uint8_t*) srcMatrices->buffer_view->buffer->data + totalOffset;
             }
 
             memcpy((uint8_t*) inverseBindMatrices.data(), (const void*) srcBuffer, requiredBytes);
@@ -284,7 +292,29 @@ inline void createSkins(cgltf_data const* gltf, bool normalize,
     }
 }
 
-inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
+static bool indexAccessorFitsBuffer(cgltf_accessor const* accessor, uint32_t bindingSize) {
+    if (!accessor->buffer_view) {
+        return false;
+    }
+    cgltf_size capacity = 0;
+    cgltf_size totalOffset = 0;
+    if (accessor->buffer_view->has_meshopt_compression) {
+        capacity = accessor->buffer_view->size;
+        totalOffset = accessor->offset;
+    } else {
+        if (!accessor->buffer_view->buffer) {
+            return false;
+        }
+        capacity = accessor->buffer_view->buffer->size;
+        totalOffset = accessor->buffer_view->offset + accessor->offset;
+    }
+    if (totalOffset >= capacity) {
+        return false;
+    }
+    return bindingSize <= capacity - totalOffset;
+}
+
+inline bool uploadBuffers(FFilamentAsset* asset, Engine& engine,
         UriDataCacheHandle uriDataCache) {
     const cgltf_accessor* kGenerateTangents = &asset->mGenerateTangents;
     const cgltf_accessor* kGenerateNormals = &asset->mGenerateNormals;
@@ -419,10 +449,10 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
         if (accessor->buffer_view) {
             if (accessor->buffer_view->has_meshopt_compression) {
                 bufferData = (const uint8_t*) accessor->buffer_view->data;
-                data = bufferData + accessor->offset;
-            } else {
+                if (bufferData) data = bufferData + accessor->offset;
+            } else if (accessor->buffer_view->buffer) {
                 bufferData = (const uint8_t*) accessor->buffer_view->buffer->data;
-                data = utility::computeBindingOffset(accessor) + bufferData;
+                if (bufferData) data = utility::computeBindingOffset(accessor) + bufferData;
             }
         }
         const uint32_t size = utility::computeBindingSize(accessor);
@@ -435,19 +465,28 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                 // Conversion path (handles null buffer_view internally via unpacking)
                 cgltf_size maxCount = accessor->count;
                 if (accessor->buffer_view) {
-                    const cgltf_size bufferSize = accessor->buffer_view->buffer->size;
-                    const cgltf_size totalOffset = accessor->buffer_view->offset + accessor->offset;
-
-                    if (totalOffset >= bufferSize) {
-                        continue;
+                    cgltf_size capacity = 0;
+                    cgltf_size totalOffset = 0;
+                    if (accessor->buffer_view->has_meshopt_compression) {
+                        capacity = accessor->buffer_view->size;
+                        totalOffset = accessor->offset;
+                    } else if (accessor->buffer_view->buffer) {
+                        capacity = accessor->buffer_view->buffer->size;
+                        totalOffset = accessor->buffer_view->offset + accessor->offset;
                     }
 
-                    const cgltf_size availableBytes = bufferSize - totalOffset;
-                    const cgltf_size stride = accessor->stride;
-                    const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
+                    if (capacity > 0) {
+                        if (totalOffset >= capacity) {
+                            continue;
+                        }
 
-                    if (stride > 0 && availableBytes >= elementSize) {
-                        maxCount = 1 + (availableBytes - elementSize) / stride;
+                        const cgltf_size availableBytes = capacity - totalOffset;
+                        const cgltf_size stride = accessor->stride;
+                        const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
+
+                        if (stride > 0 && availableBytes >= elementSize) {
+                            maxCount = 1 + (availableBytes - elementSize) / stride;
+                        }
                     }
                 }
 
@@ -502,6 +541,11 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                 continue;
             }
 
+            if (!indexAccessorFitsBuffer(accessor, size)) {
+                LOG(ERROR) << "Index accessor size exceeds buffer capacity.";
+                return false;
+            }
+
             if (accessor->component_type == cgltf_component_type_r_8u) {
                 if (size_t(size) > std::numeric_limits<size_t>::max() / 2) {
                     LOG(WARNING) << "Index buffer size would overflow on conversion, skipping.";
@@ -530,14 +574,21 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
         assert(slot.morphTargetBuffer);
 
         if (utility::requiresPacking(accessor)) {
-            const cgltf_size bufferSize = accessor->buffer_view->buffer->size;
-            const cgltf_size totalOffset = accessor->buffer_view->offset + accessor->offset;
+            cgltf_size capacity = 0;
+            cgltf_size totalOffset = 0;
+            if (accessor->buffer_view->has_meshopt_compression) {
+                capacity = accessor->buffer_view->size;
+                totalOffset = accessor->offset;
+            } else if (accessor->buffer_view->buffer) {
+                capacity = accessor->buffer_view->buffer->size;
+                totalOffset = accessor->buffer_view->offset + accessor->offset;
+            }
             
-            if (totalOffset >= bufferSize) {
+            if (capacity == 0 || totalOffset >= capacity) {
                 continue;
             }
             
-            const cgltf_size availableBytes = bufferSize - totalOffset;
+            const cgltf_size availableBytes = capacity - totalOffset;
             const cgltf_size stride = accessor->stride;
             const cgltf_size elementSize = cgltf_calc_size(accessor->type, accessor->component_type);
             
@@ -597,6 +648,7 @@ inline void uploadBuffers(FFilamentAsset* asset, Engine& engine,
                     slot.morphTargetOffset);
         }
     }
+    return true;
 }
 
 } // anonymous namespace
@@ -711,7 +763,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     cgltf_data const* gltf = asset->mSourceAsset->hierarchy;
 
     if (!isExtendedAlgo) {
-        utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache);
+        if (!utility::loadCgltfBuffers(gltf, pImpl->mGltfPath.c_str(), pImpl->mUriDataCache)) {
+            return false;
+        }
 
         // Decompress Draco meshes early on, which allows us to exploit subsequent processing such
         // as tangent generation.
@@ -728,7 +782,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
             return false;
         }
 
-        uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache);
+        if (!uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache)) {
+            return false;
+        }
 
         // Compute surface orientation quaternions if necessary. This is similar to sparse data in
         // that we need to generate the contents of a GPU buffer by processing one or more CPU

--- a/libs/gltfio/src/TangentsJob.cpp
+++ b/libs/gltfio/src/TangentsJob.cpp
@@ -16,10 +16,10 @@
 
 #include "TangentsJob.h"
 
+#include <geometry/SurfaceOrientation.h>
+
 #include <cstdlib>
 #include <memory>
-
-#include <geometry/SurfaceOrientation.h>
 
 using namespace filament::gltfio;
 using namespace filament;

--- a/libs/gltfio/src/TangentsJob.h
+++ b/libs/gltfio/src/TangentsJob.h
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <cgltf.h>
-
 #include <math/vec4.h>
+
+#include <cgltf.h>
 
 namespace filament {
 

--- a/libs/gltfio/src/TrsTransformManager.cpp
+++ b/libs/gltfio/src/TrsTransformManager.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+#include "downcast.h"
 #include "FTrsTransformManager.h"
 
-#include <utils/Log.h>
+#include <gltfio/TrsTransformManager.h>
 
-#include "downcast.h"
-#include "gltfio/TrsTransformManager.h"
+#include <utils/Log.h>
 
 using namespace utils;
 

--- a/libs/gltfio/src/UbershaderProvider.cpp
+++ b/libs/gltfio/src/UbershaderProvider.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
+#include "ArchiveCache.h"
+
 #include <gltfio/MaterialProvider.h>
 
 #include <filament/MaterialInstance.h>
 #include <filament/Texture.h>
 #include <filament/TextureSampler.h>
 
-#include <math/mat4.h>
-
 #include <utils/Log.h>
 
-#include "ArchiveCache.h"
+#include <math/mat4.h>
 
 using namespace filament;
 using namespace filament::math;

--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -292,12 +292,10 @@ bool loadCgltfBuffers(cgltf_data const* gltf, char const* gltfPath,
 
     FILAMENT_TRACING_NAME_END(FILAMENT_TRACING_CATEGORY_GLTFIO);
 
-#ifndef NDEBUG
     if (cgltf_validate((cgltf_data*) gltf) != cgltf_result_success) {
         slog.e << "Failed cgltf validation." << io::endl;
         return false;
     }
-#endif
     return true;
 }
 

--- a/libs/gltfio/src/Utility.h
+++ b/libs/gltfio/src/Utility.h
@@ -21,8 +21,8 @@
 
 #include <tsl/robin_map.h>
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 struct FFilamentAsset;
 struct cgltf_primitive;

--- a/libs/gltfio/src/Wireframe.cpp
+++ b/libs/gltfio/src/Wireframe.cpp
@@ -15,18 +15,19 @@
  */
 
 #include "Wireframe.h"
+
 #include "FFilamentAsset.h"
 
 #include <filament/Box.h>
 #include <filament/Engine.h>
-#include <filament/VertexBuffer.h>
 #include <filament/RenderableManager.h>
 #include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
 
 #include <utils/EntityManager.h>
 
-#include <math/vec3.h>
 #include <math/mat4.h>
+#include <math/vec3.h>
 
 #include <functional>
 

--- a/libs/gltfio/src/extended/AssetLoaderExtended.h
+++ b/libs/gltfio/src/extended/AssetLoaderExtended.h
@@ -20,8 +20,9 @@
 #include "../FFilamentAsset.h"
 #include "../Utility.h"
 
-#include <backend/BufferDescriptor.h>
 #include <gltfio/AssetLoader.h>
+
+#include <backend/BufferDescriptor.h>
 
 #include <cgltf.h>
 

--- a/libs/gltfio/src/extended/ResourceLoaderExtended.cpp
+++ b/libs/gltfio/src/extended/ResourceLoaderExtended.cpp
@@ -18,8 +18,9 @@
 
 #include "../FFilamentAsset.h"
 
-#include <backend/BufferDescriptor.h>
 #include <filament/BufferObject.h>
+
+#include <backend/BufferDescriptor.h>
 
 #include <cgltf.h>
 

--- a/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
+++ b/libs/gltfio/src/extended/TangentSpaceMeshWrapper.cpp
@@ -19,9 +19,9 @@
 #include <utils/debug.h>
 #include <utils/Panic.h>
 
+#include <cstring>
 #include <memory>
 #include <unordered_map>
-#include <cstring>
 
 namespace filament::gltfio {
 

--- a/libs/gltfio/src/extended/TangentsJobExtended.cpp
+++ b/libs/gltfio/src/extended/TangentsJobExtended.cpp
@@ -18,11 +18,13 @@
 
 #include "AssetLoaderExtended.h"
 #include "TangentSpaceMeshWrapper.h"
-#include "../GltfEnums.h"
+
 #include "../FFilamentAsset.h"
+#include "../GltfEnums.h"
 #include "../Utility.h"
 
 #include <geometry/TangentSpaceMesh.h>
+
 #include <utils/Log.h>
 #include <utils/Panic.h>
 #include <utils/StructureOfArrays.h>

--- a/libs/gltfio/src/extended/TangentsJobExtended.h
+++ b/libs/gltfio/src/extended/TangentsJobExtended.h
@@ -18,6 +18,7 @@
 #define GLTFIO_TANGENTS_JOB_EXTENDED_H
 
 #include <gltfio/MaterialProvider.h> // for UvMap
+
 #include <math/vec4.h>
 
 #include <cgltf.h>

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gltfio/AssetLoader.h>
 #include <gltfio/FilamentAsset.h>
+#include <gltfio/FilamentInstance.h>
 #include <gltfio/math.h>
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
@@ -31,6 +32,7 @@
 
 #include <utils/EntityManager.h>
 #include <utils/NameComponentManager.h>
+#include <utils/Panic.h>
 #include <utils/Path.h>
 
 #include <math/mathfwd.h>
@@ -40,11 +42,14 @@
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <unistd.h>
 
 using namespace filament;
 using namespace backend;
@@ -455,6 +460,177 @@ TEST_F(glTFIOTest, MorphTargetsExceedingMaxDoNotOverflow) {
         assetLoader->destroyAsset(asset);
     }
     AssetLoader::destroy(&assetLoader);
+}
+
+namespace {
+
+static std::vector<uint8_t> makeMalformedEightBitIndexGlb(uint32_t indexCount) {
+    std::string json = std::string(R"({
+  "asset": { "version": "2.0" },
+  "extensionsUsed": ["KHR_materials_unlit"],
+  "buffers": [
+    { "byteLength": 13 }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 12 },
+    { "buffer": 0, "byteOffset": 12, "byteLength": 1 }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 1,
+      "type": "VEC3",
+      "min": [0, 0, 0],
+      "max": [0, 0, 0]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5121,
+      "count": )") +
+            std::to_string(indexCount) +
+            R"(,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": { "POSITION": 0 },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    { "mesh": 0 }
+  ],
+  "scenes": [
+    { "nodes": [0] }
+  ],
+  "scene": 0
+})";
+
+    while ((json.size() % 4u) != 0u) {
+        json.push_back(' ');
+    }
+
+    std::vector<uint8_t> bin(13, 0);
+    while ((bin.size() % 4u) != 0u) {
+        bin.push_back(0);
+    }
+
+    const uint32_t jsonSize = uint32_t(json.size());
+    const uint32_t binSize = uint32_t(bin.size());
+    const uint32_t totalSize = 12u + 8u + jsonSize + 8u + binSize;
+
+    std::vector<uint8_t> glb;
+    glb.reserve(totalSize);
+
+    appendU32LE(glb, 0x46546c67u);
+    appendU32LE(glb, 2u);
+    appendU32LE(glb, totalSize);
+    appendU32LE(glb, jsonSize);
+    appendU32LE(glb, 0x4e4f534au);
+    glb.insert(glb.end(), json.begin(), json.end());
+    appendU32LE(glb, binSize);
+    appendU32LE(glb, 0x004e4942u);
+    glb.insert(glb.end(), bin.begin(), bin.end());
+
+    return glb;
+}
+
+} // namespace
+
+TEST_F(glTFIOTest, RejectsOversizedEightBitIndexAccessor) {
+    AssetLoader* loader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    ASSERT_NE(loader, nullptr);
+
+    std::vector<uint8_t> glb = makeMalformedEightBitIndexGlb(100000000u);
+    FilamentAsset* asset = loader->createAsset(glb.data(), uint32_t(glb.size()));
+    ASSERT_NE(asset, nullptr);
+
+    ResourceLoader resourceLoader({ mEngine, ".", false });
+    EXPECT_FALSE(resourceLoader.loadResources(asset));
+
+    loader->destroyAsset(asset);
+    AssetLoader::destroy(&loader);
+}
+
+TEST_F(glTFIOTest, SkipsInverseBindMatricesOutsideBufferView) {
+    namespace fs = std::filesystem;
+    const fs::path root = fs::temp_directory_path() / ("gltfio_m7_" + std::to_string(getpid()));
+    const fs::path attackerDir = root / "attacker";
+    fs::create_directories(attackerDir);
+
+    const fs::path secretPath = root / "secret.bin";
+    {
+        std::ofstream out(secretPath, std::ios::binary);
+        ASSERT_TRUE(out.good());
+        const float identity[16] = {
+                1.0f, 0.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 1.0f, 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f,
+        };
+        const float secret[16] = {
+                1337.0f, 1338.0f, 1339.0f, 1340.0f,
+                1341.0f, 1342.0f, 1343.0f, 1344.0f,
+                1345.0f, 1346.0f, 1347.0f, 1348.0f,
+                1349.0f, 1350.0f, 1351.0f, 1352.0f,
+        };
+        out.write(reinterpret_cast<const char*>(identity), sizeof(identity));
+        out.write(reinterpret_cast<const char*>(secret), sizeof(secret));
+    }
+
+    const fs::path gltfPath = attackerDir / "evil.gltf";
+    {
+        std::ofstream out(gltfPath);
+        ASSERT_TRUE(out.good());
+        out << R"({"asset":{"version":"2.0"},"scene":0,"scenes":[{"nodes":[0]}],)"
+               R"("nodes":[{"name":"root","skin":0,"children":[1,2]},{"name":"joint0"},{"name":"joint1"}],)"
+               R"("skins":[{"joints":[1,2],"inverseBindMatrices":0}],)"
+               R"("buffers":[{"uri":"../secret.bin","byteLength":128}],)"
+               R"("bufferViews":[{"buffer":0,"byteOffset":0,"byteLength":64}],)"
+               R"("accessors":[{"bufferView":0,"byteOffset":0,"componentType":5126,"count":1,"type":"MAT4"}]})";
+    }
+
+    std::ifstream in(gltfPath, std::ifstream::binary | std::ifstream::ate);
+    ASSERT_TRUE(in.good());
+    const auto contentSize = in.tellg();
+    in.seekg(0, std::ifstream::beg);
+    std::vector<uint8_t> buffer(static_cast<size_t>(contentSize));
+    ASSERT_TRUE(in.read(reinterpret_cast<char*>(buffer.data()), contentSize));
+
+    AssetLoader* assetLoader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    ResourceLoader* resourceLoader = new ResourceLoader({
+            mEngine, gltfPath.string().c_str(), false,
+    });
+
+    FilamentAsset* asset = assetLoader->createAsset(buffer.data(), buffer.size());
+    ASSERT_NE(asset, nullptr);
+    EXPECT_TRUE(resourceLoader->loadResources(asset));
+
+    FilamentInstance* instance = asset->getInstance();
+    ASSERT_NE(instance, nullptr);
+    EXPECT_EQ(instance->getSkinCount(), 1u);
+    EXPECT_EQ(instance->getJointCountAt(0), 2u);
+    EXPECT_THROW((void) instance->getInverseBindMatricesAt(0), utils::PreconditionPanic);
+
+    assetLoader->destroyAsset(asset);
+    delete resourceLoader;
+    AssetLoader::destroy(&assetLoader);
+
+    fs::remove_all(root);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Combine several security and stability fixes to gltfio:

- Reorganize header order in test and extended loader (#10141)
- Validate animation channel path against sampler output type (#10139)
- Always validate glTF buffers and check loading status (#10135)
- Harden animation validation and accessor fits checks (#10133)
- Reject index accessors that exceed buffer capacity (#10121)
- Bound inverse bind matrix copies to bufferView bounds (#10119)