### PR TITLE
vk: set the renderpass name when DebugUtils is on

### DIFF
--- a/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanAsyncHandles.cpp
@@ -17,6 +17,7 @@
 #include "VulkanAsyncHandles.h"
 
 #include "VulkanConstants.h"
+#include "VulkanDriver.h"
 #include "VulkanFencePool.h"
 
 #include "vulkan/utils/Spirv.h"

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -65,7 +65,8 @@
 #define FVK_DEBUG_PIPELINE_CACHE          0x00002000
 #define FVK_DEBUG_STAGING_ALLOCATION      0x00004000
 
-// Enable the debug utils extension if it is available.
+// Enable the debug utils extension if it is available. This will also try to set the name on
+// renderpasses, framebuffers, and more.
 #define FVK_DEBUG_DEBUG_UTILS             0x00008000
 
 // Use this to debug potential Handle/Resource leakage. It will print out reference counts for all
@@ -85,8 +86,11 @@
 
 // Useful default combinations
 #define FVK_DEBUG_EVERYTHING              (0xFFFFFFFF & ~FVK_DEBUG_PROFILING)
-#define FVK_DEBUG_PERFORMANCE     \
-    FVK_DEBUG_SYSTRACE
+#define FVK_DEBUG_PERFORMANCE             FVK_DEBUG_SYSTRACE
+
+// Uses DebugUtils extension to set the name of the renderpass. Visible on profilers like AGI and
+// APA.
+#define FVK_DEBUG_DEBUG_UTILS_RENDERPASS_NAME (FVK_DEBUG_DEBUG_UTILS | FVK_DEBUG_GROUP_MARKERS)
 
 #if defined(FILAMENT_BACKEND_DEBUG_FLAG)
 #define FVK_DEBUG_FORWARDED_FLAG (FILAMENT_BACKEND_DEBUG_FLAG & FVK_DEBUG_EVERYTHING)
@@ -95,7 +99,7 @@
 #endif
 
 #ifndef NDEBUG
-#define FVK_DEBUG_FLAGS (FVK_DEBUG_PERFORMANCE | FVK_DEBUG_FORWARDED_FLAG)
+#define FVK_DEBUG_FLAGS (FVK_DEBUG_PERFORMANCE | FVK_DEBUG_FORWARDED_FLAG | FVK_DEBUG_DEBUG_UTILS_RENDERPASS_NAME)
 #else
 #define FVK_DEBUG_FLAGS 0
 #endif
@@ -117,11 +121,6 @@ static_assert(FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS) || FVK_ENABLED(FVK_DEBUG_VALIDA
 // Ensure dependencies are met between debug options
 #if FVK_ENABLED(FVK_DEBUG_PRINT_GROUP_MARKERS)
 static_assert(FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS));
-#endif
-
-// Only enable debug utils if validation is enabled.
-#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
-static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
 #endif
 
 #if FVK_ENABLED(FVK_DEBUG_PROFILING) && FVK_DEBUG_FLAGS != FVK_DEBUG_PROFILING

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -193,7 +193,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallback(VkDebugReportFlagsEXT flags,
 }
 #endif // FVK_ENABLED(FVK_DEBUG_VALIDATION)
 
-#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS)
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS) && FVK_ENABLED(FVK_DEBUG_VALIDATION)
 VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
         VkDebugUtilsMessageTypeFlagsEXT types, const VkDebugUtilsMessengerCallbackDataEXT* cbdata,
         void* pUserData) {
@@ -2385,12 +2385,15 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
             mFramebufferCache.getFramebuffer(fbkey, &mResourceManager, rt);
 
 // Assign a label to the framebuffer for debugging purposes.
-#if FVK_ENABLED(FVK_DEBUG_GROUP_MARKERS | FVK_DEBUG_DEBUG_UTILS)
+#if FVK_ENABLED(FVK_DEBUG_DEBUG_UTILS_RENDERPASS_NAME)
     auto const topMarker = mCommands.getTopGroupMarker();
     if (!topMarker.empty()) {
-        DebugUtils::setName(VK_OBJECT_TYPE_FRAMEBUFFER, reinterpret_cast<uint64_t>(vkfb),
-                topMarker.c_str());
+        uint64_t fbVk = (uint64_t) vkfb->getVkFramebuffer();
+        uint64_t renderPassVk = (uint64_t) renderPass->getVkRenderPass();
+        DebugUtils::setName(VK_OBJECT_TYPE_FRAMEBUFFER, fbVk, topMarker.c_str());
+        DebugUtils::setName(VK_OBJECT_TYPE_RENDER_PASS, renderPassVk,topMarker.c_str());
     }
+
 #endif
 
     // The current command buffer now has references to the render target and its attachments.


### PR DESCRIPTION
 - This PR also enables DebugUtils by default on debug builds. (when to enable it will be re-visited).
 - Separated validation from DebugUtils so that they are not tied together in enablement.
 - Together with Android Performance Analyzer, you should be able to see named renderpasses in the GPU non-fragment, fragment workload on the timeline.