### PR TITLE
gltfio: out-of-bounds write / crash in createRenderable

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-#include <gltfio/Animator.h>
-#include <gltfio/AssetLoader.h>
-#include <gltfio/MaterialProvider.h>
-#include <gltfio/math.h>
-
+#include "downcast.h"
 #include "FFilamentAsset.h"
 #include "FNodeManager.h"
 #include "FTrsTransformManager.h"
 #include "GltfEnums.h"
 #include "Utility.h"
+
 #include "extended/AssetLoaderExtended.h"
+
+#include <gltfio/Animator.h>
+#include <gltfio/AssetLoader.h>
+#include <gltfio/MaterialProvider.h>
+#include <gltfio/math.h>
 
 #include <filament/Box.h>
 #include <filament/BufferObject.h>
@@ -40,24 +42,21 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 
-#include <math/mat4.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
-
 #include <private/utils/Tracing.h>
 
 #include <utils/compiler.h>
 #include <utils/EntityManager.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
-#include <utils/Panic.h>
 #include <utils/NameComponentManager.h>
+#include <utils/Panic.h>
 
-#include <tsl/robin_map.h>
+#include <math/mat4.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
 
 #include <cgltf.h>
-
-#include "downcast.h"
+#include <tsl/robin_map.h>
 
 #include <codecvt>
 #include <locale>
@@ -900,7 +899,11 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
     }
 
     FixedCapacityVector<CString> morphTargetNames(numMorphTargets);
-    for (cgltf_size i = 0, c = mesh->target_names_count; i < c; ++i) {
+    // A mesh's morph-target name count (mesh.extras.targetNames) is parsed independently of its
+    // morph-target count, and is not constrained when the mesh has no primitives (numMorphTargets
+    // is then 0). Bound the copy by the destination capacity so that a mesh declaring more target
+    // names than morph targets does not write past morphTargetNames.
+    for (cgltf_size i = 0, c = std::min(numMorphTargets, mesh->target_names_count); i < c; ++i) {
         morphTargetNames[i] = CString(mesh->target_names[i]);
     }
     auto& nm = mNodeManager;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -822,7 +822,11 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
             }
 
             UTILS_UNUSED_IN_RELEASE cgltf_accessor const* previous = nullptr;
-            for (int tindex = 0; tindex < numMorphTargets; ++tindex) {
+            // createPrimitives() caps the per-primitive morph-target count at MAX_MORPH_TARGETS and
+            // sizes slotIndices accordingly; iterate only over the slots that exist so a mesh with
+            // more morph targets than the cap does not index slotIndices out of bounds.
+            const size_t numSlots = outputPrim->slotIndices.size();
+            for (int tindex = 0; tindex < numMorphTargets && (size_t) tindex < numSlots; ++tindex) {
                 const cgltf_morph_target& inTarget = inputPrim->targets[tindex];
                 for (cgltf_size aindex = 0; aindex < inTarget.attributes_count; ++aindex) {
                     const cgltf_attribute& attribute = inTarget.attributes[aindex];

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -423,6 +423,40 @@ TEST_F(glTFIOTest, MalformedMeshTargetNamesWithoutPrimitives) {
     AssetLoader::destroy(&assetLoader);
 }
 
+// createPrimitives() caps a primitive's morph-target count at MAX_MORPH_TARGETS and sizes its
+// slotIndices vector to that cap; createRenderable() must iterate the morph-slot loop over the same
+// bound, not the raw (uncapped) morph-target count, or it indexes slotIndices out of range. This
+// loads a mesh with more morph targets than the cap and requires it parses without an out-of-bounds
+// access (validated under ASan).
+TEST_F(glTFIOTest, MorphTargetsExceedingMaxDoNotOverflow) {
+    std::string targets;
+    for (int i = 0; i < 300; ++i) {
+        targets += (i == 0) ? "{\"POSITION\":1}" : ",{\"POSITION\":1}";
+    }
+    std::string const gltf =
+            "{\"asset\":{\"version\":\"2.0\"},\"scene\":0,\"scenes\":[{\"nodes\":[0]}],"
+            "\"nodes\":[{\"mesh\":0}],"
+            "\"meshes\":[{\"primitives\":[{\"attributes\":{\"POSITION\":0},\"mode\":4,"
+            "\"targets\":[" + targets + "]}]}],"
+            "\"accessors\":["
+            "{\"bufferView\":0,\"componentType\":5126,\"count\":3,\"type\":\"VEC3\","
+            "\"min\":[0,0,0],\"max\":[1,1,1]},"
+            "{\"bufferView\":1,\"componentType\":5126,\"count\":3,\"type\":\"VEC3\"}],"
+            "\"bufferViews\":[{\"buffer\":0,\"byteOffset\":0,\"byteLength\":36},"
+            "{\"buffer\":0,\"byteOffset\":36,\"byteLength\":36}],"
+            "\"buffers\":[{\"byteLength\":72}]}";
+
+    AssetLoader* assetLoader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    FilamentAsset* const asset = assetLoader->createAsset(
+            reinterpret_cast<uint8_t const*>(gltf.data()), uint32_t(gltf.size()));
+
+    EXPECT_NE(asset, nullptr);
+    if (asset != nullptr) {
+        assetLoader->destroyAsset(asset);
+    }
+    AssetLoader::destroy(&assetLoader);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -39,6 +39,7 @@
 #include <meshoptimizer.h>
 
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <limits>
 #include <string>
@@ -392,6 +393,33 @@ TEST_F(glTFIOTest, MeshoptAllocationFailureRejectsGracefully) {
     EXPECT_FALSE(resourceLoader.loadResources(asset));
 
     assetLoader->destroyAsset(asset);
+    AssetLoader::destroy(&assetLoader);
+}
+
+// A mesh may carry morph-target names (mesh.extras.targetNames) whose count is parsed independently
+// of its morph-target count. When the mesh has no primitives the morph-target count is zero, so the
+// two counts can disagree. createRenderable() must size its name copy by the morph-target count and
+// not by the (independent) name count; otherwise it writes past the names storage. This loads such
+// a mesh and requires that it parses without an out-of-bounds access (validated under ASan) and
+// retains no more morph-target names than morph targets.
+TEST_F(glTFIOTest, MalformedMeshTargetNamesWithoutPrimitives) {
+    static char const* const kGltf =
+            R"({"asset":{"version":"2.0"},"scene":0,"scenes":[{"nodes":[0]}],)"
+            R"("nodes":[{"mesh":0}],)"
+            R"("meshes":[{"extras":{"targetNames":["t0","t1","t2","t3","t4","t5","t6","t7"]}}]})";
+
+    AssetLoader* assetLoader = AssetLoader::create({ mEngine, mMaterialProvider, mNameManager });
+    FilamentAsset* const asset = assetLoader->createAsset(
+            reinterpret_cast<uint8_t const*>(kGltf), uint32_t(std::strlen(kGltf)));
+
+    EXPECT_NE(asset, nullptr);
+    if (asset != nullptr) {
+        Entity const* renderables = asset->getRenderableEntities();
+        for (size_t i = 0, n = asset->getRenderableEntityCount(); i < n; ++i) {
+            EXPECT_EQ(asset->getMorphTargetCountAt(renderables[i]), 0u);
+        }
+        assetLoader->destroyAsset(asset);
+    }
     AssetLoader::destroy(&assetLoader);
 }
 


### PR DESCRIPTION
Fixes #10136.

`FAssetLoader::createRenderable()` has two morph-target count mismatches that index/write past their
storage when loading a structurally-parseable but malformed glTF mesh (reachable directly from
`AssetLoader::createAsset()`). Both are in the same function and the same "size by one count, iterate
by another" shape, so they're fixed together here.

## 1. Morph-target **names** vs. morph-target count

`morphTargetNames` is allocated with capacity equal to the mesh's morph-target count
(`numMorphTargets`) but filled by iterating over `mesh->target_names_count`, parsed independently from
`mesh.extras.targetNames`. When a mesh has no primitives, `numMorphTargets` is `0`, so a mesh that
still declares `targetNames` overruns the (zero-capacity) vector:

```cpp
  FixedCapacityVector<CString> morphTargetNames(numMorphTargets);            // capacity 0
- for (cgltf_size i = 0, c = mesh->target_names_count; i < c; ++i) {         // independent count
+ for (cgltf_size i = 0, c = std::min(numMorphTargets, mesh->target_names_count); i < c; ++i) {
      morphTargetNames[i] = CString(mesh->target_names[i]);
  }
```

## 2. Morph-target **slot** loop vs. the `MAX_MORPH_TARGETS` cap

`createPrimitives()` caps a primitive's morph-target count at `MAX_MORPH_TARGETS` and sizes its
`slotIndices` vector to that cap, but `createRenderable()` iterated the slot loop over the uncapped
`numMorphTargets`, so a mesh declaring more than `MAX_MORPH_TARGETS` morph targets indexed
`outputPrim->slotIndices` out of range (and then used the result to index the buffer-slot vector):

```cpp
+ const size_t numSlots = outputPrim->slotIndices.size();
- for (int tindex = 0; tindex < numMorphTargets; ++tindex) {
+ for (int tindex = 0; tindex < numMorphTargets && (size_t) tindex < numSlots; ++tindex) {
```

For well-formed assets both loops are unchanged (`numMorphTargets == target_names_count` and
`numMorphTargets == numSlots`); the only effect is that a malformed mesh's excess names/targets are
ignored instead of overrunning their storage, matching the truncation `createPrimitives()` already
performs.

## Tests

Adds two tests to `libs/gltfio/test/gltfio_test.cpp`:

- `MalformedMeshTargetNamesWithoutPrimitives` — loads a mesh declaring `extras.targetNames` with no
  primitives; pre-fix this trips a heap-buffer-overflow write in `createRenderable()` under ASan.
- `MorphTargetsExceedingMaxDoNotOverflow` — loads a mesh with 300 morph targets (> the 256 cap);
  pre-fix this trips an out-of-bounds `slotIndices` access under ASan.

Both parse cleanly post-fix.

## Notes

- Confined to `createRenderable()` plus the two tests; no public API change. Adheres to
  `CODE_STYLE.md` (4-space indent, 100 columns).
- The mesh in (1) passes the optional `cgltf_validate()` check, which only compares
  `target_names_count` to the morph-target count when the mesh has primitives.
