### PR TITLE
Fix srgb conversion for FL0 with transparent blending mode

### DIFF
--- a/shaders/src/surface_main.fs
+++ b/shaders/src/surface_main.fs
@@ -116,7 +116,13 @@ void main() {
 #if MATERIAL_FEATURE_LEVEL == 0
     if (CONFIG_SRGB_SWAPCHAIN_EMULATION) {
         if (frameUniforms.rec709 != 0) {
+#if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)
+            unpremultiply(fragColor);
             fragColor.rgb = pow(fragColor.rgb, vec3(0.45454));
+            fragColor.rgb *= fragColor.a;
+#else
+            fragColor.rgb = pow(fragColor.rgb, vec3(0.45454));
+#endif
         }
     }
 #endif


### PR DESCRIPTION
In `shaders/src/surface_main.fs`, the custom sRGB emulation for FL0 applies gamma correction to `fragColor.rgb`.
However, for materials using `blending : transparent`, `fragColor.rgb` is pre-multiplied by alpha (Color_pre = Color_linear × Alpha) before this stage.

Applying `pow` directly to the pre-multiplied color is mathematically incorrect:

Output_filament = pow(color_linear * alpha, 0.4545) = pow(color_linear, 0.4545) * pow(alpha, 0.4545)

Since alpha lies in range [0,1], then pow(alpha, 0.4545) is significantly larger than alpha for semi-transparent pixels.
This makes the source color much brighter and more opaque than intended when it is blended by the hardware.

For example, with alpha = 0.047, we have pow(alpha, 0.4545) ~ 0.25, which is more than 5x increase in effective color intensity before blending.