### PR TITLE
backend: enable webgpu on presubmit

### DIFF
--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -239,8 +239,8 @@ void assertLimitsAreExpressedInRequirementsStruct() {
     return false;
 }
 
-#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
 void printInstanceDetails(wgpu::Instance const& instance) {
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
     wgpu::SupportedWGSLLanguageFeatures supportedWGSLLanguageFeatures{};
     instance.GetWGSLLanguageFeatures(&supportedWGSLLanguageFeatures);
     FWGPU_LOGI << "WebGPU instance supported WGSL language features ("
@@ -253,8 +253,8 @@ void printInstanceDetails(wgpu::Instance const& instance) {
                     FWGPU_LOGI << "  " << webGPUPrintableToString(featureName);
                 });
     }
-}
 #endif
+}
 
 //either returns a valid instance or panics
 [[nodiscard]] wgpu::Instance createInstance() {
@@ -292,14 +292,12 @@ void printInstanceDetails(wgpu::Instance const& instance) {
 
     wgpu::Instance instance = wgpu::CreateInstance(&instanceDescriptor);
     FILAMENT_CHECK_POSTCONDITION(instance != nullptr) << "Unable to create WebGPU instance.";
-#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
     printInstanceDetails(instance);
-#endif
     return instance;
 }
 
-#ifndef NDEBUG
 void printLimit(std::string_view name, const std::variant<uint32_t, uint64_t> value) {
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
     static constexpr std::string_view indent = "  ";
     bool undefined = true;
     if (std::holds_alternative<uint32_t>(value)) {
@@ -316,6 +314,7 @@ void printLimit(std::string_view name, const std::variant<uint32_t, uint64_t> va
     if (undefined) {
         FWGPU_LOGI << indent << name.data() << ": UNDEFINED";
     }
+#endif
 }
 
 void printLimits(wgpu::Limits const& limits) {
@@ -353,7 +352,6 @@ void printLimits(wgpu::Limits const& limits) {
     printLimit("maxComputeWorkgroupSizeZ", limits.maxComputeWorkgroupSizeZ);
     printLimit("maxComputeWorkgroupsPerDimension", limits.maxComputeWorkgroupsPerDimension);
 }
-#endif
 
 struct AdapterDetails final {
     AdapterDetails()
@@ -403,7 +401,7 @@ void printAdapterDetails(AdapterDetails const& details) {
     wgpu::SupportedFeatures supportedFeatures{};
     details.adapter.GetFeatures(&supportedFeatures);
 
-#ifndef NDEBUG
+#if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
     FWGPU_LOGI << "WebGPU adapter supported features (" << supportedFeatures.featureCount
                << "):";
     if (supportedFeatures.featureCount > 0 && supportedFeatures.features != nullptr) {
@@ -418,10 +416,8 @@ void printAdapterDetails(AdapterDetails const& details) {
     if (!details.adapter.GetLimits(&supportedLimits)) {
         FWGPU_LOGW << "Failed to get WebGPU adapter supported limits. Request limits:";
     }
-#ifndef NDEBUG
     FWGPU_LOGI << "WebGPU adapter supported limits:";
     printLimits(supportedLimits);
-#endif
 }
 
 struct AdapterDetailsHash final {

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -23,10 +23,10 @@
 #include <utils/FixedCapacityVector.h>
 
 #include <GlslangToSpv.h>
+#include <gmock/gmock.h>
 #include <spirv_glsl.hpp>
 #include <spirv_msl.hpp>
 
-#include <iostream>
 #include <utility>
 #include <vector>
 
@@ -130,31 +130,20 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(ShaderStage stage, std::s
     tShader.setAutoMapBindings(true);
 
     bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
-
-    if (!ok) {
-        std::cerr << "ERROR: Unable to parse " <<
-            (stage == ShaderStage::VERTEX ? "vertex" : "fragment") << " shader:" << std::endl;
-        std::cerr << tShader.getInfoLog() << std::endl;
-        assert_invariant(false);
-    }
+    EXPECT_THAT(ok, ::testing::IsTrue()) <<
+            "ERROR: Unable to parse " <<
+            (stage == ShaderStage::VERTEX ? "vertex" : "fragment") << " shader:" <<
+            tShader.getInfoLog();
 
     program.addShader(&tShader);
+
     bool linkOk = program.link(msg);
-    if (!linkOk) {
-        std::cerr << tShader.getInfoLog() << std::endl;
-        assert_invariant(false);
-    }
+    EXPECT_THAT(linkOk, ::testing::IsTrue()) << tShader.getInfoLog();
 
     SpirvBlob spirv;
-
     GlslangToSpv(*program.getIntermediate(language), spirv);
 
     std::string result;
-
-    assert_invariant(backend == Backend::OPENGL ||
-           backend == Backend::METAL  ||
-           backend == Backend::VULKAN ||
-           backend == Backend::WEBGPU);
 
     if (backend == Backend::OPENGL) {
         if (isMobile) {
@@ -171,7 +160,7 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(ShaderStage stage, std::s
     } else if (backend == Backend::VULKAN) {
         return { (uint8_t*)spirv.data(), (uint8_t*)(spirv.data() + spirv.size()) };
     } else if (backend == Backend::WEBGPU){
-        filamat::GLSLPostProcessor::spirvToWgsl(&spirv, &result);
+        EXPECT_THAT(filamat::GLSLPostProcessor::spirvToWgsl(&spirv, &result), ::testing::IsTrue());
         return { result.c_str(), result.c_str() + result.length() + 1 };
     }
 

--- a/filament/backend/test/SharedShaders.cpp
+++ b/filament/backend/test/SharedShaders.cpp
@@ -127,6 +127,18 @@ void main() {
     fragColor = texture(test_tex, uv);
 })" };
         }
+        case FragmentShaderType::TexturedLod: {
+            return ShaderText{
+                R"(
+#version 450 core
+precision mediump int; precision highp float;
+layout(location = 0) out vec4 fragColor;
+layout(location = 0) in vec2 uv;
+)", R"(
+void main() {
+    fragColor = textureLod(test_tex, uv, 1);
+})" };
+        }
         default:
             return std::nullopt;
     }
@@ -161,7 +173,7 @@ layout(binding = 0, set = 0) uniform Params {
         }
         case ShaderUniformType::Sampler: {
             return R"(
-layout(location = 0, set = 0) uniform sampler2D test_tex;
+layout(binding = 0, set = 0) uniform sampler2D test_tex;
 )";
         }
         default:

--- a/filament/backend/test/SharedShadersConstants.h
+++ b/filament/backend/test/SharedShadersConstants.h
@@ -57,7 +57,8 @@ enum class VertexShaderType : uint8_t {
 enum class FragmentShaderType : uint8_t {
     White,
     SolidColored,
-    Textured
+    Textured,
+    TexturedLod,
 };
 
 #endif //TNT_SHAREDSHADERSCONSTANTS_H

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -99,14 +99,9 @@ struct MaterialParams {
 // The problems are caused by both uploading and rendering into the same texture, since the OpenGL
 // backend's readPixels does not work correctly with textures that have image data uploaded.
 TEST_F(BackendTest, FeedbackLoops) {
-    SKIP_IF(SkipEnvironment(OperatingSystem::APPLE, Backend::OPENGL),
-            "OpenGL image is upside down due to readPixels failing for texture with uploaded image "
-            "data");
-    SKIP_IF(SkipEnvironment(OperatingSystem::APPLE, Backend::WEBGPU),
-            "OpenGL image is upside down due to readPixels failing for texture with uploaded image "
-            "data");
-    SKIP_IF(SkipEnvironment(OperatingSystem::CI, Backend::OPENGL), "b/453756688");
-    SKIP_IF(Backend::VULKAN, "Image is unexpectedly darker, see b/453776546");
+    SKIP_IF(Backend::OPENGL, "b/453756688");
+    SKIP_IF(Backend::VULKAN, "Image is unexpectedly darker b/453776546");
+    SKIP_IF(Backend::WEBGPU, "Image is unexpectedly flipped b/453776546");
 
     auto& api = getDriverApi();
 

--- a/filament/backend/test/test_MipLevels.cpp
+++ b/filament/backend/test/test_MipLevels.cpp
@@ -20,6 +20,7 @@
 #include "Lifetimes.h"
 #include "Shader.h"
 #include "SharedShaders.h"
+#include "SharedShadersConstants.h"
 #include "TrianglePrimitive.h"
 
 #include <backend/DriverEnums.h>
@@ -27,26 +28,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Shaders
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-std::string fragmentTexturedLod (R"(#version 450 core
-
-layout(location = 0) out vec4 fragColor;
-layout(location = 0) in vec2 uv;
-
-layout(binding = 0, set = 0) uniform sampler2D backend_test_sib_tex;
-
-void main() {
-    fragColor = textureLod(backend_test_sib_tex, uv, 1);
-}
-)");
-
-}
 
 namespace test {
 
@@ -65,23 +46,16 @@ TEST_F(BackendTest, TextureViewLod) {
         api.makeCurrent(swapChain, swapChain);
 
         Shader whiteShader = SharedShaders::makeShader(api, *mCleanup, ShaderRequest {
-            .mVertexType = VertexShaderType::Textured,
+            .mVertexType = VertexShaderType::Noop,
             .mFragmentType = FragmentShaderType::White,
-            .mUniformType = ShaderUniformType::Sampler
+            .mUniformType = ShaderUniformType::None,
         });
 
         // Create a program that samples a texture.
-        std::string vertexShader = SharedShaders::getVertexShaderText(
-                VertexShaderType::Textured, ShaderUniformType::Sampler);
-        filament::SamplerInterfaceBlock::SamplerInfo samplerInfo {
-            "backend_test", "sib_tex", 0,
-            SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH, false };
-        Shader texturedShader(api, *mCleanup, ShaderConfig {
-           .vertexShader = vertexShader,
-           .fragmentShader = fragmentTexturedLod,
-           .uniforms = {{
-               "backend_test_sib_tex", DescriptorType::SAMPLER_2D_FLOAT, samplerInfo
-           }}
+        Shader texturedShader = SharedShaders::makeShader(api, *mCleanup, ShaderRequest {
+            .mVertexType = VertexShaderType::Textured,
+            .mFragmentType = FragmentShaderType::TexturedLod,
+            .mUniformType = ShaderUniformType::Sampler
         });
 
         // Create a texture that has 4 mip levels. Each level is a different color.

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -16,13 +16,9 @@
 
 #include "GLSLPostProcessor.h"
 
-#include <GlslangToSpv.h>
-#include <spirv-tools/libspirv.hpp>
+#include "MetalArgumentBuffer.h"
+#include "SpirvFixup.h"
 
-#include <spirv_glsl.hpp>
-#include <spirv_msl.hpp>
-
-#include "private/filament/DescriptorSets.h"
 #include "sca/builtinResource.h"
 #include "sca/GLSLTools.h"
 
@@ -30,8 +26,7 @@
 #include "shaders/MaterialInfo.h"
 #include "shaders/SibGenerator.h"
 
-#include "MetalArgumentBuffer.h"
-#include "SpirvFixup.h"
+#include <private/filament/DescriptorSets.h>
 
 #include <filament/MaterialEnums.h>
 
@@ -39,6 +34,14 @@
 #include <utils/debug.h>
 #include <utils/Log.h>
 #include <utils/ostream.h>
+
+#include <GlslangToSpv.h>
+#include <spirv-tools/libspirv.hpp>
+#include <spirv_glsl.hpp>
+#include <spirv_msl.hpp>
+#ifdef FILAMENT_SUPPORTS_WEBGPU
+#include <tint/tint.h>
+#endif
 
 #include <algorithm>
 #include <optional>
@@ -51,10 +54,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
-#ifdef FILAMENT_SUPPORTS_WEBGPU
-#include <tint/tint.h>
-#endif
 
 using namespace glslang;
 using namespace spirv_cross;
@@ -581,8 +580,7 @@ bool GLSLPostProcessor::spirvToWgsl(SpirvBlob *spirv, std::string *outWsl) {
 
     if (tintReadResult != tintSuccess) {
         //We know errors can potentially crop up, and want the ability to ignore them if needed for sample bringup
-#ifndef FILAMENT_WEBGPU_IGNORE_TNT_READ_ERRORS
-        slog.e << "Tint Reader Error: " << tintReadResult.Failure().reason << io::endl;
+        slog.e << "Tint Reader Error ---- : " << tintReadResult.Failure().reason << io::endl;
         spv_context context = spvContextCreate(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
         spv_text text = nullptr;
         spv_diagnostic diagnostic = nullptr;
@@ -596,9 +594,9 @@ bool GLSLPostProcessor::spirvToWgsl(SpirvBlob *spirv, std::string *outWsl) {
         slog.e << "Beginning SpirV-output dump with ret " << result << "\n\n" << text->str << "\n\nEndSPIRV\n" <<
                 io::endl;
         spvTextDestroy(text);
-        slog.e << "Tint Reader Error: " << tintReadResult.Failure().reason << io::endl;
+
+        spvContextDestroy(context);
         return false;
-#endif
     }
 
     tint::wgsl::writer::Options writerOptions;

--- a/test/backend/test.sh
+++ b/test/backend/test.sh
@@ -44,7 +44,7 @@ echo "Building ${BACKEND_TEST_TARGET}..."
 set +e
 
 GTEST_FILTER_ARG=""
-BACKENDS=("opengl" "vulkan")
+BACKENDS=("opengl" "vulkan" "webgpu")
 for arg in "$@"
 do
     if [[ "$arg" == --gtest_filter* ]] ; then


### PR DESCRIPTION
 - Change adapter limits and extensions to print when needed
 - Disable feedbackloop test for all backends for now.
 - Add webgpu as part of the backend test on presubmit