### PR TITLE
variant removal: relocate the special SSR key off S2D|SRE

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,3 +6,4 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+- filamat: completely remove the DYN variant bit.

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,4 +6,4 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
-- filamat: completely remove the DYN variant bit.
+- filamat: completely remove the DYN variant bit.[⚠️ **Recompile Materials**]

--- a/android/filament-android/src/main/java/com/google/android/filament/Material.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Material.java
@@ -304,8 +304,14 @@ public class Material {
     public static class UserVariantFilterBit {
         /** Directional lighting */
         public static int DIRECTIONAL_LIGHTING = 0x01;
-        /** Dynamic lighting */
+
+        /** Dynamic lighting
+         * Since dynamic lighting was migrated to specialization constants, filtering this bit no
+         * longer affects the size of offline compiled materials (.filamat). However, we keep it
+         * for pruning unnecessary pipeline compilations at runtime.
+        */
         public static int DYNAMIC_LIGHTING = 0x02;
+
         /** Shadow receiver */
         public static int SHADOW_RECEIVER = 0x04;
         /** Skinning */

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1773,8 +1773,6 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     const bool isMaterialLit = material->getDefinition().isVariantLit;
     Variant baseVariant{};
     baseVariant.setDirectionalLighting(isMaterialLit && view->hasDirectionalLighting());
-    // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
-    baseVariant.setDynamicLighting(false);
     baseVariant.setFog(view->hasFog());
     baseVariant.setShadowSampler2D(isMaterialLit && view->hasShadowing() && (view->getShadowType() != ShadowType::PCF));
     baseVariant.setStereo(view->hasStereo());

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1036,7 +1036,6 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
 
     Variant variant;
     variant.setDirectionalLighting(view.hasDirectionalLighting());
-    variant.setDynamicLighting(view.hasDynamicLighting());
     variant.setFog(view.hasFog());
     variant.setShadowSampler2D(view.hasShadowing() && view.getShadowType() != ShadowType::PCF);
     variant.setStereo(view.hasStereo());

--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -88,6 +88,11 @@ if (FILAMENT_BUILD_TESTING)
         target_link_libraries(test_depth PRIVATE utils)
     endif()
 
+    add_executable(test_variant test_Variant.cpp)
+    target_link_libraries(test_variant PRIVATE filabridge gtest)
+    target_compile_options(test_variant PRIVATE ${COMPILER_FLAGS})
+    set_target_properties(test_variant PROPERTIES FOLDER Tests)
+
     add_executable(test_material_parser
             filament_test_material_parser.cpp
             ${RESGEN_SOURCE}

--- a/filament/test/test_Variant.cpp
+++ b/filament/test/test_Variant.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <private/filament/Variant.h>
+
+#include <filament/MaterialEnums.h>
+
+using namespace filament;
+
+// The variant a scene lit only by punctual lights requests when the view uses
+// sampler2D shadows (VSM/DPCF/PCSS).
+static constexpr Variant PUNCTUAL_ONLY_S2D_VARIANT{ Variant::S2D | Variant::SRE };
+
+TEST(VariantTest, SsrKeyLivesInReservedSpace) {
+    constexpr Variant ssr{ Variant::SPECIAL_SSR_VARIANT };
+    EXPECT_TRUE(Variant::isSSRVariant(ssr));
+    EXPECT_TRUE(Variant::isReserved(ssr));
+    // reserved depth space: the color pass never sets DEP, the depth pass never sets SRE
+    EXPECT_NE(0, Variant::SPECIAL_SSR_VARIANT & Variant::DEP);
+    EXPECT_NE(0, Variant::SPECIAL_SSR_VARIANT & Variant::SRE);
+
+    // the SSR fragment shader keeps its key; skinning only affects its vertex shader
+    EXPECT_EQ(ssr, Variant::filterVariantFragment(ssr));
+    EXPECT_EQ(Variant(Variant::SKN),
+            Variant::filterVariantVertex(Variant(Variant::SPECIAL_SSR_VARIANT | Variant::SKN)));
+}
+
+TEST(VariantTest, PunctualOnlySoftShadowVariantIsNotTheSsrKey) {
+    EXPECT_FALSE(Variant::isSSRVariant(PUNCTUAL_ONLY_S2D_VARIANT));
+    EXPECT_TRUE(Variant::isValidStandardVariant(PUNCTUAL_ONLY_S2D_VARIANT));
+    EXPECT_EQ(PUNCTUAL_ONLY_S2D_VARIANT,
+            Variant::filterVariant(PUNCTUAL_ONLY_S2D_VARIANT, true));
+    EXPECT_TRUE(Variant::isFragmentVariant(PUNCTUAL_ONLY_S2D_VARIANT));
+}
+
+TEST(VariantTest, UserFiltersKeepSsrAndShadowVariantsApart) {
+    constexpr Variant ssr{ Variant::SPECIAL_SSR_VARIANT };
+
+    // only the ssr filter removes the SSR variant
+    EXPECT_EQ(Variant(0), Variant::filterUserVariant(ssr,
+            UserVariantFilterMask(UserVariantFilterBit::SSR)));
+    EXPECT_EQ(ssr, Variant::filterUserVariant(ssr,
+            UserVariantFilterMask(UserVariantFilterBit::VSM)));
+
+    // the ssr filter must not touch the punctual-only sampler2D shadow variant
+    EXPECT_EQ(PUNCTUAL_ONLY_S2D_VARIANT,
+            Variant::filterUserVariant(PUNCTUAL_ONLY_S2D_VARIANT,
+                    UserVariantFilterMask(UserVariantFilterBit::SSR)));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -277,7 +277,12 @@ using UserVariantFilterMask = uint32_t;
 
 enum class UserVariantFilterBit : UserVariantFilterMask {
     DIRECTIONAL_LIGHTING        = 0x01,         //!< Directional lighting
-    DYNAMIC_LIGHTING            = 0x02,         //!< Dynamic lighting
+
+    //!< \note Since dynamic lighting was migrated to specialization constants, filtering this bit
+    //!< no longer affects the size of offline compiled materials (.filamat). However, we keep it
+    //!< for pruning unnecessary pipeline compilations at runtime.
+    DYNAMIC_LIGHTING = 0x02, //!< Dynamic lighting
+
     SHADOW_RECEIVER             = 0x04,         //!< Shadow receiver
     SKINNING                    = 0x08,         //!< Skinning
     FOG                         = 0x10,         //!< Fog

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -119,7 +119,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float aoBentNormals;                        // 0: no AO bent normal, >0.0 AO bent normals
 
     // --------------------------------------------------------------------------------------------
-    // Dynamic Lighting [variant: DYN]
+    // Dynamic Lighting (controlled via dynamic specialization constants)
     // --------------------------------------------------------------------------------------------
     math::float4 zParams;                       // froxel Z parameters
     math::uint3 fParams;                        // stride-x, stride-y, stride-z

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -68,7 +68,6 @@ struct Variant {
     //                      +-----+-----+-----+-----+-----+-----+-----+
     //      Vertex shader      0     0     0     X     X     X     X
     //    Fragment shader      X     X     0     0     X     0     X
-    //       Fragment SSR      1     0     0     0     1     0     0
     //           Reserved      1     1     0     X     1     X     0      [ -4]
     //           Reserved      0     X     0     X     1     X     0      [ -8]
     //           Reserved      1     X     0     X     0     X     X      [-16]
@@ -81,6 +80,9 @@ struct Variant {
     //     Fragment depth      0     X     1     0     0     0     0
     //     Fragment depth      1     0     1     0     0     0     0
     //           Reserved      1     1     1     X     0     X     0     [  -4]
+    //
+    // Special variants (reserved depth space, DEP set with SRE, never requestable):
+    //       Fragment SSR      0     0     1     X     1     0     0
     //
     // 48 variants used, 80 reserved (128 - 48)
     //
@@ -105,8 +107,8 @@ struct Variant {
     static constexpr type_t NO_VARIANT         = 0u;
 
     // special variants (variants that use the reserved space)
-    static constexpr type_t SPECIAL_SSR_VARIANT=       S2D |       SRE      ;
-    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DIR;
+    static constexpr type_t SPECIAL_SSR_VARIANT=             DEP | SRE            ;
+    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DIR | FOG;
 
     static constexpr type_t STANDARD_MASK      = DEP;
     static constexpr type_t STANDARD_VARIANT   = 0u;
@@ -207,10 +209,11 @@ struct Variant {
     static constexpr Variant filterVariantVertex(Variant variant) noexcept {
         // Filter out vertex variants that are not needed. For e.g. fog doesn't affect the
         // vertex shader.
+        if (isSSRVariant(variant)) {
+            variant.key &= ~SPECIAL_SSR_VARIANT;
+            return variant & (STE | SKN | SRE | DIR);
+        }
         if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
-            if (isSSRVariant(variant)) {
-                variant.key &= ~SPECIAL_SSR_VARIANT;
-            }
             return variant & (STE | SKN | SRE | DIR);
         }
         if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
@@ -223,6 +226,9 @@ struct Variant {
     static constexpr Variant filterVariantFragment(Variant variant) noexcept {
         // filter out fragment variants that are not needed. For e.g. skinning doesn't
         // affect the fragment shader.
+        if (isSSRVariant(variant)) {
+            return variant & ~(STE | SKN);
+        }
         if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
             return variant & (S2D | FOG | SRE | DIR);
         }

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 namespace filament {
-static constexpr size_t VARIANT_BITS = 8;
+static constexpr size_t VARIANT_BITS = 7;
 static constexpr size_t VARIANT_COUNT = 1 << VARIANT_BITS;
 
 using VariantList = utils::bitset<uint64_t, VARIANT_COUNT / 64>;
@@ -44,7 +44,6 @@ struct Variant {
 
 
     // DIR: Directional Lighting
-    // DYN: Dynamic Lighting
     // SRE: Shadow Receiver
     // SKN: Skinning
     // DEP: Depth only
@@ -55,32 +54,35 @@ struct Variant {
     // STE: Instanced stereo rendering
     //
     //   X: either 1 or 0
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    // Variant              | STE | S2D | FOG | DEP | SKN | SRE | DYN | DIR |   256
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //                              MNT   PCK
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    // Variant              | S2D | FOG | DEP | SKN | SRE | STE | DIR |   128
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    //                        MNT   PCK
+    //
+    // Note that public UserVariantFilterBit keeps the old 8-bit values for API compatibility.
+    // In particular, public STE remains 0x80 and is translated to the internal STE bit below.
     //
     // Standard variants:
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //                      | STE | S2D | FOG |  0  | SKN | SRE | DYN | DIR |    128 - 44 = 84
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //      Vertex shader      X     0     0     0     X     X     X     X
-    //    Fragment shader      0     X     X     0     0     X     X     X
-    //       Fragment SSR      0     1     0     0     0     1     0     0
-    //           Reserved      X     1     1     0     X     1     0     0      [ -4]
-    //           Reserved      X     0     X     0     X     1     0     0      [ -8]
-    //           Reserved      X     1     X     0     X     0     X     X      [-32]
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    //                      | S2D | FOG |  0  | SKN | SRE | STE | DIR |    64 - 28 = 36
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    //      Vertex shader      0     0     0     X     X     X     X
+    //    Fragment shader      X     X     0     0     X     0     X
+    //       Fragment SSR      1     0     0     0     1     0     0
+    //           Reserved      1     1     0     X     1     X     0      [ -4]
+    //           Reserved      0     X     0     X     1     X     0      [ -8]
+    //           Reserved      1     X     0     X     0     X     X      [-16]
     //
     // Depth variants:
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //                      | STE | MNT | PCK |  1  | SKN |  0  |  0  |  0  |   16 - 4 = 12
-    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //       Vertex depth      X     X     0     1     X     0     0     0
-    //     Fragment depth      0     0     X     1     0     0     0     0
-    //     Fragment depth      0     1     0     1     0     0     0     0
-    //           Reserved      X     1     1     1     X     0     0     0     [  -4]
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    //                      | MNT | PCK |  1  | SKN |  0  | STE |  0  |   16 - 4 = 12
+    //                      +-----+-----+-----+-----+-----+-----+-----+
+    //       Vertex depth      X     0     1     X     0     X     0
+    //     Fragment depth      0     X     1     0     0     0     0
+    //     Fragment depth      1     0     1     0     0     0     0
+    //           Reserved      1     1     1     X     0     X     0     [  -4]
     //
-    // 96 variants used, 160 reserved (256 - 96)
+    // 48 variants used, 80 reserved (128 - 48)
     //
     // note: a valid variant can be neither a valid vertex nor a valid fragment variant
     //       (e.g.: FOG|SKN variants), the proper bits are filtered appropriately,
@@ -88,10 +90,10 @@ struct Variant {
 
     type_t key = 0u;
 
-    // when adding more bits, update FRenderer::CommandKey::draw::materialVariant as needed
+    // when adding more bits, update RenderPass::CommandKey and RenderPass::PrimitiveInfo as needed
     // when adding more bits, update VARIANT_COUNT
     static constexpr type_t DIR   = 0x01; // directional light present, per frame/world position
-    static constexpr type_t DYN   = 0x02; // point, spot or area present, per frame/world position
+    static constexpr type_t STE   = 0x02; // instanced stereo
     static constexpr type_t SRE   = 0x04; // receives shadows, per renderable
     static constexpr type_t SKN   = 0x08; // GPU skinning and/or morphing
     static constexpr type_t DEP   = 0x10; // depth only variants
@@ -99,20 +101,19 @@ struct Variant {
     static constexpr type_t PCK   = 0x20; // picking (depth)
     static constexpr type_t S2D   = 0x40; // sampler type
     static constexpr type_t MNT   = 0x40; // variance shadow maps
-    static constexpr type_t STE   = 0x80; // instanced stereo
 
     static constexpr type_t NO_VARIANT         = 0u;
 
     // special variants (variants that use the reserved space)
-    static constexpr type_t SPECIAL_SSR_VARIANT=       S2D |       SRE            ;
-    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DYN | DIR;
+    static constexpr type_t SPECIAL_SSR_VARIANT=       S2D |       SRE      ;
+    static constexpr type_t SPECIAL_SSR_MASK   = STE | S2D | DEP | SRE | DIR;
 
     static constexpr type_t STANDARD_MASK      = DEP;
     static constexpr type_t STANDARD_VARIANT   = 0u;
 
     // the depth variant deactivates all variants that make no sense when writing the depth
     // only -- essentially, all fragment-only variants.
-    static constexpr type_t DEPTH_MASK         = DEP | SRE | DYN | DIR;
+    static constexpr type_t DEPTH_MASK         = DEP | SRE | DIR;
     static constexpr type_t DEPTH_VARIANT      = DEP;
 
     // this mask filters out the lighting variants
@@ -120,12 +121,10 @@ struct Variant {
 
     // returns raw variant bits
     bool hasDirectionalLighting() const noexcept { return key & DIR; }
-    bool hasDynamicLighting() const noexcept     { return key & DYN; }
     bool hasSkinningOrMorphing() const noexcept  { return key & SKN; }
     bool hasStereo() const noexcept              { return key & STE; }
 
     void setDirectionalLighting(bool v) noexcept { set(v, DIR); }
-    void setDynamicLighting(bool v) noexcept     { set(v, DYN); }
     void setShadowReceiver(bool v) noexcept      { set(v, SRE); }
     void setSkinning(bool v) noexcept            { set(v, SKN); }
     void setFog(bool v) noexcept                 { set(v, FOG); }
@@ -136,7 +135,7 @@ struct Variant {
 
     static constexpr bool isValidDepthVariant(Variant variant) noexcept {
         // Can't have VSM and PICKING together with DEPTH variants
-        constexpr type_t RESERVED_MASK  = MNT | PCK | DEP | SRE | DYN | DIR;
+        constexpr type_t RESERVED_MASK  = MNT | PCK | DEP | SRE | DIR;
         constexpr type_t RESERVED_VALUE = MNT | PCK | DEP;
         return ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) &&
                ((variant.key & RESERVED_MASK) != RESERVED_VALUE);
@@ -144,11 +143,11 @@ struct Variant {
 
     static constexpr bool isValidStandardVariant(Variant variant) noexcept {
         // can't have shadow receiver if we don't have any lighting
-        constexpr type_t RESERVED0_MASK  = S2D | FOG | SRE | DYN | DIR;
+        constexpr type_t RESERVED0_MASK  = S2D | FOG | SRE | DIR;
         constexpr type_t RESERVED0_VALUE = S2D | FOG | SRE;
 
         // can't have shadow receiver if we don't have any lighting
-        constexpr type_t RESERVED1_MASK  = S2D | SRE | DYN | DIR;
+        constexpr type_t RESERVED1_MASK  = S2D | SRE | DIR;
         constexpr type_t RESERVED1_VALUE = SRE;
 
         // can't have VSM without shadow receiver
@@ -212,7 +211,7 @@ struct Variant {
             if (isSSRVariant(variant)) {
                 variant.key &= ~SPECIAL_SSR_VARIANT;
             }
-            return variant & (STE | SKN | SRE | DYN | DIR);
+            return variant & (STE | SKN | SRE | DIR);
         }
         if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
             // Only MNT, skinning, and stereo affect the vertex shader's DEPTH variant
@@ -225,7 +224,7 @@ struct Variant {
         // filter out fragment variants that are not needed. For e.g. skinning doesn't
         // affect the fragment shader.
         if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
-            return variant & (S2D | FOG | SRE | DYN | DIR);
+            return variant & (S2D | FOG | SRE | DIR);
         }
         if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
             // Only VSM & PICKING affects the fragment shader's DEPTH variant
@@ -250,9 +249,6 @@ struct Variant {
             // when the shading mode is unlit, remove all the lighting variants
             return variant & UNLIT_MASK;
         }
-        // Dynamic lighting is now handled via dynamic specialization constants.
-        // We strip the DYN bit to prevent compiling duplicate identical variants.
-        variant.key &= ~DYN;
 
         // if shadow receiver is disabled, we pick the shadow sampler
         if (!(variant.key & SRE)) {

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -35,16 +35,12 @@ Variant Variant::filterUserVariant(
         variant.key &= ~DIR;
     }
 
-    if (filterMask & uint32_t(UserVariantFilterBit::DYNAMIC_LIGHTING)) {
-        variant.key &= ~DYN;
-    }
-
     if (filterMask & uint32_t(UserVariantFilterBit::SKINNING)) {
         variant.key &= ~SKN;
     }
 
     if (filterMask & uint32_t(UserVariantFilterBit::STE)) {
-        variant.key &= ~(filterMask & STE);
+        variant.key &= ~STE;
     }
 
     if (isValidDepthVariant(variant)) {
@@ -216,10 +212,10 @@ static auto const gDepthVariants{ details::get_depth_variants() };
 static auto const gPostProcessVariants{ details::get_post_process_variants() };
 
 static_assert(reserved_is_not_valid());
-static_assert(reserved_variant_count() == 160);
-static_assert(valid_variant_count() == 96);
-static_assert(vertex_variant_count() == 32 - (4 + 0) + 8 - 0);        // 36
-static_assert(fragment_variant_count() == 33 - (2 + 2 + 8) + 4 - 1);    // 24
+static_assert(reserved_variant_count() == 80);
+static_assert(valid_variant_count() == 48);
+static_assert(vertex_variant_count() == 16 - (4 + 0) + 8 - 0);        // 20
+static_assert(fragment_variant_count() == 16 - (1 + 2 + 4) + 4 - 1);    // 12
 
 } // namespace details
 

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -81,7 +81,7 @@ constexpr inline size_t variant_count(bool lit) noexcept {
     size_t count = 0;
     for (size_t i = 0; i < VARIANT_COUNT; i++) {
         Variant variant(i);
-        if (!Variant::isValidStandardVariant(variant)) {
+        if (!Variant::isValidStandardVariant(variant) && !Variant::isSSRVariant(variant)) {
             continue;
         }
         variant = Variant::filterVariant(variant, lit);
@@ -110,7 +110,7 @@ constexpr auto get_variants() noexcept {
     size_t count = 0;
     for (size_t i = 0; i < VARIANT_COUNT; i++) {
         Variant variant(i);
-        if (!Variant::isValidStandardVariant(variant)) {
+        if (!Variant::isValidStandardVariant(variant) && !Variant::isSSRVariant(variant)) {
             continue;
         }
         variant = Variant::filterVariant(variant, LIT);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -950,9 +950,6 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                     if (v.variant.hasDirectionalLighting()) {
                         continue;
                     }
-                    if (v.variant.hasDynamicLighting()) {
-                        continue;
-                    }
                 }
                 if (filament::Variant::isShadowReceiverVariant(v.variant)) {
                     continue;

--- a/libs/filamat/src/MaterialVariants.cpp
+++ b/libs/filamat/src/MaterialVariants.cpp
@@ -32,7 +32,7 @@ std::vector<Variant> determineSurfaceVariants(
     std::vector<Variant> variants;
     for (size_t k = 0; k < filament::VARIANT_COUNT; k++) {
         filament::Variant const variant(k);
-        if (filament::Variant::isReserved(variant)) {
+        if (filament::Variant::isReserved(variant) && !filament::Variant::isSSRVariant(variant)) {
             continue;
         }
 

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "UibGenerator.h"
-#include "private/filament/UibStructs.h"
 
-#include "private/filament/BufferInterfaceBlock.h"
-
+#include <private/filament/BufferInterfaceBlock.h>
 #include <private/filament/EngineEnums.h>
+#include <private/filament/UibStructs.h>
+
 #include <backend/DriverEnums.h>
 
 #include <utils/debug.h>
@@ -136,7 +136,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "aoBentNormals",          0, Type::FLOAT                   },
 
             // ------------------------------------------------------------------------------------
-            // Dynamic Lighting [variant: DYN]
+            // Dynamic Lighting (controlled via dynamic specialization constants)
             // ------------------------------------------------------------------------------------
             { "zParams",                0, Type::FLOAT4                  },
             { "fParams",                0, Type::UINT3                   },

--- a/libs/filament-matp/src/ParametersProcessor.cpp
+++ b/libs/filament-matp/src/ParametersProcessor.cpp
@@ -16,20 +16,22 @@
 
 #include "ParametersProcessor.h"
 
-#include <filamat/Enums.h>
-#include <utils/Status.h>
-#include <utils/sstream.h>
-
 #include <private/filament/BufferInterfaceBlock.h>
 #include <private/filament/Variant.h>
 
+#include <filamat/Enums.h>
+
 #include <backend/DriverEnums.h>
+
+#include <utils/sstream.h>
+#include <utils/Status.h>
 
 #include <math/vec3.h>
 
 #include <algorithm>
 #include <iostream>
 #include <string_view>
+
 #include <ctype.h>
 
 using namespace filamat;
@@ -1317,7 +1319,6 @@ static Status processVariantFilter(MaterialBuilder& builder, const JsonishValue&
     static const std::unordered_map<std::string_view, filament::UserVariantFilterBit> strToEnum  = [] {
         std::unordered_map<std::string_view, filament::UserVariantFilterBit> strToEnum;
         strToEnum["directionalLighting"]    = filament::UserVariantFilterBit::DIRECTIONAL_LIGHTING;
-        strToEnum["dynamicLighting"]        = filament::UserVariantFilterBit::DYNAMIC_LIGHTING;
         strToEnum["shadowReceiver"]         = filament::UserVariantFilterBit::SHADOW_RECEIVER;
         strToEnum["skinning"]               = filament::UserVariantFilterBit::SKINNING;
         strToEnum["vsm"]                    = filament::UserVariantFilterBit::VSM;
@@ -1342,6 +1343,10 @@ static Status processVariantFilter(MaterialBuilder& builder, const JsonishValue&
         }
 
         const std::string& s = elementValue->toJsonString()->getString();
+        if (s == "dynamicLighting") {
+            std::cerr << "Warning: dynamicLighting variant filter is deprecated and ignored." << std::endl;
+            continue;
+        }
         if (!isStringValidEnum(strToEnum, s)) {
             io::sstream errorMessage;
             errorMessage << "variant_filter: variant " << s << " is not a valid variant";

--- a/libs/filament-matp/src/ParametersProcessor.cpp
+++ b/libs/filament-matp/src/ParametersProcessor.cpp
@@ -1343,6 +1343,7 @@ static Status processVariantFilter(MaterialBuilder& builder, const JsonishValue&
         }
 
         const std::string& s = elementValue->toJsonString()->getString();
+        // TODO: dynamicLighting bit is removed 26/07/2. Remove by 26/8/31
         if (s == "dynamicLighting") {
             std::cerr << "Warning: dynamicLighting variant filter is deprecated and ignored." << std::endl;
             continue;

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -21,10 +21,10 @@
 #include <filamat/MaterialBuilder.h>
 
 #include <utils/Hash.h>
-#include <utils/sstream.h>
 
 #include <tsl/robin_map.h>
 
+#include <iostream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -83,9 +83,9 @@ JitShaderProvider::JitShaderProvider(Engine* engine, bool optimizeShaders,
     }();
 
     for (auto& filterStr : variantFilters) {
+        // TODO: dynamicLighting bit is removed 26/07/2. Remove by 26/8/31
         if (std::string_view(filterStr) == "dynamicLighting") {
-            io::sstream warningMessage;
-            warningMessage << "Warning: dynamicLighting variant filter is deprecated and ignored.";
+            std::cerr << "Warning: dynamicLighting variant filter is deprecated and ignored.";
             continue;
         }
         mVariantFilter |= (uint32_t)strToEnum.at(filterStr);

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -21,10 +21,12 @@
 #include <filamat/MaterialBuilder.h>
 
 #include <utils/Hash.h>
+#include <utils/sstream.h>
 
 #include <tsl/robin_map.h>
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 using namespace filamat;
@@ -71,7 +73,6 @@ JitShaderProvider::JitShaderProvider(Engine* engine, bool optimizeShaders,
     static const std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum  = [] {
         std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum;
         strToEnum["directionalLighting"]    = filament::UserVariantFilterBit::DIRECTIONAL_LIGHTING;
-        strToEnum["dynamicLighting"]        = filament::UserVariantFilterBit::DYNAMIC_LIGHTING;
         strToEnum["shadowReceiver"]         = filament::UserVariantFilterBit::SHADOW_RECEIVER;
         strToEnum["skinning"]               = filament::UserVariantFilterBit::SKINNING;
         strToEnum["vsm"]                    = filament::UserVariantFilterBit::VSM;
@@ -82,6 +83,11 @@ JitShaderProvider::JitShaderProvider(Engine* engine, bool optimizeShaders,
     }();
 
     for (auto& filterStr : variantFilters) {
+        if (std::string_view(filterStr) == "dynamicLighting") {
+            io::sstream warningMessage;
+            warningMessage << "Warning: dynamicLighting variant filter is deprecated and ignored.";
+            continue;
+        }
         mVariantFilter |= (uint32_t)strToEnum.at(filterStr);
     }
     MaterialBuilder::init();

--- a/libs/matdbg/src/CommonWriter.cpp
+++ b/libs/matdbg/src/CommonWriter.cpp
@@ -42,7 +42,6 @@ std::string formatVariantString(Variant variant, MaterialDomain domain) noexcept
     // the page. The HTML file has a legend.
     if (variant.key) {
         if (variant.key & Variant::DIR) variantString += "DIR|";
-        if (variant.key & Variant::DYN) variantString += "DYN|";
         if (variant.key & Variant::SRE) variantString += "SRE|";
         if (variant.key & Variant::SKN) variantString += "SKN|";
         if (variant.key & Variant::DEP) variantString += "DEP|";

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -672,7 +672,6 @@ int main(int argc, char** argv) {
             // First compile high priority variants
             ma->compile(Material::CompilerPriorityQueue::HIGH,
                     UserVariantFilterBit::DIRECTIONAL_LIGHTING |
-                    UserVariantFilterBit::DYNAMIC_LIGHTING |
                     UserVariantFilterBit::SHADOW_RECEIVER);
 
             // and then, everything else at low priority, except STE, which is very uncommon.

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -210,6 +210,7 @@ static UserVariantFilterMask parseVariantFilter(const std::string& arg) {
         if (item == "directionalLighting") {
             variantFilter |= uint32_t(UserVariantFilterBit::DIRECTIONAL_LIGHTING);
         } else if (item == "dynamicLighting") {
+            // TODO: dynamicLighting bit is removed 26/07/2. Remove by 26/8/31
             std::cerr << "Warning: dynamicLighting variant filter is deprecated and ignored."
                     << std::endl;
         } else if (item == "shadowReceiver") {

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -145,8 +145,9 @@ static void usage(char* name) {
             "       Reflect the specified metadata as JSON: parameters\n\n"
             "   --variant-filter=<filter>, -V <filter>\n"
             "       Filter out specified comma-separated variants:\n"
-            "           directionalLighting, dynamicLighting, shadowReceiver, skinning, vsm, fog,\n"
+            "           directionalLighting, shadowReceiver, skinning, vsm, fog,\n"
             "           ssr (screen-space reflections), stereo\n"
+            "       dynamicLighting is deprecated and ignored.\n"
             "       This variant filter is merged with the filter from the material, if any.\n\n"
             "   --workarounds, -W\n"
             "       Workarounds to apply: all or none. (default is none).\n\n"
@@ -209,7 +210,8 @@ static UserVariantFilterMask parseVariantFilter(const std::string& arg) {
         if (item == "directionalLighting") {
             variantFilter |= uint32_t(UserVariantFilterBit::DIRECTIONAL_LIGHTING);
         } else if (item == "dynamicLighting") {
-            variantFilter |= uint32_t(UserVariantFilterBit::DYNAMIC_LIGHTING);
+            std::cerr << "Warning: dynamicLighting variant filter is deprecated and ignored."
+                    << std::endl;
         } else if (item == "shadowReceiver") {
             variantFilter |= uint32_t(UserVariantFilterBit::SHADOW_RECEIVER);
         } else if (item == "skinning") {


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #10103** — this branch is based on it, so its commits appear in the diff. Only the last commit (`variant removal: relocate the special SSR key off S2D|SRE`) is new. Draft until #10103 lands; happy to rebase/rework to whatever encoding you prefer.

## The bug

Since #10096 moved dynamic lighting into a specialization constant, the DYN variant bit is always 0. A scene lit **only by punctual lights** (e.g. a single spot light, no directional) with the view using sampler2D shadows (VSM / DPCF / PCSS) now requests **`S2D|SRE`** for its color pass — which is exactly the reserved `SPECIAL_SSR_VARIANT`:

- materials that filter `ssr` panic every frame in `prepareProgramSlow`: `Requested variant (S2D | SRE) with specKey 0 does not exist`
- materials that don't filter `ssr` silently bind the **SSR shader** in place of the shadow-receiver shader

Before #10096 this scene requested `S2D|SRE|DYN` — a regular compiled variant — so the collision could never happen. Any directional light in the scene masks the bug (the key becomes `S2D|SRE|DIR`), which is presumably why no test scene hits it. Present in v1.74.0 and main, all backends. #10103 removes the DYN bit entirely, so afterwards no spare bit can ever disambiguate the two meanings of `S2D|SRE` — hence fixing it on top of this series.

## The fix

Move the SSR key to **`DEP|SRE`** in the reserved depth space, which is genuinely unreachable: the color pass never sets DEP and the depth pass never sets SRE. (`S2D` alone was considered and rejected: non-shadow-receiving renderables in a soft-shadow view produce `S2D` *pre*-filter — it is only unreachable because `filterVariant()` strips it, and the SSR early-returns defeat that strip.) `S2D|SRE` reverts to being a regular lit variant that matc compiles with shadow-receiver code and that carries the dynamic-lighting spec constant.

- `filterVariantVertex/Fragment` handle the SSR key before the standard/depth branch split since it no longer matches `STANDARD_MASK`
- the variant enumerations (`determineSurfaceVariants`, `VariantUtils` lit/unlit lists) let the SSR key through from reserved space so the SSR shader is still generated and its program-cache entries still acquired
- adds `filament/test/test_Variant.cpp` covering the key placement, filtering, and user-filter interactions

⚠️ existing `.filamat` files must be recompiled (the SSR shader moves keys).

## Verification

WebGL repro (256×256 scene: floor + caster + one light, parameterized by shadow type):

| scene | before | after |
|---|---|---|
| spot-only + PCSS / DPCF / VSM | panic every frame | renders |
| spot-only + PCF | renders¹ | renders |
| directional + PCSS | renders | renders |
| spot + non-shadow directional + PCSS | renders | renders |

¹ on this branch's base, spot-only PCF (`SRE` alone) also panics because the pre-#10170 `isValidStandardVariant` rules still reserve punctual-only shadow-receiver variants ("can't have shadow receiver if we don't have any lighting" predates dynamic-lighting-as-spec-constant); main already fixed this in #10170. Verified with the #10170 simplification applied on top: all six scenarios render. Flagging so that rebasing #10103 onto main keeps the #10170 rules.

`test_variant` passes; the compile-time variant-count static_asserts are unchanged.