### PR TITLE
Add utils::debug::Mutex lock-order debugger 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ option(FILAMENT_DISABLE_GTAO "Disable GTAO" OFF)
 
 option(FILAMENT_BUILD_TESTING "Build tests" ON)
 
+option(FILAMENT_DEBUG_MUTEX "Enable utils::Mutex lock order and deadlock debugging" OFF)
+
 set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
 )
@@ -139,6 +141,10 @@ endif()
 
 if (NOT FILAMENT_ENABLE_RTTI)
     add_compile_options(-fno-rtti)
+endif()
+
+if (FILAMENT_DEBUG_MUTEX)
+    add_compile_definitions(FILAMENT_DEBUG_MUTEX)
 endif()
 
 # ==================================================================================================

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,6 +89,10 @@ buildscript {
             .gradleProperty("com.google.android.filament.matnopt")
             .isPresent()
 
+    def mutexdebug = providers
+            .gradleProperty("com.google.android.filament.mutexdebug")
+            .isPresent()
+
     def abis = ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
     def newAbis = providers
             .gradleProperty("com.google.android.filament.abis")
@@ -139,7 +143,8 @@ buildscript {
         "-DFILAMENT_SUPPORTS_WEBGPU=${includeWebGPU ? 'ON' : 'OFF'}".toString(),
         "-DFILAMENT_ENABLE_FGVIEWER=${fgviewer ? 'ON' : 'OFF'}".toString(),
         "-DFILAMENT_ENABLE_MATDBG=${matdbg ? 'ON' : 'OFF'}".toString(),
-        "-DFILAMENT_DISABLE_MATOPT=${matnopt ? 'ON' : 'OFF'}".toString()
+        "-DFILAMENT_DISABLE_MATOPT=${matnopt ? 'ON' : 'OFF'}".toString(),
+        "-DFILAMENT_DEBUG_MUTEX=${mutexdebug ? 'ON' : 'OFF'}".toString()
     ]
 
     ext.cppFlags = [

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,8 @@ function print_help {
     echo "        Enable matdbg."
     echo "    -t"
     echo "        Enable fgviewer."
+    echo "    -u"
+    echo "        Enable utils::Mutex debugging (lock-order inversion and self-deadlock detection)."
     echo "    -f"
     echo "        Always invoke CMake before incremental builds."
     echo "    -g"
@@ -204,6 +206,8 @@ MATDBG_OPTION="-DFILAMENT_ENABLE_MATDBG=OFF"
 MATDBG_GRADLE_OPTION=""
 FGVIEWER_OPTION="-DFILAMENT_ENABLE_FGVIEWER=OFF"
 FGVIEWER_GRADLE_OPTION=""
+MUTEX_DEBUG_OPTION="-DFILAMENT_DEBUG_MUTEX=OFF"
+MUTEX_DEBUG_GRADLE_OPTION=""
 
 MATOPT_OPTION=""
 MATOPT_GRADLE_OPTION=""
@@ -276,6 +280,7 @@ function build_tools_for_split_build {
         ${WEBGPU_OPTION} \
         ${architectures} \
         ${EXCEPTIONS_OPTION} \
+        ${MUTEX_DEBUG_OPTION} \
         ../..
 
     ${BUILD_COMMAND} ${WEB_HOST_TOOLS}
@@ -320,6 +325,7 @@ function build_desktop_target {
             ${STEREOSCOPIC_OPTION} \
             ${OSMESA_OPTION} \
             ${EXCEPTIONS_OPTION} \
+            ${MUTEX_DEBUG_OPTION} \
             ${architectures} \
             ../..
         ln -sf "out/cmake-${lc_target}/compile_commands.json" \
@@ -386,6 +392,7 @@ function build_wasm_with_target {
             ${WEBGPU_OPTION} \
             ${BACKEND_DEBUG_FLAG_OPTION} \
             ${EXCEPTIONS_OPTION} \
+            ${MUTEX_DEBUG_OPTION} \
             ../..
         ln -sf "out/cmake-wasm-${lc_target}/compile_commands.json" \
            ../../compile_commands.json
@@ -466,6 +473,7 @@ function build_android_target {
             ${STEREOSCOPIC_OPTION} \
             ${ENABLE_PERFETTO} \
             ${EXCEPTIONS_OPTION} \
+            ${MUTEX_DEBUG_OPTION} \
             ../..
         ln -sf "out/cmake-android-${lc_target}-${arch}/compile_commands.json" \
            ../../compile_commands.json
@@ -579,6 +587,7 @@ function build_android {
             ${MATDBG_GRADLE_OPTION} \
             ${FGVIEWER_GRADLE_OPTION} \
             ${MATOPT_GRADLE_OPTION} \
+            ${MUTEX_DEBUG_GRADLE_OPTION} \
             :filament-android:assembleDebug \
             :gltfio-android:assembleDebug \
             :filament-utils-android:assembleDebug
@@ -634,6 +643,7 @@ function build_android {
             ${MATDBG_GRADLE_OPTION} \
             ${FGVIEWER_GRADLE_OPTION} \
             ${MATOPT_GRADLE_OPTION} \
+            ${MUTEX_DEBUG_GRADLE_OPTION} \
             :filament-android:assembleRelease \
             :gltfio-android:assembleRelease \
             :filament-utils-android:assembleRelease
@@ -708,6 +718,7 @@ function build_ios_target {
             ${MATOPT_OPTION} \
             ${STEREOSCOPIC_OPTION} \
             ${EXCEPTIONS_OPTION} \
+            ${MUTEX_DEBUG_OPTION} \
             ../..
         ln -sf "out/cmake-ios-${lc_target}-${arch}/compile_commands.json" \
            ../../compile_commands.json
@@ -883,7 +894,7 @@ function check_debug_release_build {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:E" opt; do
+while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:Eu" opt; do
     case ${opt} in
         h)
             print_help
@@ -908,6 +919,11 @@ while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:E" opt; do
             PRINT_FGVIEWER_HELP=true
             FGVIEWER_OPTION="-DFILAMENT_ENABLE_FGVIEWER=ON"
             FGVIEWER_GRADLE_OPTION="-Pcom.google.android.filament.fgviewer"
+            ;;
+        u)
+            MUTEX_DEBUG_OPTION="-DFILAMENT_DEBUG_MUTEX=ON"
+            MUTEX_DEBUG_GRADLE_OPTION="-Pcom.google.android.filament.mutexdebug"
+            echo "Enabled utils::Mutex debugging"
             ;;
         f)
             ISSUE_CMAKE_ALWAYS=true

--- a/filament/backend/include/private/backend/CommandBufferQueue.h
+++ b/filament/backend/include/private/backend/CommandBufferQueue.h
@@ -24,9 +24,7 @@
 #include <utils/Mutex.h>
 
 #include <atomic>
-#include <condition_variable>
 #include <exception>
-#include <mutex>
 #include <vector>
 
 #include <stddef.h>
@@ -109,8 +107,8 @@ private:
 
     // space available in the circular buffer
 
-    mutable std::mutex mLock;
-    mutable std::condition_variable mCondition;
+    mutable utils::Mutex mLock;
+    mutable utils::Condition mCondition;
     mutable std::vector<Range> mCommandBuffersToExecute UTILS_GUARDED_BY(mLock);
     size_t mFreeSpace UTILS_GUARDED_BY(mLock) = 0;
     size_t mHighWatermark UTILS_GUARDED_BY(mLock) = 0;

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -41,7 +41,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if defined(FILAMENT_DEBUG_MUTEX) || defined(UTILS_DEBUG_MUTEX)
+#define HandleAllocatorGL   HandleAllocator<32,  96, 312>
+#else
 #define HandleAllocatorGL   HandleAllocator<32,  96, 184>    // ~4520 / pool / MiB
+#endif
 #define HandleAllocatorVK   HandleAllocator<64, 160, 312>    // ~1820 / pool / MiB
 #define HandleAllocatorMTL  HandleAllocator<32,  64, 552>    // ~1660 / pool / MiB
 // TODO WebGPU examine right size of handles

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -26,14 +26,13 @@
 #include <backend/Platform.h>
 
 #include <utils/compiler.h>
+#include <utils/Condition.h>
 #include <utils/CString.h>
 #include <utils/debug.h>
 #include <utils/Mutex.h>
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
-#include <mutex>
 #include <thread>
 #include <tuple>
 #include <utility>
@@ -323,17 +322,17 @@ protected:
 private:
     const Platform::DriverConfig mDriverConfig;
 
-    mutable std::mutex mPurgeLock;
+    mutable utils::Mutex mPurgeLock;
     std::vector<std::pair<void*, CallbackHandler::Callback>> mCallbacks UTILS_GUARDED_BY(mPurgeLock);
 
     std::thread mServiceThread;
-    mutable std::mutex mServiceThreadLock;
-    mutable std::condition_variable mServiceThreadCondition;
+    mutable utils::Mutex mServiceThreadLock;
+    mutable utils::Condition mServiceThreadCondition;
     std::vector<std::tuple<CallbackHandler*, CallbackHandler::Callback, void*>> mServiceThreadCallbackQueue UTILS_GUARDED_BY(mServiceThreadLock);
     bool mExitRequested UTILS_GUARDED_BY(mServiceThreadLock) = false;
 
-    mutable std::condition_variable mFenceCondition;
-    mutable std::mutex mFenceMutex;
+    mutable utils::Condition mFenceCondition;
+    mutable utils::Mutex mFenceMutex;
     std::atomic<bool> mHasUnrecoverableError UTILS_GUARDED_BY(mFenceMutex){false};
 };
 

--- a/filament/backend/src/JobQueue.h
+++ b/filament/backend/src/JobQueue.h
@@ -24,10 +24,8 @@
 #include <utils/JobSystem.h>
 #include <utils/Mutex.h>
 
-#include <condition_variable>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <queue>
 #include <thread>
 #include <unordered_map>
@@ -156,8 +154,8 @@ private:
 
     JobId genNextJobId() noexcept UTILS_REQUIRES(mQueueMutex);
 
-    std::mutex mQueueMutex;
-    std::condition_variable mQueueCondition;
+    utils::Mutex mQueueMutex;
+    utils::Condition mQueueCondition;
     std::unordered_map<JobId, Job> mJobsMap UTILS_GUARDED_BY(mQueueMutex);
     std::queue<JobId> mJobOrder UTILS_GUARDED_BY(mQueueMutex);
     JobId mNextJobId UTILS_GUARDED_BY(mQueueMutex) = 0;

--- a/filament/backend/src/metal/MetalBufferPool.h
+++ b/filament/backend/src/metal/MetalBufferPool.h
@@ -19,10 +19,11 @@
 
 #include "MetalBuffer.h"
 
+#include <utils/Mutex.h>
+
 #include <Metal/Metal.h>
 
 #include <map>
-#include <mutex>
 #include <unordered_set>
 
 namespace filament {
@@ -56,7 +57,7 @@ public:
 private:
     id<MTLDevice> mDevice;
 
-    std::mutex mMutex;
+    utils::Mutex mMutex;
     // The following are protected by mMutex
     TrackedMetalBuffer mCurrentUploadBuffer = nil;
     size_t mHead = 0;
@@ -91,7 +92,7 @@ private:
     // Synchronizes access to mFreeStages, mUsedStages, and mutable data inside MetalBufferPoolEntrys.
     // acquireBuffer and releaseBuffer may be called on separate threads (the engine thread and a
     // Metal callback thread, for example).
-    std::mutex mMutex;
+    utils::Mutex mMutex;
 
     // Use an ordered multimap for quick (capacity => stage) lookups using lower_bound().
     std::multimap<size_t, MetalBufferPoolEntry const*> mFreeStages;

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -22,14 +22,14 @@
 #include <utils/Panic.h>
 #include <utils/trap.h>
 
-#include <thread>
 #include <chrono>
+#include <thread>
 
 namespace filament {
 namespace backend {
 
 MetalBufferPoolEntry const* MetalBufferPool::acquireBuffer(size_t numBytes) {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     // First check if a stage exists whose capacity is greater than or equal to the requested size.
     auto iter = mFreeStages.lower_bound(numBytes);
@@ -62,13 +62,13 @@ MetalBufferPoolEntry const* MetalBufferPool::acquireBuffer(size_t numBytes) {
 }
 
 void MetalBufferPool::retainBuffer(MetalBufferPoolEntry const *stage) noexcept {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     (stage->referenceCount)++;
 }
 
 void MetalBufferPool::releaseBuffer(MetalBufferPoolEntry const *stage) noexcept {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     // Decrement the ref count. If it is at 0, move the buffer entry to the free list.
     if (--(stage->referenceCount) > 0) {
@@ -92,7 +92,7 @@ void MetalBufferPool::gc() noexcept {
     }
     const uint64_t evictionTime = mCurrentFrame - TIME_BEFORE_EVICTION;
 
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     decltype(mFreeStages) stages;
     stages.swap(mFreeStages);
@@ -106,7 +106,7 @@ void MetalBufferPool::gc() noexcept {
 }
 
 void MetalBufferPool::reset() noexcept {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     assert_invariant(mUsedStages.empty());
     for (auto pair : mFreeStages) {
@@ -136,7 +136,7 @@ std::pair<id<MTLBuffer>, size_t> MetalBumpAllocator::allocateStagingArea(size_t 
 
     // Try to allocate from the current buffer first
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        utils::LockGuard const lock(mMutex);
         assert_invariant(mCurrentUploadBuffer);
 
         // Align the head to a 4-byte boundary.
@@ -152,7 +152,7 @@ std::pair<id<MTLBuffer>, size_t> MetalBumpAllocator::allocateStagingArea(size_t 
     // Create a new buffer outside the lock.
     id<MTLBuffer> newBuffer = [mDevice newBufferWithLength:mCapacity options:MTLStorageModeShared];
 
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     // We need to re-check if another thread already reset the buffer while we were allocating.
     size_t alignedHead = (mHead + 3) & ~3;

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -29,6 +29,7 @@
 #include <QuartzCore/QuartzCore.h>
 
 #include <utils/FixedCircularBuffer.h>
+#include <utils/Mutex.h>
 
 #include <array>
 #include <atomic>
@@ -47,7 +48,7 @@ namespace backend {
 class MetalDriver;
 
 struct DriverLifetimeTracker {
-    std::mutex mutex;
+    utils::Mutex mutex;
     MetalDriver* driver = nullptr;
 };
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -268,7 +268,7 @@ MetalDriver::~MetalDriver() noexcept {
     // Notify any pending asynchronous MTLSharedEvent listener blocks that the MetalDriver
     // is being destroyed. This avoids executing blocks accessing a dangling driver pointer.
     {
-        std::lock_guard<std::mutex> lock(mContext->driverLifetimeTracker->mutex);
+        utils::LockGuard const lock(mContext->driverLifetimeTracker->mutex);
         mContext->driverLifetimeTracker->driver = nullptr;
     }
     TrackedMetalBuffer::setPlatform(nullptr);

--- a/filament/backend/src/metal/MetalErrorQueue.h
+++ b/filament/backend/src/metal/MetalErrorQueue.h
@@ -20,10 +20,10 @@
 #import <Foundation/Foundation.h>
 
 #include <utils/compiler.h>
+#include <utils/Mutex.h>
 
 #include <atomic>
 #include <functional>
-#include <mutex>
 #include <vector>
 
 class MetalErrorQueue {
@@ -33,7 +33,7 @@ public:
     }
 
     void push(NSError* error) {
-        std::lock_guard<std::mutex> lock(mMutex);
+        utils::LockGuard const lock(mMutex);
         mErrors.push_back(error);
         mHasErrors.store(true, std::memory_order_relaxed);
     }
@@ -44,7 +44,7 @@ public:
         }
         std::vector<NSError*> errors;
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            utils::LockGuard const lock(mMutex);
             std::swap(mErrors, errors);
             mHasErrors.store(false, std::memory_order_relaxed);
         }
@@ -56,7 +56,7 @@ public:
 
 private:
     std::vector<NSError*> mErrors;
-    std::mutex mMutex;
+    utils::Mutex mMutex;
 
     // Optimization to avoid locking the mutex at each call to flush.
     std::atomic<bool> mHasErrors;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -32,6 +32,7 @@
 #include <utils/bitset.h>
 #include <utils/CString.h>
 #include <utils/FixedCapacityVector.h>
+#include <utils/Mutex.h>
 #include <utils/Panic.h>
 
 #include <math/vec2.h>
@@ -41,7 +42,6 @@
 #include <QuartzCore/QuartzCore.h> // for CAMetalLayer
 
 #include <atomic>
-#include <condition_variable>
 #include <memory>
 #include <type_traits>
 #include <vector>
@@ -187,7 +187,7 @@ private:
     NSUInteger headlessWidth = 0;
     NSUInteger headlessHeight = 0;
     CAMetalLayer* layer = nullptr;
-    std::shared_ptr<std::mutex> layerDrawableMutex;
+    std::shared_ptr<utils::Mutex> layerDrawableMutex;
     MetalExternalImage externalImage;
     SwapChainType type;
     uint64_t flags;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -17,21 +17,21 @@
 #include "MetalHandles.h"
 
 #include "MetalBlitter.h"
-#include "MetalEnums.h"
-#include "MetalUtils.h"
 #include "MetalBufferPool.h"
 #include "MetalDriver.h"
+#include "MetalEnums.h"
+#include "MetalUtils.h"
 
 #include <filament/SwapChain.h>
 
+#include <private/backend/BackendUtils.h>
+
 #include <backend/DriverEnums.h>
 
-#include "private/backend/BackendUtils.h"
-
-#include <utils/Logger.h>
-#include <utils/Panic.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
+#include <utils/Logger.h>
+#include <utils/Panic.h>
 #include <utils/trap.h>
 
 #include <math/scalar.h>
@@ -116,7 +116,7 @@ MetalSwapChain::MetalSwapChain(
       platform(platform),
       depthStencilFormat(decideDepthStencilFormat(flags)),
       layer(nativeWindow),
-      layerDrawableMutex(std::make_shared<std::mutex>()),
+      layerDrawableMutex(std::make_shared<utils::Mutex>()),
       type(SwapChainType::CAMETALLAYER),
       flags(flags) {
 
@@ -227,7 +227,7 @@ bool MetalSwapChain::isAbandoned() const {
 
 void MetalSwapChain::releaseDrawable() {
     if (drawable) {
-        std::lock_guard<std::mutex> lock(*layerDrawableMutex);
+        utils::LockGuard const lock(*layerDrawableMutex);
         drawable = nil;
     }
 }
@@ -352,7 +352,7 @@ public:
     PresentDrawableData& operator=(const PresentDrawableData&) = delete;
 
     static PresentDrawableData* create(id<CAMetalDrawable> drawable,
-            std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver, uint64_t flags,
+            std::shared_ptr<utils::Mutex> drawableMutex, MetalDriver* driver, uint64_t flags,
             int64_t presentationTimeNs) {
         assert_invariant(drawableMutex);
         assert_invariant(driver);
@@ -384,7 +384,7 @@ public:
     }
 
 private:
-    PresentDrawableData(id<CAMetalDrawable> drawable, std::shared_ptr<std::mutex> drawableMutex,
+    PresentDrawableData(id<CAMetalDrawable> drawable, std::shared_ptr<utils::Mutex> drawableMutex,
             MetalDriver* driver, uint64_t flags, int64_t presentationTimeNs)
             : mDrawable(drawable),
               mDrawableMutex(drawableMutex),
@@ -394,7 +394,7 @@ private:
 
     static void cleanupAndDestroy(PresentDrawableData *that) {
         if (that->mDrawable) {
-            std::lock_guard<std::mutex> lock(*(that->mDrawableMutex));
+            utils::LockGuard const lock(*(that->mDrawableMutex));
             that->mDrawable = nil;
         }
         that->mDrawableMutex.reset();
@@ -403,7 +403,7 @@ private:
     }
 
     id<CAMetalDrawable> mDrawable;
-    std::shared_ptr<std::mutex> mDrawableMutex;
+    std::shared_ptr<utils::Mutex> mDrawableMutex;
     MetalDriver* mDriver = nullptr;
     uint64_t mFlags = 0;
     int64_t mPresentationTimeNs = 0;
@@ -423,7 +423,7 @@ void MetalSwapChain::scheduleFrameScheduledCallback(int64_t presentationTimeNs) 
 
     struct Callback {
         Callback(std::shared_ptr<FrameScheduledCallback> callback, id<CAMetalDrawable> drawable,
-                std::shared_ptr<std::mutex> drawableMutex, MetalDriver* driver, uint64_t flags,
+                std::shared_ptr<utils::Mutex> drawableMutex, MetalDriver* driver, uint64_t flags,
                 int64_t presentationTimeNs)
                 : f(callback),
                   data(PresentDrawableData::create(drawable, drawableMutex, driver, flags,
@@ -525,7 +525,7 @@ MetalAttachment MetalSwapChain::acquireBaseDrawable() {
     // calling -nextDrawable, or when releasing the last known reference
     // to any CAMetalDrawable returned from a previous -nextDrawable.
     {
-        std::lock_guard<std::mutex> lock(*layerDrawableMutex);
+        utils::LockGuard const lock(*layerDrawableMutex);
         drawable = [layer nextDrawable];
     }
 
@@ -1424,7 +1424,7 @@ void MetalFence::encode() {
                           // accessing it.
                           auto lifetime = weakDriverLifetime.lock();
                           if (s && lifetime) {
-                              std::lock_guard<std::mutex> lock(lifetime->mutex);
+                              utils::LockGuard const lock(lifetime->mutex);
                               if (lifetime->driver) {
                                   lifetime->driver->signalFence(
                                           [&] { s->status = FenceStatus::CONDITION_SATISFIED; });

--- a/filament/backend/src/metal/MetalResourceTracker.cpp
+++ b/filament/backend/src/metal/MetalResourceTracker.cpp
@@ -23,7 +23,7 @@ namespace backend {
 
 bool MetalResourceTracker::trackResource(CommandBuffer buffer, Resource resource,
         ResourceDeleter deleter) {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     auto found = mResources.find(buffer);
     if (found == mResources.end()) {
@@ -39,7 +39,7 @@ bool MetalResourceTracker::trackResource(CommandBuffer buffer, Resource resource
 }
 
 void MetalResourceTracker::clearResources(CommandBuffer buffer) {
-    std::lock_guard<std::mutex> lock(mMutex);
+    utils::LockGuard const lock(mMutex);
 
     auto found = mResources.find(buffer);
     if (found == mResources.end()) {

--- a/filament/backend/src/metal/MetalResourceTracker.h
+++ b/filament/backend/src/metal/MetalResourceTracker.h
@@ -17,11 +17,10 @@
 #ifndef TNT_METALRESOURCETRACKER_H
 #define TNT_METALRESOURCETRACKER_H
 
+#include <utils/Mutex.h>
+
 #include <tsl/robin_map.h>
 #include <tsl/robin_set.h>
-
-#include <functional>
-#include <mutex>
 
 namespace filament {
 namespace backend {
@@ -72,7 +71,7 @@ private:
     // Synchronizes access to the map.
     // trackResource and clearResources may be called on separate threads (the engine thread and a
     // Metal callback thread, for example).
-    std::mutex mMutex;
+    utils::Mutex mMutex;
 };
 
 } // namespace backend

--- a/filament/backend/src/metal/PlatformMetal.mm
+++ b/filament/backend/src/metal/PlatformMetal.mm
@@ -23,13 +23,14 @@
 
 #import <Foundation/Foundation.h>
 
+#include <utils/Mutex.h>
+
 #include <atomic>
-#include <mutex>
 
 namespace filament::backend {
 
 struct PlatformMetalImpl {
-    std::mutex mLock;   // locks mDevice and mCommandQueue
+    utils::Mutex mLock;   // locks mDevice and mCommandQueue
     id<MTLDevice> mDevice = nil;
     id<MTLCommandQueue> mCommandQueue = nil;
 
@@ -61,7 +62,7 @@ Driver* PlatformMetal::createDriver(void* /*sharedContext*/, const Platform::Dri
 
 
 bool PlatformMetal::initialize() noexcept {
-    std::lock_guard<std::mutex> lock(pImpl->mLock);
+    utils::LockGuard const lock(pImpl->mLock);
 
     MetalDevice device{};
     pImpl->createDeviceImpl(device);
@@ -79,18 +80,18 @@ bool PlatformMetal::initialize() noexcept {
 }
 
 void PlatformMetal::createDevice(MetalDevice& outDevice) noexcept {
-    std::lock_guard<std::mutex> lock(pImpl->mLock);
+    utils::LockGuard const lock(pImpl->mLock);
     pImpl->createDeviceImpl(outDevice);
 }
 
 void PlatformMetal::createCommandQueue(
         MetalDevice& device, MetalCommandQueue& outCommandQueue) noexcept {
-    std::lock_guard<std::mutex> lock(pImpl->mLock);
+    utils::LockGuard const lock(pImpl->mLock);
     pImpl->createCommandQueueImpl(device, outCommandQueue);
 }
 
 void PlatformMetal::createAndEnqueueCommandBuffer(MetalCommandBuffer& outCommandBuffer) noexcept {
-    std::lock_guard<std::mutex> lock(pImpl->mLock);
+    utils::LockGuard const lock(pImpl->mLock);
     id<MTLCommandBuffer> commandBuffer = [pImpl->mCommandQueue commandBuffer];
     [commandBuffer enqueue];
     outCommandBuffer.commandBuffer = commandBuffer;

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
@@ -50,7 +50,7 @@ struct PlatformCocoaTouchGLImpl {
     GLuint mDefaultDepthbuffer = 0;
     CVOpenGLESTextureCacheRef mTextureCache = nullptr;
     CocoaTouchExternalImage::SharedGl* mExternalImageSharedGl = nullptr;
-    struct ExternalImageCocoaTouchGL : public Platform::ExternalImage {
+    struct ExternalImageCocoaTouchGL final : public Platform::ExternalImage {
         CVPixelBufferRef cvBuffer;
     protected:
         ~ExternalImageCocoaTouchGL() noexcept final;

--- a/filament/backend/src/vulkan/VulkanAsyncHandles.h
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.h
@@ -35,7 +35,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <shared_mutex>
 #include <utility>
 #include <vector>
@@ -280,12 +279,12 @@ struct VulkanTimerQuery : public HwTimerQuery, fvkmemory::ThreadSafeResource {
           mStoppingQueryIndex(stoppingIndex) {}
 
     void setFence(std::shared_ptr<VulkanCmdFence> fence) noexcept {
-        std::lock_guard const lock(mFenceMutex);
+        utils::LockGuard const lock(mFenceMutex);
         mFence = std::move(fence);
     }
 
     bool isCompleted() noexcept {
-        std::lock_guard const lock(mFenceMutex);
+        utils::LockGuard const lock(mFenceMutex);
         // QueryValue is a synchronous call and might occur before beginTimerQuery has written
         // anything into the command buffer, which is an error according to the validation layer
         // that ships in the Android NDK.  Even when AVAILABILITY_BIT is set, validation seems to

--- a/filament/backend/src/vulkan/VulkanReadPixels.cpp
+++ b/filament/backend/src/vulkan/VulkanReadPixels.cpp
@@ -42,7 +42,7 @@ TaskHandler::TaskHandler()
 void TaskHandler::post(WorkloadFunc&& workload, OnCompleteFunc&& oncomplete) {
     assert_invariant(!mShouldStop);
     {
-        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        utils::UniqueLock lock(mTaskQueueMutex);
         mTaskQueue.push(std::make_pair(std::move(workload), std::move(oncomplete)));
     }
     mHasTaskCondition.notify_one();
@@ -51,25 +51,25 @@ void TaskHandler::post(WorkloadFunc&& workload, OnCompleteFunc&& oncomplete) {
 void TaskHandler::drain() {
     assert_invariant(!mShouldStop);
 
-    std::mutex syncPointMutex;
-    std::condition_variable syncCondition;
+    utils::Mutex syncPointMutex;
+    utils::Condition syncCondition;
     bool done = false;
     post([] {},
             [&syncPointMutex, &syncCondition, &done] {
                 {
-                    std::unique_lock<std::mutex> lock(syncPointMutex);
+                    utils::UniqueLock lock(syncPointMutex);
                     done = true;
                     syncCondition.notify_one();
                 }
             });
 
-    std::unique_lock<std::mutex> lock(syncPointMutex);
+    utils::UniqueLock lock(syncPointMutex);
     syncCondition.wait(lock, [&done] { return done; });
 }
 
 void TaskHandler::shutdown() {
     {
-        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        utils::UniqueLock lock(mTaskQueueMutex);
         mShouldStop = true;
     }
     mHasTaskCondition.notify_one();
@@ -80,7 +80,7 @@ void TaskHandler::shutdown() {
 
 void TaskHandler::loop() {
     while (true) {
-        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        utils::UniqueLock lock(mTaskQueueMutex);
         mHasTaskCondition.wait(lock, [this] { return !mTaskQueue.empty() || mShouldStop; });
         if (mShouldStop) {
             break;
@@ -94,7 +94,7 @@ void TaskHandler::loop() {
 
     // Clean-up: we still need to call oncomplete for clients to do clean-up.
     while (true) {
-        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        utils::UniqueLock lock(mTaskQueueMutex);
         if (mTaskQueue.empty()) {
             break;
         }

--- a/filament/backend/src/vulkan/VulkanReadPixels.h
+++ b/filament/backend/src/vulkan/VulkanReadPixels.h
@@ -23,11 +23,12 @@
 
 #include <bluevk/BlueVK.h>
 
+#include <utils/Condition.h>
+#include <utils/Mutex.h>
+
 #include <math/vec4.h>
 
-#include <condition_variable>
 #include <functional>
-#include <mutex>
 #include <queue>
 #include <thread>
 
@@ -63,8 +64,8 @@ public:
         void loop();
 
         bool mShouldStop;
-        std::condition_variable mHasTaskCondition;
-        std::mutex mTaskQueueMutex;
+        utils::Condition mHasTaskCondition;
+        utils::Mutex mTaskQueueMutex;
         std::queue<Task> mTaskQueue;
         std::thread mThread;
     };

--- a/filament/backend/src/webgpu/WebGPUQueueManager.cpp
+++ b/filament/backend/src/webgpu/WebGPUQueueManager.cpp
@@ -32,7 +32,7 @@ FenceStatus WebGPUSubmissionState::waitForCompletion(uint64_t timeout) {
         until = now + nanoseconds(timeout);
     }
 
-    std::unique_lock<std::mutex> lock(mLock);
+    utils::UniqueLock lock(mLock);
     mCond.wait_until(lock, until, [this] {
         return mStatus == FenceStatus::CONDITION_SATISFIED || mStatus == FenceStatus::ERROR;
     });
@@ -44,7 +44,7 @@ FenceStatus WebGPUSubmissionState::waitForCompletion(uint64_t timeout) {
 
 
 void WebGPUSubmissionState::setStatus(FenceStatus status) {
-    std::lock_guard<std::mutex> const lock(mLock);
+    utils::LockGuard const lock(mLock);
     mStatus = status;
     mCond.notify_all();
 }

--- a/filament/backend/src/webgpu/WebGPUQueueManager.h
+++ b/filament/backend/src/webgpu/WebGPUQueueManager.h
@@ -19,10 +19,12 @@
 
 #include <backend/DriverEnums.h>
 
+#include <utils/Condition.h>
+#include <utils/Mutex.h>
+
 #include <webgpu/webgpu_cpp.h>
 
 #include <memory>
-#include <mutex>
 
 namespace filament::backend {
 
@@ -36,7 +38,7 @@ struct WebGPUSubmissionState {
             : mStatus(status) {}
 
     FenceStatus getStatus() {
-        std::lock_guard<std::mutex> const lock(mLock);
+        utils::LockGuard const lock(mLock);
         return mStatus;
     }
 
@@ -45,8 +47,8 @@ struct WebGPUSubmissionState {
     void setStatus(FenceStatus status);
 
 private:
-    std::mutex mLock;
-    std::condition_variable mCond;
+    utils::Mutex mLock;
+    utils::Condition mCond;
     FenceStatus mStatus;
 };
 

--- a/filament/backend/src/webgpu/WebGPUStagePool.cpp
+++ b/filament/backend/src/webgpu/WebGPUStagePool.cpp
@@ -29,7 +29,7 @@ wgpu::Buffer WebGPUStagePool::acquireBuffer(size_t requiredSize,
         std::shared_ptr<WebGPUSubmissionState> submissionState) {
     wgpu::Buffer buffer;
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        utils::LockGuard const lock(mMutex);
         auto iter = mBuffers.lower_bound(requiredSize);
         if (iter != mBuffers.end()) {
             buffer = iter->second;
@@ -56,7 +56,7 @@ void WebGPUStagePool::recycleBuffer(wgpu::Buffer buffer) {
                     if (!data->webGPUStagePool) {
                         return;
                     }
-                    std::lock_guard<std::mutex> lock(data->webGPUStagePool->mMutex);
+                    utils::LockGuard const lock(data->webGPUStagePool->mMutex);
                     data->webGPUStagePool->mBuffers.insert(
                             { data->buffer.GetSize(), data->buffer });
                 } else {

--- a/filament/backend/src/webgpu/WebGPUStagePool.h
+++ b/filament/backend/src/webgpu/WebGPUStagePool.h
@@ -17,10 +17,11 @@
 #ifndef TNT_FILAMENT_BACKEND_WEBGPUSTAGEPOOL_H
 #define TNT_FILAMENT_BACKEND_WEBGPUSTAGEPOOL_H
 
+#include <utils/Mutex.h>
+
 #include <webgpu/webgpu_cpp.h>
 
 #include <map>
-#include <mutex>
 
 namespace filament::backend {
 
@@ -40,7 +41,7 @@ private:
     wgpu::Buffer createNewBuffer(size_t bufferSize);
     std::multimap<uint32_t, wgpu::Buffer> mBuffers;
     std::vector<std::pair<std::shared_ptr<WebGPUSubmissionState>, wgpu::Buffer>> mInProgress;
-    std::mutex mMutex;
+    utils::Mutex mMutex;
 
     wgpu::Device mDevice;
 };

--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -28,11 +28,12 @@
 #include <dawn/webgpu_cpp_print.h>
 #include <webgpu/webgpu_cpp.h>
 
+#include <utils/Mutex.h>
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <functional>
-#include <mutex>
 #include <sstream>// for one-time-ish setup string concatenation, namely error messaging
 #include <unordered_set>
 #include <utility>
@@ -471,7 +472,7 @@ struct AdapterDetailsHash final {
     // make the series of requests asynchronously, collecting compatible adapter results...
     std::unordered_set<AdapterDetails, AdapterDetailsHash> compatibleAdapters;
     compatibleAdapters.reserve(requests.size());
-    std::mutex adaptersMutex;
+    utils::Mutex adaptersMutex;
     std::vector<wgpu::Future> futures(requests.size());
     for (size_t i = 0; i < requests.size(); i++) {
         wgpu::RequestAdapterOptions const& options = requests[i];
@@ -492,7 +493,7 @@ struct AdapterDetailsHash final {
                         FILAMENT_CHECK_POSTCONDITION(readyAdapter.GetInfo(&details.info))
                                 << "Failed to get info for adapter (options: "
                                 << adapterOptionsToString(options) << ")";
-                        const std::lock_guard<std::mutex> lock(adaptersMutex);
+                        utils::LockGuard const lock(adaptersMutex);
                         compatibleAdapters.emplace(std::move(details.info), details.powerPreference,
                                 std::move(details.adapter));
                         return;

--- a/filament/backend/src/webgpu/utils/AsyncTaskCounter.cpp
+++ b/filament/backend/src/webgpu/utils/AsyncTaskCounter.cpp
@@ -17,18 +17,17 @@
 #include "AsyncTaskCounter.h"
 
 #include <utils/debug.h>
-
-#include <mutex>
+#include <utils/Mutex.h>
 
 namespace filament::backend::webgpuutils {
 
 void AsyncTaskCounter::startTask() {
-    std::lock_guard<std::mutex> lock{ mMutex };
+    utils::LockGuard const lock{ mMutex };
     ++mTasksInProgress;
 }
 
 void AsyncTaskCounter::finishTask() {
-    std::lock_guard<std::mutex> lock{ mMutex };
+    utils::LockGuard const lock{ mMutex };
     --mTasksInProgress;
     assert_invariant(mTasksInProgress >= 0);
     if (mTasksInProgress == 0) {
@@ -37,12 +36,12 @@ void AsyncTaskCounter::finishTask() {
 }
 
 void AsyncTaskCounter::waitForAllToFinish() {
-    std::unique_lock<std::mutex> lock{ mMutex };
+    utils::UniqueLock lock{ mMutex };
     mFinishedCondition.wait(lock, [this] { return mTasksInProgress == 0; });
 }
 
 bool AsyncTaskCounter::isIdle() {
-    std::lock_guard<std::mutex> lock{ mMutex };
+    utils::LockGuard const lock{ mMutex };
     return mTasksInProgress == 0;
 }
 

--- a/filament/backend/src/webgpu/utils/AsyncTaskCounter.h
+++ b/filament/backend/src/webgpu/utils/AsyncTaskCounter.h
@@ -17,8 +17,8 @@
 #ifndef TNT_FILAMENT_BACKEND_UTIL_ASYNCWORKCOUNTER_H
 #define TNT_FILAMENT_BACKEND_UTIL_ASYNCWORKCOUNTER_H
 
-#include <condition_variable>
-#include <mutex>
+#include <utils/Condition.h>
+#include <utils/Mutex.h>
 
 namespace filament::backend::webgpuutils {
 
@@ -57,8 +57,8 @@ public:
     bool isIdle();
 
 private:
-    std::mutex mMutex;
-    std::condition_variable mFinishedCondition;
+    utils::Mutex mMutex;
+    utils::Condition mFinishedCondition;
     int mTasksInProgress{ 0 };
 };
 

--- a/filament/backend/test/test_Handles.cpp
+++ b/filament/backend/test/test_Handles.cpp
@@ -28,10 +28,13 @@ using namespace filament::backend;
 static constexpr uint32_t HANDLE_HEAP_FLAG = 0x80000000u;
 static constexpr size_t POOL_SIZE_BYTES = 8 * 1024U * 1024U;
 // NOTE: actual count may be lower due to alignment requirements
+#if defined(FILAMENT_DEBUG_MUTEX) || defined(UTILS_DEBUG_MUTEX)
+constexpr size_t const POOL_HANDLE_COUNT = POOL_SIZE_BYTES / (32 + 96 + 312);
+#define HandleAllocatorTest  HandleAllocator<32,  96, 312>
+#else
 constexpr size_t const POOL_HANDLE_COUNT = POOL_SIZE_BYTES / (32 + 96 + 184); // 31775
-
-// This must match HandleAllocatorGL, so its implementation is present on all platforms.
 #define HandleAllocatorTest  HandleAllocator<32,  96, 184>    // ~4520 / pool / MiB
+#endif
 
 struct MyHandle {
 };

--- a/filament/src/details/BufferAllocator.h
+++ b/filament/src/details/BufferAllocator.h
@@ -32,7 +32,7 @@ namespace filament {
 // BufferAllocator instance will result in data races and undefined behavior.
 //
 // If an instance of this class is to be shared between threads, all calls to its member
-// functions MUST be protected by external synchronization (e.g., a std::mutex).
+// functions MUST be protected by external synchronization (e.g., a utils::Mutex).
 class BufferAllocator {
 public:
     using allocation_size_t = uint32_t;

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1652,13 +1652,13 @@ void FEngine::setPaused(bool const paused) {
 }
 
 void FEngine::setFenceUnrecoverableError() noexcept {
-    std::lock_guard const lock(mFenceLock);
+    LockGuard const lock(mFenceLock);
     mFenceHasUnrecoverableError = true;
     mFenceCondition.notify_all();
 }
 
 void FEngine::signalFence(FenceSignal& signal, FenceSignal::State s) noexcept {
-    std::lock_guard const lock(mFenceLock);
+    LockGuard const lock(mFenceLock);
     signal.mState = s;
     mFenceCondition.notify_all();
 }

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -71,18 +71,19 @@
 
 #include <utils/Allocator.h>
 #include <utils/compiler.h>
+#include <utils/Condition.h>
 #include <utils/CountDownLatch.h>
 #include <utils/debug.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Invocable.h>
 #include <utils/JobSystem.h>
 #include <utils/memalign.h>
+#include <utils/Mutex.h>
 #include <utils/Slice.h>
 #include <utils/tribool.h>
 
 #include <cstddef>
 #include <chrono>
-#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <new>
@@ -90,7 +91,6 @@
 #include <string_view>
 #include <random>
 #include <thread>
-#include <mutex>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -688,8 +688,8 @@ private:
     mutable utils::Mutex mFenceListLock;
     ResourceList<FFence> mFences UTILS_GUARDED_BY(mFenceListLock){"Fence"};
 
-    mutable std::mutex mFenceLock;
-    mutable std::condition_variable mFenceCondition;
+    mutable utils::Mutex mFenceLock;
+    mutable utils::Condition mFenceCondition;
     bool mFenceHasUnrecoverableError = false;
 
     // the sync list is accessed from multiple threads, because they are

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ project(utils)
 set(TARGET utils)
 set(TARGET_LINUX ${TARGET}/linux)
 set(TARGET_GENERIC ${TARGET}/generic)
+set(TARGET_DEBUG ${TARGET}/debug)
 set(PUBLIC_HDR_DIR include)
 
 # ==================================================================================================
@@ -65,11 +66,16 @@ set(DIST_GENERIC_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET_GENERIC}/Mutex.h
 )
 
+set(DIST_DEBUG_HDRS
+        ${PUBLIC_HDR_DIR}/${TARGET_DEBUG}/Mutex.h
+)
+
 set(SRCS
         src/api_level.cpp
         src/architecture.cpp
         src/ashmem.cpp
         src/debug.cpp
+        src/debug/Mutex.cpp
         src/Allocator.cpp
         src/AsyncJobQueue.cpp
         src/CallStack.cpp
@@ -179,6 +185,7 @@ if (ANDROID)
 else()
     install(FILES ${DIST_GENERIC_HDRS} DESTINATION include/${TARGET_GENERIC})
 endif()
+install(FILES ${DIST_DEBUG_HDRS} DESTINATION include/${TARGET_DEBUG})
 
 # ==================================================================================================
 # Test executables
@@ -216,6 +223,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_Zip2Iterator.cpp
             test/test_BinaryTreeArray.cpp
             test/test_Status.cpp
+            test/test_Mutex.cpp
     )
 
     if (WASM_PTHREADS)

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -123,7 +123,7 @@ private:
     };
 
     size_t m_frame_count = 0;
-    StackFrameInfo m_stack[NUM_FRAMES];
+    StackFrameInfo m_stack[NUM_FRAMES] = {};
 };
 
 } // namespace utils

--- a/libs/utils/include/utils/Mutex.h
+++ b/libs/utils/include/utils/Mutex.h
@@ -21,33 +21,37 @@
  * @file Mutex.h
  * @brief Custom low-overhead mutex primitives for Filament.
  *
- * Filament provides two types of mutexes: C++ standard std::mutex and custom utils::Mutex.
- * Choosing the correct one is a critical tradeoff between runtime performance, cache hygiene,
- * and OS scheduler integration.
+ * Filament prefers custom `utils::Mutex` over C++ standard `std::mutex` across all engine code.
  *
- * ARCHITECTURAL TRADEOFFS & CHOICE CRITERIA:
+ * WHY `utils::Mutex` IS PREFERRED OVER `std::mutex`:
  *
- * 1. Use C++ standard std::mutex when:
- *    - HIGH RISK OF PRIORITY INVERSION: The lock is shared between threads running at significantly
- *      different priorities (e.g., the critical Display/Render thread vs. low-priority background loader
- *      threads). std::mutex leverages OS-level pthread mutexes which support Priority Inheritance (PI)
- *      protocols, temporarily elevating the low-priority holder to prevent render pipeline stalls.
- *    - CONDITION VARIABLE SYNCHRON_VARIABLE: The lock is used in conjunction with condition variables
- *      (std::condition_variable) to block/sleep threads (e.g. CommandBufferQueue). Standard condition
- *      variables require std::mutex to operate natively and efficiently with the OS scheduler.
- *    - HIGH CONTENTION: The locked section is heavily contended, allowing modern CPU architectures
- *      (like ARMv8.1+ LSE) to utilize single-instruction atomics resolved dynamically at startup (IFUNCs).
+ * 1. UNIFIED CONCURRENCY & DEADLOCK DEBUGGING (`-u` / `FILAMENT_DEBUG_MUTEX`):
+ *    When `FILAMENT_DEBUG_MUTEX` or `UTILS_DEBUG_MUTEX` is enabled, `utils::Mutex` transparently
+ *    instruments every lock acquisition and release across the engine. It maintains a global dependency
+ *    graph verified via BFS during `lock()` and `try_lock()` to detect multi-threaded lock-order inversions
+ *    and recursive self-deadlocks on non-recursive locks, logging exact creation and acquisition `CallStack`s.
+ *    Raw `std::mutex` instances are completely untracked and invisible to this debugging facility.
  *
- * 2. Use custom utils::Mutex when:
- *    - CACHE & MEMORY FOOTPRINT IS CRITICAL: utils::Mutex is only 4 bytes (a single futex-based uint32_t)
- *      compared to standard std::mutex which is 40 bytes. For classes allocated in large numbers (such as
- *      fences, sync points, or handle maps), reducing size by 10x prevents padding bloat and maintains
- *      optimal cache line alignment hygiene (avoiding false sharing).
- *    - SAME-PRIORITY ACCESS: The lock is shared only between threads of identical high priorities
- *      (e.g., Main thread and Driver thread, both DISPLAY priority), eliminating priority inversion risks.
- *    - EXTREMELY BRIEF HOLD TIMES / LOW CONTENTION: The lock is taken for simple pointer swaps or list
- *      insertions. The fully-inlined userspace compare-and-swap (CAS) assembly fast-path executes
- *      instantly without incurring PLT/dynamic library call overhead or kernel syscalls.
+ * 2. CACHE & MEMORY FOOTPRINT HYGIENE:
+ *    On Android and Linux (`linuxutil::Mutex`), `utils::Mutex` is only 4 bytes (a single atomic uint32_t
+ *    futex word), compared to `std::mutex` (`pthread_mutex_t`), which consumes 40 bytes. For objects embedded
+ *    in high quantities (fences, sync points, handle allocators, or queue buffers), `utils::Mutex` prevents
+ *    struct bloat and preserves cache-line density and alignment hygiene.
+ *
+ * 3. FAST-PATH INLINING & HIGH CONTENTION PERFORMANCE:
+ *    `utils::Mutex` uses fully inlined atomic compare-and-swap (`compare_exchange_strong`) userspace
+ *    fast-paths. When uncontended, acquisition and release execute with zero PLT/dynamic library overhead or
+ *    kernel syscalls. Under contention (`LOCKED_CONTENDED`), `utils::Mutex` drops directly into OS kernel
+ *    futex sleep (`futex_wait_ex`), matching standard mutex high-contention efficiency without overhead.
+ *
+ * 4. CONDITION VARIABLE COMPATIBILITY:
+ *    `utils::Condition` (`Condition::wait` and `wait_until`) is explicitly templated on the mutex type (`template <typename M>`)
+ *    and works seamlessly with `std::unique_lock<utils::Mutex>` or `utils::UniqueLock<utils::Mutex>`.
+ *
+ * NOTE ON PRIORITY INVERSION:
+ *    C++ `std::mutex` (backed by POSIX `pthread_mutex_t`) does NOT prevent priority inversions out of the
+ *    box, because standard libraries initialize mutex attributes to `PTHREAD_PRIO_NONE` (rather than
+ *    `PTHREAD_PRIO_INHERIT`). Therefore, `std::mutex` provides no priority inheritance advantage over `utils::Mutex`.
  */
 
 #include <utils/compiler.h>

--- a/libs/utils/include/utils/Mutex.h
+++ b/libs/utils/include/utils/Mutex.h
@@ -59,6 +59,13 @@
 #include <utils/generic/Mutex.h>
 #endif
 
+#if defined(UTILS_DEBUG_MUTEX) || defined(FILAMENT_DEBUG_MUTEX)
+#include <utils/debug/Mutex.h>
+namespace utils {
+using Mutex = debug::Mutex;
+} // namespace utils
+#endif
+
 namespace utils {
 
 /**

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -267,6 +267,12 @@
 #define UTILS_ACQUIRE_SHARED(...) \
     UTILS_THREAD_ANNOTATION_ATTRIBUTE(acquire_shared_capability(__VA_ARGS__))
 
+#define UTILS_TRY_ACQUIRE(...) \
+    UTILS_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_capability(__VA_ARGS__))
+
+#define UTILS_TRY_ACQUIRE_SHARED(...) \
+    UTILS_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_shared_capability(__VA_ARGS__))
+
 #define UTILS_RELEASE(...) \
     UTILS_THREAD_ANNOTATION_ATTRIBUTE(release_capability(__VA_ARGS__))
 

--- a/libs/utils/include/utils/debug/Mutex.h
+++ b/libs/utils/include/utils/debug/Mutex.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_DEBUG_MUTEX_H
+#define TNT_UTILS_DEBUG_MUTEX_H
+
+#include <utils/CallStack.h>
+#include <utils/compiler.h>
+
+#include <atomic>
+
+#if defined(__ANDROID__)
+#include <utils/linux/Mutex.h>
+#else
+#include <utils/generic/Mutex.h>
+#endif
+
+namespace utils::debug {
+
+class UTILS_CAPABILITY("mutex") Mutex {
+public:
+    constexpr Mutex() noexcept = default;
+    ~Mutex() noexcept;
+
+    Mutex(const Mutex&) = delete;
+    Mutex& operator=(const Mutex&) = delete;
+
+    void lock() UTILS_ACQUIRE();
+    bool try_lock() UTILS_TRY_ACQUIRE(true);
+    void unlock() UTILS_RELEASE();
+
+    CallStack const& getCreationStack() const noexcept;
+    void ensureCreationStackCaptured() const noexcept;
+
+#if defined(__ANDROID__)
+    linuxutil::Mutex& getUnderlyingMutex() noexcept { return mUnderlying; }
+    linuxutil::Mutex const& getUnderlyingMutex() const noexcept { return mUnderlying; }
+#else
+    generic::Mutex& getUnderlyingMutex() noexcept { return mUnderlying; }
+    generic::Mutex const& getUnderlyingMutex() const noexcept { return mUnderlying; }
+#endif
+
+private:
+    friend class Condition;
+
+#if defined(__ANDROID__)
+    linuxutil::Mutex mUnderlying;
+#else
+    generic::Mutex mUnderlying;
+#endif
+
+    mutable CallStack mCreationStack;
+    mutable std::atomic<bool> mCreationCaptured = { false };
+};
+
+}
+
+#endif // TNT_UTILS_DEBUG_MUTEX_H

--- a/libs/utils/include/utils/generic/Condition.h
+++ b/libs/utils/include/utils/generic/Condition.h
@@ -23,11 +23,17 @@
 
 namespace utils {
 
+#if defined(UTILS_DEBUG_MUTEX) || defined(FILAMENT_DEBUG_MUTEX)
+class Condition : public std::condition_variable_any {
+public:
+    using std::condition_variable_any::condition_variable_any;
+#else
 class Condition : public std::condition_variable {
 public:
     using std::condition_variable::condition_variable;
+#endif
 
-    inline void notify_n(size_t n) noexcept {
+    inline void notify_n(size_t const n) noexcept {
         if (n == 1) {
             notify_one();
         } else if (n > 1) {

--- a/libs/utils/include/utils/generic/Mutex.h
+++ b/libs/utils/include/utils/generic/Mutex.h
@@ -20,8 +20,15 @@
 #include <mutex>
 
 namespace utils {
+namespace generic {
 
 using Mutex = std::mutex;
+
+} // namespace generic
+
+#if !defined(UTILS_DEBUG_MUTEX) && !defined(FILAMENT_DEBUG_MUTEX)
+using Mutex = generic::Mutex;
+#endif
 
 } // namespace utils
 

--- a/libs/utils/include/utils/linux/Condition.h
+++ b/libs/utils/include/utils/linux/Condition.h
@@ -49,45 +49,46 @@ public:
         pulse(1);
     }
 
-    void notify_n(size_t n) noexcept {
+    void notify_n(size_t const n) noexcept {
         if (n > 0) pulse(n);
     }
 
-    void wait(std::unique_lock<Mutex>& lock) noexcept {
-        wait_until(lock.mutex(), false, nullptr);
+    template <typename M>
+    void wait(std::unique_lock<M>& lock) noexcept {
+        wait_until_impl(lock.mutex(), false, nullptr);
     }
 
-    template <class P>
-    void wait(std::unique_lock<Mutex>& lock, P predicate) {
+    template <typename M, class P>
+    void wait(std::unique_lock<M>& lock, P predicate) {
         while (!predicate()) {
             wait(lock);
         }
     }
 
-    template<typename D>
-    std::cv_status wait_until(std::unique_lock<Mutex>& lock,
+    template<typename M, typename D>
+    std::cv_status wait_until(std::unique_lock<M>& lock,
             const std::chrono::time_point<std::chrono::steady_clock, D>& timeout_time) noexcept {
         // convert to nanoseconds
-        uint64_t ns = std::chrono::duration<uint64_t, std::nano>(timeout_time.time_since_epoch()).count();
+        uint64_t const ns = std::chrono::duration<uint64_t, std::nano>(timeout_time.time_since_epoch()).count();
         using sec_t = decltype(timespec::tv_sec);
         using nsec_t = decltype(timespec::tv_nsec);
         timespec ts{ sec_t(ns / 1000000000), nsec_t(ns % 1000000000) };
-        return wait_until(lock.mutex(), false, &ts);
+        return wait_until_impl(lock.mutex(), false, &ts);
     }
 
-    template<typename D>
-    std::cv_status wait_until(std::unique_lock<Mutex>& lock,
+    template<typename M, typename D>
+    std::cv_status wait_until(std::unique_lock<M>& lock,
             const std::chrono::time_point<std::chrono::system_clock, D>& timeout_time) noexcept {
         // convert to nanoseconds
-        uint64_t ns = std::chrono::duration<uint64_t, std::nano>(timeout_time.time_since_epoch()).count();
+        uint64_t const ns = std::chrono::duration<uint64_t, std::nano>(timeout_time.time_since_epoch()).count();
         using sec_t = decltype(timespec::tv_sec);
         using nsec_t = decltype(timespec::tv_nsec);
         timespec ts{ sec_t(ns / 1000000000), nsec_t(ns % 1000000000) };
-        return wait_until(lock.mutex(), true, &ts);
+        return wait_until_impl(lock.mutex(), true, &ts);
     }
 
-    template<typename C, typename D, typename P>
-    bool wait_until(std::unique_lock<Mutex>& lock,
+    template<typename M, typename C, typename D, typename P>
+    bool wait_until(std::unique_lock<M>& lock,
             const std::chrono::time_point<C, D>& timeout_time, P predicate) noexcept {
         while (!predicate()) {
             if (wait_until(lock, timeout_time) == std::cv_status::timeout) {
@@ -97,14 +98,14 @@ public:
         return true;
     }
 
-    template<typename R, typename Period>
-    std::cv_status wait_for(std::unique_lock<Mutex>& lock,
+    template<typename M, typename R, typename Period>
+    std::cv_status wait_for(std::unique_lock<M>& lock,
             const std::chrono::duration<R, Period>& rel_time) noexcept {
         return wait_until(lock, std::chrono::steady_clock::now() + rel_time);
     }
 
-    template<typename R, typename Period, typename P>
-    bool wait_for(std::unique_lock<Mutex>& lock,
+    template<typename M, typename R, typename Period, typename P>
+    bool wait_for(std::unique_lock<M>& lock,
             const std::chrono::duration<R, Period>& rel_time, P pred) noexcept {
         return wait_until(lock, std::chrono::steady_clock::now() + rel_time, std::move(pred));
     }
@@ -114,8 +115,23 @@ private:
 
     void pulse(int threadCount) noexcept;
 
-    std::cv_status wait_until(Mutex* lock,
+    std::cv_status wait_until(linuxutil::Mutex* lock,
             bool realtimeClock, timespec* ts) noexcept;
+
+    int futex_wait(uint32_t old_state, bool realtimeClock, timespec* ts) noexcept;
+
+    template <typename M>
+    std::cv_status wait_until_impl(M* lock,
+            bool const realtimeClock, timespec* ts) noexcept UTILS_NO_THREAD_SAFETY_ANALYSIS {
+        if (ts && ts->tv_sec < 0) {
+            return std::cv_status::timeout;
+        }
+        uint32_t const old_state = mState.load(std::memory_order_relaxed);
+        lock->unlock();
+        int const status = futex_wait(old_state, realtimeClock, ts);
+        lock->lock();
+        return (status == -ETIMEDOUT) ? std::cv_status::timeout : std::cv_status::no_timeout;
+    }
 };
 
 } // namespace utils

--- a/libs/utils/include/utils/linux/Mutex.h
+++ b/libs/utils/include/utils/linux/Mutex.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 namespace utils {
+namespace linuxutil {
 
 /*
  * A very simple mutex class that can be used as an (almost) drop-in replacement
@@ -45,6 +46,12 @@ public:
         }
     }
 
+    bool try_lock() noexcept UTILS_TRY_ACQUIRE(true) {
+        uint32_t old_state = UNLOCKED;
+        return mState.compare_exchange_strong(old_state,
+                LOCKED, std::memory_order_acquire, std::memory_order_relaxed);
+    }
+
     void unlock() noexcept UTILS_RELEASE() {
         if (UTILS_UNLIKELY(mState.exchange(UNLOCKED, std::memory_order_release) == LOCKED_CONTENDED)) {
             wake();
@@ -52,6 +59,8 @@ public:
     }
 
 private:
+    friend class Condition;
+
     enum {
         UNLOCKED = 0, LOCKED = 1, LOCKED_CONTENDED = 2
     };
@@ -60,6 +69,12 @@ private:
     void wait() noexcept;
     void wake() noexcept;
 };
+
+} // namespace linuxutil
+
+#if !defined(UTILS_DEBUG_MUTEX) && !defined(FILAMENT_DEBUG_MUTEX)
+using Mutex = linuxutil::Mutex;
+#endif
 
 } // namespace utils
 

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <utils/Log.h>
+#include <utils/Mutex.h>
 
 #include "ostream_.h"
 
@@ -52,7 +53,7 @@ private:
 };
 
 ostream& LogStream::flush() noexcept {
-    std::lock_guard const lock(mImpl->mLock);
+    LockGuard const lock(mImpl->mLock);
     Buffer& buf = getBuffer();
     char const* const str = buf.get();
     if (UTILS_UNLIKELY(!str)) {

--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -21,6 +21,7 @@
 #include <utils/CString.h>
 #include <utils/Log.h>
 #include <utils/Logger.h>
+#include <utils/Mutex.h>
 #include <utils/ostream.h>
 #include <utils/Panic.h>
 
@@ -59,11 +60,11 @@ class UserPanicHandler {
         }
     };
 
-    mutable std::mutex mLock{};
+    mutable Mutex mLock{};
     CallBack mCallBack{};
 
     CallBack getCallback() const noexcept {
-        std::lock_guard const lock(mLock);
+        LockGuard const lock(mLock);
         return mCallBack;
     }
 
@@ -78,7 +79,7 @@ public:
     }
 
     void set(Panic::PanicHandlerCallback const handler, void* user) noexcept {
-        std::lock_guard const lock(mLock);
+        LockGuard const lock(mLock);
         mCallBack = { handler, user };
     }
 };
@@ -114,7 +115,7 @@ static CString sprintfToString(const char* format, ...) noexcept {
 }
 
 static CString buildPanicString(
-        std::string_view const& msg, const char* function, int line,
+        std::string_view const& msg, const char* function, int const line,
         const char* file, const char* reason) {
 #ifndef NDEBUG
     return sprintfToString("%.*s\nin %s:%d\nin file %s\nreason: %s",
@@ -192,8 +193,8 @@ const CallStack& TPanic<T>::getCallStack() const noexcept {
 
 template<typename T>
 void TPanic<T>::log() const noexcept {
-    slog.e << what() << io::endl;
-    slog.e << mCallstack << io::endl;
+    LOG(ERROR) << what();
+    LOG(ERROR) << mCallstack;
 }
 
 UTILS_ALWAYS_INLINE
@@ -263,19 +264,17 @@ void panicLog(char const* function, char const* file, int const line, const char
     CString const reason{ sprintfToString(format, args) };
     va_end(args);
 
-    CString const msg = buildPanicString("PanicLog",
-            function, line, file, reason.c_str());
-
-    slog.e << msg << io::endl;
-    slog.e << CallStack::unwind(1) << io::endl;
+    CString const msg = buildPanicString("PanicLog", function, line, file, reason.c_str());
+    LOG(ERROR) << msg;
+    LOG(ERROR) << CallStack::unwind(1);
 }
 
 PanicStream::PanicStream(
         char const* function,
         char const* file,
         int const line,
-        char const* condition) noexcept
-        : mFunction(function), mFile(file), mLine(line), mLiteral(condition) {
+        char const* message) noexcept
+    : mFunction(function), mFile(file), mLine(line), mLiteral(message) {
 }
 
 PanicStream::~PanicStream() = default;

--- a/libs/utils/src/debug/Mutex.cpp
+++ b/libs/utils/src/debug/Mutex.cpp
@@ -1,0 +1,460 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/CallStack.h>
+#include <utils/compiler.h>
+#include <utils/CString.h>
+#include <utils/debug/Mutex.h>
+#include <utils/Log.h>
+#include <utils/Logger.h>
+#include <utils/Panic.h>
+#include <utils/sstream.h>
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <thread>
+#include <vector>
+
+namespace utils {
+namespace debug {
+
+namespace {
+
+struct HeldLockInfo {
+    const Mutex* mutex;
+    CallStack lockStack;
+};
+
+struct ThreadLockState {
+    static constexpr size_t MAX_HELD_LOCKS = 64;
+    HeldLockInfo heldLocks[MAX_HELD_LOCKS];
+    size_t count = 0;
+    uint64_t threadId = 0;
+
+    uint64_t getThreadId() noexcept {
+        if (UTILS_UNLIKELY(threadId == 0)) {
+            threadId = (uint64_t)std::hash<std::thread::id>()(std::this_thread::get_id());
+            if (threadId == 0) {
+                threadId = (uint64_t)(uintptr_t)this;
+            }
+        }
+        return threadId;
+    }
+};
+
+static thread_local ThreadLockState t_lockState;
+
+class GraphSpinLock {
+    std::atomic_flag mFlag = ATOMIC_FLAG_INIT;
+public:
+    void lock() noexcept {
+        while (mFlag.test_and_set(std::memory_order_acquire)) {
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+            _mm_pause();
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM))
+            __yield();
+#elif defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+            __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+            __asm__ __volatile__("yield" ::: "memory");
+#endif
+        }
+    }
+    void unlock() noexcept {
+        mFlag.clear(std::memory_order_release);
+    }
+};
+
+struct LockEdge {
+    const Mutex* from;
+    const Mutex* to;
+    CallStack fromLockStack;
+    CallStack toLockStack;
+    uint64_t threadId;
+};
+
+struct LockGraphState {
+    std::vector<LockEdge> edges;
+    std::vector<const Mutex*> nodes;
+    GraphSpinLock spinlock;
+};
+
+LockGraphState& getLockGraphState() noexcept {
+    static LockGraphState s_graphState;
+    return s_graphState;
+}
+
+bool findCyclePath(const Mutex* startNode, const Mutex* targetNode,
+        const LockGraphState& graph, std::vector<size_t>& outCycleEdges) noexcept {
+    if (startNode == targetNode) {
+        return true;
+    }
+
+    struct VisitedNode {
+        const Mutex* mutex;
+        size_t edgeIdx;
+        size_t parentVisitedIdx;
+    };
+    std::vector<VisitedNode> visited;
+    visited.reserve(32);
+    visited.push_back({ startNode, size_t(-1), size_t(-1) });
+
+    size_t queueHead = 0;
+    while (queueHead < visited.size()) {
+        const Mutex* curr = visited[queueHead].mutex;
+
+        for (size_t eIdx = 0; eIdx < graph.edges.size(); ++eIdx) {
+            const LockEdge& edge = graph.edges[eIdx];
+            if (edge.from == curr) {
+                if (edge.to == targetNode) {
+                    outCycleEdges.push_back(eIdx);
+                    size_t idx = queueHead;
+                    while (idx != 0 && visited[idx].edgeIdx != size_t(-1)) {
+                        outCycleEdges.push_back(visited[idx].edgeIdx);
+                        idx = visited[idx].parentVisitedIdx;
+                    }
+                    std::reverse(outCycleEdges.begin(), outCycleEdges.end());
+                    return true;
+                }
+
+                bool alreadyVisited = false;
+                for (const VisitedNode& v : visited) {
+                    if (v.mutex == edge.to) {
+                        alreadyVisited = true;
+                        break;
+                    }
+                }
+                if (!alreadyVisited) {
+                    visited.push_back({ edge.to, eIdx, queueHead });
+                }
+            }
+        }
+        queueHead++;
+    }
+    return false;
+}
+
+} // anonymous namespace
+
+Mutex::~Mutex() noexcept {
+    for (size_t i = 0; i < t_lockState.count; ++i) {
+        if (UTILS_UNLIKELY(t_lockState.heldLocks[i].mutex == this)) {
+            io::sstream stream;
+            stream << "[FILAMENT CONCURRENCY PANIC] Destroying Mutex (0x" << (const void*)this
+                   << ") while it is currently held by Thread (ID " << (unsigned long long)t_lockState.getThreadId() << ")!\n";
+            LOG(ERROR) << stream.c_str();
+            std::abort();
+            for (size_t j = i; j + 1 < t_lockState.count; ++j) {
+                t_lockState.heldLocks[j] = t_lockState.heldLocks[j + 1];
+            }
+            t_lockState.count--;
+            break;
+        }
+    }
+
+    LockGraphState& graph = getLockGraphState();
+    graph.spinlock.lock();
+    for (size_t i = 0; i < graph.edges.size(); ) {
+        if (graph.edges[i].from == this || graph.edges[i].to == this) {
+            graph.edges[i] = graph.edges.back();
+            graph.edges.pop_back();
+        } else {
+            i++;
+        }
+    }
+    for (size_t i = 0; i < graph.nodes.size(); ) {
+        if (graph.nodes[i] == this) {
+            graph.nodes[i] = graph.nodes.back();
+            graph.nodes.pop_back();
+        } else {
+            i++;
+        }
+    }
+    graph.spinlock.unlock();
+}
+
+CallStack const& Mutex::getCreationStack() const noexcept {
+    ensureCreationStackCaptured();
+    return mCreationStack;
+}
+
+void Mutex::ensureCreationStackCaptured() const noexcept {
+    if (UTILS_UNLIKELY(!mCreationCaptured.load(std::memory_order_relaxed))) {
+        bool expected = false;
+        if (mCreationCaptured.compare_exchange_strong(expected, true, std::memory_order_relaxed)) {
+            mCreationStack.update(4);
+        }
+    }
+}
+
+void Mutex::lock() UTILS_ACQUIRE() {
+    ensureCreationStackCaptured();
+
+    for (size_t i = 0; i < t_lockState.count; ++i) {
+        if (UTILS_UNLIKELY(t_lockState.heldLocks[i].mutex == this)) {
+            CallStack currentStack = CallStack::unwind(3);
+            io::sstream stream;
+            stream << "================================================================================\n";
+            stream << "[FILAMENT CONCURRENCY PANIC] Self-Deadlock / Recursive Lock Detected!\n";
+            stream << "================================================================================\n";
+            stream << "Thread (ID " << (unsigned long long)t_lockState.getThreadId()
+                   << ") attempted to recursively acquire non-recursive Lock (0x" << (const void*)this << ")!\n\n";
+            stream << "--- Lock currently held, acquired at:\n" << t_lockState.heldLocks[i].lockStack << "\n";
+            stream << "--- Attempted recursive acquisition at:\n" << currentStack << "\n";
+            stream << "--- Mutex creation stack trace:\n" << getCreationStack() << "\n";
+            stream << "================================================================================\n";
+            LOG(ERROR) << stream.c_str();
+            std::abort();
+        }
+    }
+
+    CallStack currentStack = CallStack::unwind(3);
+
+    if (t_lockState.count > 0) {
+        LockGraphState& graph = getLockGraphState();
+        graph.spinlock.lock();
+
+        for (size_t i = 0; i < t_lockState.count; ++i) {
+            const HeldLockInfo& heldInfo = t_lockState.heldLocks[i];
+            const Mutex* L_i = heldInfo.mutex;
+
+            bool edgeExists = false;
+            for (const LockEdge& edge : graph.edges) {
+                if (edge.from == L_i && edge.to == this) {
+                    edgeExists = true;
+                    break;
+                }
+            }
+
+            if (!edgeExists) {
+                std::vector<size_t> cycleEdges;
+                if (findCyclePath(this, L_i, graph, cycleEdges)) {
+                    io::sstream stream;
+                    stream << "================================================================================\n";
+                    stream << "[FILAMENT CONCURRENCY PANIC] Lock-Order Inversion / Potential Deadlock Detected!\n";
+                    stream << "================================================================================\n";
+                    stream << "Thread (ID " << (unsigned long long)t_lockState.getThreadId()
+                           << ") attempted to acquire Lock (0x" << (const void*)this
+                           << ") while holding Lock (0x" << (const void*)L_i << ")!\n";
+                    stream << "Acquiring this lock creates a cyclic lock dependency graph across threads:\n\n";
+
+                    for (size_t eIdx : cycleEdges) {
+                        const LockEdge& edge = graph.edges[eIdx];
+                        stream << "--- Lock (0x" << (const void*)edge.from
+                               << ") acquired before Lock (0x" << (const void*)edge.to
+                               << ") in Thread (ID " << (unsigned long long)edge.threadId << "):\n";
+                        stream << "[Lock (0x" << (const void*)edge.from << ") locked at:]\n" << edge.fromLockStack << "\n";
+                        stream << "[Lock (0x" << (const void*)edge.to << ") locked at:]\n" << edge.toLockStack << "\n";
+                    }
+
+                    stream << "--- BUT Lock (0x" << (const void*)L_i
+                           << ") acquired before Lock (0x" << (const void*)this
+                           << ") in Thread (ID " << (unsigned long long)t_lockState.getThreadId() << ") [CURRENT THREAD]:\n";
+                    stream << "[Lock (0x" << (const void*)L_i << ") locked at:]\n" << heldInfo.lockStack << "\n";
+                    stream << "[Lock (0x" << (const void*)this << ") attempted acquisition at:]\n" << currentStack << "\n";
+
+                    stream << "--------------------------------------------------------------------------------\n";
+                    stream << "Creation Stack Traces for Involved Locks:\n";
+                    std::vector<const Mutex*> involvedLocks;
+                    for (size_t eIdx : cycleEdges) {
+                        const LockEdge& edge = graph.edges[eIdx];
+                        bool foundFrom = false, foundTo = false;
+                        for (const Mutex* m : involvedLocks) {
+                            if (m == edge.from) foundFrom = true;
+                            if (m == edge.to) foundTo = true;
+                        }
+                        if (!foundFrom) involvedLocks.push_back(edge.from);
+                        if (!foundTo) involvedLocks.push_back(edge.to);
+                    }
+                    bool foundLi = false, foundThis = false;
+                    for (const Mutex* m : involvedLocks) {
+                        if (m == L_i) foundLi = true;
+                        if (m == this) foundThis = true;
+                    }
+                    if (!foundLi) involvedLocks.push_back(L_i);
+                    if (!foundThis) involvedLocks.push_back(this);
+
+                    for (const Mutex* m : involvedLocks) {
+                        stream << "Lock (0x" << (const void*)m << ") created at:\n" << m->getCreationStack() << "\n";
+                    }
+                    stream << "================================================================================\n";
+
+                    graph.spinlock.unlock();
+                    LOG(ERROR) << stream.c_str();
+                    std::abort();
+                } else {
+                    graph.edges.push_back({ L_i, this, heldInfo.lockStack, currentStack, t_lockState.getThreadId() });
+                }
+            }
+        }
+
+        graph.spinlock.unlock();
+    }
+
+    mUnderlying.lock();
+
+    if (UTILS_LIKELY(t_lockState.count < ThreadLockState::MAX_HELD_LOCKS)) {
+        t_lockState.heldLocks[t_lockState.count++] = { this, currentStack };
+    }
+}
+
+bool Mutex::try_lock() UTILS_TRY_ACQUIRE(true) {
+    if (!mUnderlying.try_lock()) {
+        return false;
+    }
+
+    ensureCreationStackCaptured();
+
+    for (size_t i = 0; i < t_lockState.count; ++i) {
+        if (UTILS_UNLIKELY(t_lockState.heldLocks[i].mutex == this)) {
+            CallStack currentStack = CallStack::unwind(3);
+            io::sstream stream;
+            stream << "================================================================================\n";
+            stream << "[FILAMENT CONCURRENCY PANIC] Self-Deadlock / Recursive Lock Detected!\n";
+            stream << "================================================================================\n";
+            stream << "Thread (ID " << (unsigned long long)t_lockState.getThreadId()
+                   << ") attempted to recursively acquire non-recursive Lock (0x" << (const void*)this << ")!\n\n";
+            stream << "--- Lock currently held, acquired at:\n" << t_lockState.heldLocks[i].lockStack << "\n";
+            stream << "--- Attempted recursive acquisition at:\n" << currentStack << "\n";
+            stream << "--- Mutex creation stack trace:\n" << getCreationStack() << "\n";
+            stream << "================================================================================\n";
+            LOG(ERROR) << stream.c_str();
+            std::abort();
+        }
+    }
+
+    CallStack currentStack = CallStack::unwind(3);
+
+    if (t_lockState.count > 0) {
+        LockGraphState& graph = getLockGraphState();
+        graph.spinlock.lock();
+
+        for (size_t i = 0; i < t_lockState.count; ++i) {
+            const HeldLockInfo& heldInfo = t_lockState.heldLocks[i];
+            const Mutex* L_i = heldInfo.mutex;
+
+            bool edgeExists = false;
+            for (const LockEdge& edge : graph.edges) {
+                if (edge.from == L_i && edge.to == this) {
+                    edgeExists = true;
+                    break;
+                }
+            }
+
+            if (!edgeExists) {
+                std::vector<size_t> cycleEdges;
+                if (findCyclePath(this, L_i, graph, cycleEdges)) {
+                    io::sstream stream;
+                    stream << "================================================================================\n";
+                    stream << "[FILAMENT CONCURRENCY PANIC] Lock-Order Inversion / Potential Deadlock Detected!\n";
+                    stream << "================================================================================\n";
+                    stream << "Thread (ID " << (unsigned long long)t_lockState.getThreadId()
+                           << ") attempted to acquire Lock (0x" << (const void*)this
+                           << ") while holding Lock (0x" << (const void*)L_i << ")!\n";
+                    stream << "Acquiring this lock creates a cyclic lock dependency graph across threads:\n\n";
+
+                    for (size_t eIdx : cycleEdges) {
+                        const LockEdge& edge = graph.edges[eIdx];
+                        stream << "--- Lock (0x" << (const void*)edge.from
+                               << ") acquired before Lock (0x" << (const void*)edge.to
+                               << ") in Thread (ID " << (unsigned long long)edge.threadId << "):\n";
+                        stream << "[Lock (0x" << (const void*)edge.from << ") locked at:]\n" << edge.fromLockStack << "\n";
+                        stream << "[Lock (0x" << (const void*)edge.to << ") locked at:]\n" << edge.toLockStack << "\n";
+                    }
+
+                    stream << "--- BUT Lock (0x" << (const void*)L_i
+                           << ") acquired before Lock (0x" << (const void*)this
+                           << ") in Thread (ID " << (unsigned long long)t_lockState.getThreadId() << ") [CURRENT THREAD]:\n";
+                    stream << "[Lock (0x" << (const void*)L_i << ") locked at:]\n" << heldInfo.lockStack << "\n";
+                    stream << "[Lock (0x" << (const void*)this << ") attempted acquisition at:]\n" << currentStack << "\n";
+
+                    stream << "--------------------------------------------------------------------------------\n";
+                    stream << "Creation Stack Traces for Involved Locks:\n";
+                    std::vector<const Mutex*> involvedLocks;
+                    for (size_t eIdx : cycleEdges) {
+                        const LockEdge& edge = graph.edges[eIdx];
+                        bool foundFrom = false, foundTo = false;
+                        for (const Mutex* m : involvedLocks) {
+                            if (m == edge.from) foundFrom = true;
+                            if (m == edge.to) foundTo = true;
+                        }
+                        if (!foundFrom) involvedLocks.push_back(edge.from);
+                        if (!foundTo) involvedLocks.push_back(edge.to);
+                    }
+                    bool foundLi = false, foundThis = false;
+                    for (const Mutex* m : involvedLocks) {
+                        if (m == L_i) foundLi = true;
+                        if (m == this) foundThis = true;
+                    }
+                    if (!foundLi) involvedLocks.push_back(L_i);
+                    if (!foundThis) involvedLocks.push_back(this);
+
+                    for (const Mutex* m : involvedLocks) {
+                        stream << "Lock (0x" << (const void*)m << ") created at:\n" << m->getCreationStack() << "\n";
+                    }
+                    stream << "================================================================================\n";
+
+                    graph.spinlock.unlock();
+                    LOG(ERROR) << stream.c_str();
+                    std::abort();
+                } else {
+                    graph.edges.push_back({ L_i, this, heldInfo.lockStack, currentStack, t_lockState.getThreadId() });
+                }
+            }
+        }
+
+        graph.spinlock.unlock();
+    }
+
+    if (UTILS_LIKELY(t_lockState.count < ThreadLockState::MAX_HELD_LOCKS)) {
+        t_lockState.heldLocks[t_lockState.count++] = { this, currentStack };
+    }
+    return true;
+}
+
+void Mutex::unlock() UTILS_RELEASE() {
+    bool found = false;
+    for (size_t i = t_lockState.count; i > 0; --i) {
+        if (t_lockState.heldLocks[i - 1].mutex == this) {
+            for (size_t j = i - 1; j + 1 < t_lockState.count; ++j) {
+                t_lockState.heldLocks[j] = t_lockState.heldLocks[j + 1];
+            }
+            t_lockState.count--;
+            found = true;
+            break;
+        }
+    }
+
+    if (UTILS_UNLIKELY(!found)) {
+        io::sstream stream;
+        stream << "[FILAMENT CONCURRENCY PANIC] Attempting to unlock Mutex (0x" << (const void*)this
+               << ") that is not held by Thread (ID " << (unsigned long long)t_lockState.getThreadId() << ")!\n";
+        LOG(ERROR) << stream.c_str();
+        std::abort();
+    }
+
+    mUnderlying.unlock();
+}
+
+} // namespace debug
+} // namespace utils

--- a/libs/utils/src/linux/Condition.cpp
+++ b/libs/utils/src/linux/Condition.cpp
@@ -20,7 +20,11 @@
 
 namespace utils {
 
-std::cv_status Condition::wait_until(Mutex* lock,
+int Condition::futex_wait(uint32_t old_state, bool realtimeClock, struct timespec* ts) noexcept {
+    return linuxutil::futex_wait_ex(&mState, false, old_state, realtimeClock, ts);
+}
+
+std::cv_status Condition::wait_until(linuxutil::Mutex* lock,
         bool realtimeClock, struct timespec* ts) noexcept UTILS_NO_THREAD_SAFETY_ANALYSIS {
     if (ts && ts->tv_sec < 0) {
         return std::cv_status::timeout;

--- a/libs/utils/src/linux/Mutex.cpp
+++ b/libs/utils/src/linux/Mutex.cpp
@@ -19,6 +19,7 @@
 #include <utils/linux/Mutex.h>
 
 namespace utils {
+namespace linuxutil {
 
 void Mutex::wait() noexcept {
     while (UTILS_UNLIKELY(mState.exchange(LOCKED_CONTENDED, std::memory_order_acquire) != UNLOCKED)) {
@@ -30,5 +31,6 @@ void Mutex::wake() noexcept {
     linuxutil::futex_wake_ex(&mState, false, LOCKED);
 }
 
+} // namespace linuxutil
 } // namespace utils
 

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -41,7 +41,7 @@ ostream::~ostream() = default;
 
 void ostream::setConsumer(ConsumerCallback consumer, void* user) noexcept {
     auto* const pImpl = mImpl;
-    std::lock_guard const lock(pImpl->mLock);
+    LockGuard const lock(pImpl->mLock);
     pImpl->mConsumer = { consumer, user };
 }
 
@@ -75,7 +75,7 @@ ostream::Buffer const& ostream::getBuffer() const noexcept {
     return mImpl->mData;
 }
 
-const char* ostream::getFormat(type t) const noexcept {
+const char* ostream::getFormat(type const t) const noexcept {
     switch (t) {
         case SHORT:       return mImpl->mShowHex ? "0x%hx"  : "%hd";
         case USHORT:      return mImpl->mShowHex ? "0x%hx"  : "%hu";
@@ -129,72 +129,72 @@ ostream& ostream::print(const char* format, ...) noexcept {
     return *this;
 }
 
-ostream& ostream::operator<<(short value) noexcept {
+ostream& ostream::operator<<(short const value) noexcept {
     const char* format = getFormat(SHORT);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(unsigned short value) noexcept {
+ostream& ostream::operator<<(unsigned short const value) noexcept {
     const char* format = getFormat(USHORT);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(char value) noexcept {
+ostream& ostream::operator<<(char const value) noexcept {
     const char* format = getFormat(CHAR);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(unsigned char value) noexcept {
+ostream& ostream::operator<<(unsigned char const value) noexcept {
     const char* format = getFormat(UCHAR);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(int value) noexcept {
+ostream& ostream::operator<<(int const value) noexcept {
     const char* format = getFormat(INT);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(unsigned int value) noexcept {
+ostream& ostream::operator<<(unsigned int const value) noexcept {
     const char* format = getFormat(UINT);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(long value) noexcept {
+ostream& ostream::operator<<(long const value) noexcept {
     const char* format = getFormat(LONG);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(unsigned long value) noexcept {
+ostream& ostream::operator<<(unsigned long const value) noexcept {
     const char* format = getFormat(ULONG);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(long long value) noexcept {
+ostream& ostream::operator<<(long long const value) noexcept {
     const char* format = getFormat(LONG_LONG);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(unsigned long long value) noexcept {
+ostream& ostream::operator<<(unsigned long long const value) noexcept {
     const char* format = getFormat(ULONG_LONG);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(float value) noexcept {
+ostream& ostream::operator<<(float const value) noexcept {
     const char* format = getFormat(FLOAT);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(double value) noexcept {
+ostream& ostream::operator<<(double const value) noexcept {
     const char* format = getFormat(DOUBLE);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(long double value) noexcept {
+ostream& ostream::operator<<(long double const value) noexcept {
     const char* format = getFormat(LONG_DOUBLE);
     return print(format, value);
 }
 
-ostream& ostream::operator<<(bool value) noexcept {
+ostream& ostream::operator<<(bool const value) noexcept {
     return operator<<(value ? "true" : "false");
 }
 
@@ -235,7 +235,7 @@ ostream::Buffer::~Buffer() noexcept {
     free(buffer);
 }
 
-void ostream::Buffer::advance(ssize_t n) noexcept {
+void ostream::Buffer::advance(ssize_t const n) noexcept {
     if (n > 0) {
         size_t const written = n < sizeRemaining ? size_t(n) : sizeRemaining;
         curr += written;
@@ -243,12 +243,12 @@ void ostream::Buffer::advance(ssize_t n) noexcept {
     }
 }
 
-void ostream::Buffer::reserve(size_t newCapacity) noexcept {
+void ostream::Buffer::reserve(size_t const newCapacity) noexcept {
     size_t const offset = curr - buffer;
     if (buffer == nullptr) {
-        buffer = (char*)malloc(newCapacity);
+        buffer = static_cast<char*>(malloc(newCapacity));
     } else {
-        buffer = (char*)realloc(buffer, newCapacity);
+        buffer = static_cast<char*>(realloc(buffer, newCapacity));
     }
     assert(buffer);
     capacity = newCapacity;
@@ -260,7 +260,7 @@ void ostream::Buffer::reset() noexcept {
     // aggressively shrink the buffer
     if (capacity > 1024) {
         free(buffer);
-        buffer = (char*)malloc(1024);
+        buffer = static_cast<char*>(malloc(1024));
         capacity = 1024;
     }
     curr = buffer;
@@ -271,7 +271,7 @@ size_t ostream::Buffer::length() const noexcept {
     return curr - buffer;
 }
 
-std::pair<char*, size_t> ostream::Buffer::grow(size_t s) noexcept {
+std::pair<char*, size_t> ostream::Buffer::grow(size_t const s) noexcept {
     if (UTILS_UNLIKELY(sizeRemaining < s)) {
         size_t const usedSize = curr - buffer;
         size_t const neededCapacity = usedSize + s;

--- a/libs/utils/src/ostream_.h
+++ b/libs/utils/src/ostream_.h
@@ -17,6 +17,7 @@
 #ifndef TNT_UTILS_OSTREAM__H
 #define TNT_UTILS_OSTREAM__H
 
+#include <utils/Mutex.h>
 #include <utils/ostream.h>
 
 #include <mutex>
@@ -25,7 +26,7 @@
 namespace utils::io {
 
 struct ostream_ {
-    std::mutex mLock;
+    Mutex mLock;
     ostream::Buffer mData;
     std::pair<ostream::ConsumerCallback, void*> mConsumer{};
     bool mShowHex = false;

--- a/libs/utils/test/test_Mutex.cpp
+++ b/libs/utils/test/test_Mutex.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/debug/Mutex.h>
+#include <utils/Mutex.h>
+#include <utils/Panic.h>
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+using namespace utils;
+
+TEST(MutexTest, BasicLockUnlock) {
+    Mutex mLock;
+    mLock.lock();
+    mLock.unlock();
+
+    EXPECT_TRUE(mLock.try_lock());
+    mLock.unlock();
+
+    {
+        LockGuard const guard(mLock);
+    }
+
+    {
+        UniqueLock lock(mLock);
+        lock.unlock();
+        lock.lock();
+    }
+}
+
+TEST(DebugMutexTest, SelfDeadlock) {
+#ifdef GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH({
+        debug::Mutex mLock;
+        mLock.lock();
+        mLock.lock();
+    }, "Self-Deadlock / Recursive Lock Detected");
+#endif
+}
+
+TEST(DebugMutexTest, ValidOrderNoCycle) {
+    debug::Mutex A;
+    debug::Mutex B;
+    debug::Mutex C;
+
+    A.lock();
+    B.lock();
+    C.lock();
+
+    C.unlock();
+    B.unlock();
+    A.unlock();
+}
+
+TEST(DebugMutexTest, DirectOrderInversion) {
+#ifdef GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH({
+        debug::Mutex A;
+        debug::Mutex B;
+
+        // Thread 1 establishes A -> B order
+        A.lock();
+        B.lock();
+        B.unlock();
+        A.unlock();
+
+        // Thread 2 attempts B -> A inversion
+        std::thread t([&A, &B]() {
+            B.lock();
+            A.lock();
+        });
+        t.join();
+    }, "Lock-Order Inversion / Potential Deadlock Detected");
+#endif
+}
+
+TEST(DebugMutexTest, TransitiveOrderInversion) {
+#ifdef GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH({
+        debug::Mutex A;
+        debug::Mutex B;
+        debug::Mutex C;
+
+        // Thread 1 establishes A -> B
+        A.lock();
+        B.lock();
+        B.unlock();
+        A.unlock();
+
+        // Thread 2 establishes B -> C
+        std::thread t2([&B, &C]() {
+            B.lock();
+            C.lock();
+            C.unlock();
+            B.unlock();
+        });
+        t2.join();
+
+        // Thread 3 attempts C -> A (closing the 3-node cycle A -> B -> C -> A)
+        std::thread t3([&C, &A]() {
+            C.lock();
+            A.lock();
+        });
+        t3.join();
+    }, "Lock-Order Inversion / Potential Deadlock Detected");
+#endif
+}
+
+TEST(DebugMutexTest, DestructionPointerReuse) {
+    debug::Mutex B;
+    {
+        debug::Mutex A;
+        A.lock();
+        B.lock();
+        B.unlock();
+        A.unlock();
+    } // A is destroyed here, clearing edge A -> B from the graph
+
+    // Now creating a new mutex and establishing B -> A2 should not trigger a cycle
+    debug::Mutex A2;
+    B.lock();
+    A2.lock();
+    A2.unlock();
+    B.unlock();
+}
+
+TEST(DebugMutexTest, OutOfOrderUnlock) {
+    debug::Mutex A;
+    debug::Mutex B;
+
+    A.lock();
+    B.lock();
+    // Unlock out of LIFO order
+    A.unlock();
+    B.unlock();
+}
+
+TEST(DebugMutexTest, EbrStallTimelineLockInversion) {
+#ifdef GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH({
+        debug::Mutex mEbrEntitiesLock; // Lock A
+        debug::Mutex mTimelineLock;    // Lock B
+
+        // Trace 1 (Main Thread): removeComponentsImpl() locks A, then suspend() -> unregisterWatermark() locks B
+        mEbrEntitiesLock.lock();
+        mTimelineLock.lock();
+        mTimelineLock.unlock();
+        mEbrEntitiesLock.unlock();
+
+        // Trace 2 (Background/Engine Thread): advanceEpoch() locks B, then getExpiredEpochsLocked() locks A
+        std::thread backgroundThread([&mTimelineLock, &mEbrEntitiesLock]() {
+            mTimelineLock.lock();
+            mEbrEntitiesLock.lock();
+        });
+        backgroundThread.join();
+    }, "Lock-Order Inversion / Potential Deadlock Detected");
+#endif
+}

--- a/skills/cpp_static_thread_safety/SKILL.md
+++ b/skills/cpp_static_thread_safety/SKILL.md
@@ -13,12 +13,12 @@ Filament leverages Clang's static thread safety analysis to verify lock holding 
 
 ## 1. Selecting the Correct Lock Primitive
 
-*   **Standard Primitives (`std::mutex` & `std::condition_variable`)**:
-    *   *Use Case*: Heavy producer-consumer queues or structures performing blocking wait loops (`wait()`).
-    *   *Rationale*: Required for native kernel thread scheduling, priority queues, and preventing priority inversion stutters via Priority Inheritance (PI).
-*   **Lightweight Primitives (`utils::Mutex` & `utils::Condition`)**:
-    *   *Use Case*: High-frequency, low-contention locks guarding simple structures (like hashmap lookups or state changes) with **zero condition waits**.
-    *   *Rationale*: Custom 4-byte futex wrappers (compared to standard mutex's 40 bytes) that minimize cache-line footprint in hot render paths.
+*   **Filament Primitives (`utils::Mutex` & `utils::Condition`) — MANDATORY**:
+    *   *Rule*: All engine, backend, and utility code under `filament/` must use `utils::Mutex` and `utils::Condition` exclusively. Do **not** use `std::mutex` or `std::condition_variable`.
+    *   *Deadlock & Order Debugging*: `utils::Mutex` transparently integrates with Filament's compile-time lock debugging facility (`FILAMENT_DEBUG_MUTEX` / `-u`). When enabled, it maintains a global cycle dependency graph via BFS during `lock()` and `try_lock()`, immediately trapping lock-order inversions and self-deadlocks with exact `CallStack` traces. Any locks defined via `std::mutex` bypass this tracker entirely and remain invisible to deadlock diagnostics.
+    *   *Memory & Cache Hygiene*: On Android and Linux (`linuxutil::Mutex`), `utils::Mutex` is only 4 bytes (a single atomic futex word) versus 40 bytes for `std::mutex`. For structures allocated in large volumes or embedded in handles/fences, this 10x size reduction prevents struct bloat and maintains cache-line density.
+    *   *Condition Variable Support*: `utils::Condition` (`Condition::wait` / `wait_until`) is explicitly templated (`template <typename M>`) to work seamlessly with `UniqueLock<utils::Mutex>` for producer-consumer queues and blocking wait loops.
+    *   *Priority Inversion Reality*: C++ standard `std::mutex` (`pthread_mutex_t`) does **not** provide priority inheritance out of the box (`PTHREAD_PRIO_NONE`). Therefore, `std::mutex` offers zero priority inversion protection over `utils::Mutex`.
 
 ---
 


### PR DESCRIPTION
Introduce an opt-in, graph-based lock debugging tool (`debug::Mutex`)
to detect multi-threaded lock-order inversions and self-deadlocks at
runtime.

Key changes:
- utils::debug::Mutex: Implements a global dependency graph checked via
  BFS during lock() and try_lock(). When a cyclic dependency or
  recursive lock on a non-recursive mutex is detected, logs a detailed
  diagnostic report to LOG(ERROR) and calls std::abort().
- Callstack Tracing: Captures exact CallStack traces for lock creation
  points (`getCreationStack()`) and lock acquisition points (`lock()`
  and `try_lock()`), stripping internal wrapper frames.
- Condition Variable Integration: Updated generic and Linux condition
  variables (`Condition::wait`) to support templated mutex types so
  they work transparently with debug::Mutex.
- Build & Sizing Integration: Enabled via the `-u` build.sh flag or
  `-DFILAMENT_DEBUG_MUTEX=ON`. Enlarges backend HandleAllocator pool
  bucket sizes when enabled (`P2 = 312` bytes) so instrumented mutexes
  inside objects like GLSyncFence fit without pool overflow.