### PR TITLE
material: fix colored penumbra enablement

### DIFF
--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -545,8 +545,7 @@ std::string ShaderGenerator::createSurfaceFragmentProgram(ShaderModel const shad
             material.multiBounceAO : shaderModel == ShaderModel::DESKTOP;
     CodeGenerator::generateDefine(fs, "MULTI_BOUNCE_AMBIENT_OCCLUSION", multiBounceAO ? 1u : 0u);
 
-    bool const coloredPenumbra = material.hasColoredPenumbra;
-    CodeGenerator::generateDefine(fs, "HAS_COLORED_PENUMBRA", coloredPenumbra ? 1u : 0u);
+    CodeGenerator::generateDefine(fs, "HAS_COLORED_PENUMBRA", material.hasColoredPenumbra);
 
     generateSurfaceMaterialVariantProperties(fs, mProperties, mDefines);
 


### PR DESCRIPTION
In the shader the use of color penumbra is guarded with "#if defined(HAS_COLORED_PENUMBRA)"

However,
"CodeGenerator::generateDefine(fs, "HAS_COLORED_PENUMBRA", hasColoredPenumbra ? 1u : 0u);"

means that HAS_COLORED_PENUMBRA is always defined.  This means we're accidentally enabling this feature.

The fix is use to boolean overload of
`CodeGenerator::generateDefine`, which ensures that the literal is not defined when the feature is not enabled in the material definition.