### PR TITLE
Support compositor deadline in pacing estimator

### DIFF
--- a/filament/include/filament/FramePipelineEstimator.h
+++ b/filament/include/filament/FramePipelineEstimator.h
@@ -21,9 +21,7 @@
 
 #include <utils/Slice.h>
 
-#include <algorithm>
 #include <chrono>
-#include <cmath>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -44,16 +42,36 @@ namespace filament {
  *
  * @code
  * auto const history = renderer->getFrameInfoHistory(renderer->getMaxFrameHistorySize());
- * auto const estimation = FramePipelineEstimator::estimate(history,
+ *
+ * // 1. Estimate unthrottled timing bottleneck (throughput workload limit)
+ * auto const workload = FramePipelineEstimator::estimateWorkload(history,
  *         FramePipelineEstimator::TargetPercentile::P90);
  *
- * renderer->setDesiredPresentationTime(now + estimation.idealFrameDuration);
+ * // 2. Size latency and safe delay for vsync-locked 60 FPS pacing cadence
+ * auto const pacingPeriod = std::chrono::nanoseconds(16666666); // 60Hz pacing step
+ * auto const sizing = FramePipelineEstimator::estimatePacing(history,
+ *         pacingPeriod, FramePipelineEstimator::TargetPercentile::P90);
+ *
+ * renderer->setDesiredPresentationTime(now + workload.idealFrameDuration);
+ * pacer->configure(sizing.latencyFrames, sizing.safeDelayDuration);
  * @endcode
  */
 class FramePipelineEstimator {
 public:
     /**
      * TargetPercentile specifies the desired statistical confidence interval for workload estimation.
+     *
+     * The percentile P (e.g., P90 = 90%) represents the probability that a frame's processing
+     * time will fall within the estimated workload budget. Conversely, 1 - P represents the
+     * theoretical probability of exceeding the budget and missing a frame deadline (jank/stutter):
+     *
+     * - P50 (Z = 0.0): 50% theoretical miss rate. Expect constant judder (30 drops/sec at 60Hz).
+     * - P90 (Z = 1.282): 10% theoretical miss rate. Expect a drop every 10 frames (~6 drops/sec at 60Hz).
+     * - P95 (Z = 1.645): 5% theoretical miss rate. Expect a drop every 20 frames (~3 drops/sec at 60Hz).
+     *
+     * Note: In practice, actual visual stutters are significantly lower because:
+     * 1. Frame workloads have temporal coherence (spikes are clustered rather than independent).
+     * 2. The FramePacer's structural latency (queue depth) acts as a shock absorber.
      */
     enum class TargetPercentile {
         P50, //!< 50th percentile (mean workload, Z = 0.0)
@@ -62,13 +80,19 @@ public:
     };
 
     /**
-     * Estimation encapsulates the computed ideal throughput and pipeline latency recommendations.
+     * Workload encapsulates the computed ideal throughput recommendation (raw bottleneck).
      */
-    struct Estimation {
+    struct Workload {
         std::chrono::nanoseconds idealFrameDuration{16666666}; //!< Ideal bottleneck frame duration (Throughput)
         float idealFrameRate = 60.0f;                          //!< Ideal frame rate in Hz (1.0 / idealFrameDuration)
-        uint32_t idealLatencyFrames = 2;                       //!< Ideal structural latency (Pipeline Depth in frames)
-        std::chrono::nanoseconds safeDelayDuration{0};         //!< Maximum safe delay (slack) before starting CPU work (Touch latency optimization)
+    };
+
+    /**
+     * PacingSizing encapsulates the structural latency and CPU delay recommendations relative to a pacing period.
+     */
+    struct PacingSizing {
+        uint32_t latencyFrames = 2;                            //!< Recommended structural latency (Pipeline Depth in frames)
+        std::chrono::nanoseconds safeDelayDuration{0};         //!< Maximum safe delay (slack) before starting CPU work
     };
 
     /**
@@ -84,30 +108,50 @@ public:
      * @param targetPercentile Desired confidence interval percentile.
      * @return Standard normal distribution Z-score.
      */
-    static double getZScore(TargetPercentile const targetPercentile) noexcept;
+    static double getZScore(TargetPercentile targetPercentile) noexcept;
 
     /**
-     * Evaluates historical frame telemetry to recommend ideal throughput and latency sizing.
+     * Evaluates historical frame telemetry to estimate raw unthrottled throughput limit.
      *
      * @param history Contiguous slice of past Renderer::FrameInfo records.
      * @param targetPercentile Statistical confidence interval (defaults to P90).
-     * @param targetVsyncInterval Target VSYNC cadence frame duration (defaults to 16.67ms).
-     * @return Recommended Estimation containing frame duration, refresh rate, structural latency, and safe delay.
+     * @return Estimated Workload.
      */
-    static Estimation estimate(FrameInfoHistory history,
-            TargetPercentile const targetPercentile = TargetPercentile::P90,
-            std::chrono::nanoseconds targetVsyncInterval = std::chrono::nanoseconds(16666666)) noexcept;
+    static Workload estimateWorkload(FrameInfoHistory history,
+            TargetPercentile targetPercentile = TargetPercentile::P90) noexcept;
 
     /**
-     * Evaluates historical frame telemetry using a custom standard normal distribution Z-score.
+     * Evaluates historical frame telemetry to estimate raw unthrottled throughput limit using a custom Z-score.
      *
      * @param history Contiguous slice of past Renderer::FrameInfo records.
      * @param zScore Normal distribution Z-score multiplier for standard deviation.
-     * @param targetVsyncInterval Target VSYNC cadence frame duration (defaults to 16.67ms).
-     * @return Recommended Estimation containing frame duration, refresh rate, structural latency, and safe delay.
+     * @return Estimated Workload.
      */
-    static Estimation estimate(FrameInfoHistory history, double const zScore,
-            std::chrono::nanoseconds targetVsyncInterval = std::chrono::nanoseconds(16666666)) noexcept;
+    static Workload estimateWorkload(FrameInfoHistory history, double zScore) noexcept;
+
+    /**
+     * Evaluates historical frame telemetry to size latency and safe delay for a given pacing period.
+     *
+     * @param history Contiguous slice of past Renderer::FrameInfo records.
+     * @param pacingPeriod Frame interval step at which the pipeline is throttled (e.g. 16.67ms VSYNC period).
+     * @param targetPercentile Statistical confidence interval (defaults to P90).
+     * @return Estimated latency and safe delay pacing configurations.
+     */
+    static PacingSizing estimatePacing(FrameInfoHistory history,
+            std::chrono::nanoseconds pacingPeriod,
+            TargetPercentile targetPercentile = TargetPercentile::P90) noexcept;
+
+    /**
+     * Evaluates historical frame telemetry to size latency and safe delay for a given pacing period using a custom Z-score.
+     *
+     * @param history Contiguous slice of past Renderer::FrameInfo records.
+     * @param pacingPeriod Frame interval step at which the pipeline is throttled.
+     * @param zScore Normal distribution Z-score multiplier for standard deviation.
+     * @return Estimated latency and safe delay pacing configurations.
+     */
+    static PacingSizing estimatePacing(FrameInfoHistory history,
+            std::chrono::nanoseconds pacingPeriod,
+            double zScore) noexcept;
 };
 
 

--- a/filament/src/FramePipelineEstimator.cpp
+++ b/filament/src/FramePipelineEstimator.cpp
@@ -18,7 +18,8 @@
 
 #include <utils/Log.h>
 
-#include <time.h>
+#include <algorithm>
+#include <cmath>
 
 #ifndef FILAMENT_LOG_PIPELINE_ESTIMATOR
 #define FILAMENT_LOG_PIPELINE_ESTIMATOR 0
@@ -27,54 +28,60 @@
 namespace filament {
 
 namespace {
+struct TelemetryStats {
+    uint32_t count = 0;
+    uint32_t countGpu = 0;
+    uint32_t countMargin = 0;
+
+    double meanMain = 0.0;
+    double meanBackend = 0.0;
+    double meanGpu = 0.0;
+    double meanMargin = 0.0;
+
+    double stdDevMain = 0.0;
+    double stdDevBackend = 0.0;
+    double stdDevGpu = 0.0;
+    double stdDevMargin = 0.0;
+
+    double effectiveMain = 0.0;
+    double effectiveBackend = 0.0;
+    double effectiveGpu = 0.0;
+    double totalTransitTimeNs = 0.0;
+    double effectiveCompositionMarginNs = 0.0;
+};
+
 struct PipelineLogger {
-    static inline void log(
-            uint32_t count, uint32_t countGpu, double zScore,
-            double meanMain, double meanApp, double meanRender, double meanBackend, double meanGpu,
-            double standardDeviationMain, double standardDeviationRender, double standardDeviationBackend, double standardDeviationGpu,
-            double effectiveMain, double effectiveBackend, double effectiveGpu,
-            float idealFrameRate, uint32_t idealLatency, double safeDelayNs) noexcept {
+    static void log(
+            TelemetryStats const& stats, double zScore,
+            double pacingIntervalNs, uint32_t idealLatency, double safeDelayNs) noexcept {
 #if FILAMENT_LOG_PIPELINE_ESTIMATOR
         LOG(INFO) << "FramePipelineEstimator: "
-                << "history=" << count << " (gpu=" << countGpu << "), "
+                << "history=" << stats.count
+                << " (gpu=" << stats.countGpu
+                << ", margin=" << stats.countMargin << "), "
                 << "Z=" << zScore << "\n"
-                << "  mean   CPU=" << meanMain / 1e6 << "ms (App=" << meanApp / 1e6 << "ms, Render=" << meanRender / 1e6 << "ms), BE=" << meanBackend / 1e6 << "ms, GPU=" << meanGpu / 1e6 << "ms\n"
-                << "  stddev CPU=" << standardDeviationMain / 1e6 << "ms (Render=" << standardDeviationRender / 1e6 << "ms), BE=" << standardDeviationBackend / 1e6 << "ms, GPU=" << standardDeviationGpu / 1e6 << "ms\n"
-                << "  effect CPU=" << effectiveMain / 1e6 << "ms, BE=" << effectiveBackend / 1e6 << "ms, GPU=" << effectiveGpu / 1e6 << "ms\n"
-                << "  ideal  fps=" << idealFrameRate << ", latency=" << idealLatency << ", safeDelay=" << safeDelayNs / 1e6 << "ms";
+                << "  mean   CPU=" << stats.meanMain / 1e6 << "ms, BE=" << stats.meanBackend / 1e6 << "ms, GPU=" << stats.meanGpu / 1e6 << "ms, Margin=" << stats.meanMargin / 1e6 << "ms\n"
+                << "  stddev CPU=" << stats.stdDevMain / 1e6 << "ms, BE=" << stats.stdDevBackend / 1e6 << "ms, GPU=" << stats.stdDevGpu / 1e6 << "ms, Margin=" << stats.stdDevMargin / 1e6 << "ms\n"
+                << "  effect CPU=" << stats.effectiveMain / 1e6 << "ms, BE=" << stats.effectiveBackend / 1e6 << "ms, GPU=" << stats.effectiveGpu / 1e6 << "ms, Margin=" << stats.effectiveCompositionMarginNs / 1e6 << "ms\n"
+                << "  pacing interval=" << pacingIntervalNs / 1e6 << "ms, latency=" << idealLatency << " frames, safeDelay=" << safeDelayNs / 1e6 << "ms";
 #endif
     }
 };
-} // namespace
 
-double FramePipelineEstimator::getZScore(TargetPercentile const targetPercentile) noexcept {
-    switch (targetPercentile) {
-        case TargetPercentile::P50: return 0.0;
-        case TargetPercentile::P90: return 1.282;
-        case TargetPercentile::P95: return 1.645;
-    }
-    return 0.0;
-}
-
-FramePipelineEstimator::Estimation FramePipelineEstimator::estimate(FrameInfoHistory history,
-        TargetPercentile const targetPercentile,
-        std::chrono::nanoseconds targetVsyncInterval) noexcept {
-    return estimate(history, getZScore(targetPercentile), targetVsyncInterval);
-}
-
-FramePipelineEstimator::Estimation FramePipelineEstimator::estimate(FrameInfoHistory history,
-        double const zScore, std::chrono::nanoseconds targetVsyncInterval) noexcept {
+TelemetryStats computeStats(FramePipelineEstimator::FrameInfoHistory history, double const zScore) noexcept {
     if (history.empty()) {
-        return Estimation{};
+        return {};
     }
 
     uint32_t const count = static_cast<uint32_t>(history.size());
     uint32_t countGpu = 0;
+    uint32_t countMargin = 0;
 
     double sumApp = 0.0;
     double sumRender = 0.0;
     double sumBackend = 0.0;
     double sumGpu = 0.0;
+    double sumMargin = 0.0;
 
     auto const getCpuStart = [](Renderer::FrameInfo const& f) {
         return (f.frameScheduleTime != Renderer::FrameInfo::INVALID && f.frameScheduleTime != 0) ?
@@ -91,36 +98,37 @@ FramePipelineEstimator::Estimation FramePipelineEstimator::estimate(FrameInfoHis
             sumGpu += static_cast<double>(frameInfo.gpuFrameDuration);
             countGpu++;
         }
+        if (frameInfo.displayPresent > 0 && frameInfo.presentDeadline > 0 &&
+                frameInfo.displayPresent != Renderer::FrameInfo::INVALID &&
+                frameInfo.presentDeadline != Renderer::FrameInfo::INVALID &&
+                frameInfo.displayPresent > frameInfo.presentDeadline) {
+            sumMargin += static_cast<double>(frameInfo.displayPresent - frameInfo.presentDeadline);
+            countMargin++;
+        }
     }
 
-    double const meanApp = sumApp / count;
-    double const meanRender = sumRender / count;
-    double const meanMain = (sumApp + sumRender) / count; // total CPU (endFrame - frameScheduleTime)
+    double const meanMain = (sumApp + sumRender) / count;
     double const meanBackend = sumBackend / count;
     double const meanGpu = countGpu > 0 ? sumGpu / countGpu : 0.0;
+    double const meanMargin = countMargin > 0 ? sumMargin / countMargin : 0.0;
 
     double varianceMain = 0.0;
-    double varianceRender = 0.0;
     double varianceBackend = 0.0;
     double varianceGpu = 0.0;
+    double varianceMargin = 0.0;
 
     if (count > 1) {
         double squareSumMain = 0.0;
-        double squareSumRender = 0.0;
         double squareSumBackend = 0.0;
         for (uint32_t i = 0; i < count; ++i) {
             auto const& frameInfo = history[i];
             double const durationMain = static_cast<double>(frameInfo.endFrame - getCpuStart(frameInfo));
             squareSumMain += (durationMain - meanMain) * (durationMain - meanMain);
 
-            double const durationRender = static_cast<double>(frameInfo.endFrame - frameInfo.beginFrame);
-            squareSumRender += (durationRender - meanRender) * (durationRender - meanRender);
-
             double const durationBackend = static_cast<double>(frameInfo.backendEndFrame - frameInfo.backendBeginFrame);
             squareSumBackend += (durationBackend - meanBackend) * (durationBackend - meanBackend);
         }
         varianceMain = squareSumMain / (count - 1);
-        varianceRender = squareSumRender / (count - 1);
         varianceBackend = squareSumBackend / (count - 1);
     }
 
@@ -136,47 +144,119 @@ FramePipelineEstimator::Estimation FramePipelineEstimator::estimate(FrameInfoHis
         varianceGpu = squareSumGpu / (countGpu - 1);
     }
 
+    if (countMargin > 1) {
+        double squareSumMargin = 0.0;
+        for (uint32_t i = 0; i < count; ++i) {
+            auto const& frameInfo = history[i];
+            if (frameInfo.displayPresent > 0 && frameInfo.presentDeadline > 0 &&
+                    frameInfo.displayPresent != Renderer::FrameInfo::INVALID &&
+                    frameInfo.presentDeadline != Renderer::FrameInfo::INVALID &&
+                    frameInfo.displayPresent > frameInfo.presentDeadline) {
+                double const margin = static_cast<double>(frameInfo.displayPresent - frameInfo.presentDeadline);
+                squareSumMargin += (margin - meanMargin) * (margin - meanMargin);
+            }
+        }
+        varianceMargin = squareSumMargin / (countMargin - 1);
+    }
+
     double const standardDeviationMain = std::sqrt(varianceMain);
-    double const standardDeviationRender = std::sqrt(varianceRender);
     double const standardDeviationBackend = std::sqrt(varianceBackend);
     double const standardDeviationGpu = std::sqrt(varianceGpu);
+    double const standardDeviationMargin = std::sqrt(varianceMargin);
 
-    // Reverted math: CPU total duration (response time) is used for throughput bottleneck.
     double const effectiveMain = std::max(0.0, meanMain + (zScore * standardDeviationMain));
     double const effectiveBackend = std::max(0.0, meanBackend + (zScore * standardDeviationBackend));
     double const effectiveGpu = std::max(0.0, meanGpu + (zScore * standardDeviationGpu));
+    double const totalTransitTimeNs = effectiveMain + effectiveBackend + effectiveGpu;
+    double const effectiveCompositionMargin = std::max(0.0, meanMargin + (zScore * standardDeviationMargin));
 
-    double idealFrameTimeNs = std::max({effectiveMain, effectiveBackend, effectiveGpu});
+    return {
+        count,
+        countGpu,
+        countMargin,
+        meanMain,
+        meanBackend,
+        meanGpu,
+        meanMargin,
+        standardDeviationMain,
+        standardDeviationBackend,
+        standardDeviationGpu,
+        standardDeviationMargin,
+        effectiveMain,
+        effectiveBackend,
+        effectiveGpu,
+        totalTransitTimeNs,
+        effectiveCompositionMargin
+    };
+}
+} // namespace
+
+double FramePipelineEstimator::getZScore(TargetPercentile const targetPercentile) noexcept {
+    switch (targetPercentile) {
+        case TargetPercentile::P50: return 0.0;
+        case TargetPercentile::P90: return 1.282;
+        case TargetPercentile::P95: return 1.645;
+    }
+    return 0.0;
+}
+
+FramePipelineEstimator::Workload FramePipelineEstimator::estimateWorkload(FrameInfoHistory history,
+        TargetPercentile const targetPercentile) noexcept {
+    return estimateWorkload(history, getZScore(targetPercentile));
+}
+
+FramePipelineEstimator::Workload FramePipelineEstimator::estimateWorkload(FrameInfoHistory history,
+        double const zScore) noexcept {
+    if (history.empty()) {
+        return Workload{};
+    }
+
+    TelemetryStats const stats = computeStats(history, zScore);
+    double idealFrameTimeNs = std::max({stats.effectiveMain, stats.effectiveBackend, stats.effectiveGpu});
     if (idealFrameTimeNs <= 0.0) {
         idealFrameTimeNs = 16666666.0;
     }
 
-    double const totalTransitTimeNs = effectiveMain + effectiveBackend + effectiveGpu;
+    Workload workload;
+    workload.idealFrameDuration = std::chrono::nanoseconds(static_cast<int64_t>(idealFrameTimeNs));
+    workload.idealFrameRate = static_cast<float>(1e9 / idealFrameTimeNs);
+    return workload;
+}
 
-    uint32_t idealLatency = static_cast<uint32_t>(std::ceil(totalTransitTimeNs / idealFrameTimeNs));
+FramePipelineEstimator::PacingSizing FramePipelineEstimator::estimatePacing(FrameInfoHistory history,
+        std::chrono::nanoseconds pacingPeriod,
+        TargetPercentile const targetPercentile) noexcept {
+    return estimatePacing(history, pacingPeriod, getZScore(targetPercentile));
+}
+
+FramePipelineEstimator::PacingSizing FramePipelineEstimator::estimatePacing(FrameInfoHistory history,
+        std::chrono::nanoseconds pacingPeriod,
+        double const zScore) noexcept {
+    if (history.empty() || pacingPeriod.count() <= 0) {
+        return PacingSizing{};
+    }
+
+    TelemetryStats const stats = computeStats(history, zScore);
+
+    double const pacingIntervalNs = static_cast<double>(pacingPeriod.count());
+    uint32_t idealLatency = static_cast<uint32_t>(
+            std::ceil((stats.totalTransitTimeNs + stats.effectiveCompositionMarginNs) / pacingIntervalNs));
     if (idealLatency < 1) {
         idealLatency = 1;
     }
 
-    float const idealFrameRate = static_cast<float>(1e9 / idealFrameTimeNs);
+    double const budgetNs = idealLatency * pacingIntervalNs - stats.effectiveCompositionMarginNs;
+    double const safeDelayNs = budgetNs - stats.totalTransitTimeNs;
 
-    double const budgetNs = idealLatency * static_cast<double>(targetVsyncInterval.count());
-    double const safeDelayNs = budgetNs - totalTransitTimeNs;
+#if FILAMENT_LOG_PIPELINE_ESTIMATOR
+    PipelineLogger::log(stats, zScore, pacingIntervalNs, idealLatency, safeDelayNs);
+#endif
 
-    PipelineLogger::log(count, countGpu, zScore,
-            meanMain, meanApp, meanRender, meanBackend, meanGpu,
-            standardDeviationMain, standardDeviationRender, standardDeviationBackend, standardDeviationGpu,
-            effectiveMain, effectiveBackend, effectiveGpu,
-            idealFrameRate, idealLatency, safeDelayNs);
-
-    Estimation estimation;
-    estimation.idealFrameDuration = std::chrono::nanoseconds(static_cast<int64_t>(idealFrameTimeNs));
-    estimation.idealFrameRate     = idealFrameRate;
-    estimation.idealLatencyFrames = idealLatency;
-    estimation.safeDelayDuration  = std::chrono::nanoseconds(
+    PacingSizing sizing;
+    sizing.latencyFrames = idealLatency;
+    sizing.safeDelayDuration = std::chrono::nanoseconds(
             static_cast<int64_t>(std::max(0.0, safeDelayNs)));
-
-    return estimation;
+    return sizing;
 }
 
 } // namespace filament

--- a/filament/src/details/FramePacer.cpp
+++ b/filament/src/details/FramePacer.cpp
@@ -361,14 +361,16 @@ void FFramePacer::applyPresentationTime(FRenderer* renderer) const {
     }
 
     if constexpr (false) {
-        auto estimation = FramePipelineEstimator::estimate(
-                renderer->getFrameInfoHistory(renderer->getMaxFrameHistorySize()),
-                FramePipelineEstimator::TargetPercentile::P90,
-                mActiveTargetStep);
+        auto history = renderer->getFrameInfoHistory(renderer->getMaxFrameHistorySize());
+        auto workload = FramePipelineEstimator::estimateWorkload(history,
+                FramePipelineEstimator::TargetPercentile::P90);
+        auto sizing = FramePipelineEstimator::estimatePacing(history,
+                mActiveTargetStep,
+                FramePipelineEstimator::TargetPercentile::P90);
 
-        LOG(INFO) << "ideal fps = " << 1000000000.0 / estimation.idealFrameDuration.count()
-                << ", " << estimation.idealLatencyFrames << "-frame latency, safe delay = "
-                << estimation.safeDelayDuration.count() / 1000000.0 << " ms";
+        LOG(INFO) << "ideal fps = " << workload.idealFrameRate
+                << ", " << sizing.latencyFrames << "-frame latency, safe delay = "
+                << sizing.safeDelayDuration.count() / 1000000.0 << " ms";
     }
 }
 

--- a/filament/test/test_FramePacer.cpp
+++ b/filament/test/test_FramePacer.cpp
@@ -1053,19 +1053,23 @@ TEST_F(FramePacerTest, FramePipelineEstimatorModel) {
     // TotalTransitTime = 13.29 + 9.645 + 16.935 = 39.87 ms (39,870,000 ns)
     // IdealLatencyFrames = ceil(39.87 / 16.935) = ceil(2.354) = 3 frames
 
-    auto estimation = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
+    auto workload = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
+    auto sizing = FramePipelineEstimator::estimatePacing({history.data(), history.size()},
+            workload.idealFrameDuration,
+            FramePipelineEstimator::TargetPercentile::P95);
 
-    EXPECT_NEAR(estimation.idealFrameDuration.count(), 16935000, 1000);
-    EXPECT_EQ(estimation.idealLatencyFrames, 3);
-    EXPECT_NEAR(estimation.safeDelayDuration.count(), 10130000, 1000);
+    EXPECT_NEAR(workload.idealFrameDuration.count(), 16935000, 1000);
+    EXPECT_EQ(sizing.latencyFrames, 3);
+    EXPECT_NEAR(sizing.safeDelayDuration.count(), 10935000, 1000);
 }
 
 TEST_F(FramePacerTest, FramePipelineEstimator_EmptyHistory) {
-    auto const estimation = FramePipelineEstimator::estimate({});
+    auto const workload = FramePipelineEstimator::estimateWorkload({});
+    auto const sizing = FramePipelineEstimator::estimatePacing({}, std::chrono::nanoseconds(16666666));
 
-    EXPECT_NEAR(estimation.idealFrameDuration.count(), 16666666, 1000);
-    EXPECT_NEAR(estimation.idealFrameRate, 60.0f, 0.1f);
-    EXPECT_EQ(estimation.idealLatencyFrames, 2);
+    EXPECT_NEAR(workload.idealFrameDuration.count(), 16666666, 1000);
+    EXPECT_NEAR(workload.idealFrameRate, 60.0f, 0.1f);
+    EXPECT_EQ(sizing.latencyFrames, 2);
 }
 
 TEST_F(FramePacerTest, FramePipelineEstimator_GapsInHistory) {
@@ -1098,12 +1102,15 @@ TEST_F(FramePacerTest, FramePipelineEstimator_GapsInHistory) {
     history[2].backendEndFrame   = 30000000; // Backend: 9 ms
     history[2].gpuFrameDuration  = 15000000; // GPU: 15 ms
 
-    auto estimation = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
+    auto workload = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
+    auto sizing = FramePipelineEstimator::estimatePacing({history.data(), history.size()},
+            workload.idealFrameDuration,
+            FramePipelineEstimator::TargetPercentile::P95);
 
     // Results must match the contiguous case in FramePipelineEstimatorModel exactly
-    EXPECT_NEAR(estimation.idealFrameDuration.count(), 16935000, 1000);
-    EXPECT_EQ(estimation.idealLatencyFrames, 3);
-    EXPECT_NEAR(estimation.safeDelayDuration.count(), 10130000, 1000);
+    EXPECT_NEAR(workload.idealFrameDuration.count(), 16935000, 1000);
+    EXPECT_EQ(sizing.latencyFrames, 3);
+    EXPECT_NEAR(sizing.safeDelayDuration.count(), 10935000, 1000);
 }
 
 TEST_F(FramePacerTest, FramePipelineEstimator_NoGpuTimings) {
@@ -1133,10 +1140,13 @@ TEST_F(FramePacerTest, FramePipelineEstimator_NoGpuTimings) {
     history[2].backendEndFrame   = 30000000; // Backend: 9 ms
     history[2].gpuFrameDuration  = 0;
 
-    auto const estimation = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P90);
+    auto const workload = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P90);
+    auto const sizing = FramePipelineEstimator::estimatePacing({history.data(), history.size()},
+            workload.idealFrameDuration,
+            FramePipelineEstimator::TargetPercentile::P90);
 
-    EXPECT_NEAR(estimation.idealFrameDuration.count(), 12564000, 1000);
-    EXPECT_EQ(estimation.idealLatencyFrames, 2);
+    EXPECT_NEAR(workload.idealFrameDuration.count(), 12564000, 1000);
+    EXPECT_EQ(sizing.latencyFrames, 2);
 }
 
 TEST_F(FramePacerTest, FramePipelineEstimator_Percentiles) {
@@ -1166,9 +1176,9 @@ TEST_F(FramePacerTest, FramePipelineEstimator_Percentiles) {
     history[2].backendEndFrame   = 30000000; // Backend: 9 ms
     history[2].gpuFrameDuration  = 15000000; // GPU: 15 ms
 
-    auto const est50 = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P50);
-    auto const est90 = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P90);
-    auto const est95 = FramePipelineEstimator::estimate({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
+    auto const est50 = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P50);
+    auto const est90 = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P90);
+    auto const est95 = FramePipelineEstimator::estimateWorkload({history.data(), history.size()}, FramePipelineEstimator::TargetPercentile::P95);
 
     EXPECT_NEAR(est50.idealFrameDuration.count(), 12000000, 1000);
 
@@ -1216,42 +1226,150 @@ TEST_F(FramePacerTest, FramePipelineEstimator_SafeDelay) {
     // IdealLatency = ceil(28.487 / 12.564) = 3 frames
 
     // Test 1: VSYNC = 16.666ms (60Hz)
-    // Budget = 3 * 16.666666ms = 50ms (50,000,000 ns)
-    // SafeDelay = 50,000,000 - 28,487,000 = 21,513,000 ns
+    // pacingPeriod = 12.564ms
+    // Budget = 3 * 12.564 = 37.692ms (37,692,000 ns)
+    // SafeDelay = 37,692,000 - 28,487,000 = 9,205,000 ns
     {
-        auto const est = FramePipelineEstimator::estimate(
+        auto const workload = FramePipelineEstimator::estimateWorkload(
                 {history.data(), history.size()},
-                FramePipelineEstimator::TargetPercentile::P90,
-                std::chrono::nanoseconds(16666666));
+                FramePipelineEstimator::TargetPercentile::P90);
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {history.data(), history.size()},
+                workload.idealFrameDuration,
+                FramePipelineEstimator::TargetPercentile::P90);
 
-        EXPECT_EQ(est.idealLatencyFrames, 3);
-        EXPECT_NEAR(est.safeDelayDuration.count(), 21513000, 5000);
+        EXPECT_EQ(sizing.latencyFrames, 3);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 9205000, 5000);
     }
 
     // Test 2: VSYNC = 11.111ms (90Hz)
-    // Budget = 3 * 11.111111ms = 33.333333ms (33,333,333 ns)
-    // SafeDelay = 33,333,333 - 28,487,000 = 4,846,333 ns
+    // pacingPeriod = 12.564ms
+    // Budget = 3 * 12.564 = 37.692ms (37,692,000 ns)
+    // SafeDelay = 37,692,000 - 28,487,000 = 9,205,000 ns
     {
-        auto const est = FramePipelineEstimator::estimate(
+        auto const workload = FramePipelineEstimator::estimateWorkload(
                 {history.data(), history.size()},
-                FramePipelineEstimator::TargetPercentile::P90,
-                std::chrono::nanoseconds(11111111));
+                FramePipelineEstimator::TargetPercentile::P90);
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {history.data(), history.size()},
+                workload.idealFrameDuration,
+                FramePipelineEstimator::TargetPercentile::P90);
 
-        EXPECT_EQ(est.idealLatencyFrames, 3);
-        EXPECT_NEAR(est.safeDelayDuration.count(), 4846333, 5000);
+        EXPECT_EQ(sizing.latencyFrames, 3);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 9205000, 5000);
     }
 
     // Test 3: VSYNC = 8.333ms (120Hz)
-    // Budget = 3 * 8.333333ms = 25ms (25,000,000 ns)
-    // SafeDelay = 25,000,000 - 28,487,000 = -3.487ms -> Clamped to 0
+    // pacingPeriod = 12.564ms
+    // Budget = 3 * 12.564 = 37.692ms (37,692,000 ns)
+    // SafeDelay = 37,692,000 - 28,487,000 = 9,205,000 ns
     {
-        auto const est = FramePipelineEstimator::estimate(
+        auto const workload = FramePipelineEstimator::estimateWorkload(
                 {history.data(), history.size()},
-                FramePipelineEstimator::TargetPercentile::P90,
-                std::chrono::nanoseconds(8333333));
+                FramePipelineEstimator::TargetPercentile::P90);
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {history.data(), history.size()},
+                workload.idealFrameDuration,
+                FramePipelineEstimator::TargetPercentile::P90);
 
-        EXPECT_EQ(est.idealLatencyFrames, 3);
-        EXPECT_EQ(est.safeDelayDuration.count(), 0);
+        EXPECT_EQ(sizing.latencyFrames, 3);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 9205000, 5000);
+    }
+
+    // Test 4: VSYNC-locked pacing estimation (60Hz Display, workload paced at 60 FPS = 16.667ms pacing Period)
+    // PacingPeriod = 16.666666ms (16,666,666 ns)
+    // TotalTransit = 28.487 ms (28,487,000 ns)
+    // idealLatency = ceil(28.487 / 16.666) = 2 frames (Instead of 3!)
+    // Budget = 2 * 16.666666ms = 33.333333ms (33,333,333 ns)
+    // SafeDelay = 33,333,333 - 28,487,000 = 4,846,333 ns
+    {
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {history.data(), history.size()},
+                std::chrono::nanoseconds(16666666),
+                FramePipelineEstimator::TargetPercentile::P90);
+
+        EXPECT_EQ(sizing.latencyFrames, 2);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 4846333, 5000);
+    }
+}
+
+TEST_F(FramePacerTest, FramePipelineEstimator_CompositionDeadline) {
+    std::vector<Renderer::FrameInfo> history(3);
+
+    // Populate history with 5ms compositor latch margin (displayPresent - presentDeadline = 5ms)
+    // CPU: 8ms, Backend: 4ms (using backendEndFrame - backendBeginFrame), GPU: 12ms
+    // TotalTransit = 29.5ms (with Z-score stddev adjustments)
+    for (int i = 0; i < 3; ++i) {
+        history[i].vsync             = i * 16666666;
+        history[i].beginFrame        = i * 16666666 + 1000000;
+        history[i].endFrame          = i * 16666666 + 9000000; // Main: 8 ms
+        history[i].backendBeginFrame = i * 16666666 + 1000000;
+        history[i].backendEndFrame   = i * 16666666 + 5000000; // Backend: 4 ms
+        history[i].gpuFrameDuration  = 12000000;               // GPU: 12 ms
+
+        history[i].displayPresent    = i * 16666666 + 50000000; // Expected Present (arbitrary offset)
+        history[i].presentDeadline   = i * 16666666 + 45000000; // Compositor Deadline is 5ms before presentation
+    }
+
+    // Workload averages (mean, Z-score calculations):
+    // Since jitter/variance is 0 in this simplified history:
+    // EffMain = 8.0ms, EffBackend = 4.0ms, EffGpu = 12.0ms -> TotalTransit = 24.0 ms
+    // CompositionMargin = 5.0ms (5,000,000 ns)
+
+    // Test 1: VSYNC-locked 60Hz pacing, no compositor margin support (margin not in history or effMargin = 0)
+    // TotalTransit = 25.0ms (Main=9ms, Backend=4ms, GPU=12ms), pacingPeriod = 16.67ms
+    // idealLatency = ceil(25.0 / 16.67) = 2 frames
+    // safeDelay = 2 * 16.67 - 25.0 = 8.33ms (8,333,333 ns)
+    {
+        // Let's create a temporary history without composition margin info
+        std::vector<Renderer::FrameInfo> historyNoMargin = history;
+        for (auto& f : historyNoMargin) {
+            f.displayPresent = 0;
+            f.presentDeadline = 0;
+        }
+
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {historyNoMargin.data(), historyNoMargin.size()},
+                std::chrono::nanoseconds(16666666),
+                FramePipelineEstimator::TargetPercentile::P90);
+
+        EXPECT_EQ(sizing.latencyFrames, 2);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 8333333, 5000);
+    }
+
+    // Test 2: VSYNC-locked 60Hz pacing, WITH compositor margin support (margin = 5ms)
+    // totalTransit + Margin = 25.0 + 5.0 = 30.0ms
+    // idealLatency = ceil(30.0 / 16.67) = 2 frames
+    // budget = 2 * 16.67 - 5.0 = 28.33ms
+    // safeDelay = 28.33 - 25.0 = 3.33ms (3,333,333 ns)
+    {
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {history.data(), history.size()},
+                std::chrono::nanoseconds(16666666),
+                FramePipelineEstimator::TargetPercentile::P90);
+
+        EXPECT_EQ(sizing.latencyFrames, 2);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 3333333, 5000);
+    }
+
+    // Test 3: Workload transit = 30.0ms (using 17ms GPU duration)
+    // totalTransit + Margin = 30.0 + 5.0 = 35.0ms (exceeds 2-frame budget 33.33ms)
+    // idealLatency = ceil(35.0 / 16.67) = 3 frames
+    // budget = 3 * 16.67 - 5.0 = 45.0ms
+    // safeDelay = 45.0 - 30.0 = 15.0ms (15,000,000 ns)
+    {
+        std::vector<Renderer::FrameInfo> historyHeavy = history;
+        for (auto& f : historyHeavy) {
+            f.gpuFrameDuration = 17000000; // GPU: 17 ms -> Transit = 9 + 4 + 17 = 30 ms
+        }
+
+        auto const sizing = FramePipelineEstimator::estimatePacing(
+                {historyHeavy.data(), historyHeavy.size()},
+                std::chrono::nanoseconds(16666666),
+                FramePipelineEstimator::TargetPercentile::P90);
+
+        EXPECT_EQ(sizing.latencyFrames, 3);
+        EXPECT_NEAR(sizing.safeDelayDuration.count(), 15000000, 5000);
     }
 }
 

--- a/tools/frame_pipeline_visualizer/app.js
+++ b/tools/frame_pipeline_visualizer/app.js
@@ -1,0 +1,662 @@
+// Core State Manager
+const state = {
+    zScore: 1.282,
+    vsyncRate: 60,
+    latchMargin: 3.0,
+    pacingMode: 'auto',
+    cpu: { mean: 8.0, std: 1.5 },
+    backend: { mean: 4.0, std: 0.8 },
+    gpu: { mean: 12.0, std: 2.0 }
+};
+
+// UI Elements
+const els = {
+    btnP50: document.getElementById('btn-p50'),
+    btnP90: document.getElementById('btn-p90'),
+    btnP95: document.getElementById('btn-p95'),
+    zScoreInput: document.getElementById('z-score'),
+    zScoreVal: document.getElementById('val-z-score'),
+    
+    vsyncRateInput: document.getElementById('vsync-rate'),
+    vsyncRateVal: document.getElementById('val-vsync-rate'),
+    latchMarginInput: document.getElementById('latch-margin'),
+    latchMarginVal: document.getElementById('val-latch-margin'),
+    
+    cpuMeanInput: document.getElementById('cpu-mean'),
+    cpuMeanVal: document.getElementById('val-cpu-mean'),
+    cpuStdInput: document.getElementById('cpu-std'),
+    cpuStdVal: document.getElementById('val-cpu-std'),
+    
+    backendMeanInput: document.getElementById('backend-mean'),
+    backendMeanVal: document.getElementById('val-backend-mean'),
+    backendStdInput: document.getElementById('backend-std'),
+    backendStdVal: document.getElementById('val-backend-std'),
+    
+    gpuMeanInput: document.getElementById('gpu-mean'),
+    gpuMeanVal: document.getElementById('val-gpu-mean'),
+    gpuStdInput: document.getElementById('gpu-std'),
+    gpuStdVal: document.getElementById('val-gpu-std'),
+    
+    pacingAutoBtn: document.getElementById('pacing-auto'),
+    pacingVsyncBtn: document.getElementById('pacing-vsync'),
+    
+    kpiLatency: document.getElementById('kpi-val-latency'),
+    kpiLatencyMs: document.getElementById('kpi-val-latency-ms'),
+    kpiFps: document.getElementById('kpi-val-fps'),
+    kpiFrameDuration: document.getElementById('kpi-val-frame-duration'),
+    kpiDelay: document.getElementById('kpi-val-delay'),
+    kpiBottleneck: document.getElementById('kpi-val-bottleneck'),
+    kpiBottleneckDetail: document.getElementById('kpi-val-bottleneck-detail'),
+    
+    gaussianCanvas: document.getElementById('gaussian-canvas'),
+    timelineCanvas: document.getElementById('pipeline-timeline-canvas')
+};
+
+// Initialize Event Listeners
+function initListeners() {
+    // Percentile Buttons
+    const buttons = [els.btnP50, els.btnP90, els.btnP95];
+    buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            buttons.forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            const z = parseFloat(btn.dataset.z);
+            state.zScore = z;
+            els.zScoreInput.value = z;
+            els.zScoreVal.innerText = z.toFixed(2);
+            update();
+        });
+    });
+
+    // Z-Score Slider
+    els.zScoreInput.addEventListener('input', (e) => {
+        buttons.forEach(b => b.classList.remove('active'));
+        const z = parseFloat(e.target.value);
+        state.zScore = z;
+        els.zScoreVal.innerText = z.toFixed(2);
+        
+        // Match active class if close to presets
+        if (Math.abs(z - 0.0) < 0.05) els.btnP50.classList.add('active');
+        else if (Math.abs(z - 1.282) < 0.05) els.btnP90.classList.add('active');
+        else if (Math.abs(z - 1.645) < 0.05) els.btnP95.classList.add('active');
+        
+        update();
+    });
+
+    // Vsync Slider
+    els.vsyncRateInput.addEventListener('input', (e) => {
+        state.vsyncRate = parseInt(e.target.value);
+        els.vsyncRateVal.innerText = `${state.vsyncRate} Hz`;
+        update();
+    });
+
+    // Latch Margin Slider
+    els.latchMarginInput.addEventListener('input', (e) => {
+        state.latchMargin = parseFloat(e.target.value);
+        els.latchMarginVal.innerText = `${state.latchMargin.toFixed(1)} ms`;
+        update();
+    });
+
+    // CPU Inputs
+    els.cpuMeanInput.addEventListener('input', (e) => {
+        state.cpu.mean = parseFloat(e.target.value);
+        els.cpuMeanVal.innerText = `${state.cpu.mean.toFixed(1)} ms`;
+        update();
+    });
+    els.cpuStdInput.addEventListener('input', (e) => {
+        state.cpu.std = parseFloat(e.target.value);
+        els.cpuStdVal.innerText = `${state.cpu.std.toFixed(1)} ms`;
+        update();
+    });
+
+    // Backend Inputs
+    els.backendMeanInput.addEventListener('input', (e) => {
+        state.backend.mean = parseFloat(e.target.value);
+        els.backendMeanVal.innerText = `${state.backend.mean.toFixed(1)} ms`;
+        update();
+    });
+    els.backendStdInput.addEventListener('input', (e) => {
+        state.backend.std = parseFloat(e.target.value);
+        els.backendStdVal.innerText = `${state.backend.std.toFixed(1)} ms`;
+        update();
+    });
+
+    // GPU Inputs
+    els.gpuMeanInput.addEventListener('input', (e) => {
+        state.gpu.mean = parseFloat(e.target.value);
+        els.gpuMeanVal.innerText = `${state.gpu.mean.toFixed(1)} ms`;
+        update();
+    });
+    els.gpuStdInput.addEventListener('input', (e) => {
+        state.gpu.std = parseFloat(e.target.value);
+        els.gpuStdVal.innerText = `${state.gpu.std.toFixed(1)} ms`;
+        update();
+    });
+    
+    // Pacing Buttons
+    const pacingButtons = [els.pacingAutoBtn, els.pacingVsyncBtn];
+    pacingButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            pacingButtons.forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            
+            const mode = btn.id.replace('pacing-', '');
+            state.pacingMode = mode;
+            update();
+        });
+    });
+
+    // Auto-resize canvases on window resize
+    window.addEventListener('resize', () => {
+        setupCanvas(els.gaussianCanvas);
+        setupCanvas(els.timelineCanvas);
+        draw();
+    });
+}
+
+// Setup Canvas for High DPI screens (retina support)
+function setupCanvas(canvas) {
+    const rect = canvas.parentNode.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const baseHeight = parseFloat(canvas.dataset.baseHeight || canvas.getAttribute('height'));
+    
+    canvas.width = rect.width * dpr;
+    canvas.height = baseHeight * dpr;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${baseHeight}px`;
+    
+    const ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+}
+
+// Normal Distribution Probability Density Function
+function normalPDF(x, mu, sigma) {
+    if (sigma === 0) return x === mu ? 1.0 : 0.0;
+    const exponent = -0.5 * Math.pow((x - mu) / sigma, 2);
+    return (1 / (sigma * Math.sqrt(2 * Math.PI))) * Math.exp(exponent);
+}
+
+// Core Calculations (FramePipelineEstimator math)
+function calculate() {
+    const vsyncInterval = 1000.0 / state.vsyncRate; // ms
+    
+    // Effective durations: mu + Z * std
+    const effCpu = Math.max(0.1, state.cpu.mean + (state.zScore * state.cpu.std));
+    const effBackend = Math.max(0.1, state.backend.mean + (state.zScore * state.backend.std));
+    const effGpu = Math.max(0.1, state.gpu.mean + (state.zScore * state.gpu.std));
+    
+    // Bottleneck stage (slowest stage determines throughput limit)
+    let bottleneckVal = effCpu;
+    let bottleneckName = 'Main CPU';
+    if (effBackend > bottleneckVal) {
+        bottleneckVal = effBackend;
+        bottleneckName = 'Backend Driver';
+    }
+    if (effGpu > bottleneckVal) {
+        bottleneckVal = effGpu;
+        bottleneckName = 'GPU Execution';
+    }
+    
+    const idealFrameTime = bottleneckVal;
+    
+    // Pacing frame step (duration): auto (bottleneck) or vsync
+    let pacingInterval = idealFrameTime;
+    if (state.pacingMode === 'vsync') {
+        pacingInterval = vsyncInterval;
+    }
+    
+    const totalTransitTime = effCpu + effBackend + effGpu;
+    const latchMargin = state.latchMargin;
+    
+    // Structural latency based on pacing interval and composition latch margin
+    const idealLatency = Math.max(1, Math.ceil((totalTransitTime + latchMargin) / pacingInterval));
+    
+    // Target budget: idealLatency * pacingInterval - latchMargin
+    const budget = idealLatency * pacingInterval - latchMargin;
+    
+    // Safe delay (slack)
+    const safeDelay = Math.max(0, budget - totalTransitTime);
+    
+    // Recommended frame rate
+    const idealFps = 1000.0 / pacingInterval;
+    
+    return {
+        vsyncInterval,
+        effCpu,
+        effBackend,
+        effGpu,
+        bottleneckName,
+        bottleneckVal,
+        idealFrameTime,
+        pacingInterval,
+        totalTransitTime,
+        idealLatency,
+        budget,
+        safeDelay,
+        idealFps,
+        latchMargin
+    };
+}
+
+// Update KPI cards and text readouts
+function updateKPIs(calc) {
+    els.kpiLatency.innerText = `${calc.idealLatency} Frame${calc.idealLatency > 1 ? 's' : ''}`;
+    els.kpiLatencyMs.innerText = `${(calc.idealLatency * calc.vsyncInterval).toFixed(1)} ms target latency`;
+    
+    els.kpiFps.innerText = `${calc.idealFps.toFixed(1)} Hz`;
+    els.kpiFrameDuration.innerText = `${calc.pacingInterval.toFixed(1)} ms pacing step`;
+    
+    els.kpiDelay.innerText = `${calc.safeDelay.toFixed(1)} ms`;
+    
+    els.kpiBottleneck.innerText = calc.bottleneckName;
+    els.kpiBottleneckDetail.innerText = `Effective workload: ${calc.bottleneckVal.toFixed(1)} ms`;
+}
+
+// Drawing Logic
+function draw() {
+    const calc = calculate();
+    updateKPIs(calc);
+    
+    drawGaussian(calc);
+    drawTimeline(calc);
+}
+
+// Draw Gaussian Distribution Canvas
+function drawGaussian(calc) {
+    const canvas = els.gaussianCanvas;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width / (window.devicePixelRatio || 1);
+    const h = canvas.height / (window.devicePixelRatio || 1);
+    
+    ctx.clearRect(0, 0, w, h);
+    
+    const paddingLeft = 40;
+    const paddingRight = 20;
+    const paddingTop = 20;
+    const paddingBottom = 30;
+    
+    const graphWidth = w - paddingLeft - paddingRight;
+    const graphHeight = h - paddingTop - paddingBottom;
+    
+    // Max X limit (40ms base, or scaled up if workload is large)
+    const maxVal = Math.max(40, state.cpu.mean + 3.5 * state.cpu.std, state.gpu.mean + 3.5 * state.gpu.std);
+    
+    // Find maximum Y value for scale mapping
+    let maxPDF = 0.05; // baseline minimum scale
+    for (let x = 0; x <= maxVal; x += 0.2) {
+        maxPDF = Math.max(maxPDF, 
+            normalPDF(x, state.cpu.mean, state.cpu.std),
+            normalPDF(x, state.backend.mean, state.backend.std),
+            normalPDF(x, state.gpu.mean, state.gpu.std)
+        );
+    }
+    
+    const scaleX = graphWidth / maxVal;
+    const scaleY = graphHeight / (maxPDF * 1.1); // add 10% headroom
+    
+    // Helper: Map data coordinate to screen space
+    function mapX(val) { return paddingLeft + val * scaleX; }
+    function mapY(val) { return h - paddingBottom - val * scaleY; }
+    
+    // Draw Grid Lines (X-Axis intervals every 5ms)
+    ctx.strokeStyle = '#2d3748';
+    ctx.lineWidth = 1;
+    ctx.fillStyle = '#6b7280';
+    ctx.font = '10px var(--font-mono)';
+    ctx.textAlign = 'center';
+    
+    for (let val = 0; val <= maxVal; val += 5) {
+        const x = mapX(val);
+        ctx.beginPath();
+        ctx.moveTo(x, paddingTop);
+        ctx.lineTo(x, h - paddingBottom);
+        ctx.stroke();
+        ctx.fillText(`${val}`, x, h - paddingBottom + 16);
+    }
+    
+    // Axis line
+    ctx.strokeStyle = '#4b5563';
+    ctx.beginPath();
+    ctx.moveTo(paddingLeft, h - paddingBottom);
+    ctx.lineTo(w - paddingRight, h - paddingBottom);
+    ctx.stroke();
+    
+    // Draw VSYNC Line (dashed green)
+    ctx.strokeStyle = '#10b981';
+    ctx.lineWidth = 1.5;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(mapX(calc.vsyncInterval), paddingTop);
+    ctx.lineTo(mapX(calc.vsyncInterval), h - paddingBottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = '#34d399';
+    ctx.font = '10px var(--font-sans)';
+    ctx.textAlign = 'left';
+    ctx.fillText('VSYNC Target', mapX(calc.vsyncInterval) + 4, paddingTop + 12);
+    
+    // Draw Compositor Latch Line (dashed red)
+    if (calc.latchMargin > 0) {
+        const deadlineMs = calc.vsyncInterval - calc.latchMargin;
+        ctx.strokeStyle = '#ef4444';
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(mapX(deadlineMs), paddingTop);
+        ctx.lineTo(mapX(deadlineMs), h - paddingBottom);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.fillStyle = '#f87171';
+        ctx.font = '10px var(--font-sans)';
+        ctx.textAlign = 'right';
+        ctx.fillText('Compositor Latch', mapX(deadlineMs) - 4, paddingTop + 12);
+    }
+    
+    // Function to draw a single stage curve
+    function drawCurve(mu, sigma, color, effVal) {
+        // Curve path
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        let started = false;
+        
+        for (let vx = 0; vx <= maxVal; vx += 0.2) {
+            const vy = normalPDF(vx, mu, sigma);
+            const x = mapX(vx);
+            const y = mapY(vy);
+            if (!started) {
+                ctx.moveTo(x, y);
+                started = true;
+            } else {
+                ctx.lineTo(x, y);
+            }
+        }
+        ctx.stroke();
+        
+        // Draw shaded confidence region (0 up to mu + Z*sigma)
+        ctx.fillStyle = color.replace(')', ', 0.05)').replace('rgb', 'rgba'); // semi transparent
+        ctx.beginPath();
+        ctx.moveTo(mapX(0), mapY(0));
+        
+        for (let vx = 0; vx <= effVal; vx += 0.2) {
+            const vy = normalPDF(vx, mu, sigma);
+            ctx.lineTo(mapX(vx), mapY(vy));
+        }
+        ctx.lineTo(mapX(effVal), mapY(0));
+        ctx.closePath();
+        ctx.fill();
+        
+        // Draw vertical cutoff line at effVal
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([2, 2]);
+        ctx.beginPath();
+        ctx.moveTo(mapX(effVal), mapY(0));
+        ctx.lineTo(mapX(effVal), mapY(normalPDF(effVal, mu, sigma)));
+        ctx.stroke();
+        ctx.setLineDash([]);
+    }
+    
+    // Render the three stage curves
+    drawCurve(state.cpu.mean, state.cpu.std, '#3b82f6', calc.effCpu);
+    drawCurve(state.backend.mean, state.backend.std, '#14b8a6', calc.effBackend);
+    drawCurve(state.gpu.mean, state.gpu.std, '#f59e0b', calc.effGpu);
+    
+    // Y-Axis label
+    ctx.save();
+    ctx.translate(12, h / 2);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillStyle = '#6b7280';
+    ctx.font = '10px var(--font-sans)';
+    ctx.textAlign = 'center';
+    ctx.fillText('Probability Density', 0, 0);
+    ctx.restore();
+    
+    // X-Axis label
+    ctx.fillStyle = '#6b7280';
+    ctx.font = '10px var(--font-sans)';
+    ctx.textAlign = 'center';
+    ctx.fillText('Duration (ms)', paddingLeft + graphWidth / 2, h - 4);
+}
+
+// Draw Interactive Pipeline Overlap (Timeline Flow)
+function drawTimeline(calc) {
+    const canvas = els.timelineCanvas;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width / (window.devicePixelRatio || 1);
+    const h = canvas.height / (window.devicePixelRatio || 1);
+    
+    ctx.clearRect(0, 0, w, h);
+    
+    const paddingLeft = 80;
+    const paddingRight = 40;
+    const paddingTop = 30;
+    const paddingBottom = 40;
+    
+    const timelineWidth = w - paddingLeft - paddingRight;
+    const timelineHeight = h - paddingTop - paddingBottom;
+    
+    // Determine horizontal scale: we display 4 complete VSYNC intervals
+    const totalDurationDisplayed = calc.vsyncInterval * 4.5;
+    const scaleX = timelineWidth / totalDurationDisplayed;
+    
+    function mapX(ms) { return paddingLeft + ms * scaleX; }
+    
+    // Draw VSYNC vertical grids
+    ctx.lineWidth = 1;
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '10px var(--font-mono)';
+    ctx.textAlign = 'center';
+    
+    for (let i = 0; i <= 4; ++i) {
+        const timeMs = i * calc.vsyncInterval;
+        const x = mapX(timeMs);
+        
+        ctx.strokeStyle = '#1f2937';
+        ctx.beginPath();
+        ctx.moveTo(x, paddingTop - 10);
+        ctx.lineTo(x, h - paddingBottom);
+        ctx.stroke();
+        
+        // Text labels for Vsync ticks
+        ctx.fillText(`VSYNC ${i}`, x, paddingTop - 16);
+        ctx.fillText(`${timeMs.toFixed(1)}ms`, x, h - paddingBottom + 14);
+
+        // Draw Composition Deadline (if latchMargin > 0 and i > 0)
+        if (calc.latchMargin > 0 && i > 0) {
+            const deadlineMs = timeMs - calc.latchMargin;
+            const dx = mapX(deadlineMs);
+            
+            ctx.beginPath();
+            ctx.strokeStyle = 'rgba(239, 68, 68, 0.35)'; // Red dash
+            ctx.lineWidth = 1;
+            ctx.setLineDash([2, 4]);
+            ctx.moveTo(dx, paddingTop - 10);
+            ctx.lineTo(dx, h - paddingBottom);
+            ctx.stroke();
+            ctx.setLineDash([]);
+        }
+    }
+    
+    // Stage rows properties
+    const rowHeight = 36;
+    const rowGap = 16;
+    
+    function getRowY(rowIndex) {
+        return paddingTop + rowIndex * (rowHeight + rowGap);
+    }
+    
+    // Label stages on the left
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '11px var(--font-sans)';
+    ctx.fontWeight = '600';
+    ctx.textAlign = 'right';
+    
+    ctx.fillText('Main CPU', paddingLeft - 10, getRowY(0) + rowHeight / 2 + 4);
+    ctx.fillText('Backend', paddingLeft - 10, getRowY(1) + rowHeight / 2 + 4);
+    ctx.fillText('GPU Exec', paddingLeft - 10, getRowY(2) + rowHeight / 2 + 4);
+    
+    // Helper to draw stage blocks for multiple parallel frames
+    function drawFrame(frameIndex, offsetVsyncCount) {
+        const frameStartMs = offsetVsyncCount * calc.pacingInterval + calc.safeDelay;
+        
+        const cpuStart = frameStartMs;
+        const cpuWidth = calc.effCpu;
+        
+        const backendStart = cpuStart + cpuWidth;
+        const backendWidth = calc.effBackend;
+        
+        const gpuStart = backendStart + backendWidth;
+        const gpuWidth = calc.effGpu;
+        
+        const targetPresentTime = (offsetVsyncCount + calc.idealLatency) * calc.vsyncInterval;
+        
+        // Draw CPU Box
+        ctx.fillStyle = 'rgba(59, 130, 246, 0.85)';
+        ctx.strokeStyle = '#3b82f6';
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.roundRect(mapX(cpuStart), getRowY(0), cpuWidth * scaleX, rowHeight, 4);
+        ctx.fill();
+        ctx.stroke();
+        
+        // Draw Backend Box
+        ctx.fillStyle = 'rgba(20, 184, 166, 0.85)';
+        ctx.strokeStyle = '#14b8a6';
+        ctx.beginPath();
+        ctx.roundRect(mapX(backendStart), getRowY(1), backendWidth * scaleX, rowHeight, 4);
+        ctx.fill();
+        ctx.stroke();
+        
+        // Draw GPU Box
+        ctx.fillStyle = 'rgba(245, 158, 11, 0.85)';
+        ctx.strokeStyle = '#f59e0b';
+        ctx.beginPath();
+        ctx.roundRect(mapX(gpuStart), getRowY(2), gpuWidth * scaleX, rowHeight, 4);
+        ctx.fill();
+        ctx.stroke();
+        
+        // Print frame index labels inside the boxes if wide enough
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '10px var(--font-sans)';
+        ctx.fontWeight = 'bold';
+        ctx.textAlign = 'center';
+        
+        if (cpuWidth * scaleX > 24) ctx.fillText(`F${frameIndex}`, mapX(cpuStart + cpuWidth / 2), getRowY(0) + rowHeight / 2 + 4);
+        if (backendWidth * scaleX > 24) ctx.fillText(`F${frameIndex}`, mapX(backendStart + backendWidth / 2), getRowY(1) + rowHeight / 2 + 4);
+        if (gpuWidth * scaleX > 24) ctx.fillText(`F${frameIndex}`, mapX(gpuStart + gpuWidth / 2), getRowY(2) + rowHeight / 2 + 4);
+        
+        // Draw a dotted vertical line from end of GPU execution to presentation line height
+        const gpuEnd = gpuStart + gpuWidth;
+        ctx.strokeStyle = '#10b981';
+        ctx.lineWidth = 1;
+        ctx.setLineDash([2, 2]);
+        ctx.beginPath();
+        ctx.moveTo(mapX(gpuEnd), getRowY(2) + rowHeight);
+        ctx.lineTo(mapX(gpuEnd), h - paddingBottom - 10);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        
+        // Draw compositor deadline target anchor circle (subtle red dot)
+        const targetDeadlineTime = targetPresentTime - calc.latchMargin;
+        if (calc.latchMargin > 0) {
+            ctx.fillStyle = '#ef4444';
+            ctx.beginPath();
+            ctx.arc(mapX(targetDeadlineTime), h - paddingBottom, 3.5, 0, 2 * Math.PI);
+            ctx.fill();
+        }
+
+        // Draw presentation anchor circle
+        ctx.fillStyle = '#10b981';
+        ctx.beginPath();
+        ctx.arc(mapX(targetPresentTime), h - paddingBottom, 5, 0, 2 * Math.PI);
+        ctx.fill();
+        
+        // Show Present target text for the frame
+        ctx.fillStyle = '#10b981';
+        ctx.font = '10px var(--font-sans)';
+        ctx.textAlign = 'center';
+        ctx.fillText(`F${frameIndex} PRESENT`, mapX(targetPresentTime), h - paddingBottom - 10);
+    }
+    
+    // Draw three overlapping consecutive frames to demonstrate structural pipeline latency
+    drawFrame(1, 0);
+    drawFrame(2, 1);
+    drawFrame(3, 2);
+    
+    // Draw Safe Delay visual indicator bracket
+    if (calc.safeDelay > 0) {
+        const startX = mapX(0);
+        const endX = mapX(calc.safeDelay);
+        const lineY = getRowY(0) - 8;
+        
+        ctx.strokeStyle = '#c084fc';
+        ctx.lineWidth = 1.5;
+        
+        // Horizontal line
+        ctx.beginPath();
+        ctx.moveTo(startX, lineY);
+        ctx.lineTo(endX, lineY);
+        ctx.stroke();
+        
+        // End brackets
+        ctx.beginPath();
+        ctx.moveTo(startX, lineY - 4);
+        ctx.lineTo(startX, lineY + 4);
+        ctx.moveTo(endX, lineY - 4);
+        ctx.lineTo(endX, lineY + 4);
+        ctx.stroke();
+        
+        // Text
+        ctx.fillStyle = '#c084fc';
+        ctx.font = '9px var(--font-mono)';
+        ctx.textAlign = 'left';
+        ctx.fillText(`Safe Delay: ${calc.safeDelay.toFixed(1)}ms`, endX + 6, lineY + 3);
+    }
+
+    // Draw Transit Time range bracket for Frame 1 at the bottom
+    const transitStartX = mapX(calc.safeDelay);
+    const transitEndX = mapX(calc.safeDelay + calc.totalTransitTime);
+    const transitLineY = getRowY(2) + rowHeight + 12;
+    
+    ctx.strokeStyle = '#9ca3af'; // Neutral slate color
+    ctx.lineWidth = 1.5;
+    
+    // Horizontal line
+    ctx.beginPath();
+    ctx.moveTo(transitStartX, transitLineY);
+    ctx.lineTo(transitEndX, transitLineY);
+    ctx.stroke();
+    
+    // End brackets
+    ctx.beginPath();
+    ctx.moveTo(transitStartX, transitLineY - 4);
+    ctx.lineTo(transitStartX, transitLineY + 4);
+    ctx.moveTo(transitEndX, transitLineY - 4);
+    ctx.lineTo(transitEndX, transitLineY + 4);
+    ctx.stroke();
+    
+    // Text label
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '9px var(--font-mono)';
+    ctx.textAlign = 'center';
+    ctx.fillText(`Total Transit Time (Pipeline Latency): ${calc.totalTransitTime.toFixed(1)}ms`, transitStartX + (transitEndX - transitStartX) / 2, transitLineY + 12);
+}
+
+// Initial Update Trigger
+function update() {
+    draw();
+}
+
+// Application Startup
+document.addEventListener('DOMContentLoaded', () => {
+    // Cache base height attributes to prevent double-scaling on subsequent resizes
+    document.querySelectorAll('canvas').forEach(canvas => {
+        canvas.dataset.baseHeight = canvas.getAttribute('height');
+    });
+    
+    initListeners();
+    setupCanvas(els.gaussianCanvas);
+    setupCanvas(els.timelineCanvas);
+    update();
+});

--- a/tools/frame_pipeline_visualizer/index.css
+++ b/tools/frame_pipeline_visualizer/index.css
@@ -1,0 +1,354 @@
+/* Core Design Tokens & System */
+:root {
+    --bg-base: #090d16;
+    --bg-surface: #111827;
+    --bg-card: #1f2937;
+    --border-color: #374151;
+    
+    --color-text-primary: #f3f4f6;
+    --color-text-secondary: #9ca3af;
+    --color-text-muted: #6b7280;
+    
+    --color-cpu: #3b82f6;      /* Blue */
+    --color-cpu-bg: rgba(59, 130, 246, 0.15);
+    --color-backend: #14b8a6;  /* Teal */
+    --color-backend-bg: rgba(20, 184, 166, 0.15);
+    --color-gpu: #f59e0b;      /* Amber */
+    --color-gpu-bg: rgba(245, 158, 11, 0.15);
+    
+    --color-success: #10b981;
+    --color-success-bg: rgba(16, 185, 129, 0.15);
+    --color-warning: #f43f5e;
+    --color-warning-bg: rgba(244, 63, 94, 0.15);
+    
+    --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    
+    --radius-sm: 6px;
+    --radius-md: 10px;
+    --radius-lg: 16px;
+    
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    
+    --transition-fast: 0.15s ease;
+    --transition-normal: 0.25s ease;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-base);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    padding: 2rem;
+    min-height: 100vh;
+}
+
+header {
+    margin-bottom: 2.5rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+h1 {
+    font-size: 1.75rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    background: linear-gradient(to right, #3b82f6, #14b8a6, #f59e0b);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+}
+
+.main-layout {
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 2rem;
+    max-width: 1600px;
+    margin: 0 auto;
+}
+
+/* Sidebar Controls */
+.controls-card {
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    height: fit-content;
+}
+
+.control-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-bottom: 1px solid #2d3748;
+    padding-bottom: 1.25rem;
+}
+
+.control-section:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.section-title {
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.slider-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.slider-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.label-title {
+    color: var(--color-text-secondary);
+}
+
+.label-value {
+    font-family: var(--font-mono);
+    color: var(--color-text-primary);
+    font-weight: 600;
+}
+
+.input-slider {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: #374151;
+    outline: none;
+}
+
+.input-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+/* Color codes for thumbs */
+#cpu-mean::-webkit-slider-thumb, #cpu-std::-webkit-slider-thumb { background: var(--color-cpu); }
+#backend-mean::-webkit-slider-thumb, #backend-std::-webkit-slider-thumb { background: var(--color-backend); }
+#gpu-mean::-webkit-slider-thumb, #gpu-std::-webkit-slider-thumb { background: var(--color-gpu); }
+#z-score::-webkit-slider-thumb { background: #a78bfa; }
+#vsync-rate::-webkit-slider-thumb { background: var(--color-success); }
+#latch-margin::-webkit-slider-thumb { background: #ef4444; }
+
+.select-button-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+    gap: 0.5rem;
+}
+
+.btn-select {
+    background-color: var(--bg-card);
+    border: 1px solid var(--border-color);
+    color: var(--color-text-secondary);
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 600;
+    transition: var(--transition-fast);
+}
+
+.btn-select:hover {
+    border-color: #4b5563;
+    color: var(--color-text-primary);
+}
+
+.btn-select.active {
+    background-color: rgba(167, 139, 250, 0.15);
+    border-color: #a78bfa;
+    color: #c084fc;
+}
+
+/* Dashboard / Output area */
+.dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+/* KPI Grid */
+.kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.25rem;
+}
+
+.kpi-card {
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.25rem;
+    box-shadow: var(--shadow-md);
+    position: relative;
+    overflow: hidden;
+}
+
+.kpi-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.kpi-value {
+    font-size: 1.875rem;
+    font-weight: 800;
+    font-family: var(--font-mono);
+    line-height: 1.2;
+}
+
+.kpi-desc {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 0.25rem;
+}
+
+/* Cards with indicator lines */
+.kpi-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 4px;
+}
+
+.kpi-latency::before { background-color: #a78bfa; }
+.kpi-fps::before { background-color: var(--color-success); }
+.kpi-delay::before { background-color: var(--color-backend); }
+.kpi-bottleneck::before { background-color: var(--color-gpu); }
+
+/* Visualizations Cards */
+.vis-card {
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-md);
+}
+
+.vis-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.25rem;
+}
+
+.vis-title {
+    font-size: 1rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.vis-title svg {
+    width: 20px;
+    height: 20px;
+}
+
+.vis-body {
+    position: relative;
+    width: 100%;
+}
+
+/* Charts styling */
+canvas {
+    width: 100% !important;
+    height: auto !important;
+}
+
+#pipeline-timeline-canvas {
+    background-color: #0b0f19;
+    border-radius: var(--radius-md);
+    border: 1px solid #1f2937;
+}
+
+/* Legend styling */
+.chart-legend {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.8125rem;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    color: var(--color-text-secondary);
+}
+
+.legend-color {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+}
+
+.legend-cpu { background-color: var(--color-cpu); }
+.legend-backend { background-color: var(--color-backend); }
+.legend-gpu { background-color: var(--color-gpu); }
+.legend-vsync { background-color: #4b5563; border: 1px dashed #9ca3af; }
+
+/* Micro-animations */
+@keyframes pulse-slow {
+    0%, 100% { opacity: 0.8; }
+    50% { opacity: 0.3; }
+}
+
+.pulsing-line {
+    animation: pulse-slow 3s infinite ease-in-out;
+}
+
+/* Responsive grid tweak */
+@media (max-width: 1024px) {
+    .main-layout {
+        grid-template-columns: 1fr;
+    }
+    .kpi-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}

--- a/tools/frame_pipeline_visualizer/index.html
+++ b/tools/frame_pipeline_visualizer/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frame Pipeline Estimator & Pacer Visualizer</title>
+    <link rel="stylesheet" href="index.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <div>
+            <h1>Frame Pipeline Estimator & Pacer</h1>
+            <p class="subtitle">Interactive visualization of probabilistic timing models and structural latency sizing</p>
+        </div>
+    </header>
+
+    <main class="main-layout">
+        <!-- Control Panel (Sidebar) -->
+        <section class="controls-card">
+            <!-- Percentiles & Z-Score -->
+            <div class="control-section">
+                <h2 class="section-title">Statistical Confidence</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Confidence Percentile</span>
+                    </div>
+                    <div class="select-button-group">
+                        <button class="btn-select" id="btn-p50" data-z="0.0">P50 (Mean)</button>
+                        <button class="btn-select active" id="btn-p90" data-z="1.282">P90 (90%)</button>
+                        <button class="btn-select" id="btn-p95" data-z="1.645">P95 (95%)</button>
+                    </div>
+                </div>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Custom Z-Score</span>
+                        <span class="label-value" id="val-z-score">1.28</span>
+                    </div>
+                    <input type="range" class="input-slider" id="z-score" min="0" max="3" step="0.01" value="1.282">
+                </div>
+            </div>
+
+            <!-- VSYNC Display Capabilities -->
+            <div class="control-section">
+                <h2 class="section-title">Display VSYNC</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Physical VSYNC rate</span>
+                        <span class="label-value" id="val-vsync-rate">60 Hz</span>
+                    </div>
+                    <input type="range" class="input-slider" id="vsync-rate" min="30" max="144" step="1" value="60">
+                </div>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Compositor Latch Margin</span>
+                        <span class="label-value" id="val-latch-margin">3.0 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="latch-margin" min="0" max="10" step="0.1" value="3.0">
+                </div>
+            </div>
+
+            <!-- Pacing Cadence -->
+            <div class="control-section">
+                <h2 class="section-title">Pacing Target</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Pacing Mode</span>
+                    </div>
+                    <div class="select-button-group">
+                        <button class="btn-select active" id="pacing-auto">Auto</button>
+                        <button class="btn-select" id="pacing-vsync">1:1 VSYNC</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- CPU (Main) Stage -->
+            <div class="control-section">
+                <h2 class="section-title" style="color: var(--color-cpu);">1. Main CPU Stage</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Average Time (μ)</span>
+                        <span class="label-value" id="val-cpu-mean">8.0 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="cpu-mean" min="1" max="40" step="0.1" value="8.0">
+                </div>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Jitter (σ)</span>
+                        <span class="label-value" id="val-cpu-std">1.5 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="cpu-std" min="0" max="10" step="0.1" value="1.5">
+                </div>
+            </div>
+
+            <!-- Backend Driver Stage -->
+            <div class="control-section">
+                <h2 class="section-title" style="color: var(--color-backend);">2. Backend Driver</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Average Time (μ)</span>
+                        <span class="label-value" id="val-backend-mean">4.0 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="backend-mean" min="1" max="40" step="0.1" value="4.0">
+                </div>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Jitter (σ)</span>
+                        <span class="label-value" id="val-backend-std">0.8 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="backend-std" min="0" max="10" step="0.1" value="0.8">
+                </div>
+            </div>
+
+            <!-- GPU Stage -->
+            <div class="control-section">
+                <h2 class="section-title" style="color: var(--color-gpu);">3. GPU Execution</h2>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Average Time (μ)</span>
+                        <span class="label-value" id="val-gpu-mean">12.0 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="gpu-mean" min="1" max="40" step="0.1" value="12.0">
+                </div>
+                <div class="slider-group">
+                    <div class="slider-label">
+                        <span class="label-title">Jitter (σ)</span>
+                        <span class="label-value" id="val-gpu-std">2.0 ms</span>
+                    </div>
+                    <input type="range" class="input-slider" id="gpu-std" min="0" max="10" step="0.1" value="2.0">
+                </div>
+            </div>
+        </section>
+
+        <!-- Main Dashboard -->
+        <section class="dashboard">
+            <!-- Output KPIs -->
+            <div class="kpi-grid">
+                <div class="kpi-card kpi-latency">
+                    <div class="kpi-title">Structural Latency</div>
+                    <div class="kpi-value" id="kpi-val-latency">2 Frames</div>
+                    <div class="kpi-desc" id="kpi-val-latency-ms">33.3 ms target latency</div>
+                </div>
+                <div class="kpi-card kpi-fps">
+                    <div class="kpi-title">Ideal Frame Rate</div>
+                    <div class="kpi-value" id="kpi-val-fps">60.0 Hz</div>
+                    <div class="kpi-desc" id="kpi-val-frame-duration">16.67 ms bottleneck</div>
+                </div>
+                <div class="kpi-card kpi-delay">
+                    <div class="kpi-title">Safe CPU Delay</div>
+                    <div class="kpi-value" id="kpi-val-delay">4.2 ms</div>
+                    <div class="kpi-desc">Max input latency delay (slack)</div>
+                </div>
+                <div class="kpi-card kpi-bottleneck">
+                    <div class="kpi-title">Pipeline Bottleneck</div>
+                    <div class="kpi-value" id="kpi-val-bottleneck">GPU Stage</div>
+                    <div class="kpi-desc" id="kpi-val-bottleneck-detail">Effective duration: 14.56ms</div>
+                </div>
+            </div>
+
+            <!-- Visualization: Gaussian Curves -->
+            <div class="vis-card">
+                <div class="vis-header">
+                    <h3 class="vis-title">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18M18.7 8l-5.1 5.2-2.8-2.7L7 14.3"/></svg>
+                        Probabilistic Timing Distributions
+                    </h3>
+                    <div class="chart-legend">
+                        <div class="legend-item"><span class="legend-color legend-cpu"></span> CPU</div>
+                        <div class="legend-item"><span class="legend-color legend-backend"></span> Backend</div>
+                        <div class="legend-item"><span class="legend-color legend-gpu"></span> GPU</div>
+                        <div class="legend-item"><span class="legend-color legend-vsync"></span> VSYNC</div>
+                    </div>
+                </div>
+                <div class="vis-body">
+                    <canvas id="gaussian-canvas" height="240"></canvas>
+                </div>
+            </div>
+
+            <!-- Visualization: Pipeline Overlap Timeline -->
+            <div class="vis-card">
+                <div class="vis-header">
+                    <h3 class="vis-title">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+                        Parallel Frame Pipeline Overlap (Timeline Flow)
+                    </h3>
+                </div>
+                <div class="vis-body">
+                    <canvas id="pipeline-timeline-canvas" height="300"></canvas>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- Extract composition margin (displayPresent - presentDeadline) from historical telemetry records in FramePipelineEstimator.
- Adjust pacing budget to subtract composition margin, ensuring GPU execution completes before compositor latch.
- Automatically increment structural latency frames when transit plus compositor margin exceeds the target pacing period.
- Simplify estimatePacing API by removing the redundant targetVsyncInterval parameter.
- Restore and enhance the helper FILAMENT_LOG_PIPELINE_ESTIMATOR logger in FramePipelineEstimator.cpp to track composition margins.
- Add "Compositor Latch Margin" slider control to visualizer UI.
- Draw vertical dashed red composition deadlines on timeline flow canvas and highlight deadline target anchors.
- Render VSYNC Target (green) and Compositor Latch (red) vertical lines on the PDF timing distributions graph.
- Update slider styling: color vsync knob green and latch margin knob red.
- Add unit tests verifying deadline-aware latency and safe delay sizing.

<img width="640" height="708" alt="visualizer" src="https://github.com/user-attachments/assets/ffd19327-a131-4f80-8624-b1b98a89c6bc" />
