### PR TITLE
gltfio: fix OOB read in WEIGHTS animation playback caused by duplicate timestamps

### DIFF
--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -53,6 +53,7 @@ struct Sampler {
     TimeValues times;
     SourceValues values;
     enum { LINEAR, STEP, CUBIC } interpolation;
+    size_t inputCount = 0;
 };
 
 struct Channel {
@@ -102,6 +103,12 @@ static void createSampler(const cgltf_animation_sampler& src, Sampler& dst) {
     }
     for (size_t i = 0, len = timelineAccessor->count; i < len; ++i) {
         dst.times[timelineFloats[i]] = i;
+    }   
+    dst.inputCount = timelineAccessor->count;
+    if (UTILS_UNLIKELY(dst.times.size() != dst.inputCount)) {
+        GLTFIO_WARN("Animation sampler has duplicate timestamps; animation disabled.");
+        dst.times.clear();
+        return;
     }
 
     // Convert source data to float.
@@ -553,8 +560,8 @@ void AnimatorImpl::applyAnimation(const Channel& channel, float t, size_t prevIn
 
         case Channel::WEIGHTS: {
             const float* const samplerValues = sampler->values.data();
-            assert(sampler->values.size() % times.size() == 0);
-            const int valuesPerKeyframe = sampler->values.size() / times.size();
+            assert(sampler->values.size() % sampler->inputCount == 0);
+            const int valuesPerKeyframe = (int)(sampler->values.size() / sampler->inputCount);
 
             if (sampler->interpolation == Sampler::CUBIC) {
                 assert(valuesPerKeyframe % 3 == 0);


### PR DESCRIPTION
## Problem

 `AnimatorImpl::applyAnimation()` computes `valuesPerKeyframe` by dividing `sampler->values.size()` by `times.size()`, where `times` is a `std::map<float, size_t>`. If an animation input accessor contains duplicate timestamp values, duplicate keys collapse in the map and `times.size()` ends up smaller than `timelineAccessor->count`. The values buffer is sized from `output->count` (based on the full keyframe count), so the computed stride is inflated. Subsequent accesses using `iter->second` — which stores the raw accessor index and can be as large as `count - 1` — then read past the end of the `sampler->values` buffer. This fires on every animation frame while the animation plays.

The assert at line 556 (`assert(sampler->values.size() % times.size() == 0)`) is compiled out under NDEBUG and provides no protection in release builds. Even in debug builds, for inputs where `values.size()` happens to be divisible by `times.size()`, the assert passes silently.

  ## Fix

  1. Detect duplicate timestamps in `createSampler()` and disable the sampler early, consistent with how other malformed inputs are handled.

  2. Store `inputCount` in the `Sampler` struct and use it instead of `times.size()` when computing `valuesPerKeyframe`, so the stride is always derived from the accessor's declared count rather than the deduplicated map size.