### PR TITLE
Fix pixel format validation for RGB5_A1 and RGBA4

### DIFF
--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -881,8 +881,6 @@ bool FTexture::validatePixelFormatAndType(TextureFormat const internalFormat,
 
         case TextureFormat::RGB565:
         case TextureFormat::RGB9_E5:
-        case TextureFormat::RGB5_A1:
-        case TextureFormat::RGBA4:
         case TextureFormat::RGB8:
         case TextureFormat::SRGB8:
         case TextureFormat::RGB8_SNORM:
@@ -905,6 +903,8 @@ bool FTexture::validatePixelFormatAndType(TextureFormat const internalFormat,
             }
             break;
 
+        case TextureFormat::RGB5_A1:
+        case TextureFormat::RGBA4:
         case TextureFormat::RGBA8:
         case TextureFormat::SRGB8_A8:
         case TextureFormat::RGBA8_SNORM:


### PR DESCRIPTION
These formats contain an alpha channel and should be validated against PixelDataFormat::RGBA instead of PixelDataFormat::RGB.