### PR TITLE
Part 1: don't crash if swapchain has no depth

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -99,12 +99,16 @@ void VulkanSwapChain::update() {
         mColors.push_back(colorTexture);
     }
 
-    mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, mContext, device,
-            mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
-            bundle.depthFormat, VK_NULL_HANDLE /*ycrcb */,
-            VK_NULL_HANDLE, VK_NULL_HANDLE, Platform::ExternalImageHandle(),
-            1, bundle.extent.width,
-            bundle.extent.height, bundle.layerCount, depthUsage, mStagePool);
+    if (bundle.depth != VK_NULL_HANDLE) {
+        mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, mContext, device,
+                mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
+                bundle.depthFormat, VK_NULL_HANDLE /*ycrcb */,
+                VK_NULL_HANDLE, VK_NULL_HANDLE, Platform::ExternalImageHandle(),
+                1, bundle.extent.width,
+                bundle.extent.height, bundle.layerCount, depthUsage, mStagePool);
+    } else {
+        mDepth = {};
+    }
 
     mExtent = bundle.extent;
     mLayerCount = bundle.layerCount;


### PR DESCRIPTION
If the swapchain bundle doesn't have a depth buffer, right now, we'll still attempt to wrap it in a Texture, and eventually crash. Downstream (e.g. in VulkanHandles), the lack of a depth buffer is already handled.

It's likely that the scenario where the depth buffer isn't present is where the swapchain is being derived by an app and provided with custom behavior. To that end, right now, the priority is simply supporting those usecases by avoiding a crash. There will be a followup to allow creation of a swapchain without a depth buffer intentionally, using the built-in vulkan swapchain.

Tested by removing the depth buffer from the swapchain, and running hellotriangle (with the skybox set to render first).