### PR TITLE
fix the incorrect standard variant filtering rule

### DIFF
--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -105,7 +105,7 @@ struct Variant {
 
     // special variants (variants that use the reserved space)
     static constexpr type_t SPECIAL_SSR_VARIANT=       S2D |       SRE            ;
-    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DYN | DIR;
+    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DYN | DIR | FOG;
 
     static constexpr type_t STANDARD_MASK      = DEP;
     static constexpr type_t STANDARD_VARIANT   = 0u;
@@ -143,21 +143,11 @@ struct Variant {
    }
 
     static constexpr bool isValidStandardVariant(Variant variant) noexcept {
-        // can't have shadow receiver if we don't have any lighting
-        constexpr type_t RESERVED0_MASK  = S2D | FOG | SRE | DYN | DIR;
-        constexpr type_t RESERVED0_VALUE = S2D | FOG | SRE;
-
-        // can't have shadow receiver if we don't have any lighting
-        constexpr type_t RESERVED1_MASK  = S2D | SRE | DYN | DIR;
-        constexpr type_t RESERVED1_VALUE = SRE;
-
         // can't have VSM without shadow receiver
         constexpr type_t RESERVED2_MASK  = S2D | SRE;
         constexpr type_t RESERVED2_VALUE = S2D;
 
         return ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) &&
-               ((variant.key & RESERVED0_MASK) != RESERVED0_VALUE) &&
-               ((variant.key & RESERVED1_MASK) != RESERVED1_VALUE) &&
                ((variant.key & RESERVED2_MASK) != RESERVED2_VALUE);
     }
 

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -144,11 +144,11 @@ struct Variant {
 
     static constexpr bool isValidStandardVariant(Variant variant) noexcept {
         // can't have VSM without shadow receiver
-        constexpr type_t RESERVED2_MASK  = S2D | SRE;
-        constexpr type_t RESERVED2_VALUE = S2D;
+        constexpr type_t RESERVED_MASK = S2D | SRE;
+        constexpr type_t RESERVED_VALUE = S2D;
 
         return ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) &&
-               ((variant.key & RESERVED2_MASK) != RESERVED2_VALUE);
+               ((variant.key & RESERVED_MASK) != RESERVED_VALUE);
     }
 
     static constexpr bool isVertexVariant(Variant variant) noexcept {

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -218,8 +218,8 @@ static auto const gPostProcessVariants{ details::get_post_process_variants() };
 static_assert(reserved_is_not_valid());
 static_assert(reserved_variant_count() == 148);
 static_assert(valid_variant_count() == 108);
-static_assert(vertex_variant_count() == 40);
-static_assert(fragment_variant_count() == 27);
+static_assert(vertex_variant_count() == 32 - 0 + 8 - 0);   // 40
+static_assert(fragment_variant_count() == 32 - 8 + 4 - 1); // 27
 
 } // namespace details
 

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -216,10 +216,10 @@ static auto const gDepthVariants{ details::get_depth_variants() };
 static auto const gPostProcessVariants{ details::get_post_process_variants() };
 
 static_assert(reserved_is_not_valid());
-static_assert(reserved_variant_count() == 160);
-static_assert(valid_variant_count() == 96);
-static_assert(vertex_variant_count() == 32 - (4 + 0) + 8 - 0);        // 36
-static_assert(fragment_variant_count() == 33 - (2 + 2 + 8) + 4 - 1);    // 24
+static_assert(reserved_variant_count() == 148);
+static_assert(valid_variant_count() == 108);
+static_assert(vertex_variant_count() == 40);
+static_assert(fragment_variant_count() == 27);
 
 } // namespace details
 


### PR DESCRIPTION
In commit `b22899f5b2ab1c617c4ddf6a57145f789fa665bc`, dynamic lighting (`DYN`) was migrated to dynamic specialization constants and stripped from the variant key (`variant.key &= ~DYN;`).
Consequently, a shadow-receiving object (`SRE`) in a scene with only dynamic lights (and no directional light, `DIR`=0) is filtered to `SRE` (alone) at runtime. Then it will be filtered out by the reserved mask in `isValidStandardVariant` .

We have to update the rule of `isValidStandardVariant` to allow these cases.

- Remove reserved masks: prevent the case above from being filtered out
- Update SSR mask: Removing `RESERVED0` made the variant `(S2D | FOG | SRE)` valid. However, because the `SPECIAL_SSR_MASK` did not check `FOG`, the variant was incorrectly classified as an SSR variant and then use the incorrect descriptor set layout. Here we add the `FOG` bit to `SPECIAL_SSR_MASK` to make sure `(S2D | FOG | SRE)` is not classified as a SSR variant.