### PR TITLE
filamentapp: add asset loading class

### DIFF
--- a/libs/filamentapp/CMakeLists.txt
+++ b/libs/filamentapp/CMakeLists.txt
@@ -18,6 +18,8 @@ set(MATERIAL_DIR  "${GENERATION_ROOT}/generated/material")
 # ==================================================================================================
 
 set(PUBLIC_HDRS
+        include/filamentapp/AssetLoader.h
+        include/filamentapp/DesktopAssetLoader.h
         include/filamentapp/Config.h
         include/filamentapp/Cube.h
         include/filamentapp/Grid.h
@@ -31,6 +33,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/Cube.cpp
+        src/DesktopAssetLoader.cpp
         src/Grid.cpp
         src/FilamentApp.cpp
         src/IBL.cpp

--- a/libs/filamentapp/include/filamentapp/AssetLoader.h
+++ b/libs/filamentapp/include/filamentapp/AssetLoader.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENTAPP_ASSETLOADER_H
+#define TNT_FILAMENTAPP_ASSETLOADER_H
+
+#include <utils/Path.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace filament::app {
+
+class AssetLoader {
+public:
+    virtual ~AssetLoader() = default;
+
+    virtual std::vector<uint8_t> load(utils::Path const& path) const = 0;
+};
+
+} // namespace filament::app
+
+#endif // TNT_FILAMENTAPP_ASSETLOADER_H

--- a/libs/filamentapp/include/filamentapp/DesktopAssetLoader.h
+++ b/libs/filamentapp/include/filamentapp/DesktopAssetLoader.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENTAPP_DESKTOPASSETLOADER_H
+#define TNT_FILAMENTAPP_DESKTOPASSETLOADER_H
+
+#include <filamentapp/AssetLoader.h>
+
+#include <utils/Path.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace filament::app {
+
+class DesktopAssetLoader : public AssetLoader {
+public:
+    ~DesktopAssetLoader() override = default;
+
+    std::vector<uint8_t> load(utils::Path const& path) const override;
+};
+
+} // namespace filament::app
+
+#endif // TNT_FILAMENTAPP_DESKTOPASSETLOADER_H

--- a/libs/filamentapp/src/DesktopAssetLoader.cpp
+++ b/libs/filamentapp/src/DesktopAssetLoader.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filamentapp/AssetLoader.h>
+#include <filamentapp/DesktopAssetLoader.h>
+
+#include <fstream>
+
+namespace filament::app {
+
+std::vector<uint8_t> DesktopAssetLoader::load(utils::Path const& path) const {
+    std::ifstream in(path.c_str(), std::ifstream::binary | std::ifstream::ate);
+    if (!in.is_open()) {
+        return {};
+    }
+
+    auto size = in.tellg();
+    if (size <= 0) {
+        return {};
+    }
+
+    in.seekg(0, std::ios::beg);
+    std::vector<uint8_t> buffer(static_cast<size_t>(size));
+    if (!in.read(reinterpret_cast<char*>(buffer.data()), size)) {
+        return {};
+    }
+
+    return buffer;
+}
+
+} // namespace filament::app

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -44,6 +44,8 @@ struct ResourceConfiguration {
 
     //! Optional path or URI that points to the base glTF file. This is used solely
     //! to resolve relative paths. The string pointer is not retained.
+    // TODO: Deprecated 26/07/1. Remove by 27/07/1
+    UTILS_DEPRECATED
     const char* gltfPath;
 
     //! If true, adjusts skinning weights to sum to 1. Well formed glTF files do not need this,

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -944,6 +944,9 @@ std::pair<Texture*, CacheResult> ResourceLoader::Impl::getOrCreateTexture(FFilam
 
     // Finally, try the file system.
     else if constexpr (GLTFIO_USE_FILESYSTEM) {
+        utils::slog.w << "gltfio: Auto-loading resources from the filesystem is deprecated. "
+                      << "Please manually load bytes and use ResourceLoader::addResourceData."
+                      << utils::io::endl;
         if (auto iter = mFilepathTextureCache[cacheIdx].find(uri);
                 iter != mFilepathTextureCache[cacheIdx].end()) {
             return {iter->second, CacheResult::FOUND};

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -16,7 +16,20 @@
 
 #include "common/arguments.h"
 
+#include "generated/resources/gltf_demo.h"
+
+#include "materials/uberarchive.h"
+
+#include <viewer/ViewerGui.h>
+
+#include <gltfio/AssetLoader.h>
+#include <gltfio/FilamentAsset.h>
+#include <gltfio/ResourceLoader.h>
+#include <gltfio/TextureProvider.h>
+
+#include <filamentapp/AssetLoader.h>
 #include <filamentapp/Config.h>
+#include <filamentapp/DesktopAssetLoader.h>
 #include <filamentapp/FilamentApp.h>
 #include <filamentapp/IBL.h>
 
@@ -26,27 +39,16 @@
 #include <filament/TransformManager.h>
 #include <filament/View.h>
 
-#include <gltfio/AssetLoader.h>
-#include <gltfio/FilamentAsset.h>
-#include <gltfio/ResourceLoader.h>
-#include <gltfio/TextureProvider.h>
-
-#include <viewer/ViewerGui.h>
-
 #include <camutils/Manipulator.h>
 
 #include <utils/getopt.h>
-
 #include <utils/NameComponentManager.h>
-
-#include <iostream>
-#include <fstream>
-#include <string>
 
 #include <math/mat4.h>
 
-#include "generated/resources/gltf_demo.h"
-#include "materials/uberarchive.h"
+#include <fstream>
+#include <iostream>
+#include <string>
 
 using namespace filament;
 using namespace filament::math;
@@ -64,6 +66,7 @@ struct App {
     Engine* engine;
     ViewerGui* viewer;
     Config config;
+    filament::app::AssetLoader* rawAssetLoader = nullptr;
     AssetLoader* loader;
     FilamentAsset* asset = nullptr;
     NameComponentManager* names;
@@ -172,18 +175,9 @@ int main(int argc, char** argv) {
     }
 
     auto loadAsset = [&app](utils::Path filename) {
-        // Peek at the file size to allow pre-allocation.
-        long contentSize = static_cast<long>(getFileSize(filename.c_str()));
-        if (contentSize <= 0) {
+        std::vector<uint8_t> buffer = app.rawAssetLoader->load(filename);
+        if (buffer.empty()) {
             std::cerr << "Unable to open " << filename << std::endl;
-            exit(1);
-        }
-
-        // Consume the glTF file.
-        std::ifstream in(filename.c_str(), std::ifstream::binary | std::ifstream::in);
-        std::vector<uint8_t> buffer(static_cast<unsigned long>(contentSize));
-        if (!in.read((char*) buffer.data(), contentSize)) {
-            std::cerr << "Unable to read " << filename << std::endl;
             exit(1);
         }
 
@@ -222,6 +216,26 @@ int main(int argc, char** argv) {
             }
         }
 
+        // We explicitly fetch the raw bytes and push them into ResourceLoader via addResourceData.
+        // This pre-populates the cache and completely bypasses ResourceLoader's internal disk I/O,
+        // which is required for Android compatibility (where assets are packed in the APK).
+        for (size_t i = 0, c = app.asset->getResourceUriCount(); i < c; i++) {
+            const char* uri = app.asset->getResourceUris()[i];
+            utils::Path uriPath = filename.getParent() + uri;
+            std::vector<uint8_t> buffer = app.rawAssetLoader->load(uriPath);
+            if (!buffer.empty()) {
+                auto* b = new std::vector<uint8_t>(std::move(buffer));
+                gltfio::ResourceLoader::BufferDescriptor desc(
+                    b->data(), b->size(),
+                    [](void*, size_t, void* user) {
+                        delete static_cast<std::vector<uint8_t>*>(user);
+                    },
+                    b
+                );
+                app.resourceLoader->addResourceData(uri, std::move(desc));
+            }
+        }
+
         if (!app.resourceLoader->asyncBeginLoad(app.asset)) {
             std::cerr << "Unable to start loading resources for " << filename << std::endl;
             exit(1);
@@ -248,6 +262,7 @@ int main(int argc, char** argv) {
     };
 
     auto setup = [&](Engine* engine, View* view, Scene* scene) {
+        app.rawAssetLoader = new filament::app::DesktopAssetLoader();
         app.engine = engine;
         app.names = new NameComponentManager(EntityManager::get());
         app.viewer = new ViewerGui(engine, scene, view);
@@ -287,6 +302,7 @@ int main(int argc, char** argv) {
         delete app.stbDecoder;
         delete app.ktxDecoder;
         delete app.webpDecoder;
+        delete app.rawAssetLoader;
 
         AssetLoader::destroy(&app.loader);
     };

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -29,7 +29,9 @@
 #include <gltfio/ResourceLoader.h>
 #include <gltfio/TextureProvider.h>
 
+#include <filamentapp/AssetLoader.h>
 #include <filamentapp/Config.h>
+#include <filamentapp/DesktopAssetLoader.h>
 #include <filamentapp/FilamentApp.h>
 #include <filamentapp/IBL.h>
 
@@ -98,6 +100,7 @@ struct App {
     Camera* mainCamera;
     Entity rootTransformEntity;
 
+    filament::app::AssetLoader* rawAssetLoader = nullptr;
     AssetLoader* assetLoader;
     FilamentAsset* asset = nullptr;
     FilamentInstance* instance = nullptr;
@@ -627,18 +630,9 @@ int main(int argc, char** argv) {
     }
 
     auto loadAsset = [&app](const utils::Path& filename) {
-        // Peek at the file size to allow pre-allocation.
-        long const contentSize = static_cast<long>(getFileSize(filename.c_str()));
-        if (contentSize <= 0) {
+        std::vector<uint8_t> buffer = app.rawAssetLoader->load(filename);
+        if (buffer.empty()) {
             std::cerr << "Unable to open " << filename << std::endl;
-            exit(1);
-        }
-
-        // Consume the glTF file.
-        std::ifstream in(filename.c_str(), std::ifstream::binary | std::ifstream::in);
-        std::vector<uint8_t> buffer(static_cast<unsigned long>(contentSize));
-        if (!in.read((char*) buffer.data(), contentSize)) {
-            std::cerr << "Unable to read " << filename << std::endl;
             exit(1);
         }
 
@@ -722,6 +716,26 @@ int main(int argc, char** argv) {
             app.resourceLoader->setConfiguration(configuration);
         }
 
+        // We explicitly fetch the raw bytes and push them into ResourceLoader via addResourceData.
+        // This pre-populates the cache and completely bypasses ResourceLoader's internal disk I/O,
+        // which is required for Android compatibility (where assets are packed in the APK).
+        for (size_t i = 0, c = app.asset->getResourceUriCount(); i < c; i++) {
+            const char* uri = app.asset->getResourceUris()[i];
+            utils::Path uriPath = filename.getParent() + uri;
+            std::vector<uint8_t> buffer = app.rawAssetLoader->load(uriPath);
+            if (!buffer.empty()) {
+                auto* b = new std::vector<uint8_t>(std::move(buffer));
+                gltfio::ResourceLoader::BufferDescriptor desc(
+                    b->data(), b->size(),
+                    [](void*, size_t, void* user) {
+                        delete static_cast<std::vector<uint8_t>*>(user);
+                    },
+                    b
+                );
+                app.resourceLoader->addResourceData(uri, std::move(desc));
+            }
+        }
+
         if (!app.resourceLoader->asyncBeginLoad(app.asset)) {
             std::cerr << "Unable to start loading resources for " << filename << std::endl;
             exit(1);
@@ -744,6 +758,7 @@ int main(int argc, char** argv) {
     };
 
     auto setup = [&](Engine* engine, View* view, Scene* scene) {
+        app.rawAssetLoader = new filament::app::DesktopAssetLoader();
         app.engine = engine;
         app.names = new NameComponentManager(EntityManager::get());
         app.viewer = new ViewerGui(engine, scene, view, 410);
@@ -1084,6 +1099,7 @@ int main(int argc, char** argv) {
         delete app.stbDecoder;
         delete app.ktxDecoder;
         delete app.webpDecoder;
+        delete app.rawAssetLoader;
         delete app.automationSpec;
         delete app.automationEngine;
 


### PR DESCRIPTION
This abstraction allows us to load assets from non-desktop
platforms such as Android or web.

We mark the auto-disk-load behavior in gltfio deprecated so that
disk-related action can eventually be removed from gltfio.