### PR TITLE
Fix clear coat BRDF doc listing

### DIFF
--- a/docs_src/src_markdeep/Filament.md.html
+++ b/docs_src/src_markdeep/Filament.md.html
@@ -892,7 +892,7 @@ void BRDF(...) {
     float Frc = (Dc * Vc) * Fc;
 
     // account for energy loss in the base layer
-    return color * ((Fd + Fr * (1.0 - Fc)) * (1.0 - Fc) + Frc);
+    return color * ((Fd + Fr) * (1.0 - Fc) + Frc);
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Listing [clearCoatBRDF]: Implementation of the clear coat BRDF in GLSL]


### PR DESCRIPTION
The clear coat documentation formula attenuates both base diffuse and base specular lobes once by `(1 - Fc)`, but the GLSL listing attenuated `Fr` twice.

This updates the listing to match the formula and the current shader implementation.

Issue:
#10146 