### PR TITLE
vulkan: Support external textures with mipmaps

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -366,6 +366,11 @@ public:
         uint32_t height;
 
         /**
+         * The number of mipmap levels of the external image
+         */
+        uint32_t mipLevels;
+
+        /**
          * The layer count of the external image
          */
         uint32_t layers;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -997,10 +997,9 @@ void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::S
             mExternalImageManager.getVkSamplerYcbcrConversion(metadata);
     auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mContext,
             mPlatform->getDevice(), mAllocator, &mResourceManager, &mCommands, vkimage, memory,
-            vkformat, conversion,
-            imgData.internal.stagingMemory, imgData.internal.stagingBuffer, externalImage,
-            metadata.samples, metadata.width, metadata.height,
-            metadata.layers, usage, mStagePool);
+            vkformat, conversion, imgData.internal.stagingMemory, imgData.internal.stagingBuffer,
+            externalImage, static_cast<uint8_t>(metadata.mipLevels), metadata.samples,
+            metadata.width, metadata.height, metadata.layers, usage, mStagePool);
     auto& commands = mCommands.get();
     // Unlike uploaded textures or swapchains, we need to explicit transition this
     // texture into the read layout.
@@ -1693,9 +1692,9 @@ void VulkanDriver::updateStreams(CommandStream* driver) {
 
                     auto newTexture = resource_ptr<VulkanTexture>::construct(&mResourceManager,
                             mContext, mPlatform->getDevice(), mAllocator, &mResourceManager,
-                            &mCommands, vkimage, memory, vkformat, conversion,
-                            VK_NULL_HANDLE, VK_NULL_HANDLE, Platform::ExternalImageHandle(),
-                            metadata.samples,
+                            &mCommands, vkimage, memory, vkformat, conversion, VK_NULL_HANDLE,
+                            VK_NULL_HANDLE, Platform::ExternalImageHandle(),
+                            static_cast<uint8_t>(metadata.mipLevels), metadata.samples,
                             metadata.width, metadata.height, metadata.layers,
                             metadata.filamentUsage, mStagePool);
 

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -92,19 +92,18 @@ void VulkanSwapChain::update() {
     for (auto const color: bundle.colors) {
         auto colorTexture = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager,
                 mContext, device, mAllocator, mResourceManager, mCommands, color, VK_NULL_HANDLE,
-                bundle.colorFormat, VK_NULL_HANDLE /*ycrcb */,
-                VK_NULL_HANDLE, VK_NULL_HANDLE, Platform::ExternalImageHandle(),
-                1, bundle.extent.width,
-                bundle.extent.height, bundle.layerCount, colorUsage, mStagePool);
+                bundle.colorFormat, VK_NULL_HANDLE /*ycrcb */, VK_NULL_HANDLE, VK_NULL_HANDLE,
+                Platform::ExternalImageHandle(),
+                /*levels=*/1, /*samples=*/1, bundle.extent.width, bundle.extent.height,
+                bundle.layerCount, colorUsage, mStagePool);
         mColors.push_back(colorTexture);
     }
 
     if (bundle.depth != VK_NULL_HANDLE) {
-        mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, mContext, device,
-                mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
-                bundle.depthFormat, VK_NULL_HANDLE /*ycrcb */,
-                VK_NULL_HANDLE, VK_NULL_HANDLE, Platform::ExternalImageHandle(),
-                1, bundle.extent.width,
+        mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, mContext,
+                device, mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
+                bundle.depthFormat, VK_NULL_HANDLE /*ycrcb */, VK_NULL_HANDLE, VK_NULL_HANDLE,
+                Platform::ExternalImageHandle(), /*levels=*/1, /*samples=*/1, bundle.extent.width,
                 bundle.extent.height, bundle.layerCount, depthUsage, mStagePool);
     } else {
         mDepth = {};

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -377,17 +377,17 @@ VulkanTexture::VulkanTexture(VulkanContext const& context, VkDevice device, VmaA
         fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
         VkDeviceMemory memory, VkFormat format, VkSamplerYcbcrConversion conversion,
         VkDeviceMemory stagingMemory, VkBuffer stagingBuffer, Platform::ExternalImageHandle ahBuffer,
-        uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage tusage,
-        VulkanStagePool& stagePool)
-    : HwTexture(getSamplerTypeFromDepth(depth), 1, samples, width, height, depth,
+        uint8_t levels, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
+        TextureUsage tusage, VulkanStagePool& stagePool)
+    : HwTexture(getSamplerTypeFromDepth(depth), levels, samples, width, height, depth,
               TextureFormat::UNUSED, tusage, false),
       mState(fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, stagePool,
               commands, allocator, device, image, memory,
               stagingMemory, stagingBuffer, ahBuffer,
               format, fvkutils::getViewType(SamplerType::SAMPLER_2D),
-              /*mipLevels=*/1, getLayerCountFromDepth(depth), conversion,
+              /*mipLevels=*/levels, getLayerCountFromDepth(depth), conversion,
               getUsage(context, samples, VK_NULL_HANDLE, format, tusage),
-              any(usage & TextureUsage::PROTECTED))) {
+              any(tusage & TextureUsage::PROTECTED))) {
     mPrimaryViewRange = mState->mFullViewRange;
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -173,7 +173,7 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
             fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
             VkDeviceMemory memory, VkFormat format, VkSamplerYcbcrConversion conversion,
             VkDeviceMemory stagingMemory, VkBuffer stagingBuffer, Platform::ExternalImageHandle ahBuffer,
-            uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
+            uint8_t levels, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
             TextureUsage tusage, VulkanStagePool& stagePool);
 
     // Constructor for creating a texture view for wrt specific mip range

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -293,9 +293,8 @@ VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImag
         metadata.samples = VK_SAMPLE_COUNT_1_BIT;
         metadata.isStagingRequired = isSoftwareDecodedYUV(bufferDesc.format, bufferDesc.usage);
 
-        // Calculate mip levels. Software-decoded (staging) images are always single-level.
-        // Use ilogbf (exact, exponent-based) instead of floor(log2(...)) to avoid an
-        // off-by-one for power-of-two dimensions. Mirrors FTexture::maxLevelCount().
+        // Calculate mip levels. Use ilogbf (exact, exponent-based) instead of floor(log2(...)) to
+        // avoid an off-by-one for power-of-two dimensions. Mirrors FTexture::maxLevelCount().
         if (bufferDesc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE) {
             uint32_t const maxDimension = std::max(bufferDesc.width, bufferDesc.height);
             metadata.mipLevels = std::max(1, std::ilogbf(float(maxDimension)) + 1);

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -277,11 +277,6 @@ bool VulkanPlatformAndroid::copyExternalImageToMemoryYUV(
     return false;
 }
 
-// Define fallback preprocessor guards to avoid compilation errors on older Android SDKs.
-#ifndef AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE
-#define AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE 0x4000000ULL
-#endif
-
 VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImageMetadata(
     ExternalImageHandleRef image) const {
     if (__builtin_available(android 26, *)) {

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -35,6 +35,8 @@
 #include <android/hardware_buffer.h>
 #include <android/native_window.h>
 
+#include <algorithm>
+#include <cmath>
 #include <new>
 #include <utility>
 
@@ -275,6 +277,11 @@ bool VulkanPlatformAndroid::copyExternalImageToMemoryYUV(
     return false;
 }
 
+// Define fallback preprocessor guards to avoid compilation errors on older Android SDKs.
+#ifndef AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE
+#define AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE 0x4000000ULL
+#endif
+
 VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImageMetadata(
     ExternalImageHandleRef image) const {
     if (__builtin_available(android 26, *)) {
@@ -290,6 +297,17 @@ VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImag
         metadata.layers = bufferDesc.layers;
         metadata.samples = VK_SAMPLE_COUNT_1_BIT;
         metadata.isStagingRequired = isSoftwareDecodedYUV(bufferDesc.format, bufferDesc.usage);
+
+        // Calculate mip levels. Software-decoded (staging) images are always single-level.
+        // Use ilogbf (exact, exponent-based) instead of floor(log2(...)) to avoid an
+        // off-by-one for power-of-two dimensions. Mirrors FTexture::maxLevelCount().
+        if (!metadata.isStagingRequired &&
+                (bufferDesc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)) {
+            uint32_t const maxDimension = std::max(bufferDesc.width, bufferDesc.height);
+            metadata.mipLevels = std::max(1, std::ilogbf(float(maxDimension)) + 1);
+        } else {
+            metadata.mipLevels = 1;
+        }
 
         // Get the VkFormat directly from the driver.
         VkAndroidHardwareBufferFormatPropertiesANDROID formatInfo = {
@@ -440,7 +458,7 @@ VulkanPlatform::ImageData VulkanPlatformAndroid::createVkImageFromExternal(
                 metadata.height,
                 1u,
             },
-            .mipLevels = 1,
+            .mipLevels = metadata.mipLevels,
             .arrayLayers = metadata.layers,
             .samples = metadata.samples,
             .usage = metadata.usage,

--- a/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformAndroid.cpp
@@ -301,8 +301,7 @@ VulkanPlatform::ExternalImageMetadata VulkanPlatformAndroid::extractExternalImag
         // Calculate mip levels. Software-decoded (staging) images are always single-level.
         // Use ilogbf (exact, exponent-based) instead of floor(log2(...)) to avoid an
         // off-by-one for power-of-two dimensions. Mirrors FTexture::maxLevelCount().
-        if (!metadata.isStagingRequired &&
-                (bufferDesc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)) {
+        if (bufferDesc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE) {
             uint32_t const maxDimension = std::max(bufferDesc.width, bufferDesc.height);
             metadata.mipLevels = std::max(1, std::ilogbf(float(maxDimension)) + 1);
         } else {


### PR DESCRIPTION
Support importing external textures (Android Hardware Buffers) with a full mipmap chain under the Vulkan backend, leveraging Android's AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE flag.

- Add a `mipLevels` field to VulkanPlatform::ExternalImageMetadata.
- Extract and calculate the mipmap chain length from the hardware buffer descriptor in VulkanPlatformAndroid if the GPU_MIPMAP_COMPLETE flag is set.
- Pass the dynamic mipmap level count to VkImageCreateInfo when allocating the VkImage, keeping YUV staging images at 1 mip level.
- Update the specialized VulkanTexture constructor to accept the levels parameter and propagate it to HwTexture and VulkanTextureState.
- Update driver stream updates and swapchain color/depth allocations to pass the correct level count to VulkanTexture.

BUGS=[498943553]