### PR TITLE
filamentapp: FilamentApp2 to replace FilamentApp

### DIFF
--- a/libs/filamentapp/CMakeLists.txt
+++ b/libs/filamentapp/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PUBLIC_HDRS
         include/filamentapp/Cube.h
         include/filamentapp/Grid.h
         include/filamentapp/FilamentApp.h
+        include/filamentapp/FilamentApp2.h
         include/filamentapp/IBL.h
         include/filamentapp/IcoSphere.h
         include/filamentapp/MeshAssimp.h
@@ -36,14 +37,15 @@ set(SRCS
         src/DesktopAssetLoader.cpp
         src/Grid.cpp
         src/FilamentApp.cpp
+        src/FilamentApp2.cpp
         src/IBL.cpp
         src/IcoSphere.cpp
         src/MeshAssimp.cpp
         src/Sphere.cpp
         src/PlatformHelper.cpp
         src/PlatformHelper.h
-        src/DisplayManager.h
-        src/AppEvent.h
+        include/filamentapp/DisplayManager.h
+        include/filamentapp/AppEvent.h
         src/FilamentAppGui.h
         src/FilamentAppGui.cpp
 )

--- a/libs/filamentapp/include/filamentapp/AppEvent.h
+++ b/libs/filamentapp/include/filamentapp/AppEvent.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_FILAMENTAPP_APPEVENT_H
 #define TNT_FILAMENT_FILAMENTAPP_APPEVENT_H
 
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 
 #include <cstdint>
 #include <string>
@@ -167,7 +167,7 @@ struct AppEvent {
         TEXTINPUT
     } type;
 
-    FilamentApp::Window::Handle windowId = nullptr;
+    FilamentApp2::Window::Handle windowId = nullptr;
 
     union {
         struct {

--- a/libs/filamentapp/include/filamentapp/Config.h
+++ b/libs/filamentapp/include/filamentapp/Config.h
@@ -23,14 +23,17 @@
 
 #include <string>
 
-struct Config {
+struct [[deprecated("Use FilamentApp2::Builder methods instead. Deadline: 2027/07/20")]] Config {
     std::string title;
+    uint32_t width = 1024;
+    uint32_t height = 640;
     std::string iblDirectory;
     std::string dirt;
     float scale = 1.0f;
     bool splitView = false;
     mutable filament::Engine::Backend backend = filament::Engine::Backend::DEFAULT;
-    mutable filament::backend::FeatureLevel featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
+    mutable filament::backend::FeatureLevel featureLevel =
+            filament::backend::FeatureLevel::FEATURE_LEVEL_3;
     filament::camutils::Mode cameraMode = filament::camutils::Mode::ORBIT;
     bool resizeable = true;
     bool headless = false;
@@ -51,7 +54,8 @@ struct Config {
     DisplayManager displayManager = DisplayManager::SDL;
 
     // Asynchronous mode for Engine
-    filament::backend::AsynchronousMode asynchronousMode = filament::backend::AsynchronousMode::NONE;
+    filament::backend::AsynchronousMode asynchronousMode =
+            filament::backend::AsynchronousMode::NONE;
 };
 
 #endif // TNT_FILAMENT_SAMPLE_CONFIG_H

--- a/libs/filamentapp/include/filamentapp/DisplayManager.h
+++ b/libs/filamentapp/include/filamentapp/DisplayManager.h
@@ -20,7 +20,7 @@
 #include "AppEvent.h"
 
 #include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/Renderer.h>
@@ -59,14 +59,14 @@ public:
      * @param headless Whether the window should be created in headless mode.
      * @return A handle to the created window.
      */
-    virtual FilamentApp::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
+    virtual FilamentApp2::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
             bool resizable, bool headless) = 0;
 
     /**
      * Destroys a window.
      * @param window The handle of the window to destroy.
      */
-    virtual void destroyWindow(FilamentApp::Window::Handle window) = 0;
+    virtual void destroyWindow(FilamentApp2::Window::Handle window) = 0;
 
     /**
      * Returns the underlying native window handle for the specified platform window.
@@ -74,14 +74,14 @@ public:
      * @return The native window handle (e.g., HWND, NSWindow*). Returns nullptr for headless/web
      * platforms.
      */
-    virtual void* getNativeWindow(FilamentApp::Window::Handle window) const = 0;
+    virtual void* getNativeWindow(FilamentApp2::Window::Handle window) const = 0;
 
     /**
      * Sets the title of a window.
      * @param window The window handle.
      * @param title The new title.
      */
-    virtual void setWindowTitle(FilamentApp::Window::Handle window, const char* title) = 0;
+    virtual void setWindowTitle(FilamentApp2::Window::Handle window, const char* title) = 0;
 
     /**
      * Returns the size of a window.
@@ -89,7 +89,7 @@ public:
      * @param w Pointer to store the width.
      * @param h Pointer to store the height.
      */
-    virtual void getWindowSize(FilamentApp::Window::Handle window, uint32_t* w,
+    virtual void getWindowSize(FilamentApp2::Window::Handle window, uint32_t* w,
             uint32_t* h) const = 0;
 
     /**
@@ -98,7 +98,7 @@ public:
      * @param w Pointer to store the width.
      * @param h Pointer to store the height.
      */
-    virtual void getDrawableSize(FilamentApp::Window::Handle window, uint32_t* w,
+    virtual void getDrawableSize(FilamentApp2::Window::Handle window, uint32_t* w,
             uint32_t* h) const = 0;
 
     /**
@@ -111,7 +111,7 @@ public:
      * Called when a window has been resized.
      * @param window The window handle.
      */
-    virtual void onWindowResized(FilamentApp::Window::Handle window) {}
+    virtual void onWindowResized(FilamentApp2::Window::Handle window) {}
 
     /**
      * Returns the current mouse state.
@@ -126,7 +126,7 @@ public:
      * @param window The window handle.
      * @return true if the window has focus.
      */
-    virtual bool isWindowFocused(FilamentApp::Window::Handle window) const { return true; }
+    virtual bool isWindowFocused(FilamentApp2::Window::Handle window) const { return true; }
 
     /**
      * Returns the current time in seconds.
@@ -139,7 +139,7 @@ public:
      * @param engine The Filament engine.
      * @param renderer The Filament renderer.
      */
-    virtual void onFrameFinished(FilamentApp::Window::Handle window, filament::Engine* engine,
+    virtual void onFrameFinished(FilamentApp2::Window::Handle window, filament::Engine* engine,
             filament::Renderer* renderer) {}
 
     /**

--- a/libs/filamentapp/include/filamentapp/FilamentApp.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp.h
@@ -18,75 +18,33 @@
 #define TNT_FILAMENT_SAMPLE_FILAMENTAPP_H
 
 #include "Config.h"
-#include "Cube.h"
-#include "Grid.h"
-#include "IBL.h"
 
-#include <filament/Engine.h>
-#include <filament/Viewport.h>
+#include <filamentapp/FilamentApp2.h>
 
-#include <camutils/Manipulator.h>
-
-#include <utils/Entity.h>
 #include <utils/Path.h>
 
 #include <functional>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
-namespace filament {
-class Renderer;
-class Scene;
-class SwapChain;
-class View;
-} // namespace filament
-
-class FilamentAppGui;
-
-class IBL;
-class MeshAssimp;
-
-// For customizing the vulkan backend
-namespace filament::backend {
-#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
-class VulkanPlatform;
-#endif
-
-#if defined(FILAMENT_SUPPORTS_WEBGPU)
-class WebGPUPlatform;
-#endif
-
-}
-
-namespace filament::app {
-class DisplayManager;
-enum class AppKey : uint32_t;
-} // namespace filament::app
-
-class FilamentApp {
+class [[deprecated("Use FilamentApp2 instead. Deadline: 2027/07/20")]] FilamentApp {
 public:
-    using SetupCallback = std::function<void(filament::Engine*, filament::View*, filament::Scene*)>;
-    using CleanupCallback =
-            std::function<void(filament::Engine*, filament::View*, filament::Scene*)>;
-    using PreRenderCallback = std::function<void(filament::Engine*, filament::View*,
-            filament::Scene*, filament::Renderer*)>;
-    using PostRenderCallback = std::function<void(filament::Engine*, filament::View*,
-            filament::Scene*, filament::Renderer*)>;
-    using ImGuiCallback = std::function<void(filament::Engine*, filament::View*)>;
-    using AnimCallback = std::function<void(filament::Engine*, filament::View*, double now)>;
-    using ResizeCallback = std::function<void(filament::Engine*, filament::View*)>;
-    using DropCallback = std::function<void(std::string_view)>;
+    using SetupCallback = FilamentApp2::SetupCallback;
+    using CleanupCallback = FilamentApp2::CleanupCallback;
+    using PreRenderCallback = FilamentApp2::PreRenderCallback;
+    using PostRenderCallback = FilamentApp2::PostRenderCallback;
+    using ImGuiCallback = FilamentApp2::ImGuiCallback;
+    using AnimCallback = FilamentApp2::AnimCallback;
+    using ResizeCallback = FilamentApp2::ResizeCallback;
+    using DropCallback = FilamentApp2::DropCallback;
 
     static FilamentApp& get();
 
     ~FilamentApp();
 
     void animate(AnimCallback animation) { mAnimation = animation; }
-
     void resize(ResizeCallback resize) { mResize = resize; }
-
     void setDropHandler(DropCallback handler) { mDropHandler = handler; }
 
     void run(const Config& config, SetupCallback setup, CleanupCallback cleanup,
@@ -95,45 +53,29 @@ public:
             PostRenderCallback postRender = PostRenderCallback(), size_t width = 1024,
             size_t height = 640);
 
-    void reconfigureCameras() { mReconfigureCameras = true; }
+    void reconfigureCameras();
 
-    filament::Material const* getDefaultMaterial() const noexcept { return mDefaultMaterial; }
-    filament::Material const* getTransparentMaterial() const noexcept {
-        return mTransparentMaterial;
-    }
-    IBL* getIBL() const noexcept { return mIBL.get(); }
-    filament::Texture* getDirtTexture() const noexcept { return mDirt; }
+    filament::Material const* getDefaultMaterial() const noexcept;
+    filament::Material const* getTransparentMaterial() const noexcept;
+    IBL* getIBL() const noexcept;
+    filament::Texture* getDirtTexture() const noexcept;
     filament::View* getGuiView() const noexcept;
-    filament::SwapChain* getPrimarySwapChain() const noexcept { return mPrimarySwapChain; }
+    filament::SwapChain* getPrimarySwapChain() const noexcept;
 
-    void close() { mClosed = true; }
+    void close();
 
     void onSurfaceCreated(void* nativeWindow);
     void onSurfaceChanged(int width, int height);
     void onSurfaceDestroyed();
     void onTouchEvent(int action, float x, float y);
 
-    void setSidebarWidth(int width) {
-        mCameraParams.sidebarWidth = width;
-        mReconfigureCameras = true;
-    }
+    void setSidebarWidth(int width);
+    void setWindowTitle(const char* title);
+    void setCameraFocalLength(float focalLength);
+    void setCameraNearFar(float near, float far);
+    void addOffscreenView(filament::View* view);
 
-    void setWindowTitle(const char* title) { mWindowTitle = title; }
-
-    void setCameraFocalLength(float focalLength) {
-        mCameraParams.focalLength = focalLength;
-        mReconfigureCameras = true;
-    }
-
-    void setCameraNearFar(float near, float far) {
-        mCameraParams.near = near;
-        mCameraParams.far = far;
-        mReconfigureCameras = true;
-    }
-
-    void addOffscreenView(filament::View* view) { mOffscreenViews.push_back(view); }
-
-    size_t getSkippedFrameCount() const { return mSkippedFrames; }
+    size_t getSkippedFrameCount() const;
 
     void loadIBL(std::string_view path);
 
@@ -150,194 +92,22 @@ public:
     FilamentApp& operator=(const FilamentApp& rhs) = delete;
     FilamentApp& operator=(FilamentApp&& rhs) = delete;
 
-    /**
-     * Returns the path to the Filament root for loading assets. This is determined from the
-     * executable folder, which allows users to launch samples from any folder.
-     *
-     * This takes into account multi-configuration CMake generators, like Visual Studio or Xcode,
-     * that have different executable paths compared to single-configuration generators, like Ninja.
-     */
     static const utils::Path& getRootAssetsPath();
 
 private:
     FilamentApp();
 
-    using CameraManipulator = filament::camutils::Manipulator<float>;
+    std::unique_ptr<FilamentApp2> mImpl;
 
-    static bool manipulatorKeyFromKeycode(filament::app::AppKey scancode,
-            CameraManipulator::Key& key);
-
-    class CView {
-    public:
-        CView(filament::Renderer& renderer, std::string name);
-        virtual ~CView();
-
-        void setCameraManipulator(CameraManipulator* cm);
-        void setViewport(filament::Viewport const& viewport);
-        void setCamera(filament::Camera* camera);
-        bool intersects(ssize_t x, ssize_t y);
-
-        virtual void mouseDown(int button, ssize_t x, ssize_t y);
-        virtual void mouseUp(ssize_t x, ssize_t y);
-        virtual void mouseMoved(ssize_t x, ssize_t y);
-        virtual void mouseWheel(ssize_t x);
-        virtual void keyDown(filament::app::AppKey scancode);
-        virtual void keyUp(filament::app::AppKey scancode);
-
-        filament::View const* getView() const { return view; }
-        filament::View* getView() { return view; }
-        CameraManipulator* getCameraManipulator() { return mCameraManipulator; }
-
-    private:
-        enum class Mode : uint8_t {
-            NONE, ROTATE, TRACK
-        };
-
-        filament::Engine& engine;
-        filament::Viewport mViewport;
-        filament::View* view = nullptr;
-        CameraManipulator* mCameraManipulator = nullptr;
-        std::string mName;
-    };
-
-    class GodView : public CView {
-    public:
-        using CView::CView;
-        void setGodCamera(filament::Camera* camera);
-    };
-
-    struct WindowCameraParams {
-        int sidebarWidth = 0;
-        float focalLength = 28.0f;
-        float near = 0.1f;
-        float far = 100.0f;
-
-        bool operator==(WindowCameraParams const& params) const noexcept {
-            return sidebarWidth == params.sidebarWidth && focalLength == params.focalLength &&
-                   near == params.near && far == params.far;
-        }
-
-        bool operator!=(WindowCameraParams const& params) const noexcept {
-            return !(*this == params);
-        }
-    };
-
-public:
-    class Window {
-        friend class FilamentApp;
-    public:
-        using Handle = void*;
-        virtual ~Window();
-
-    private:
-        Window(FilamentApp* filamentApp, const Config& config, std::string title,
-                WindowCameraParams const& cameraParams, size_t w, size_t h);
-
-        void mouseDown(int button, ssize_t x, ssize_t y);
-        void mouseUp(ssize_t x, ssize_t y);
-        void mouseMoved(ssize_t x, ssize_t y);
-        void mouseWheel(ssize_t x);
-        void keyDown(filament::app::AppKey scancode);
-        void keyUp(filament::app::AppKey scancode);
-        void resize(WindowCameraParams const& cameraParams);
-
-        filament::Renderer* getRenderer() { return mRenderer; }
-        filament::SwapChain* getSwapChain() { return mSwapChain; }
-
-        void configureCamerasForWindow(WindowCameraParams const& camera);
-        void fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const;
-
-        filament::app::DisplayManager* const mDisplayManager = nullptr;
-        filament::Engine* const mEngine = nullptr;
-        Config mConfig;
-        const bool mIsHeadless;
-
-        Handle mWindow = nullptr;
-        filament::Renderer* mRenderer = nullptr;
-        filament::Engine::Backend mBackend;
-
-        CameraManipulator* mMainCameraMan;
-        CameraManipulator* mDebugCameraMan;
-        filament::SwapChain* mSwapChain = nullptr;
-
-        utils::Entity mCameraEntities[3];
-        filament::Camera* mCameras[3] = { nullptr };
-        filament::Camera* mMainCamera;
-        filament::Camera* mDebugCamera;
-        filament::Camera* mOrthoCamera;
-
-        std::vector<std::unique_ptr<CView>> mViews;
-        CView* mMainView;   // well, the main view
-        CView* mUiView;     // the imgui ui
-        CView* mDepthView;
-        GodView* mGodView;  // the debug view with "god" camera
-        CView* mOrthoView;  // directional shadow map view
-
-        size_t mWidth = 0;
-        size_t mHeight = 0;
-        ssize_t mLastX = 0;
-        ssize_t mLastY = 0;
-
-        CView* mMouseEventTarget = nullptr;
-
-        // Keep track of which view should receive a key's keyUp event.
-        std::unordered_map<filament::app::AppKey, CView*> mKeyEventTarget;
-    };
-
-private:
-    friend class Window;
-
-    void loadIBL(const Config& config);
-    void loadDirt(const Config& config);
-
-    bool doFrame();
-    void shutdown();
-
-    filament::Engine* mEngine = nullptr;
-    filament::Scene* mScene = nullptr;
-    std::unique_ptr<IBL> mIBL;
-    filament::SwapChain* mPrimarySwapChain = nullptr;
-    filament::Texture* mDirt = nullptr;
-    bool mClosed = false;
-    double mTime = 0;
-
-    filament::Material const* mDefaultMaterial = nullptr;
-    filament::Material const* mTransparentMaterial = nullptr;
-    filament::Material const* mDepthMaterial = nullptr;
-    filament::MaterialInstance* mDepthMI = nullptr;
-    std::unique_ptr<FilamentAppGui> mAppGui;
     AnimCallback mAnimation;
     ResizeCallback mResize;
     DropCallback mDropHandler;
-    size_t mSkippedFrames = 0;
+    int mSidebarWidth = 0;
     std::string mWindowTitle;
+    float mCameraFocalLength = 0.0f;
+    float mCameraNear = 0.0f;
+    float mCameraFar = 0.0f;
     std::vector<filament::View*> mOffscreenViews;
-    WindowCameraParams mCameraParams{};
-    bool mReconfigureCameras = false;
-    uint8_t mFroxelInfoAge = 0x42;
-    uint8_t mFroxelGridEnabled = 0;
-    uint8_t mDirectionalShadowFrustumEnabled = 0x2;
-    uint8_t mCameraFrustumEnabled = 0x2;
-
-    filament::app::DisplayManager* mDisplayManager = nullptr;
-
-    filament::backend::Platform* mVulkanPlatform = nullptr;
-    filament::backend::Platform* mWebGPUPlatform = nullptr;
-
-    std::unique_ptr<Window> mWindow;
-    CleanupCallback mCleanupCallback;
-    ImGuiCallback mImguiCallback {};
-    PreRenderCallback mPreRender {};
-    PostRenderCallback mPostRender {};
-    bool mMousePressed[3] = { false };
-    bool mIsSplitView = false;
-
-    std::unique_ptr<Cube> mCameraCube;
-    std::unique_ptr<Grid> mCameraGrid;
-
-    // we can't cull the light-frustum because it's not applied a rigid transform
-    // and currently, filament assumes that for culling
-    std::vector<Cube> mLightmapCubes;
 };
 
 #endif // TNT_FILAMENT_SAMPLE_FILAMENTAPP_H

--- a/libs/filamentapp/include/filamentapp/FilamentApp2.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp2.h
@@ -1,0 +1,556 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_SAMPLE_FILAMENTAPP2_H
+#define TNT_FILAMENT_SAMPLE_FILAMENTAPP2_H
+
+#include "Config.h"
+#include "Cube.h"
+#include "Grid.h"
+#include "IBL.h"
+
+#include <filament/Engine.h>
+#include <filament/Viewport.h>
+
+#include <camutils/Manipulator.h>
+
+#include <utils/Entity.h>
+#include <utils/Path.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace filament {
+class Renderer;
+class Scene;
+class SwapChain;
+class View;
+} // namespace filament
+
+class FilamentAppGui;
+
+class IBL;
+class MeshAssimp;
+
+// For customizing the vulkan backend
+namespace filament::backend {
+#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
+class VulkanPlatform;
+#endif
+
+#if defined(FILAMENT_SUPPORTS_WEBGPU)
+class WebGPUPlatform;
+#endif
+
+} // namespace filament::backend
+
+namespace filament::app {
+class DisplayManager;
+enum class AppKey : uint32_t;
+} // namespace filament::app
+
+class FilamentApp2 {
+public:
+    using WebGPUBackend = filament::Engine::Backend;
+    enum class DisplayManager { SDL, WEB };
+public:
+    using SetupCallback = std::function<void(filament::Engine*, filament::View*, filament::Scene*)>;
+    using CleanupCallback =
+            std::function<void(filament::Engine*, filament::View*, filament::Scene*)>;
+    using PreRenderCallback = std::function<void(filament::Engine*, filament::View*,
+            filament::Scene*, filament::Renderer*)>;
+    using PostRenderCallback = std::function<void(filament::Engine*, filament::View*,
+            filament::Scene*, filament::Renderer*)>;
+    using ImGuiCallback = std::function<void(filament::Engine*, filament::View*)>;
+    using AnimCallback = std::function<void(filament::Engine*, filament::View*, double now)>;
+    using ResizeCallback = std::function<void(filament::Engine*, filament::View*)>;
+    using DropCallback = std::function<void(std::string_view)>;
+
+    class Builder {
+    public:
+        Builder() = default;
+
+        Builder& title(const std::string& title) {
+            mTitle = title;
+            return *this;
+        }
+        Builder& size(uint32_t width, uint32_t height) {
+            mWidth = width;
+            mHeight = height;
+            return *this;
+        }
+        Builder& iblDirectory(const std::string& iblDirectory) {
+            mIblDirectory = iblDirectory;
+            return *this;
+        }
+        Builder& dirt(const std::string& dirt) {
+            mDirt = dirt;
+            return *this;
+        }
+        Builder& scale(float scale) {
+            mScale = scale;
+            return *this;
+        }
+        Builder& splitView(bool splitView) {
+            mSplitView = splitView;
+            return *this;
+        }
+        Builder& backend(filament::Engine::Backend backend) {
+            mBackend = backend;
+            return *this;
+        }
+        Builder& featureLevel(filament::backend::FeatureLevel featureLevel) {
+            mFeatureLevel = featureLevel;
+            return *this;
+        }
+        Builder& cameraMode(filament::camutils::Mode cameraMode) {
+            mCameraMode = cameraMode;
+            return *this;
+        }
+        Builder& resizeable(bool resizeable) {
+            mResizeable = resizeable;
+            return *this;
+        }
+        Builder& headless(bool headless) {
+            mHeadless = headless;
+            return *this;
+        }
+        Builder& stereoscopicEyeCount(int stereoscopicEyeCount) {
+            mStereoscopicEyeCount = stereoscopicEyeCount;
+            return *this;
+        }
+        Builder& samples(uint8_t samples) {
+            mSamples = samples;
+            return *this;
+        }
+        Builder& vulkanGPUHint(const std::string& vulkanGPUHint) {
+            mVulkanGPUHint = vulkanGPUHint;
+            return *this;
+        }
+        Builder& forcedWebGPUBackend(WebGPUBackend forcedWebGPUBackend) {
+            mForcedWebGPUBackend = forcedWebGPUBackend;
+            return *this;
+        }
+        Builder& configDisplayManager(DisplayManager displayManager) {
+            mDisplayManagerConfig = displayManager;
+            return *this;
+        }
+        Builder& asynchronousMode(filament::backend::AsynchronousMode asynchronousMode) {
+            mAsynchronousMode = asynchronousMode;
+            return *this;
+        }
+        /**
+         * Sets a custom DisplayManager for the application.
+         *
+         * @param displayManager Pointer to a DisplayManager implementation.
+         *                       If nullptr or not set, the app will create a default one based on
+         *                       the config's backend.
+         */
+        Builder& displayManager(filament::app::DisplayManager* displayManager) {
+            mDisplayManager = displayManager;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked once the Engine, View, and Scene have been initialized.
+         * This is where you should create your Filament entities, materials, and geometry.
+         *
+         * @param setup A callback function to initialize application state.
+         */
+        Builder& setup(SetupCallback setup) {
+            mSetup = setup;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked just before the Engine is destroyed.
+         * This is where you should destroy all entities, materials, and geometry created in the
+         * setup phase.
+         *
+         * @param cleanup A callback function to cleanup application state.
+         */
+        Builder& cleanup(CleanupCallback cleanup) {
+            mCleanup = cleanup;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked every frame right before the scene is rendered.
+         * Useful for updating camera parameters or performing rendering operations.
+         *
+         * @param preRender A callback function invoked before rendering.
+         */
+        Builder& preRender(PreRenderCallback preRender) {
+            mPreRender = preRender;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked every frame right after the scene is rendered.
+         *
+         * @param postRender A callback function invoked after rendering.
+         */
+        Builder& postRender(PostRenderCallback postRender) {
+            mPostRender = postRender;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked every frame for rendering ImGui UI overlays.
+         *
+         * @param imgui A callback function for ImGui drawing commands.
+         */
+        Builder& imgui(ImGuiCallback imgui) {
+            mImgui = imgui;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked every frame to update object animations.
+         *
+         * @param animation A callback function containing animation logic.
+         *                  The 'now' parameter provides the elapsed time in seconds.
+         */
+        Builder& animation(AnimCallback animation) {
+            mAnimation = animation;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked whenever the application window is resized.
+         *
+         * @param resize A callback function for handling resize events.
+         */
+        Builder& resize(ResizeCallback resize) {
+            mResize = resize;
+            return *this;
+        }
+
+        /**
+         * Sets the callback invoked when a file is dropped onto the application window.
+         *
+         * @param handler A callback function receiving the dropped file path.
+         */
+        Builder& dropHandler(DropCallback handler) {
+            mDropHandler = handler;
+            return *this;
+        }
+
+        /**
+         * Creates a FilamentApp2 instance configured with the parameters provided to the Builder.
+         *
+         * @return A unique_ptr owning the constructed FilamentApp2.
+         */
+        std::unique_ptr<FilamentApp2> build();
+
+    private:
+        friend class FilamentApp2;
+        std::string mTitle;
+        uint32_t mWidth = 1024;
+        uint32_t mHeight = 640;
+        std::string mIblDirectory;
+        std::string mDirt;
+        float mScale = 1.0f;
+        bool mSplitView = false;
+        filament::Engine::Backend mBackend = filament::Engine::Backend::DEFAULT;
+        filament::backend::FeatureLevel mFeatureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
+        filament::camutils::Mode mCameraMode = filament::camutils::Mode::ORBIT;
+        bool mResizeable = true;
+        bool mHeadless = false;
+        int mStereoscopicEyeCount = 2;
+        uint8_t mSamples = 1;
+        std::string mVulkanGPUHint;
+        WebGPUBackend mForcedWebGPUBackend = WebGPUBackend::DEFAULT;
+        DisplayManager mDisplayManagerConfig = DisplayManager::SDL;
+        filament::backend::AsynchronousMode mAsynchronousMode = filament::backend::AsynchronousMode::NONE;
+        filament::app::DisplayManager* mDisplayManager = nullptr;
+        SetupCallback mSetup;
+        CleanupCallback mCleanup;
+        PreRenderCallback mPreRender;
+        PostRenderCallback mPostRender;
+        ImGuiCallback mImgui;
+        AnimCallback mAnimation;
+        ResizeCallback mResize;
+        DropCallback mDropHandler;
+    };
+
+    ~FilamentApp2();
+
+    void run();
+
+    void reconfigureCameras() { mReconfigureCameras = true; }
+
+    filament::Material const* getDefaultMaterial() const noexcept { return mDefaultMaterial; }
+    filament::Material const* getTransparentMaterial() const noexcept {
+        return mTransparentMaterial;
+    }
+    IBL* getIBL() const noexcept { return mIBL.get(); }
+    filament::Texture* getDirtTexture() const noexcept { return mDirt; }
+    filament::View* getGuiView() const noexcept;
+    filament::SwapChain* getPrimarySwapChain() const noexcept { return mPrimarySwapChain; }
+
+    void close() { mClosed = true; }
+
+    void onSurfaceCreated(void* nativeWindow);
+    void onSurfaceChanged(int width, int height);
+    void onSurfaceDestroyed();
+    void onTouchEvent(int action, float x, float y);
+
+    void setSidebarWidth(int width) {
+        mCameraParams.sidebarWidth = width;
+        mReconfigureCameras = true;
+    }
+
+    void setCameraFocalLength(float focalLength) {
+        mCameraParams.focalLength = focalLength;
+        mReconfigureCameras = true;
+    }
+
+    void setCameraNearFar(float near, float far) {
+        mCameraParams.near = near;
+        mCameraParams.far = far;
+        mReconfigureCameras = true;
+    }
+
+    void addOffscreenView(filament::View* view) { mOffscreenViews.push_back(view); }
+
+    size_t getSkippedFrameCount() const { return mSkippedFrames; }
+
+    void loadIBL(std::string_view path);
+
+    // debugging: enable/disable the froxel grid
+    void setCameraFrustumEnabled(bool enabled) noexcept;
+    void setDirectionalShadowFrustumEnabled(bool enabled) noexcept;
+    void setFroxelGridEnabled(bool enabled) noexcept;
+    bool isCameraFrustumEnabled() const noexcept;
+    bool isDirectionalShadowFrustumEnabled() const noexcept;
+    bool isFroxelGridEnabled() const noexcept;
+
+    FilamentApp2(const FilamentApp2& rhs) = delete;
+    FilamentApp2(FilamentApp2&& rhs) = delete;
+    FilamentApp2& operator=(const FilamentApp2& rhs) = delete;
+    FilamentApp2& operator=(FilamentApp2&& rhs) = delete;
+
+    /**
+     * Returns the path to the Filament root for loading assets. This is determined from the
+     * executable folder, which allows users to launch samples from any folder.
+     *
+     * This takes into account multi-configuration CMake generators, like Visual Studio or Xcode,
+     * that have different executable paths compared to single-configuration generators, like Ninja.
+     */
+    static const utils::Path& getRootAssetsPath();
+
+private:
+    using CameraManipulator = filament::camutils::Manipulator<float>;
+
+    static bool manipulatorKeyFromKeycode(filament::app::AppKey scancode,
+            CameraManipulator::Key& key);
+
+    class CView {
+    public:
+        CView(filament::Renderer& renderer, std::string name);
+        virtual ~CView();
+
+        void setCameraManipulator(CameraManipulator* cm);
+        void setViewport(filament::Viewport const& viewport);
+        void setCamera(filament::Camera* camera);
+        bool intersects(ssize_t x, ssize_t y);
+
+        virtual void mouseDown(int button, ssize_t x, ssize_t y);
+        virtual void mouseUp(ssize_t x, ssize_t y);
+        virtual void mouseMoved(ssize_t x, ssize_t y);
+        virtual void mouseWheel(ssize_t x);
+        virtual void keyDown(filament::app::AppKey scancode);
+        virtual void keyUp(filament::app::AppKey scancode);
+
+        filament::View const* getView() const { return view; }
+        filament::View* getView() { return view; }
+        CameraManipulator* getCameraManipulator() { return mCameraManipulator; }
+
+    private:
+        enum class Mode : uint8_t { NONE, ROTATE, TRACK };
+
+        filament::Engine& engine;
+        filament::Viewport mViewport;
+        filament::View* view = nullptr;
+        CameraManipulator* mCameraManipulator = nullptr;
+        std::string mName;
+    };
+
+    class GodView : public CView {
+    public:
+        using CView::CView;
+        void setGodCamera(filament::Camera* camera);
+    };
+
+    struct WindowCameraParams {
+        int sidebarWidth = 0;
+        float focalLength = 28.0f;
+        float near = 0.1f;
+        float far = 100.0f;
+
+        bool operator==(WindowCameraParams const& params) const noexcept {
+            return sidebarWidth == params.sidebarWidth && focalLength == params.focalLength &&
+                   near == params.near && far == params.far;
+        }
+
+        bool operator!=(WindowCameraParams const& params) const noexcept {
+            return !(*this == params);
+        }
+    };
+
+public:
+    class Window {
+        friend class FilamentApp2;
+
+    public:
+        using Handle = void*;
+        virtual ~Window();
+
+    private:
+        Window(FilamentApp2* filamentApp, std::string title,
+                WindowCameraParams const& cameraParams, size_t w, size_t h);
+
+        void mouseDown(int button, ssize_t x, ssize_t y);
+        void mouseUp(ssize_t x, ssize_t y);
+        void mouseMoved(ssize_t x, ssize_t y);
+        void mouseWheel(ssize_t x);
+        void keyDown(filament::app::AppKey scancode);
+        void keyUp(filament::app::AppKey scancode);
+        void resize(WindowCameraParams const& cameraParams);
+
+        filament::Renderer* getRenderer() { return mRenderer; }
+        filament::SwapChain* getSwapChain() { return mSwapChain; }
+
+        void configureCamerasForWindow(WindowCameraParams const& camera);
+        void fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const;
+
+        filament::app::DisplayManager* const mDisplayManager = nullptr;
+        filament::Engine* const mEngine = nullptr;
+        FilamentApp2* const mApp = nullptr;
+
+        Handle mWindow = nullptr;
+        filament::Renderer* mRenderer = nullptr;
+        filament::Engine::Backend mBackend;
+
+        CameraManipulator* mMainCameraMan;
+        CameraManipulator* mDebugCameraMan;
+        filament::SwapChain* mSwapChain = nullptr;
+
+        utils::Entity mCameraEntities[3];
+        filament::Camera* mCameras[3] = { nullptr };
+        filament::Camera* mMainCamera;
+        filament::Camera* mDebugCamera;
+        filament::Camera* mOrthoCamera;
+
+        std::vector<std::unique_ptr<CView>> mViews;
+        CView* mMainView; // well, the main view
+        CView* mUiView;   // the imgui ui
+        CView* mDepthView;
+        GodView* mGodView; // the debug view with "god" camera
+        CView* mOrthoView; // directional shadow map view
+
+        size_t mWidth = 0;
+        size_t mHeight = 0;
+        ssize_t mLastX = 0;
+        ssize_t mLastY = 0;
+
+        CView* mMouseEventTarget = nullptr;
+
+        // Keep track of which view should receive a key's keyUp event.
+        std::unordered_map<filament::app::AppKey, CView*> mKeyEventTarget;
+    };
+
+private:
+    friend class Window;
+    friend class Builder;
+
+    explicit FilamentApp2(const Builder& builder);
+
+    void loadIBL();
+    void loadDirt();
+
+    bool doFrame();
+    void shutdown();
+
+    filament::Engine* mEngine = nullptr;
+    filament::Scene* mScene = nullptr;
+    std::unique_ptr<IBL> mIBL;
+    filament::SwapChain* mPrimarySwapChain = nullptr;
+    filament::Texture* mDirt = nullptr;
+    bool mClosed = false;
+    double mTime = 0;
+
+    filament::Material const* mDefaultMaterial = nullptr;
+    filament::Material const* mTransparentMaterial = nullptr;
+    filament::Material const* mDepthMaterial = nullptr;
+    filament::MaterialInstance* mDepthMI = nullptr;
+    std::unique_ptr<FilamentAppGui> mAppGui;
+    AnimCallback mAnimation;
+    ResizeCallback mResize;
+    DropCallback mDropHandler;
+    size_t mSkippedFrames = 0;
+    std::string mWindowTitle;
+    std::vector<filament::View*> mOffscreenViews;
+    WindowCameraParams mCameraParams{};
+    bool mReconfigureCameras = false;
+    uint8_t mFroxelInfoAge = 0x42;
+    uint8_t mFroxelGridEnabled = 0;
+    uint8_t mDirectionalShadowFrustumEnabled = 0x2;
+    uint8_t mCameraFrustumEnabled = 0x2;
+
+    filament::app::DisplayManager* mDisplayManager = nullptr;
+
+    filament::backend::Platform* mVulkanPlatform = nullptr;
+    filament::backend::Platform* mWebGPUPlatform = nullptr;
+
+    std::unique_ptr<Window> mWindow;
+    uint32_t mWindowWidth = 1024;
+    uint32_t mWindowHeight = 640;
+    std::string mIblDirectory;
+    std::string mDirtPath;
+    float mScale = 1.0f;
+    filament::Engine::Backend mBackend = filament::Engine::Backend::DEFAULT;
+    filament::backend::FeatureLevel mFeatureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
+    filament::camutils::Mode mCameraMode = filament::camutils::Mode::ORBIT;
+    bool mResizeable = true;
+    bool mHeadless = false;
+    int mStereoscopicEyeCount = 2;
+    uint8_t mSamples = 1;
+    std::string mVulkanGPUHint;
+    WebGPUBackend mForcedWebGPUBackend = WebGPUBackend::DEFAULT;
+    DisplayManager mDisplayManagerConfig = DisplayManager::SDL;
+    filament::backend::AsynchronousMode mAsynchronousMode = filament::backend::AsynchronousMode::NONE;
+    SetupCallback mSetupCallback;
+    CleanupCallback mCleanupCallback;
+    ImGuiCallback mImguiCallback{};
+    PreRenderCallback mPreRender{};
+    PostRenderCallback mPostRender{};
+    bool mMousePressed[3] = { false };
+    bool mIsSplitView = false;
+
+    std::unique_ptr<Cube> mCameraCube;
+    std::unique_ptr<Grid> mCameraGrid;
+
+    // we can't cull the light-frustum because it's not applied a rigid transform
+    // and currently, filament assumes that for culling
+    std::vector<Cube> mLightmapCubes;
+};
+
+#endif // TNT_FILAMENT_SAMPLE_FILAMENTAPP2_H

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -15,1013 +15,163 @@
  */
 
 #include <filamentapp/FilamentApp.h>
-
-#include "PlatformHelper.h"
-
-
-#if defined(FILAMENTAPP_HAS_WEB_UI)
-#include "display_managers/HtmlDisplayManager.h"
-#endif // defined(FILAMENTAPP_HAS_WEB_UI)
-
-#include "DisplayManager.h"
-
-#ifdef FILAMENTAPP_HAS_SDL
-#include "display_managers/SDLDisplayManager.h"
-#endif // defined(FILAMENTAPP_HAS_SDL)
-
-#if defined(WIN32)
-#    include <utils/unwindows.h>
-#endif
-
-#include <iostream>
-
-#include "FilamentAppGui.h"
-
-#include <utils/EntityManager.h>
-#include <utils/Logger.h>
-#include <utils/Panic.h>
-#include <utils/Path.h>
-
-#include <filament/Camera.h>
-#include <filament/Material.h>
-#include <filament/MaterialInstance.h>
-#include <filament/Renderer.h>
-#include <filament/RenderableManager.h>
-#include <filament/Scene.h>
-#include <filament/Skybox.h>
-#include <filament/SwapChain.h>
-#include <filament/View.h>
-
-#include <backend/Platform.h>
-
-#ifndef NDEBUG
-#include <filament/DebugRegistry.h>
-#endif
-
-#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
-#include <backend/platforms/VulkanPlatform.h>
-#endif
-
-
-
-#include <stb_image.h>
-
-#include <algorithm>
-#include <cstdlib>
-#include <memory>
-#include <thread>
-#include <vector>
-
-#ifdef __EXCEPTIONS
-#include <exception>
-#endif
-
-#include <stdint.h>
-
-#include "generated/resources/filamentapp.h"
-
-using namespace filament;
-
-using namespace filament::math;
-using namespace utils;
-using namespace filament::app;
-
-namespace {
-
-using namespace filament::backend;
-}
+#include <filamentapp/FilamentApp2.h>
 
 FilamentApp& FilamentApp::get() {
-    static FilamentApp filamentApp;
-    return filamentApp;
+    static FilamentApp app;
+    return app;
 }
 
-FilamentApp::FilamentApp() {}
+FilamentApp::FilamentApp() = default;
 
-FilamentApp::~FilamentApp() {
-    if (mDisplayManager) {
-        mDisplayManager->terminate();
-        delete mDisplayManager;
-    }
+FilamentApp::~FilamentApp() = default;
+
+void FilamentApp::run(const Config& config, SetupCallback setup, CleanupCallback cleanup,
+        ImGuiCallback imgui, PreRenderCallback preRender,
+        PostRenderCallback postRender, size_t width, size_t height) {
+
+    mImpl = FilamentApp2::Builder()
+            .title(mWindowTitle.empty() ? config.title : mWindowTitle)
+            .backend(config.backend)
+            .size(width, height)
+            .setup(setup)
+            .cleanup(cleanup)
+            .imgui(imgui)
+            .preRender(preRender)
+            .postRender(postRender)
+            .animation(mAnimation)
+            .resize(mResize)
+            .dropHandler(mDropHandler)
+            .iblDirectory(config.iblDirectory)
+            .dirt(config.dirt)
+            .scale(config.scale)
+            .splitView(config.splitView)
+            .featureLevel(config.featureLevel)
+            .cameraMode(config.cameraMode)
+            .resizeable(config.resizeable)
+            .headless(config.headless)
+            .stereoscopicEyeCount(config.stereoscopicEyeCount)
+            .samples(config.samples)
+            .vulkanGPUHint(config.vulkanGPUHint)
+            .forcedWebGPUBackend(static_cast<FilamentApp2::WebGPUBackend>(config.forcedWebGPUBackend))
+            .configDisplayManager(static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+            .asynchronousMode(config.asynchronousMode)
+            .build();
+
+    if (mSidebarWidth != 0) mImpl->setSidebarWidth(mSidebarWidth);
+    if (mCameraFocalLength != 0.0f) mImpl->setCameraFocalLength(mCameraFocalLength);
+    if (mCameraNear != 0.0f || mCameraFar != 0.0f) mImpl->setCameraNearFar(mCameraNear, mCameraFar);
+    for (auto* view : mOffscreenViews) mImpl->addOffscreenView(view);
+
+    mImpl->run();
+}
+
+void FilamentApp::reconfigureCameras() {
+    if (mImpl) mImpl->reconfigureCameras();
+}
+
+filament::Material const* FilamentApp::getDefaultMaterial() const noexcept {
+    return mImpl ? mImpl->getDefaultMaterial() : nullptr;
+}
+
+filament::Material const* FilamentApp::getTransparentMaterial() const noexcept {
+    return mImpl ? mImpl->getTransparentMaterial() : nullptr;
+}
+
+IBL* FilamentApp::getIBL() const noexcept {
+    return mImpl ? mImpl->getIBL() : nullptr;
+}
+
+filament::Texture* FilamentApp::getDirtTexture() const noexcept {
+    return mImpl ? mImpl->getDirtTexture() : nullptr;
+}
+
+filament::View* FilamentApp::getGuiView() const noexcept {
+    return mImpl ? mImpl->getGuiView() : nullptr;
+}
+
+filament::SwapChain* FilamentApp::getPrimarySwapChain() const noexcept {
+    return mImpl ? mImpl->getPrimarySwapChain() : nullptr;
+}
+
+void FilamentApp::close() {
+    if (mImpl) mImpl->close();
 }
 
 void FilamentApp::onSurfaceCreated(void* nativeWindow) {
-    // To be implemented in later PRs
+    if (mImpl) mImpl->onSurfaceCreated(nativeWindow);
 }
 
 void FilamentApp::onSurfaceChanged(int width, int height) {
-    // To be implemented in later PRs
+    if (mImpl) mImpl->onSurfaceChanged(width, height);
 }
 
 void FilamentApp::onSurfaceDestroyed() {
-    // To be implemented in later PRs
+    if (mImpl) mImpl->onSurfaceDestroyed();
 }
 
 void FilamentApp::onTouchEvent(int action, float x, float y) {
-    // To be implemented in later PRs
+    if (mImpl) mImpl->onTouchEvent(action, x, y);
 }
 
-View* FilamentApp::getGuiView() const noexcept { return mAppGui ? mAppGui->getView() : nullptr; }
-
-void FilamentApp::run(Config const& config, SetupCallback setupCallback,
-        CleanupCallback cleanupCallback, ImGuiCallback imguiCallback, PreRenderCallback preRender,
-        PostRenderCallback postRender, size_t width, size_t height) {
-
-    mCleanupCallback = cleanupCallback;
-    mImguiCallback = imguiCallback;
-    mPreRender = preRender;
-    mPostRender = postRender;
-    mIsSplitView = config.splitView;
-
-    // Note that we need to determine the backend in order to build custom platforms.
-    Engine::Backend backend = filament::app::resolveBackend(config.backend);
-
-    backend::Platform* platform = nullptr;
-    if (backend == Engine::Backend::VULKAN) {
-        platform = mVulkanPlatform =
-                filament::app::createVulkanPlatform(config.vulkanGPUHint.c_str());
-    } else if (backend == Engine::Backend::WEBGPU) {
-        platform = mWebGPUPlatform =
-                filament::app::createWebGPUPlatform(config.forcedWebGPUBackend);
-    }
-
-    Engine::Config engineConfig = {
-#if defined(FILAMENT_SAMPLES_STEREO_TYPE_INSTANCED)
-        .stereoscopicType = Engine::StereoscopicType::INSTANCED,
-#elif defined(FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
-        .stereoscopicType = Engine::StereoscopicType::MULTIVIEW,
-#else
-        .stereoscopicType = Engine::StereoscopicType::NONE,
-#endif
-        .stereoscopicEyeCount = (uint8_t) config.stereoscopicEyeCount,
-        .asynchronousMode = config.asynchronousMode,
-    };
-
-    // "backend.enable_asynchronous_operation" is forcibly enabled here, inheriting the setting
-    // from the Engine, purely to demonstrate the object's asynchronous behavior within
-    // Filament. Users should manage this flag at their discretion.
-    mEngine = Engine::Builder()
-                      .backend(backend)
-                      .featureLevel(config.featureLevel)
-                      .feature("backend.enable_asynchronous_operation",
-                              engineConfig.asynchronousMode != AsynchronousMode::NONE)
-                      .platform(platform)
-                      .config(&engineConfig)
-                      .build();
-
-    assert_invariant(mEngine->getBackend() == backend);
-
-    // By now we have resolved to a specific backend (instead of default).
-    config.backend = backend;
-
-    if (config.displayManager == Config::DisplayManager::WEB) {
-#if defined(FILAMENTAPP_HAS_WEB_UI)
-        mDisplayManager = new HtmlDisplayManager();
-#endif // defined(FILAMENTAPP_HAS_WEB_UI)
-    } else {
-#ifdef FILAMENTAPP_HAS_SDL
-        mDisplayManager = new SDLDisplayManager();
-#else // !defined(FILAMENTAPP_HAS_SDL)
-        FILAMENT_CHECK_POSTCONDITION(false) << "SDLDisplayManager is not available on this platform";
-#endif // defined(FILAMENTAPP_HAS_SDL)
-    }
-
-    if (!mDisplayManager->init(config)) {
-        LOG(ERROR) << "Failed to initialize display manager" << utils::io::endl;
-        return;
-    }
-
-    mWindowTitle = config.title;
-    mWindow.reset(
-            new FilamentApp::Window(this, config, config.title, mCameraParams, width, height));
-    Window* window = mWindow.get();
-
-    mDepthMaterial = Material::Builder()
-            .package(FILAMENTAPP_DEPTHVISUALIZER_DATA, FILAMENTAPP_DEPTHVISUALIZER_SIZE)
-            .build(*mEngine);
-
-    mDepthMI = mDepthMaterial->createInstance();
-
-    mDefaultMaterial = Material::Builder()
-            .package(FILAMENTAPP_AIDEFAULTMAT_DATA, FILAMENTAPP_AIDEFAULTMAT_SIZE)
-            .build(*mEngine);
-
-    mTransparentMaterial = Material::Builder()
-            .package(FILAMENTAPP_TRANSPARENTCOLOR_DATA, FILAMENTAPP_TRANSPARENTCOLOR_SIZE)
-            .build(*mEngine);
-
-    mCameraCube.reset(new Cube(*mEngine, mTransparentMaterial, { 1, 0, 0 }));
-    mCameraGrid.reset(new Grid(*mEngine, mTransparentMaterial, { 1, 1, 0 }));
-
-    // we can't cull the light-frustum because it's not applied a rigid transform
-    // and currently, filament assumes that for culling
-    mLightmapCubes.reserve(4);
-    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 0, 1, 0 }, false);
-    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 0, 0, 1 }, false);
-    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 1, 1, 0 }, false);
-    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 1, 0, 0 }, false);
-
-    mScene = mEngine->createScene();
-
-    window->mMainView->getView()->setVisibleLayers(0x4, 0x4);
-    window->mMainView->getView()->setFroxelVizEnabled(true);
-
-    if (config.splitView) {
-        mScene->addEntity(mCameraCube->getSolidRenderable());
-        mScene->addEntity(mCameraCube->getWireFrameRenderable());
-        for (auto&& cube: mLightmapCubes) {
-            mScene->addEntity(cube.getSolidRenderable());
-            mScene->addEntity(cube.getWireFrameRenderable());
-        }
-
-        window->mDepthView->getView()->setVisibleLayers(0x4, 0x4);
-        window->mGodView->getView()->setVisibleLayers(0x6, 0x6);
-        window->mOrthoView->getView()->setVisibleLayers(0x6, 0x6);
-
-        // only preserve the color buffer for additional views; depth and stencil can be discarded.
-        window->mDepthView->getView()->setShadowingEnabled(false);
-        window->mGodView->getView()->setShadowingEnabled(false);
-        window->mOrthoView->getView()->setShadowingEnabled(false);
-    }
-
-    // froxel debug grid always added (but hidden)
-    mScene->addEntity(mCameraGrid->getWireFrameRenderable());
-
-    loadDirt(config);
-    loadIBL(config);
-
-    for (auto& view : window->mViews) {
-        if (view.get() != window->mUiView) {
-            view->getView()->setScene(mScene);
-        }
-    }
-
-    setupCallback(mEngine, window->mMainView->getView(), mScene);
-
-    if (imguiCallback) {
-        mAppGui = std::make_unique<FilamentAppGui>(mEngine, window->mUiView->getView(),
-                getRootAssetsPath() + "assets/fonts/Roboto-Medium.ttf");
-    }
-
-    mDisplayManager->startRendering([this] { return doFrame(); });
+void FilamentApp::setSidebarWidth(int width) {
+    mSidebarWidth = width;
+    if (mImpl) mImpl->setSidebarWidth(width);
 }
 
-
-bool FilamentApp::doFrame() {
-#ifdef __EXCEPTIONS
-try {
-#endif
-    Window* window = mWindow.get();
-    if (!window) {
-        return true;
-    }
-
-    if (!UTILS_HAS_THREADING) {
-        mEngine->execute();
-    }
-
-    // Allow the app to animate the scene if desired.
-    if (mAnimation) {
-        mAnimation(mEngine, window->mMainView->getView(), mDisplayManager->getTime());
-    }
-
-    // Loop over fresh events twice: first stash them and let ImGui process them, then allow
-    // the app to process the stashed events. This is done because ImGui might wish to block
-    // certain events from the app (e.g., when dragging the mouse over an obscuring window).
-    std::vector<filament::app::AppEvent> events;
-    mDisplayManager->pollEvents(events);
-
-    if (mAppGui) {
-        mAppGui->processAppEvents(events);
-    }
-
-    // Now, loop over the events a second time for app-side processing.
-    for (const auto& event: events) {
-        if (mClosed) {
-            break;
-        }
-        bool wantCaptureMouse = mAppGui ? mAppGui->wantCaptureMouse() : false;
-        switch (event.type) {
-            case AppEvent::Type::QUIT:
-                mClosed = true;
-                break;
-            case AppEvent::Type::KEYDOWN:
-                if (event.key.code == AppKey::ESCAPE) {
-                    mClosed = true;
-                }
-#if !defined(NDEBUG) && !defined(__ANDROID__)
-                if (event.key.code == AppKey::PRINT_SCREEN) {
-                    filament::DebugRegistry& debug = mEngine->getDebugRegistry();
-                    if (bool* captureFrame = debug.getPropertyAddress<bool>("d.renderer.doFrameCapture")) {
-                        *captureFrame = true;
-                    }
-                }
-#endif
-                window->keyDown(event.key.code);
-                break;
-            case AppEvent::Type::KEYUP:
-                window->keyUp(event.key.code);
-                break;
-            case AppEvent::Type::MOUSE_WHEEL:
-                if (!wantCaptureMouse) window->mouseWheel(event.mouseWheel.delta);
-                break;
-            case AppEvent::Type::MOUSE_BUTTON_DOWN:
-                if (!wantCaptureMouse)
-                    window->mouseDown(event.mouseButton.button, event.mouseButton.x,
-                            event.mouseButton.y);
-                break;
-            case AppEvent::Type::MOUSE_BUTTON_UP:
-                if (!wantCaptureMouse)
-                    window->mouseUp(event.mouseButton.x, event.mouseButton.y);
-                break;
-            case AppEvent::Type::MOUSE_MOVE:
-                if (!wantCaptureMouse)
-                    window->mouseMoved(event.mouseMove.x, event.mouseMove.y);
-                break;
-            case AppEvent::Type::DROP_FILE:
-                if (mDropHandler) {
-                    mDropHandler(event.dropFile.path);
-                }
-                break;
-            case AppEvent::Type::RESIZED:
-                window->resize(mCameraParams);
-                // Call the resize callback, if this FilamentApp has one. This must be done
-                // after configureCamerasForWindow, so the viewports are correct.
-                if (mResize) {
-                    mResize(mEngine, window->mMainView->getView());
-                }
-                break;
-            default:
-                break;
-        }
-    }
-
-    // Note that shutdown() does not destroy the DisplayManager, but the destructor does. The
-    // return here will go back to the caller, which is a DisplayManager.
-    if (mClosed) {
-        shutdown();
-        return true;
-    }
-
-    // Calculate the time step.
-    static double lastTime = 0;
-    double now = mDisplayManager->getTime();
-    const float timeStep = lastTime > 0 ? (float) (now - lastTime) : (float) (1.0f / 60.0f);
-    lastTime = now;
-
-    // Populate the UI scene, regardless of whether Filament wants to a skip frame. We should
-    // always let ImGui generate a command list; if it skips a frame it'll destroy its widgets.
-    if (mAppGui) {
-        mAppGui->render(timeStep, mDisplayManager, window->mWindow, mImguiCallback, mMousePressed);
-    }
-
-    // Update the camera manipulators for each view.
-    for (auto const& view: window->mViews) {
-        auto* cm = view->getCameraManipulator();
-        if (cm) {
-            cm->update(timeStep);
-        }
-    }
-
-    // Update the position and orientation of the two cameras.
-    filament::math::float3 eye, center, up;
-    window->mMainCameraMan->getLookAt(&eye, &center, &up);
-    window->mMainCamera->lookAt(eye, center, up);
-
-    window->mDebugCameraMan->getLookAt(&eye, &center, &up);
-    window->mDebugCamera->lookAt(eye, center, up);
-    window->mDebugCamera->setExposure(window->mMainCamera->getAperture(),
-            window->mMainCamera->getShutterSpeed(), window->mMainCamera->getSensitivity());
-
-    window->mOrthoCamera->setExposure(window->mMainCamera->getAperture(),
-            window->mMainCamera->getShutterSpeed(), window->mMainCamera->getSensitivity());
-
-    auto const fci = window->mMainView->getView()->getFroxelConfigurationInfo();
-    if (UTILS_UNLIKELY(fci.age != mFroxelInfoAge)) {
-        mFroxelInfoAge = fci.age;
-        auto width = fci.info.width;
-        auto height = fci.info.height;
-        auto depth = fci.info.depth;
-        auto froxelDimension = fci.info.froxelDimension;
-        auto viewportWidth = fci.info.viewportWidth;
-        auto viewportHeight = fci.info.viewportHeight;
-        auto zLightFar = fci.info.zLightFar;
-        auto linearizer = fci.info.linearizer;
-        auto p = fci.info.p;
-        auto ct = fci.info.clipTransform;
-        mCameraGrid->update(
-                width, height, depth,
-                [=](int const i) {
-                    float x = float(2 * i * froxelDimension.x) / float(viewportWidth) - 1.0f;
-                    x = (x - ct.z) / ct.x;
-                    return x;
-                },
-                [=](int const j) {
-                    float y = float(2 * j * froxelDimension.y) / float(viewportHeight) - 1.0f;
-                    y = (y - ct.w) / ct.y;
-                    return y;
-                },
-                [=](int const k) {
-                    float const z_view = -zLightFar * std::exp2(float(k - depth) * linearizer);
-                    auto c = p * float4{ 0, 0, z_view, 1 };
-                    float const z_clip_dx = k == 0 ? 1.0f : c.z / c.w;
-                    float const z_clip_gl = (1 - z_clip_dx) * 2.0f - 1.0f;
-                    return z_clip_gl;
-                });
-    }
-
-    auto& rcm = mEngine->getRenderableManager();
-    if (mIsSplitView) {
-        rcm.setLayerMask(rcm.getInstance(mCameraCube->getSolidRenderable()), 0x3,
-                mCameraFrustumEnabled);
-        rcm.setLayerMask(rcm.getInstance(mCameraCube->getWireFrameRenderable()), 0x3,
-                mCameraFrustumEnabled);
-    }
-    rcm.setLayerMask(rcm.getInstance(mCameraGrid->getWireFrameRenderable()), 0x3,
-            mFroxelGridEnabled);
-
-    // Update the cube distortion matrix used for frustum visualization.
-    auto const csm = window->mMainView->getView()->getDirectionalShadowCameras();
-    // show/hide the cascades
-    for (size_t i = 0; i < 4; i++) {
-        rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getSolidRenderable()), 0x3, 0x0);
-        rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getWireFrameRenderable()), 0x3, 0x0);
-    }
-    if (!csm.empty()) {
-        for (size_t i = 0, c = csm.size(); i < c; i++) {
-            if (csm[i]) {
-                mLightmapCubes[i].mapFrustum(*mEngine, csm[i]);
-            }
-            uint8_t const layer = csm[i] ? mDirectionalShadowFrustumEnabled : 0x0;
-            rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getSolidRenderable()), 0x3,
-                    layer);
-            rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getWireFrameRenderable()), 0x3,
-                    layer);
-        }
-    }
-
-    mCameraCube->mapFrustum(*mEngine, window->mMainCamera);
-    mCameraGrid->mapFrustum(*mEngine, window->mMainCamera);
-    Renderer* renderer = window->getRenderer();
-
-    if (mPreRender) {
-        mPreRender(mEngine, window->mViews[0]->getView(), mScene, renderer);
-    }
-
-    if (mReconfigureCameras) {
-        window->configureCamerasForWindow(mCameraParams);
-        mReconfigureCameras = false;
-    }
-
-    if (mIsSplitView) {
-        if (!window->mOrthoView->getView()->hasCamera()) {
-            auto const csm = window->mMainView->getView()->getDirectionalShadowCameras();
-            if (!csm.empty()) {
-                // here we could choose the cascade
-                Camera const* debugDirectionalShadowCamera = csm[0];
-                if (debugDirectionalShadowCamera) {
-                    window->mOrthoView->setCamera(
-                            const_cast<Camera*>(debugDirectionalShadowCamera));
-                }
-            }
-        }
-    }
-
-    if (renderer->beginFrame(window->getSwapChain())) {
-        for (filament::View* offscreenView: mOffscreenViews) {
-            renderer->render(offscreenView);
-        }
-        for (auto const& view: window->mViews) {
-            renderer->render(view->getView());
-        }
-
-        mDisplayManager->onFrameFinished(window->mWindow, mEngine, renderer);
-
-        if (mPostRender) {
-            mPostRender(mEngine, window->mViews[0]->getView(), mScene, renderer);
-        }
-        renderer->endFrame();
-    } else {
-        ++mSkippedFrames;
-    }
-
-#ifdef __EXCEPTIONS
-} catch (Panic const& e) {
-    LOG(ERROR) << "Filament exception (terminate cleanly): " << e.what();
-    LOG(ERROR) << e.getCallStack();
-} catch (std::exception const& e) {
-    LOG(ERROR) << "System exception (terminate cleanly): " << e.what();
-} catch (...) {
-    LOG(ERROR) << "Unknown exception! (terminate cleanly)";
-}
-#endif
-    return false;
+void FilamentApp::setWindowTitle(const char* title) {
+    mWindowTitle = title ? title : "";
+    // mImpl doesn't have setWindowTitle; we handle it via Builder if called before run.
 }
 
-void FilamentApp::shutdown() {
-    if (mAppGui) {
-        mAppGui.reset();
-    }
-
-    mCleanupCallback(mEngine, mWindow->mMainView->getView(), mScene);
-
-    mCameraCube.reset();
-    mCameraGrid.reset();
-    mLightmapCubes.clear();
-    mWindow.reset();
-    mPrimarySwapChain = nullptr;    
-
-    mIBL.reset();
-    mEngine->destroy(mDepthMI);
-    mEngine->destroy(mDepthMaterial);
-    mEngine->destroy(mDefaultMaterial);
-    mEngine->destroy(mTransparentMaterial);
-    mEngine->destroy(mScene);
-    Engine::destroy(&mEngine);
-    mEngine = nullptr;
-
-    if (mVulkanPlatform) {
-        filament::app::destroyVulkanPlatform(mVulkanPlatform);
-        mVulkanPlatform = nullptr;
-    }
-    if (mWebGPUPlatform) {
-        filament::app::destroyWebGPUPlatform(mWebGPUPlatform);
-        mWebGPUPlatform = nullptr;
-    }
+void FilamentApp::setCameraFocalLength(float focalLength) {
+    mCameraFocalLength = focalLength;
+    if (mImpl) mImpl->setCameraFocalLength(focalLength);
 }
 
-// RELATIVE_ASSET_PATH is set inside samples/CMakeLists.txt and used to support multi-configuration
-// generators, like Visual Studio or Xcode.
-#ifndef RELATIVE_ASSET_PATH
-#define RELATIVE_ASSET_PATH "."
-#endif
+void FilamentApp::setCameraNearFar(float near, float far) {
+    mCameraNear = near;
+    mCameraFar = far;
+    if (mImpl) mImpl->setCameraNearFar(near, far);
+}
 
-const utils::Path& FilamentApp::getRootAssetsPath() {
-    static const utils::Path root = utils::Path::getCurrentExecutable().getParent() + RELATIVE_ASSET_PATH;
-    return root;
+void FilamentApp::addOffscreenView(filament::View* view) {
+    mOffscreenViews.push_back(view);
+    if (mImpl) mImpl->addOffscreenView(view);
+}
+
+size_t FilamentApp::getSkippedFrameCount() const {
+    return mImpl ? mImpl->getSkippedFrameCount() : 0;
 }
 
 void FilamentApp::loadIBL(std::string_view path) {
-    Path iblPath(path);
-    if (!iblPath.exists()) {
-        std::cerr << "The specified IBL path does not exist: " << iblPath << std::endl;
-        return;
-    }
-
-    // Note that IBL holds a skybox, and Scene also holds a reference.  We cannot release IBL's
-    // skybox until after new skybox has been set in the scene.
-    std::unique_ptr<IBL> oldIBL = std::move(mIBL);
-    mIBL = std::make_unique<IBL>(*mEngine);
-
-    if (!iblPath.isDirectory()) {
-        if (!mIBL->loadFromEquirect(iblPath)) {
-            std::cerr << "Could not load the specified IBL: " << iblPath << std::endl;
-            mIBL.reset(nullptr);
-            return;
-        }
-    } else {
-        if (!mIBL->loadFromDirectory(iblPath)) {
-            std::cerr << "Could not load the specified IBL: " << iblPath << std::endl;
-            mIBL.reset(nullptr);
-            return;
-        }
-    }
-
-    if (mIBL != nullptr) {
-        mIBL->getSkybox()->setLayerMask(0x7, 0x4);
-        mScene->setSkybox(mIBL->getSkybox());
-        mScene->setIndirectLight(mIBL->getIndirectLight());
-    }
-}
-
-void FilamentApp::loadIBL(const Config& config) {
-    if (config.iblDirectory.empty()) {
-        return;
-    }
-    loadIBL(config.iblDirectory);
-}
-
-void FilamentApp::loadDirt(const Config& config) {
-    if (!config.dirt.empty()) {
-        Path dirtPath(config.dirt);
-
-        if (!dirtPath.exists()) {
-            std::cerr << "The specified dirt file does not exist: " << dirtPath << std::endl;
-            return;
-        }
-
-        if (!dirtPath.isFile()) {
-            std::cerr << "The specified dirt path is not a file: " << dirtPath << std::endl;
-            return;
-        }
-
-        int w, h, n;
-
-        unsigned char* data = stbi_load(dirtPath.getAbsolutePath().c_str(), &w, &h, &n, 3);
-        assert(n == 3);
-
-        mDirt = Texture::Builder()
-                .width(w)
-                .height(h)
-                .format(Texture::InternalFormat::RGB8)
-                .build(*mEngine);
-
-        mDirt->setImage(*mEngine, 0, { data, size_t(w * h * 3),
-                Texture::Format::RGB, Texture::Type::UBYTE,
-                (Texture::PixelBufferDescriptor::Callback)&stbi_image_free });
-    }
+    if (mImpl) mImpl->loadIBL(path);
 }
 
 void FilamentApp::setCameraFrustumEnabled(bool enabled) noexcept {
-    mCameraFrustumEnabled = enabled ? 0x2 : 0x0;
+    if (mImpl) mImpl->setCameraFrustumEnabled(enabled);
 }
 
 void FilamentApp::setDirectionalShadowFrustumEnabled(bool enabled) noexcept {
-    mDirectionalShadowFrustumEnabled = enabled ? 0x2 : 0x0;
+    if (mImpl) mImpl->setDirectionalShadowFrustumEnabled(enabled);
 }
 
 void FilamentApp::setFroxelGridEnabled(bool enabled) noexcept {
-    mFroxelGridEnabled = enabled ? 0x3 : 0x0;
+    if (mImpl) mImpl->setFroxelGridEnabled(enabled);
 }
 
 bool FilamentApp::isCameraFrustumEnabled() const noexcept {
-    return !!mCameraFrustumEnabled;
+    return mImpl ? mImpl->isCameraFrustumEnabled() : false;
 }
 
 bool FilamentApp::isDirectionalShadowFrustumEnabled() const noexcept {
-    return !!mDirectionalShadowFrustumEnabled;
+    return mImpl ? mImpl->isDirectionalShadowFrustumEnabled() : false;
 }
 
 bool FilamentApp::isFroxelGridEnabled() const noexcept {
-    return !!mFroxelGridEnabled;
+    return mImpl ? mImpl->isFroxelGridEnabled() : false;
 }
 
-// ------------------------------------------------------------------------------------------------
-
-FilamentApp::Window::Window(FilamentApp* filamentApp, const Config& config, std::string title,
-        WindowCameraParams const& cameraParams, size_t w, size_t h)
-        : mDisplayManager(filamentApp->mDisplayManager),
-          mEngine(filamentApp->mEngine),
-          mConfig(config),
-          mIsHeadless(config.headless) {
-    mWindow =
-            mDisplayManager->createWindow(title.c_str(), w, h, config.resizeable, config.headless);
-
-    void* nativeWindow = mDisplayManager->getNativeWindow(mWindow);
-    auto engine = mEngine;
-
-    mWidth = w;
-    mHeight = h;
-
-    // Write back the active feature level.
-    config.featureLevel = engine->getActiveFeatureLevel();
-
-
-    if (config.headless) {
-        mSwapChain = engine->createSwapChain((uint32_t) w, (uint32_t) h);
-    } else {
-        mSwapChain = engine->createSwapChain(nativeWindow,
-                filament::SwapChain::CONFIG_HAS_STENCIL_BUFFER);
-    }
-    filamentApp->mPrimarySwapChain = mSwapChain;
-
-    mRenderer = engine->createRenderer();
-
-    // create cameras
-    utils::EntityManager& em = utils::EntityManager::get();
-    em.create(3, mCameraEntities);
-    mCameras[0] = mMainCamera = engine->createCamera(mCameraEntities[0]);
-    mCameras[1] = mDebugCamera = engine->createCamera(mCameraEntities[1]);
-    mCameras[2] = mOrthoCamera = engine->createCamera(mCameraEntities[2]);
-
-    // set exposure
-    for (auto camera : mCameras) {
-        camera->setExposure(16.0f, 1 / 125.0f, 100.0f);
-    }
-
-    // create views
-    mViews.emplace_back(mMainView = new CView(*mRenderer, "Main View"));
-    if (config.splitView) {
-        mViews.emplace_back(mDepthView = new CView(*mRenderer, "Depth View"));
-        mViews.emplace_back(mGodView = new GodView(*mRenderer, "God View"));
-        mViews.emplace_back(mOrthoView = new CView(*mRenderer, "Shadow View"));
-    }
-    mViews.emplace_back(mUiView = new CView(*mRenderer, "UI View"));
-
-    // set-up the camera manipulators
-    mMainCameraMan = CameraManipulator::Builder()
-            .targetPosition(0, 0, -4)
-            .flightMoveDamping(15.0)
-            .build(config.cameraMode);
-    mDebugCameraMan = CameraManipulator::Builder()
-            .targetPosition(0, 0, -4)
-            .flightMoveDamping(15.0)
-            .build(config.cameraMode);
-
-    mMainView->setCamera(mMainCamera);
-    mMainView->setCameraManipulator(mMainCameraMan);
-    if (config.splitView) {
-        // Depth view always uses the main camera
-        mDepthView->setCamera(mMainCamera);
-        mDepthView->setCameraManipulator(mMainCameraMan);
-
-        // The god view uses the main camera for culling, but the debug camera for viewing
-        mGodView->setCamera(mMainCamera);
-        mGodView->setGodCamera(mDebugCamera);
-        mGodView->setCameraManipulator(mDebugCameraMan);
-    }
-
-    // configure the cameras
-    configureCamerasForWindow(cameraParams);
-
-    mMainCamera->lookAt({4, 0, -4}, {0, 0, -4}, {0, 1, 0});
-}
-
-FilamentApp::Window::~Window() {
-    mViews.clear();
-    utils::EntityManager& em = utils::EntityManager::get();
-    for (auto e : mCameraEntities) {
-        mEngine->destroyCameraComponent(e);
-        em.destroy(e);
-    }
-    mEngine->destroy(mRenderer);
-    mEngine->destroy(mSwapChain);
-    mDisplayManager->destroyWindow(mWindow);
-    delete mMainCameraMan;
-    delete mDebugCameraMan;
-}
-
-void FilamentApp::Window::mouseDown(int button, ssize_t x, ssize_t y) {
-    fixupMouseCoordinatesForHdpi(x, y);
-    y = mHeight - y;
-    for (auto const& view : mViews) {
-        if (view->intersects(x, y)) {
-            mMouseEventTarget = view.get();
-            view->mouseDown(button, x, y);
-            break;
-        }
-    }
-}
-
-void FilamentApp::Window::mouseWheel(ssize_t x) {
-    if (mMouseEventTarget) {
-        mMouseEventTarget->mouseWheel(x);
-    } else {
-        for (auto const& view : mViews) {
-            if (view->intersects(mLastX, mLastY)) {
-                view->mouseWheel(x);
-                break;
-            }
-        }
-    }
-}
-
-void FilamentApp::Window::mouseUp(ssize_t x, ssize_t y) {
-    fixupMouseCoordinatesForHdpi(x, y);
-    if (mMouseEventTarget) {
-        y = mHeight - y;
-        mMouseEventTarget->mouseUp(x, y);
-        mMouseEventTarget = nullptr;
-    }
-}
-
-void FilamentApp::Window::mouseMoved(ssize_t x, ssize_t y) {
-    fixupMouseCoordinatesForHdpi(x, y);
-    y = mHeight - y;
-    if (mMouseEventTarget) {
-        mMouseEventTarget->mouseMoved(x, y);
-    }
-    mLastX = x;
-    mLastY = y;
-}
-
-void FilamentApp::Window::keyDown(AppKey key) {
-    auto& eventTarget = mKeyEventTarget[key];
-
-    // keyDown events can be sent multiple times per key (for key repeat)
-    // If this key is already down, do nothing.
-    if (eventTarget) {
-        return;
-    }
-
-    // Decide which view will get this key's corresponding keyUp event.
-    // If we're currently in a mouse grap session, it should be the mouse grab's target view.
-    // Otherwise, it should be whichever view we're currently hovering over.
-    CView* targetView = nullptr;
-    if (mMouseEventTarget) {
-        targetView = mMouseEventTarget;
-    } else {
-        for (auto const& view : mViews) {
-            if (view->intersects(mLastX, mLastY)) {
-                targetView = view.get();
-                break;
-            }
-        }
-    }
-
-    if (targetView) {
-        targetView->keyDown(key);
-        eventTarget = targetView;
-    }
-}
-
-void FilamentApp::Window::keyUp(AppKey key) {
-    auto& eventTarget = mKeyEventTarget[key];
-    if (!eventTarget) {
-        return;
-    }
-    eventTarget->keyUp(key);
-    eventTarget = nullptr;
-}
-
-void FilamentApp::Window::fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const {
-    uint32_t dw, dh, ww, wh;
-    mDisplayManager->getDrawableSize(mWindow, &dw, &dh);
-    mDisplayManager->getWindowSize(mWindow, &ww, &wh);
-    x = x * (ssize_t) dw / (ssize_t) ww;
-    y = y * (ssize_t) dh / (ssize_t) wh;
-}
-
-void FilamentApp::Window::resize(WindowCameraParams const& cameraParams) {
-    mDisplayManager->onWindowResized(mWindow);
-    configureCamerasForWindow(cameraParams);
-}
-
-void FilamentApp::Window::configureCamerasForWindow(WindowCameraParams const& cameraParams) {
-    float dpiScaleX = 1.0f;
-    float dpiScaleY = 1.0f;
-
-    // If the app is not headless, query the window for its physical & virtual sizes.
-    if (!mIsHeadless) {
-        uint32_t width, height;
-        mDisplayManager->getDrawableSize(mWindow, &width, &height);
-        mWidth = (size_t) width;
-        mHeight = (size_t) height;
-
-        uint32_t virtualWidth, virtualHeight;
-        mDisplayManager->getWindowSize(mWindow, &virtualWidth, &virtualHeight);
-        dpiScaleX = (float) width / virtualWidth;
-        dpiScaleY = (float) height / virtualHeight;
-    } else {
-        uint32_t width, height;
-        mDisplayManager->getWindowSize(mWindow, &width, &height);
-        if (width != mWidth || height != mHeight) {
-            mWidth = width;
-            mHeight = height;
-            if (mSwapChain) {
-                mEngine->destroy(mSwapChain);
-            }
-            mSwapChain = mEngine->createSwapChain((uint32_t) width, (uint32_t) height);
-        }
-    }
-
-    const uint32_t width = mWidth;
-    const uint32_t height = mHeight;
-
-    const float3 at(0, 0, -4);
-    const double ratio = double(height) / double(width);
-    const int sidebar = cameraParams.sidebarWidth * dpiScaleX;
-
-    const bool splitview = mViews.size() > 2;
-
-    const uint32_t mainWidth = std::max(2, (int) width - sidebar);
-
-    double near = cameraParams.near;
-    double far = cameraParams.far;
-    auto aspectRatio = double(mainWidth) / height;
-    if (mMainView->getView()->getStereoscopicOptions().enabled) {
-        const int ec = mConfig.stereoscopicEyeCount;
-        aspectRatio = double(mainWidth) / ec / height;
-
-        mat4 projections[4];
-        projections[0] = Camera::projection(cameraParams.focalLength, aspectRatio, near, far);
-        projections[1] = projections[0];
-        // simulate foveated rendering
-        projections[2] = Camera::projection(cameraParams.focalLength * 2.0, aspectRatio, near, far);
-        projections[3] = projections[2];
-        mMainCamera->setCustomEyeProjection(projections, 4, projections[0], near, far);
-    } else {
-        mMainCamera->setLensProjection(cameraParams.focalLength, aspectRatio, near, far);
-    }
-    mDebugCamera->setProjection(45.0, aspectRatio, 0.0625, 4096, Camera::Fov::VERTICAL);
-
-    // We're in split view when there are more views than just the Main and UI views.
-    if (splitview) {
-        uint32_t const vpw = mainWidth / 2;
-        uint32_t const vph = height / 2;
-        mMainView->setViewport ({ sidebar +            0,            0, vpw, vph });
-        mDepthView->setViewport({ sidebar + int32_t(vpw),            0, vpw, vph });
-        mGodView->setViewport  ({ sidebar + int32_t(vpw), int32_t(vph), vpw, vph });
-        mOrthoView->setViewport({ sidebar +            0, int32_t(vph), vpw, vph });
-    } else {
-        mMainView->setViewport({ sidebar, 0, mainWidth, height });
-    }
-    mUiView->setViewport({ 0, 0, width, height });
-}
-
-// ------------------------------------------------------------------------------------------------
-
-FilamentApp::CView::CView(Renderer& renderer, std::string name)
-        : engine(*renderer.getEngine()), mName(name) {
-    view = engine.createView();
-    view->setName(name.c_str());
-}
-
-FilamentApp::CView::~CView() {
-    engine.destroy(view);
-}
-
-void FilamentApp::CView::setViewport(filament::Viewport const& viewport) {
-    mViewport = viewport;
-    view->setViewport(viewport);
-    if (mCameraManipulator) {
-        mCameraManipulator->setViewport(viewport.width, viewport.height);
-    }
-}
-
-void FilamentApp::CView::mouseDown(int button, ssize_t x, ssize_t y) {
-    if (mCameraManipulator) {
-        mCameraManipulator->grabBegin(x, y, button == 3);
-    }
-}
-
-void FilamentApp::CView::mouseUp(ssize_t x, ssize_t y) {
-    if (mCameraManipulator) {
-        mCameraManipulator->grabEnd();
-    }
-}
-
-void FilamentApp::CView::mouseMoved(ssize_t x, ssize_t y) {
-    if (mCameraManipulator) {
-        mCameraManipulator->grabUpdate(x, y);
-    }
-}
-
-void FilamentApp::CView::mouseWheel(ssize_t x) {
-    if (mCameraManipulator) {
-        mCameraManipulator->scroll(0, 0, x);
-    }
-}
-
-bool FilamentApp::manipulatorKeyFromKeycode(AppKey scancode, CameraManipulator::Key& key) {
-    switch (scancode) {
-        case AppKey::W:
-            key = CameraManipulator::Key::FORWARD;
-            return true;
-        case AppKey::A:
-            key = CameraManipulator::Key::LEFT;
-            return true;
-        case AppKey::S:
-            key = CameraManipulator::Key::BACKWARD;
-            return true;
-        case AppKey::D:
-            key = CameraManipulator::Key::RIGHT;
-            return true;
-        case AppKey::E:
-            key = CameraManipulator::Key::UP;
-            return true;
-        case AppKey::Q:
-            key = CameraManipulator::Key::DOWN;
-            return true;
-        default:
-            return false;
-    }
-}
-
-void FilamentApp::CView::keyUp(AppKey scancode) {
-    if (mCameraManipulator) {
-        CameraManipulator::Key key;
-        if (manipulatorKeyFromKeycode(scancode, key)) {
-            mCameraManipulator->keyUp(key);
-        }
-    }
-}
-
-void FilamentApp::CView::keyDown(AppKey scancode) {
-    if (mCameraManipulator) {
-        CameraManipulator::Key key;
-        if (manipulatorKeyFromKeycode(scancode, key)) {
-            mCameraManipulator->keyDown(key);
-        }
-    }
-}
-
-bool FilamentApp::CView::intersects(ssize_t x, ssize_t y) {
-    if (x >= mViewport.left && x < mViewport.left + mViewport.width)
-        if (y >= mViewport.bottom && y < mViewport.bottom + mViewport.height)
-            return true;
-
-    return false;
-}
-
-void FilamentApp::CView::setCameraManipulator(CameraManipulator* cm) {
-    mCameraManipulator = cm;
-}
-
-void FilamentApp::CView::setCamera(Camera* camera) {
-    view->setCamera(camera);
-}
-
-void FilamentApp::GodView::setGodCamera(Camera* camera) {
-    getView()->setDebugCamera(camera);
+const utils::Path& FilamentApp::getRootAssetsPath() {
+    return FilamentApp2::getRootAssetsPath();
 }

--- a/libs/filamentapp/src/FilamentApp2.cpp
+++ b/libs/filamentapp/src/FilamentApp2.cpp
@@ -1,0 +1,1059 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filamentapp/FilamentApp2.h>
+
+#include <filamentapp/Config.h>
+
+#include "PlatformHelper.h"
+
+
+#if defined(FILAMENTAPP_HAS_WEB_UI)
+#include "display_managers/HtmlDisplayManager.h"
+#endif // defined(FILAMENTAPP_HAS_WEB_UI)
+
+#include <filamentapp/DisplayManager.h>
+
+#ifdef FILAMENTAPP_HAS_SDL
+#include "display_managers/SDLDisplayManager.h"
+#endif // defined(FILAMENTAPP_HAS_SDL)
+
+#if defined(WIN32)
+#include <utils/unwindows.h>
+#endif
+
+#include <iostream>
+
+#include "FilamentAppGui.h"
+
+#include <utils/EntityManager.h>
+#include <utils/Logger.h>
+#include <utils/Panic.h>
+#include <utils/Path.h>
+
+#include <filament/Camera.h>
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+#include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
+#include <filament/Scene.h>
+#include <filament/Skybox.h>
+#include <filament/SwapChain.h>
+#include <filament/View.h>
+
+#include <backend/Platform.h>
+
+#ifndef NDEBUG
+#include <filament/DebugRegistry.h>
+#endif
+
+#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
+#include <backend/platforms/VulkanPlatform.h>
+#endif
+
+
+#include <stb_image.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#ifdef __EXCEPTIONS
+#include <exception>
+#endif
+
+#include <stdint.h>
+
+#include "generated/resources/filamentapp.h"
+
+using namespace filament;
+
+using namespace filament::math;
+using namespace utils;
+using namespace filament::app;
+
+namespace {
+
+using namespace filament::backend;
+}
+
+std::unique_ptr<FilamentApp2> FilamentApp2::Builder::build() {
+    return std::unique_ptr<FilamentApp2>(new FilamentApp2(*this));
+}
+
+FilamentApp2::FilamentApp2(const Builder& builder)
+        : mWindowWidth(builder.mWidth),
+          mWindowHeight(builder.mHeight),
+          mIblDirectory(builder.mIblDirectory),
+          mDirtPath(builder.mDirt),
+          mScale(builder.mScale),
+          mBackend(builder.mBackend),
+          mFeatureLevel(builder.mFeatureLevel),
+          mCameraMode(builder.mCameraMode),
+          mResizeable(builder.mResizeable),
+          mHeadless(builder.mHeadless),
+          mStereoscopicEyeCount(builder.mStereoscopicEyeCount),
+          mSamples(builder.mSamples),
+          mVulkanGPUHint(builder.mVulkanGPUHint),
+          mForcedWebGPUBackend(builder.mForcedWebGPUBackend),
+          mDisplayManagerConfig(builder.mDisplayManagerConfig),
+          mAsynchronousMode(builder.mAsynchronousMode),
+          mDisplayManager(builder.mDisplayManager),
+          mSetupCallback(builder.mSetup),
+          mCleanupCallback(builder.mCleanup),
+          mPreRender(builder.mPreRender),
+          mPostRender(builder.mPostRender),
+          mImguiCallback(builder.mImgui),
+          mAnimation(builder.mAnimation),
+          mResize(builder.mResize),
+          mDropHandler(builder.mDropHandler) {}
+
+FilamentApp2::~FilamentApp2() {
+    if (mDisplayManager) {
+        mDisplayManager->terminate();
+        delete mDisplayManager;
+    }
+}
+
+void FilamentApp2::onSurfaceCreated(void* nativeWindow) {
+    // To be implemented in later PRs
+}
+
+void FilamentApp2::onSurfaceChanged(int width, int height) {
+    // To be implemented in later PRs
+}
+
+void FilamentApp2::onSurfaceDestroyed() {
+    // To be implemented in later PRs
+}
+
+void FilamentApp2::onTouchEvent(int action, float x, float y) {
+    // To be implemented in later PRs
+}
+
+View* FilamentApp2::getGuiView() const noexcept { return mAppGui ? mAppGui->getView() : nullptr; }
+
+void FilamentApp2::run() {
+
+
+    // Note that we need to determine the backend in order to build custom platforms.
+    Engine::Backend backend = filament::app::resolveBackend(mBackend);
+
+    backend::Platform* platform = nullptr;
+    if (backend == Engine::Backend::VULKAN) {
+        platform = mVulkanPlatform = filament::app::createVulkanPlatform(mVulkanGPUHint.c_str());
+    } else if (backend == Engine::Backend::WEBGPU) {
+        platform = mWebGPUPlatform = filament::app::createWebGPUPlatform(mForcedWebGPUBackend);
+    }
+
+    Engine::Config engineConfig = {
+#if defined(FILAMENT_SAMPLES_STEREO_TYPE_INSTANCED)
+        .stereoscopicType = Engine::StereoscopicType::INSTANCED,
+#elif defined(FILAMENT_SAMPLES_STEREO_TYPE_MULTIVIEW)
+        .stereoscopicType = Engine::StereoscopicType::MULTIVIEW,
+#else
+        .stereoscopicType = Engine::StereoscopicType::NONE,
+#endif
+        .stereoscopicEyeCount = (uint8_t) mStereoscopicEyeCount,
+        .asynchronousMode = mAsynchronousMode,
+    };
+
+    // "backend.enable_asynchronous_operation" is forcibly enabled here, inheriting the setting
+    // from the Engine, purely to demonstrate the object's asynchronous behavior within
+    // Filament. Users should manage this flag at their discretion.
+    mEngine = Engine::Builder()
+                      .backend(backend)
+                      .featureLevel(mFeatureLevel)
+                      .feature("backend.enable_asynchronous_operation",
+                              engineConfig.asynchronousMode != AsynchronousMode::NONE)
+                      .platform(platform)
+                      .config(&engineConfig)
+                      .build();
+
+    assert_invariant(mEngine->getBackend() == backend);
+
+    // By now we have resolved to a specific backend (instead of default).
+    mBackend = backend;
+
+    if (!mDisplayManager) {
+        if (mDisplayManagerConfig == DisplayManager::WEB) {
+#if defined(FILAMENTAPP_HAS_WEB_UI)
+            mDisplayManager = new HtmlDisplayManager();
+#endif // defined(FILAMENTAPP_HAS_WEB_UI)
+        } else {
+#ifdef FILAMENTAPP_HAS_SDL
+            mDisplayManager = new SDLDisplayManager();
+#else  // !defined(FILAMENTAPP_HAS_SDL)
+            FILAMENT_CHECK_POSTCONDITION(false)
+                    << "SDLDisplayManager is not available on this platform";
+#endif // defined(FILAMENTAPP_HAS_SDL)
+        }
+    }
+
+
+    Config dummyConfig;
+    dummyConfig.title = mWindowTitle;
+    dummyConfig.width = mWindowWidth;
+    dummyConfig.height = mWindowHeight;
+    dummyConfig.iblDirectory = mIblDirectory;
+    dummyConfig.dirt = mDirtPath;
+    dummyConfig.scale = mScale;
+    dummyConfig.splitView = mIsSplitView;
+    dummyConfig.backend = mBackend;
+    dummyConfig.featureLevel = mFeatureLevel;
+    dummyConfig.cameraMode = mCameraMode;
+    dummyConfig.resizeable = mResizeable;
+    dummyConfig.headless = mHeadless;
+    dummyConfig.stereoscopicEyeCount = mStereoscopicEyeCount;
+    dummyConfig.samples = mSamples;
+    dummyConfig.vulkanGPUHint = mVulkanGPUHint;
+    dummyConfig.forcedWebGPUBackend = mForcedWebGPUBackend;
+    dummyConfig.displayManager = static_cast<Config::DisplayManager>(mDisplayManagerConfig);
+    dummyConfig.asynchronousMode = mAsynchronousMode;
+
+    if (!mDisplayManager->init(dummyConfig)) {
+        LOG(ERROR) << "Failed to initialize display manager" << utils::io::endl;
+        return;
+    }
+
+
+    mWindow.reset(new FilamentApp2::Window(this, mWindowTitle, mCameraParams, mWindowWidth,
+            mWindowHeight));
+    Window* window = mWindow.get();
+
+    mDepthMaterial =
+            Material::Builder()
+                    .package(FILAMENTAPP_DEPTHVISUALIZER_DATA, FILAMENTAPP_DEPTHVISUALIZER_SIZE)
+                    .build(*mEngine);
+
+    mDepthMI = mDepthMaterial->createInstance();
+
+    mDefaultMaterial =
+            Material::Builder()
+                    .package(FILAMENTAPP_AIDEFAULTMAT_DATA, FILAMENTAPP_AIDEFAULTMAT_SIZE)
+                    .build(*mEngine);
+
+    mTransparentMaterial =
+            Material::Builder()
+                    .package(FILAMENTAPP_TRANSPARENTCOLOR_DATA, FILAMENTAPP_TRANSPARENTCOLOR_SIZE)
+                    .build(*mEngine);
+
+    mCameraCube.reset(new Cube(*mEngine, mTransparentMaterial, { 1, 0, 0 }));
+    mCameraGrid.reset(new Grid(*mEngine, mTransparentMaterial, { 1, 1, 0 }));
+
+    // we can't cull the light-frustum because it's not applied a rigid transform
+    // and currently, filament assumes that for culling
+    mLightmapCubes.reserve(4);
+    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 0, 1, 0 }, false);
+    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 0, 0, 1 }, false);
+    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 1, 1, 0 }, false);
+    mLightmapCubes.emplace_back(*mEngine, mTransparentMaterial, float3{ 1, 0, 0 }, false);
+
+    mScene = mEngine->createScene();
+
+    window->mMainView->getView()->setVisibleLayers(0x4, 0x4);
+    window->mMainView->getView()->setFroxelVizEnabled(true);
+
+    if (mIsSplitView) {
+        mScene->addEntity(mCameraCube->getSolidRenderable());
+        mScene->addEntity(mCameraCube->getWireFrameRenderable());
+        for (auto&& cube: mLightmapCubes) {
+            mScene->addEntity(cube.getSolidRenderable());
+            mScene->addEntity(cube.getWireFrameRenderable());
+        }
+
+        window->mDepthView->getView()->setVisibleLayers(0x4, 0x4);
+        window->mGodView->getView()->setVisibleLayers(0x6, 0x6);
+        window->mOrthoView->getView()->setVisibleLayers(0x6, 0x6);
+
+        // only preserve the color buffer for additional views; depth and stencil can be discarded.
+        window->mDepthView->getView()->setShadowingEnabled(false);
+        window->mGodView->getView()->setShadowingEnabled(false);
+        window->mOrthoView->getView()->setShadowingEnabled(false);
+    }
+
+    // froxel debug grid always added (but hidden)
+    mScene->addEntity(mCameraGrid->getWireFrameRenderable());
+
+    loadDirt();
+    loadIBL();
+
+    for (auto& view: window->mViews) {
+        if (view.get() != window->mUiView) {
+            view->getView()->setScene(mScene);
+        }
+    }
+
+    if (mSetupCallback) {
+        mSetupCallback(mEngine, window->mMainView->getView(), mScene);
+    }
+
+    if (mImguiCallback) {
+        mAppGui = std::make_unique<FilamentAppGui>(mEngine, window->mUiView->getView(),
+                getRootAssetsPath() + "assets/fonts/Roboto-Medium.ttf");
+    }
+
+    mDisplayManager->startRendering([this] { return doFrame(); });
+}
+
+
+bool FilamentApp2::doFrame() {
+#ifdef __EXCEPTIONS
+    try {
+#endif
+        Window* window = mWindow.get();
+        if (!window) {
+            return true;
+        }
+
+        if (!UTILS_HAS_THREADING) {
+            mEngine->execute();
+        }
+
+        // Allow the app to animate the scene if desired.
+        if (mAnimation) {
+            mAnimation(mEngine, window->mMainView->getView(), mDisplayManager->getTime());
+        }
+
+        // Loop over fresh events twice: first stash them and let ImGui process them, then allow
+        // the app to process the stashed events. This is done because ImGui might wish to block
+        // certain events from the app (e.g., when dragging the mouse over an obscuring window).
+        std::vector<filament::app::AppEvent> events;
+        mDisplayManager->pollEvents(events);
+
+        if (mAppGui) {
+            mAppGui->processAppEvents(events);
+        }
+
+        // Now, loop over the events a second time for app-side processing.
+        for (const auto& event: events) {
+            if (mClosed) {
+                break;
+            }
+            bool wantCaptureMouse = mAppGui ? mAppGui->wantCaptureMouse() : false;
+            switch (event.type) {
+                case AppEvent::Type::QUIT:
+                    mClosed = true;
+                    break;
+                case AppEvent::Type::KEYDOWN:
+                    if (event.key.code == AppKey::ESCAPE) {
+                        mClosed = true;
+                    }
+#if !defined(NDEBUG) && !defined(__ANDROID__)
+                    if (event.key.code == AppKey::PRINT_SCREEN) {
+                        DebugRegistry& debug = mEngine->getDebugRegistry();
+                        if (bool* captureFrame = debug.getPropertyAddress<bool>(
+                                    "d.renderer.doFrameCapture")) {
+                            *captureFrame = true;
+                        }
+                    }
+#endif
+                    window->keyDown(event.key.code);
+                    break;
+                case AppEvent::Type::KEYUP:
+                    window->keyUp(event.key.code);
+                    break;
+                case AppEvent::Type::MOUSE_WHEEL:
+                    if (!wantCaptureMouse) window->mouseWheel(event.mouseWheel.delta);
+                    break;
+                case AppEvent::Type::MOUSE_BUTTON_DOWN:
+                    if (!wantCaptureMouse)
+                        window->mouseDown(event.mouseButton.button, event.mouseButton.x,
+                                event.mouseButton.y);
+                    break;
+                case AppEvent::Type::MOUSE_BUTTON_UP:
+                    if (!wantCaptureMouse)
+                        window->mouseUp(event.mouseButton.x, event.mouseButton.y);
+                    break;
+                case AppEvent::Type::MOUSE_MOVE:
+                    if (!wantCaptureMouse) window->mouseMoved(event.mouseMove.x, event.mouseMove.y);
+                    break;
+                case AppEvent::Type::DROP_FILE:
+                    if (mDropHandler) {
+                        mDropHandler(event.dropFile.path);
+                    }
+                    break;
+                case AppEvent::Type::RESIZED:
+                    window->resize(mCameraParams);
+                    // Call the resize callback, if this FilamentApp2 has one. This must be done
+                    // after configureCamerasForWindow, so the viewports are correct.
+                    if (mResize) {
+                        mResize(mEngine, window->mMainView->getView());
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Note that shutdown() does not destroy the DisplayManager, but the destructor does. The
+        // return here will go back to the caller, which is a DisplayManager.
+        if (mClosed) {
+            shutdown();
+            return true;
+        }
+
+        // Calculate the time step.
+        static double lastTime = 0;
+        double now = mDisplayManager->getTime();
+        const float timeStep = lastTime > 0 ? (float) (now - lastTime) : (float) (1.0f / 60.0f);
+        lastTime = now;
+
+        // Populate the UI scene, regardless of whether Filament wants to a skip frame. We should
+        // always let ImGui generate a command list; if it skips a frame it'll destroy its widgets.
+        if (mAppGui) {
+            mAppGui->render(timeStep, mDisplayManager, window->mWindow, mImguiCallback,
+                    mMousePressed);
+        }
+
+        // Update the camera manipulators for each view.
+        for (auto const& view: window->mViews) {
+            auto* cm = view->getCameraManipulator();
+            if (cm) {
+                cm->update(timeStep);
+            }
+        }
+
+        // Update the position and orientation of the two cameras.
+        filament::math::float3 eye, center, up;
+        window->mMainCameraMan->getLookAt(&eye, &center, &up);
+        window->mMainCamera->lookAt(eye, center, up);
+
+        window->mDebugCameraMan->getLookAt(&eye, &center, &up);
+        window->mDebugCamera->lookAt(eye, center, up);
+        window->mDebugCamera->setExposure(window->mMainCamera->getAperture(),
+                window->mMainCamera->getShutterSpeed(), window->mMainCamera->getSensitivity());
+
+        window->mOrthoCamera->setExposure(window->mMainCamera->getAperture(),
+                window->mMainCamera->getShutterSpeed(), window->mMainCamera->getSensitivity());
+
+        auto const fci = window->mMainView->getView()->getFroxelConfigurationInfo();
+        if (UTILS_UNLIKELY(fci.age != mFroxelInfoAge)) {
+            mFroxelInfoAge = fci.age;
+            auto width = fci.info.width;
+            auto height = fci.info.height;
+            auto depth = fci.info.depth;
+            auto froxelDimension = fci.info.froxelDimension;
+            auto viewportWidth = fci.info.viewportWidth;
+            auto viewportHeight = fci.info.viewportHeight;
+            auto zLightFar = fci.info.zLightFar;
+            auto linearizer = fci.info.linearizer;
+            auto p = fci.info.p;
+            auto ct = fci.info.clipTransform;
+            mCameraGrid->update(
+                    width, height, depth,
+                    [=](int const i) {
+                        float x = float(2 * i * froxelDimension.x) / float(viewportWidth) - 1.0f;
+                        x = (x - ct.z) / ct.x;
+                        return x;
+                    },
+                    [=](int const j) {
+                        float y = float(2 * j * froxelDimension.y) / float(viewportHeight) - 1.0f;
+                        y = (y - ct.w) / ct.y;
+                        return y;
+                    },
+                    [=](int const k) {
+                        float const z_view = -zLightFar * std::exp2(float(k - depth) * linearizer);
+                        auto c = p * float4{ 0, 0, z_view, 1 };
+                        float const z_clip_dx = k == 0 ? 1.0f : c.z / c.w;
+                        float const z_clip_gl = (1 - z_clip_dx) * 2.0f - 1.0f;
+                        return z_clip_gl;
+                    });
+        }
+
+        auto& rcm = mEngine->getRenderableManager();
+        if (mIsSplitView) {
+            rcm.setLayerMask(rcm.getInstance(mCameraCube->getSolidRenderable()), 0x3,
+                    mCameraFrustumEnabled);
+            rcm.setLayerMask(rcm.getInstance(mCameraCube->getWireFrameRenderable()), 0x3,
+                    mCameraFrustumEnabled);
+        }
+        rcm.setLayerMask(rcm.getInstance(mCameraGrid->getWireFrameRenderable()), 0x3,
+                mFroxelGridEnabled);
+
+        // Update the cube distortion matrix used for frustum visualization.
+        auto const csm = window->mMainView->getView()->getDirectionalShadowCameras();
+        // show/hide the cascades
+        for (size_t i = 0; i < 4; i++) {
+            rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getSolidRenderable()), 0x3, 0x0);
+            rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getWireFrameRenderable()), 0x3, 0x0);
+        }
+        if (!csm.empty()) {
+            for (size_t i = 0, c = csm.size(); i < c; i++) {
+                if (csm[i]) {
+                    mLightmapCubes[i].mapFrustum(*mEngine, csm[i]);
+                }
+                uint8_t const layer = csm[i] ? mDirectionalShadowFrustumEnabled : 0x0;
+                rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getSolidRenderable()), 0x3,
+                        layer);
+                rcm.setLayerMask(rcm.getInstance(mLightmapCubes[i].getWireFrameRenderable()), 0x3,
+                        layer);
+            }
+        }
+
+        mCameraCube->mapFrustum(*mEngine, window->mMainCamera);
+        mCameraGrid->mapFrustum(*mEngine, window->mMainCamera);
+        Renderer* renderer = window->getRenderer();
+
+        if (mPreRender) {
+            mPreRender(mEngine, window->mViews[0]->getView(), mScene, renderer);
+        }
+
+        if (mReconfigureCameras) {
+            window->configureCamerasForWindow(mCameraParams);
+            mReconfigureCameras = false;
+        }
+
+        if (mIsSplitView) {
+            if (!window->mOrthoView->getView()->hasCamera()) {
+                auto const csm = window->mMainView->getView()->getDirectionalShadowCameras();
+                if (!csm.empty()) {
+                    // here we could choose the cascade
+                    Camera const* debugDirectionalShadowCamera = csm[0];
+                    if (debugDirectionalShadowCamera) {
+                        window->mOrthoView->setCamera(
+                                const_cast<Camera*>(debugDirectionalShadowCamera));
+                    }
+                }
+            }
+        }
+
+        if (renderer->beginFrame(window->getSwapChain())) {
+            for (filament::View* offscreenView: mOffscreenViews) {
+                renderer->render(offscreenView);
+            }
+            for (auto const& view: window->mViews) {
+                renderer->render(view->getView());
+            }
+
+            mDisplayManager->onFrameFinished(window->mWindow, mEngine, renderer);
+
+            if (mPostRender) {
+                mPostRender(mEngine, window->mViews[0]->getView(), mScene, renderer);
+            }
+            renderer->endFrame();
+        } else {
+            ++mSkippedFrames;
+        }
+
+#ifdef __EXCEPTIONS
+    } catch (Panic const& e) {
+        LOG(ERROR) << "Filament exception (terminate cleanly): " << e.what();
+        LOG(ERROR) << e.getCallStack();
+    } catch (std::exception const& e) {
+        LOG(ERROR) << "System exception (terminate cleanly): " << e.what();
+    } catch (...) {
+        LOG(ERROR) << "Unknown exception! (terminate cleanly)";
+    }
+#endif
+    return false;
+}
+
+void FilamentApp2::shutdown() {
+    if (mAppGui) {
+        mAppGui.reset();
+    }
+
+    mCleanupCallback(mEngine, mWindow->mMainView->getView(), mScene);
+
+    mCameraCube.reset();
+    mCameraGrid.reset();
+    mLightmapCubes.clear();
+    mWindow.reset();
+    mPrimarySwapChain = nullptr;
+
+    mIBL.reset();
+    mEngine->destroy(mDepthMI);
+    mEngine->destroy(mDepthMaterial);
+    mEngine->destroy(mDefaultMaterial);
+    mEngine->destroy(mTransparentMaterial);
+    mEngine->destroy(mScene);
+    Engine::destroy(&mEngine);
+    mEngine = nullptr;
+
+    if (mVulkanPlatform) {
+        filament::app::destroyVulkanPlatform(mVulkanPlatform);
+        mVulkanPlatform = nullptr;
+    }
+    if (mWebGPUPlatform) {
+        filament::app::destroyWebGPUPlatform(mWebGPUPlatform);
+        mWebGPUPlatform = nullptr;
+    }
+}
+
+// RELATIVE_ASSET_PATH is set inside samples/CMakeLists.txt and used to support multi-configuration
+// generators, like Visual Studio or Xcode.
+#ifndef RELATIVE_ASSET_PATH
+#define RELATIVE_ASSET_PATH "."
+#endif
+
+const utils::Path& FilamentApp2::getRootAssetsPath() {
+    static const utils::Path root =
+            utils::Path::getCurrentExecutable().getParent() + RELATIVE_ASSET_PATH;
+    return root;
+}
+
+void FilamentApp2::loadIBL(std::string_view path) {
+    Path iblPath(path);
+    if (!iblPath.exists()) {
+        std::cerr << "The specified IBL path does not exist: " << iblPath << std::endl;
+        return;
+    }
+
+    // Note that IBL holds a skybox, and Scene also holds a reference.  We cannot release IBL's
+    // skybox until after new skybox has been set in the scene.
+    std::unique_ptr<IBL> oldIBL = std::move(mIBL);
+    mIBL = std::make_unique<IBL>(*mEngine);
+
+    if (!iblPath.isDirectory()) {
+        if (!mIBL->loadFromEquirect(iblPath)) {
+            std::cerr << "Could not load the specified IBL: " << iblPath << std::endl;
+            mIBL.reset(nullptr);
+            return;
+        }
+    } else {
+        if (!mIBL->loadFromDirectory(iblPath)) {
+            std::cerr << "Could not load the specified IBL: " << iblPath << std::endl;
+            mIBL.reset(nullptr);
+            return;
+        }
+    }
+
+    if (mIBL != nullptr) {
+        mIBL->getSkybox()->setLayerMask(0x7, 0x4);
+        mScene->setSkybox(mIBL->getSkybox());
+        mScene->setIndirectLight(mIBL->getIndirectLight());
+    }
+}
+
+void FilamentApp2::loadIBL() {
+    if (mIblDirectory.empty()) {
+        return;
+    }
+    loadIBL(mIblDirectory);
+}
+
+void FilamentApp2::loadDirt() {
+    if (!mDirtPath.empty()) {
+        Path dirtPath(mDirtPath);
+
+        if (!dirtPath.exists()) {
+            std::cerr << "The specified dirt file does not exist: " << dirtPath << std::endl;
+            return;
+        }
+
+        if (!dirtPath.isFile()) {
+            std::cerr << "The specified dirt path is not a file: " << dirtPath << std::endl;
+            return;
+        }
+
+        int w, h, n;
+
+        unsigned char* data = stbi_load(dirtPath.getAbsolutePath().c_str(), &w, &h, &n, 3);
+        assert(n == 3);
+
+        mDirt = Texture::Builder()
+                        .width(w)
+                        .height(h)
+                        .format(Texture::InternalFormat::RGB8)
+                        .build(*mEngine);
+
+        mDirt->setImage(*mEngine, 0,
+                { data, size_t(w * h * 3), Texture::Format::RGB, Texture::Type::UBYTE,
+                    (Texture::PixelBufferDescriptor::Callback) &stbi_image_free });
+    }
+}
+
+void FilamentApp2::setCameraFrustumEnabled(bool enabled) noexcept {
+    mCameraFrustumEnabled = enabled ? 0x2 : 0x0;
+}
+
+void FilamentApp2::setDirectionalShadowFrustumEnabled(bool enabled) noexcept {
+    mDirectionalShadowFrustumEnabled = enabled ? 0x2 : 0x0;
+}
+
+void FilamentApp2::setFroxelGridEnabled(bool enabled) noexcept {
+    mFroxelGridEnabled = enabled ? 0x3 : 0x0;
+}
+
+bool FilamentApp2::isCameraFrustumEnabled() const noexcept { return !!mCameraFrustumEnabled; }
+
+bool FilamentApp2::isDirectionalShadowFrustumEnabled() const noexcept {
+    return !!mDirectionalShadowFrustumEnabled;
+}
+
+bool FilamentApp2::isFroxelGridEnabled() const noexcept { return !!mFroxelGridEnabled; }
+
+// ------------------------------------------------------------------------------------------------
+
+FilamentApp2::Window::Window(FilamentApp2* filamentApp, std::string title,
+        WindowCameraParams const& cameraParams, size_t w, size_t h)
+        : mDisplayManager(filamentApp->mDisplayManager),
+          mEngine(filamentApp->mEngine),
+          mApp(filamentApp) {
+    mWindow = mDisplayManager->createWindow(title.c_str(), w, h, filamentApp->mResizeable,
+            filamentApp->mHeadless);
+
+    void* nativeWindow = mDisplayManager->getNativeWindow(mWindow);
+    auto engine = mEngine;
+
+    mWidth = w;
+    mHeight = h;
+
+    // Write back the active feature level.
+    filamentApp->mFeatureLevel = engine->getActiveFeatureLevel();
+
+
+    if (filamentApp->mHeadless) {
+        mSwapChain = engine->createSwapChain((uint32_t) w, (uint32_t) h);
+    } else {
+        mSwapChain = engine->createSwapChain(nativeWindow,
+                filament::SwapChain::CONFIG_HAS_STENCIL_BUFFER);
+    }
+    filamentApp->mPrimarySwapChain = mSwapChain;
+
+    mRenderer = engine->createRenderer();
+
+    // create cameras
+    utils::EntityManager& em = utils::EntityManager::get();
+    em.create(3, mCameraEntities);
+    mCameras[0] = mMainCamera = engine->createCamera(mCameraEntities[0]);
+    mCameras[1] = mDebugCamera = engine->createCamera(mCameraEntities[1]);
+    mCameras[2] = mOrthoCamera = engine->createCamera(mCameraEntities[2]);
+
+    // set exposure
+    for (auto camera: mCameras) {
+        camera->setExposure(16.0f, 1 / 125.0f, 100.0f);
+    }
+
+    // create views
+    mViews.emplace_back(mMainView = new CView(*mRenderer, "Main View"));
+    if (filamentApp->mIsSplitView) {
+        mViews.emplace_back(mDepthView = new CView(*mRenderer, "Depth View"));
+        mViews.emplace_back(mGodView = new GodView(*mRenderer, "God View"));
+        mViews.emplace_back(mOrthoView = new CView(*mRenderer, "Shadow View"));
+    }
+    mViews.emplace_back(mUiView = new CView(*mRenderer, "UI View"));
+
+    // set-up the camera manipulators
+    mMainCameraMan =
+            CameraManipulator::Builder().targetPosition(0, 0, -4).flightMoveDamping(15.0).build(
+                    filamentApp->mCameraMode);
+    mDebugCameraMan =
+            CameraManipulator::Builder().targetPosition(0, 0, -4).flightMoveDamping(15.0).build(
+                    filamentApp->mCameraMode);
+
+    mMainView->setCamera(mMainCamera);
+    mMainView->setCameraManipulator(mMainCameraMan);
+    if (filamentApp->mIsSplitView) {
+        // Depth view always uses the main camera
+        mDepthView->setCamera(mMainCamera);
+        mDepthView->setCameraManipulator(mMainCameraMan);
+
+        // The god view uses the main camera for culling, but the debug camera for viewing
+        mGodView->setCamera(mMainCamera);
+        mGodView->setGodCamera(mDebugCamera);
+        mGodView->setCameraManipulator(mDebugCameraMan);
+    }
+
+    // configure the cameras
+    configureCamerasForWindow(cameraParams);
+
+    mMainCamera->lookAt({ 4, 0, -4 }, { 0, 0, -4 }, { 0, 1, 0 });
+}
+
+FilamentApp2::Window::~Window() {
+    mViews.clear();
+    utils::EntityManager& em = utils::EntityManager::get();
+    for (auto e: mCameraEntities) {
+        mEngine->destroyCameraComponent(e);
+        em.destroy(e);
+    }
+    mEngine->destroy(mRenderer);
+    mEngine->destroy(mSwapChain);
+    mDisplayManager->destroyWindow(mWindow);
+    delete mMainCameraMan;
+    delete mDebugCameraMan;
+}
+
+void FilamentApp2::Window::mouseDown(int button, ssize_t x, ssize_t y) {
+    fixupMouseCoordinatesForHdpi(x, y);
+    y = mHeight - y;
+    for (auto const& view: mViews) {
+        if (view->intersects(x, y)) {
+            mMouseEventTarget = view.get();
+            view->mouseDown(button, x, y);
+            break;
+        }
+    }
+}
+
+void FilamentApp2::Window::mouseWheel(ssize_t x) {
+    if (mMouseEventTarget) {
+        mMouseEventTarget->mouseWheel(x);
+    } else {
+        for (auto const& view: mViews) {
+            if (view->intersects(mLastX, mLastY)) {
+                view->mouseWheel(x);
+                break;
+            }
+        }
+    }
+}
+
+void FilamentApp2::Window::mouseUp(ssize_t x, ssize_t y) {
+    fixupMouseCoordinatesForHdpi(x, y);
+    if (mMouseEventTarget) {
+        y = mHeight - y;
+        mMouseEventTarget->mouseUp(x, y);
+        mMouseEventTarget = nullptr;
+    }
+}
+
+void FilamentApp2::Window::mouseMoved(ssize_t x, ssize_t y) {
+    fixupMouseCoordinatesForHdpi(x, y);
+    y = mHeight - y;
+    if (mMouseEventTarget) {
+        mMouseEventTarget->mouseMoved(x, y);
+    }
+    mLastX = x;
+    mLastY = y;
+}
+
+void FilamentApp2::Window::keyDown(AppKey key) {
+    auto& eventTarget = mKeyEventTarget[key];
+
+    // keyDown events can be sent multiple times per key (for key repeat)
+    // If this key is already down, do nothing.
+    if (eventTarget) {
+        return;
+    }
+
+    // Decide which view will get this key's corresponding keyUp event.
+    // If we're currently in a mouse grap session, it should be the mouse grab's target view.
+    // Otherwise, it should be whichever view we're currently hovering over.
+    CView* targetView = nullptr;
+    if (mMouseEventTarget) {
+        targetView = mMouseEventTarget;
+    } else {
+        for (auto const& view: mViews) {
+            if (view->intersects(mLastX, mLastY)) {
+                targetView = view.get();
+                break;
+            }
+        }
+    }
+
+    if (targetView) {
+        targetView->keyDown(key);
+        eventTarget = targetView;
+    }
+}
+
+void FilamentApp2::Window::keyUp(AppKey key) {
+    auto& eventTarget = mKeyEventTarget[key];
+    if (!eventTarget) {
+        return;
+    }
+    eventTarget->keyUp(key);
+    eventTarget = nullptr;
+}
+
+void FilamentApp2::Window::fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const {
+    uint32_t dw, dh, ww, wh;
+    mDisplayManager->getDrawableSize(mWindow, &dw, &dh);
+    mDisplayManager->getWindowSize(mWindow, &ww, &wh);
+    x = x * (ssize_t) dw / (ssize_t) ww;
+    y = y * (ssize_t) dh / (ssize_t) wh;
+}
+
+void FilamentApp2::Window::resize(WindowCameraParams const& cameraParams) {
+    mDisplayManager->onWindowResized(mWindow);
+    configureCamerasForWindow(cameraParams);
+}
+
+void FilamentApp2::Window::configureCamerasForWindow(WindowCameraParams const& cameraParams) {
+    float dpiScaleX = 1.0f;
+    float dpiScaleY = 1.0f;
+
+    // If the app is not headless, query the window for its physical & virtual sizes.
+    if (!mApp->mHeadless) {
+        uint32_t width, height;
+        mDisplayManager->getDrawableSize(mWindow, &width, &height);
+        mWidth = (size_t) width;
+        mHeight = (size_t) height;
+
+        uint32_t virtualWidth, virtualHeight;
+        mDisplayManager->getWindowSize(mWindow, &virtualWidth, &virtualHeight);
+        dpiScaleX = (float) width / virtualWidth;
+        dpiScaleY = (float) height / virtualHeight;
+    } else {
+        uint32_t width, height;
+        mDisplayManager->getWindowSize(mWindow, &width, &height);
+        if (width != mWidth || height != mHeight) {
+            mWidth = width;
+            mHeight = height;
+            if (mSwapChain) {
+                mEngine->destroy(mSwapChain);
+            }
+            mSwapChain = mEngine->createSwapChain((uint32_t) width, (uint32_t) height);
+        }
+    }
+
+    const uint32_t width = mWidth;
+    const uint32_t height = mHeight;
+
+    const float3 at(0, 0, -4);
+    const double ratio = double(height) / double(width);
+    const int sidebar = cameraParams.sidebarWidth * dpiScaleX;
+
+    const bool splitview = mViews.size() > 2;
+
+    const uint32_t mainWidth = std::max(2, (int) width - sidebar);
+
+    double near = cameraParams.near;
+    double far = cameraParams.far;
+    auto aspectRatio = double(mainWidth) / height;
+    if (mMainView->getView()->getStereoscopicOptions().enabled) {
+        const int ec = mApp->mStereoscopicEyeCount;
+        aspectRatio = double(mainWidth) / ec / height;
+
+        mat4 projections[4];
+        projections[0] = Camera::projection(cameraParams.focalLength, aspectRatio, near, far);
+        projections[1] = projections[0];
+        // simulate foveated rendering
+        projections[2] = Camera::projection(cameraParams.focalLength * 2.0, aspectRatio, near, far);
+        projections[3] = projections[2];
+        mMainCamera->setCustomEyeProjection(projections, 4, projections[0], near, far);
+    } else {
+        mMainCamera->setLensProjection(cameraParams.focalLength, aspectRatio, near, far);
+    }
+    mDebugCamera->setProjection(45.0, aspectRatio, 0.0625, 4096, Camera::Fov::VERTICAL);
+
+    // We're in split view when there are more views than just the Main and UI views.
+    if (splitview) {
+        uint32_t const vpw = mainWidth / 2;
+        uint32_t const vph = height / 2;
+        mMainView->setViewport({ sidebar + 0, 0, vpw, vph });
+        mDepthView->setViewport({ sidebar + int32_t(vpw), 0, vpw, vph });
+        mGodView->setViewport({ sidebar + int32_t(vpw), int32_t(vph), vpw, vph });
+        mOrthoView->setViewport({ sidebar + 0, int32_t(vph), vpw, vph });
+    } else {
+        mMainView->setViewport({ sidebar, 0, mainWidth, height });
+    }
+    mUiView->setViewport({ 0, 0, width, height });
+}
+
+// ------------------------------------------------------------------------------------------------
+
+FilamentApp2::CView::CView(Renderer& renderer, std::string name)
+        : engine(*renderer.getEngine()),
+          mName(name) {
+    view = engine.createView();
+    view->setName(name.c_str());
+}
+
+FilamentApp2::CView::~CView() { engine.destroy(view); }
+
+void FilamentApp2::CView::setViewport(filament::Viewport const& viewport) {
+    mViewport = viewport;
+    view->setViewport(viewport);
+    if (mCameraManipulator) {
+        mCameraManipulator->setViewport(viewport.width, viewport.height);
+    }
+}
+
+void FilamentApp2::CView::mouseDown(int button, ssize_t x, ssize_t y) {
+    if (mCameraManipulator) {
+        mCameraManipulator->grabBegin(x, y, button == 3);
+    }
+}
+
+void FilamentApp2::CView::mouseUp(ssize_t x, ssize_t y) {
+    if (mCameraManipulator) {
+        mCameraManipulator->grabEnd();
+    }
+}
+
+void FilamentApp2::CView::mouseMoved(ssize_t x, ssize_t y) {
+    if (mCameraManipulator) {
+        mCameraManipulator->grabUpdate(x, y);
+    }
+}
+
+void FilamentApp2::CView::mouseWheel(ssize_t x) {
+    if (mCameraManipulator) {
+        mCameraManipulator->scroll(0, 0, x);
+    }
+}
+
+bool FilamentApp2::manipulatorKeyFromKeycode(AppKey scancode, CameraManipulator::Key& key) {
+    switch (scancode) {
+        case AppKey::W:
+            key = CameraManipulator::Key::FORWARD;
+            return true;
+        case AppKey::A:
+            key = CameraManipulator::Key::LEFT;
+            return true;
+        case AppKey::S:
+            key = CameraManipulator::Key::BACKWARD;
+            return true;
+        case AppKey::D:
+            key = CameraManipulator::Key::RIGHT;
+            return true;
+        case AppKey::E:
+            key = CameraManipulator::Key::UP;
+            return true;
+        case AppKey::Q:
+            key = CameraManipulator::Key::DOWN;
+            return true;
+        default:
+            return false;
+    }
+}
+
+void FilamentApp2::CView::keyUp(AppKey scancode) {
+    if (mCameraManipulator) {
+        CameraManipulator::Key key;
+        if (manipulatorKeyFromKeycode(scancode, key)) {
+            mCameraManipulator->keyUp(key);
+        }
+    }
+}
+
+void FilamentApp2::CView::keyDown(AppKey scancode) {
+    if (mCameraManipulator) {
+        CameraManipulator::Key key;
+        if (manipulatorKeyFromKeycode(scancode, key)) {
+            mCameraManipulator->keyDown(key);
+        }
+    }
+}
+
+bool FilamentApp2::CView::intersects(ssize_t x, ssize_t y) {
+    if (x >= mViewport.left && x < mViewport.left + mViewport.width)
+        if (y >= mViewport.bottom && y < mViewport.bottom + mViewport.height) return true;
+
+    return false;
+}
+
+void FilamentApp2::CView::setCameraManipulator(CameraManipulator* cm) { mCameraManipulator = cm; }
+
+void FilamentApp2::CView::setCamera(Camera* camera) { view->setCamera(camera); }
+
+void FilamentApp2::GodView::setGodCamera(Camera* camera) { getView()->setDebugCamera(camera); }

--- a/libs/filamentapp/src/FilamentAppGui.cpp
+++ b/libs/filamentapp/src/FilamentAppGui.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "FilamentAppGui.h"
-#include "DisplayManager.h"
+#include <filamentapp/DisplayManager.h>
 #if defined(FILAMENTAPP_HAS_IMGUI)
 #include <filagui/ImGuiHelper.h>
 #include <imgui.h>
@@ -336,7 +336,7 @@ bool FilamentAppGui::wantCaptureMouse() const {
 }
 
 void FilamentAppGui::render(float timeStep, filament::app::DisplayManager* displayManager,
-        void* window, FilamentApp::ImGuiCallback imguiCallback, bool mousePressed[3]) {
+        void* window, FilamentApp2::ImGuiCallback imguiCallback, bool mousePressed[3]) {
 #if defined(FILAMENTAPP_HAS_IMGUI)
     if (pImpl->helper) {
         uint32_t windowWidth, windowHeight;

--- a/libs/filamentapp/src/FilamentAppGui.h
+++ b/libs/filamentapp/src/FilamentAppGui.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENTAPP_FILAMENTAPPGUI_H
 #define TNT_FILAMENTAPP_FILAMENTAPPGUI_H
 
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/View.h>
@@ -52,7 +52,7 @@ public:
     bool wantCaptureMouse() const;
 
     void render(float timeStep, filament::app::DisplayManager* displayManager, void* window,
-            FilamentApp::ImGuiCallback imguiCallback, bool mousePressed[3]);
+            FilamentApp2::ImGuiCallback imguiCallback, bool mousePressed[3]);
 
     filament::View* getView() const noexcept;
 

--- a/libs/filamentapp/src/display_managers/HtmlDisplayManager.cpp
+++ b/libs/filamentapp/src/display_managers/HtmlDisplayManager.cpp
@@ -151,32 +151,32 @@ void HtmlDisplayManager::terminate() {
     }
 }
 
-FilamentApp::Window::Handle HtmlDisplayManager::createWindow(const char* title, uint32_t w,
+FilamentApp2::Window::Handle HtmlDisplayManager::createWindow(const char* title, uint32_t w,
         uint32_t h, bool resizable, bool headless) {
     LockGuard<Mutex> lock(mMutex);
-    FilamentApp::Window::Handle handle =
-            (FilamentApp::Window::Handle)(uintptr_t) (mWindows.size() + 1);
+    FilamentApp2::Window::Handle handle =
+            (FilamentApp2::Window::Handle)(uintptr_t) (mWindows.size() + 1);
     mWindows[handle] = { utils::CString(title), w, h };
     return handle;
 }
 
-void HtmlDisplayManager::destroyWindow(FilamentApp::Window::Handle window) {
+void HtmlDisplayManager::destroyWindow(FilamentApp2::Window::Handle window) {
     LockGuard<Mutex> lock(mMutex);
     mWindows.erase(window);
 }
 
-void* HtmlDisplayManager::getNativeWindow(FilamentApp::Window::Handle window) const {
+void* HtmlDisplayManager::getNativeWindow(FilamentApp2::Window::Handle window) const {
     return nullptr; // Headless
 }
 
-void HtmlDisplayManager::setWindowTitle(FilamentApp::Window::Handle window, const char* title) {
+void HtmlDisplayManager::setWindowTitle(FilamentApp2::Window::Handle window, const char* title) {
     LockGuard<Mutex> lock(mMutex);
     if (mWindows.count(window)) {
         mWindows[window].title = utils::CString(title);
     }
 }
 
-void HtmlDisplayManager::getWindowSize(FilamentApp::Window::Handle window, uint32_t* w,
+void HtmlDisplayManager::getWindowSize(FilamentApp2::Window::Handle window, uint32_t* w,
         uint32_t* h) const {
     LockGuard<Mutex> lock(mMutex);
     if (mWindows.count(window)) {
@@ -186,7 +186,7 @@ void HtmlDisplayManager::getWindowSize(FilamentApp::Window::Handle window, uint3
     }
 }
 
-void HtmlDisplayManager::getDrawableSize(FilamentApp::Window::Handle window, uint32_t* w,
+void HtmlDisplayManager::getDrawableSize(FilamentApp2::Window::Handle window, uint32_t* w,
         uint32_t* h) const {
     getWindowSize(window, w, h);
 }
@@ -225,7 +225,7 @@ struct ReadPixelsUser {
     uint32_t height;
 };
 
-void HtmlDisplayManager::onFrameFinished(FilamentApp::Window::Handle window,
+void HtmlDisplayManager::onFrameFinished(FilamentApp2::Window::Handle window,
         filament::Engine* engine, filament::Renderer* renderer) {
     uint32_t width, height;
     getWindowSize(window, &width, &height);

--- a/libs/filamentapp/src/display_managers/HtmlDisplayManager.h
+++ b/libs/filamentapp/src/display_managers/HtmlDisplayManager.h
@@ -17,9 +17,8 @@
 #ifndef TNT_FILAMENT_FILAMENTAPP_WEB_DISPLAY_MANAGER_H
 #define TNT_FILAMENT_FILAMENTAPP_WEB_DISPLAY_MANAGER_H
 
-#include "../DisplayManager.h"
-
 #include <filamentapp/Config.h>
+#include <filamentapp/DisplayManager.h>
 
 #include <utils/CString.h>
 #include <utils/Mutex.h>
@@ -41,26 +40,26 @@ public:
     bool init(const Config& config) override;
     void terminate() override;
 
-    FilamentApp::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
+    FilamentApp2::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
             bool resizable, bool headless) override;
-    void destroyWindow(FilamentApp::Window::Handle window) override;
+    void destroyWindow(FilamentApp2::Window::Handle window) override;
 
-    void* getNativeWindow(FilamentApp::Window::Handle window) const override;
+    void* getNativeWindow(FilamentApp2::Window::Handle window) const override;
 
-    void setWindowTitle(FilamentApp::Window::Handle window, const char* title) override;
-    void getWindowSize(FilamentApp::Window::Handle window, uint32_t* w, uint32_t* h) const override;
-    void getDrawableSize(FilamentApp::Window::Handle window, uint32_t* w,
+    void setWindowTitle(FilamentApp2::Window::Handle window, const char* title) override;
+    void getWindowSize(FilamentApp2::Window::Handle window, uint32_t* w, uint32_t* h) const override;
+    void getDrawableSize(FilamentApp2::Window::Handle window, uint32_t* w,
             uint32_t* h) const override;
 
     void pollEvents(std::vector<AppEvent>& events) override;
 
     uint32_t getMouseState(int* x, int* y) const override;
 
-    bool isWindowFocused(FilamentApp::Window::Handle window) const override { return true; }
+    bool isWindowFocused(FilamentApp2::Window::Handle window) const override { return true; }
 
     double getTime() const override;
 
-    void onFrameFinished(FilamentApp::Window::Handle window, filament::Engine* engine,
+    void onFrameFinished(FilamentApp2::Window::Handle window, filament::Engine* engine,
             filament::Renderer* renderer) override;
 
     void startRendering(std::function<bool()> doFrame) override;
@@ -91,7 +90,7 @@ private:
     std::unique_ptr<WebSocketHandler> mWebSocketHandler;
     std::vector<struct mg_connection*> mConnections;
 
-    std::unordered_map<FilamentApp::Window::Handle, WindowInfo> mWindows;
+    std::unordered_map<FilamentApp2::Window::Handle, WindowInfo> mWindows;
     std::queue<AppEvent> mEventQueue;
     uint32_t mMouseButtons = 0;
     int32_t mMouseX = 0;

--- a/libs/filamentapp/src/display_managers/SDLDisplayManager.cpp
+++ b/libs/filamentapp/src/display_managers/SDLDisplayManager.cpp
@@ -17,7 +17,7 @@
 #include "SDLDisplayManager.h"
 
 #include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/NativeWindowHelper.h>
 
 #include <utils/Panic.h>
@@ -44,7 +44,7 @@ bool SDLDisplayManager::init(const Config& config) {
 void SDLDisplayManager::terminate() { SDL_Quit(); }
 
 
-FilamentApp::Window::Handle SDLDisplayManager::createWindow(const char* title, uint32_t w,
+FilamentApp2::Window::Handle SDLDisplayManager::createWindow(const char* title, uint32_t w,
         uint32_t h, bool resizable, bool headless) {
     uint32_t windowFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
     if (resizable) {
@@ -75,23 +75,23 @@ FilamentApp::Window::Handle SDLDisplayManager::createWindow(const char* title, u
 #endif
 
     mNativeWindowMap[window] = nativeWindow;
-    return (FilamentApp::Window::Handle) window;
+    return (FilamentApp2::Window::Handle) window;
 }
 
-void SDLDisplayManager::destroyWindow(FilamentApp::Window::Handle window) {
+void SDLDisplayManager::destroyWindow(FilamentApp2::Window::Handle window) {
     SDL_DestroyWindow((SDL_Window*) window);
 }
 
-void* SDLDisplayManager::getNativeWindow(FilamentApp::Window::Handle window) const {
+void* SDLDisplayManager::getNativeWindow(FilamentApp2::Window::Handle window) const {
     assert_invariant(mNativeWindowMap.count(window) > 0);
     return mNativeWindowMap[window];
 }
 
-void SDLDisplayManager::setWindowTitle(FilamentApp::Window::Handle window, const char* title) {
+void SDLDisplayManager::setWindowTitle(FilamentApp2::Window::Handle window, const char* title) {
     SDL_SetWindowTitle((SDL_Window*) window, title);
 }
 
-void SDLDisplayManager::getWindowSize(FilamentApp::Window::Handle window, uint32_t* w,
+void SDLDisplayManager::getWindowSize(FilamentApp2::Window::Handle window, uint32_t* w,
         uint32_t* h) const {
     int iw, ih;
     SDL_GetWindowSize((SDL_Window*) window, &iw, &ih);
@@ -99,7 +99,7 @@ void SDLDisplayManager::getWindowSize(FilamentApp::Window::Handle window, uint32
     *h = (uint32_t) ih;
 }
 
-void SDLDisplayManager::getDrawableSize(FilamentApp::Window::Handle window, uint32_t* w,
+void SDLDisplayManager::getDrawableSize(FilamentApp2::Window::Handle window, uint32_t* w,
         uint32_t* h) const {
     int iw, ih;
     SDL_GL_GetDrawableSize((SDL_Window*) window, &iw, &ih);
@@ -109,7 +109,7 @@ void SDLDisplayManager::getDrawableSize(FilamentApp::Window::Handle window, uint
 
 uint32_t SDLDisplayManager::getMouseState(int* x, int* y) const { return SDL_GetMouseState(x, y); }
 
-bool SDLDisplayManager::isWindowFocused(FilamentApp::Window::Handle window) const {
+bool SDLDisplayManager::isWindowFocused(FilamentApp2::Window::Handle window) const {
     return (SDL_GetWindowFlags((SDL_Window*) window) & SDL_WINDOW_INPUT_FOCUS) != 0;
 }
 
@@ -186,7 +186,7 @@ void SDLDisplayManager::pollEvents(std::vector<AppEvent>& events) {
     }
 }
 
-void SDLDisplayManager::onWindowResized(FilamentApp::Window::Handle window) {
+void SDLDisplayManager::onWindowResized(FilamentApp2::Window::Handle window) {
 #if defined(__APPLE__)
     void* nativeWindow = getNativeWindow(window);
     if (mConfig.backend == filament::Engine::Backend::METAL ||

--- a/libs/filamentapp/src/display_managers/SDLDisplayManager.h
+++ b/libs/filamentapp/src/display_managers/SDLDisplayManager.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_FILAMENTAPP_SDL_DISPLAY_MANAGER_H
 #define TNT_FILAMENT_FILAMENTAPP_SDL_DISPLAY_MANAGER_H
 
-#include "../DisplayManager.h"
+#include <filamentapp/DisplayManager.h>
 
 #include <SDL.h>
 
@@ -33,23 +33,23 @@ public:
     bool init(const Config& config) override;
     void terminate() override;
 
-    FilamentApp::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
+    FilamentApp2::Window::Handle createWindow(const char* title, uint32_t w, uint32_t h,
             bool resizable, bool headless) override;
-    void destroyWindow(FilamentApp::Window::Handle window) override;
+    void destroyWindow(FilamentApp2::Window::Handle window) override;
 
-    void* getNativeWindow(FilamentApp::Window::Handle window) const override;
+    void* getNativeWindow(FilamentApp2::Window::Handle window) const override;
 
-    void setWindowTitle(FilamentApp::Window::Handle window, const char* title) override;
-    void getWindowSize(FilamentApp::Window::Handle window, uint32_t* w, uint32_t* h) const override;
-    void getDrawableSize(FilamentApp::Window::Handle window, uint32_t* w,
+    void setWindowTitle(FilamentApp2::Window::Handle window, const char* title) override;
+    void getWindowSize(FilamentApp2::Window::Handle window, uint32_t* w, uint32_t* h) const override;
+    void getDrawableSize(FilamentApp2::Window::Handle window, uint32_t* w,
             uint32_t* h) const override;
 
     uint32_t getMouseState(int* x, int* y) const override;
-    bool isWindowFocused(FilamentApp::Window::Handle window) const override;
+    bool isWindowFocused(FilamentApp2::Window::Handle window) const override;
 
     void pollEvents(std::vector<AppEvent>& events) override;
 
-    void onWindowResized(FilamentApp::Window::Handle window) override;
+    void onWindowResized(FilamentApp2::Window::Handle window) override;
 
     double getTime() const override;
 
@@ -57,7 +57,7 @@ public:
 
 private:
     Config mConfig;
-    mutable std::unordered_map<FilamentApp::Window::Handle, void*> mNativeWindowMap;
+    mutable std::unordered_map<FilamentApp2::Window::Handle, void*> mNativeWindowMap;
     static AppKey mapKey(SDL_Scancode scancode);
     static uint16_t getModifiers();
 };

--- a/samples/animation.cpp
+++ b/samples/animation.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -30,18 +35,14 @@
 
 #include <utils/EntityManager.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <cmath>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
 using utils::EntityManager;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -65,7 +66,7 @@ static Vertex TRIANGLE_VERTICES[3] = {
 static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "animation";
     config.backend = samples::parseArgumentsForBackend(argc, argv);
 
@@ -105,9 +106,15 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
 
-        #if 0
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+
+#if 0
         engine->destroy(app.vb);
         auto vb = app.vb = VertexBuffer::Builder()
                 .vertexCount(3)
@@ -116,40 +123,42 @@ int main(int argc, char** argv) {
                 .attribute(VertexAttribute::COLOR, 0, VertexBuffer::AttributeType::UBYTE4, 8, 12)
                 .normalized(VertexAttribute::COLOR)
                 .build(*engine);
-        #else
-        auto vb = app.vb;
-        #endif
+#else
+                                  auto vb = app.vb;
+#endif
 
-        void* verts = malloc(36);
-        TRIANGLE_VERTICES[0].position.y = sin(now * 4);
-        memcpy(verts, TRIANGLE_VERTICES, 36);
-        vb->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(verts, 36,
-                (VertexBuffer::BufferDescriptor::Callback) free));
+                                  void* verts = malloc(36);
+                                  TRIANGLE_VERTICES[0].position.y = sin(now * 4);
+                                  memcpy(verts, TRIANGLE_VERTICES, 36);
+                                  vb->setBufferAt(*engine, 0,
+                                          VertexBuffer::BufferDescriptor(verts, 36,
+                                                  (VertexBuffer::BufferDescriptor::Callback) free));
 
-        auto& rcm = engine->getRenderableManager();
-        rcm.destroy(app.renderable);
-        RenderableManager::Builder(1)
-                .boundingBox({{ -1, -1, -1 }, { 1, 1, 1 }})
-                .material(0, app.mat->getDefaultInstance())
-                .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, app.vb, app.ib, 0, 3)
-                .culling(false)
-                .receiveShadows(false)
-                .castShadows(false)
-                .build(*engine, app.renderable);
+                                  auto& rcm = engine->getRenderableManager();
+                                  rcm.destroy(app.renderable);
+                                  RenderableManager::Builder(1)
+                                          .boundingBox({ { -1, -1, -1 }, { 1, 1, 1 } })
+                                          .material(0, app.mat->getDefaultInstance())
+                                          .geometry(0, RenderableManager::PrimitiveType::TRIANGLES,
+                                                  app.vb, app.ib, 0, 3)
+                                          .culling(false)
+                                          .receiveShadows(false)
+                                          .castShadows(false)
+                                          .build(*engine, app.renderable);
 
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
-        auto& tcm = engine->getTransformManager();
-        tcm.setTransform(tcm.getInstance(app.renderable),
-                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 0, 1 }));
-    });
-
-    FilamentApp::get().run(config, setup, cleanup);
+                                  constexpr float ZOOM = 1.5f;
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                          aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
+                                  auto& tcm = engine->getTransformManager();
+                                  tcm.setTransform(tcm.getInstance(app.renderable),
+                                          filament::math::mat4f::rotation(now,
+                                                  filament::math::float3{ 0, 0, 1 }));
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/common/SampleConfig.h
+++ b/samples/common/SampleConfig.h
@@ -1,0 +1,34 @@
+#ifndef SAMPLE_CONFIG_H
+#define SAMPLE_CONFIG_H
+
+#include <filament/Engine.h>
+
+#include <camutils/Manipulator.h>
+
+#include <string>
+
+struct SampleConfig {
+    std::string title;
+    uint32_t width = 1024;
+    uint32_t height = 640;
+    std::string iblDirectory;
+    std::string dirt;
+    float scale = 1.0f;
+    bool splitView = false;
+    mutable filament::Engine::Backend backend = filament::Engine::Backend::DEFAULT;
+    mutable filament::backend::FeatureLevel featureLevel =
+            filament::backend::FeatureLevel::FEATURE_LEVEL_3;
+    filament::camutils::Mode cameraMode = filament::camutils::Mode::ORBIT;
+    bool resizeable = true;
+    bool headless = false;
+    int stereoscopicEyeCount = 2;
+    uint8_t samples = 1;
+    std::string vulkanGPUHint;
+    using WebGPUBackend = filament::Engine::Backend;
+    WebGPUBackend forcedWebGPUBackend = WebGPUBackend::DEFAULT;
+    enum class DisplayManager { SDL, WEB };
+    DisplayManager displayManager = DisplayManager::SDL;
+    filament::backend::AsynchronousMode asynchronousMode =
+            filament::backend::AsynchronousMode::NONE;
+};
+#endif

--- a/samples/depthtesting.cpp
+++ b/samples/depthtesting.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -28,22 +33,18 @@
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
-#include <imgui.h>
-
 #include <utils/EntityManager.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <imgui.h>
 
 #include <cmath>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
 using utils::EntityManager;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -69,7 +70,7 @@ static const Vertex TRIANGLE_VERTICES[3] = {
 static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "depthtesting";
     config.backend = samples::parseArgumentsForBackend(argc, argv);
 
@@ -151,20 +152,27 @@ int main(int argc, char** argv) {
         }
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-                -aspect * ZOOM, aspect * ZOOM,
-                -ZOOM, ZOOM, -5, 5);
-        auto& tcm = engine->getTransformManager();
-        tcm.setTransform(tcm.getInstance(app.colorTriangle),
-                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 1, 0 }));
-    });
 
-    FilamentApp::get().run(config, setup, cleanup, gui);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui(gui)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  constexpr float ZOOM = 1.5f;
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                          aspect * ZOOM, -ZOOM, ZOOM, -5, 5);
+                                  auto& tcm = engine->getTransformManager();
+                                  tcm.setTransform(tcm.getInstance(app.colorTriangle),
+                                          filament::math::mat4f::rotation(now,
+                                                  filament::math::float3{ 0, 1, 0 }));
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/frame_generator.cpp
+++ b/samples/frame_generator.cpp
@@ -35,15 +35,15 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include <imageio/ImageEncoder.h>
 
 #include <image/ColorTransform.h>
 #include <image/LinearImage.h>
 
-#include <imageio/ImageEncoder.h>
-
-#include <filamentapp/Config.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/IBL.h>
-#include <filamentapp/FilamentApp.h>
 #include <filamentapp/MeshAssimp.h>
 
 #include <filament/Color.h>
@@ -51,8 +51,8 @@
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
-#include <filament/Renderer.h>
 #include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
@@ -60,6 +60,7 @@
 
 #include <backend/PixelBufferDescriptor.h>
 
+#include <utils/getopt.h>
 #include <utils/Path.h>
 
 #include <math/mat3.h>
@@ -67,8 +68,6 @@
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
-
-#include <utils/getopt.h>
 
 #include <algorithm>
 #include <atomic>
@@ -81,9 +80,9 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -124,7 +123,8 @@ static const Material* g_material = nullptr;
 static MaterialInstance* g_materialInstance = nullptr;
 static Entity g_light;
 
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 
 // Prints the usage message to the console.
 static void printUsage(char* name) {
@@ -183,8 +183,8 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-// Parses command line arguments and populates the Config object.
-static int handleCommandLineArguments(int argc, char* argv[], Config* config) {
+// Parses command line arguments and populates the SampleConfig object.
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:s:li:m:c:p:x:yb:S:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",        utils::getopt::no_argument,       nullptr, 'h' },
@@ -459,7 +459,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
         }
     }
 
-    auto const ibl = FilamentApp::get().getIBL();
+    auto const ibl = g_filamentApp->getIBL();
     if (!ibl || !g_skyboxOn) {
         g_skybox = Skybox::Builder().color({
                 float((g_clearColor >> 16) & 0xFF) / 255.0f,
@@ -538,13 +538,14 @@ static void postRender(Engine*, View* view, Scene*, Renderer* renderer) {
     }
 
     if (g_savedFrames.load() == g_materialVariantCount) {
-        FilamentApp::get().close();
+        g_filamentApp->close();
     }
 
     g_currentFrame++;
 }
 
 // Main entry point: parses args, validates inputs, and runs the Filament application.
+
 int main(int const argc, char* argv[]) {
     int const option_index = handleCommandLineArguments(argc, argv, &g_config);
     int const num_args = argc - option_index;
@@ -564,9 +565,17 @@ int main(int const argc, char* argv[]) {
 
     g_config.title = "Frame Generator";
     g_config.headless = true;
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.run(g_config,
-            setup, cleanup, FilamentApp::ImGuiCallback(), render, postRender, g_width, g_height);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .size(g_width, g_height)
+                            .scale(g_config.scale)
+                            .headless(g_config.headless)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .preRender(render)
+                            .postRender(postRender)
+                            .build();
+    g_filamentApp->run();
 
     return 0;
 }

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
 #include "generated/resources/gltf_demo.h"
 
@@ -28,9 +29,8 @@
 #include <gltfio/TextureProvider.h>
 
 #include <filamentapp/AssetLoader.h>
-#include <filamentapp/Config.h>
 #include <filamentapp/DesktopAssetLoader.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/IBL.h>
 
 #include <filament/Engine.h>
@@ -63,9 +63,10 @@ enum MaterialSource {
 };
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Engine* engine;
     ViewerGui* viewer;
-    Config config;
+    SampleConfig config;
     filament::app::AssetLoader* rawAssetLoader = nullptr;
     AssetLoader* loader;
     FilamentAsset* asset = nullptr;
@@ -161,7 +162,7 @@ int main(int argc, char** argv) {
     App app;
 
     app.config.title = "glTF Instancing";
-    app.config.iblDirectory = FilamentApp::getRootAssetsPath() + DEFAULT_IBL;
+    app.config.iblDirectory = FilamentApp2::getRootAssetsPath() + DEFAULT_IBL;
 
     int optionIndex = handleCommandLineArguments(argc, argv, &app);
     utils::Path filename;
@@ -241,7 +242,7 @@ int main(int argc, char** argv) {
             exit(1);
         }
 
-        auto ibl = FilamentApp::get().getIBL();
+        auto ibl = app.filamentApp->getIBL();
         if (ibl) {
             app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
         }
@@ -343,11 +344,17 @@ int main(int argc, char** argv) {
     auto gui = [&app](Engine* engine, View* view) { };
 
     auto preRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) { };
-
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.animate(animate);
-
-    filamentApp.run(app.config, setup, cleanup, gui, preRender);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .iblDirectory(app.config.iblDirectory)
+                              .backend(app.config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui(gui)
+                              .preRender(preRender)
+                              .animation(animate)
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
 #include "generated/resources/gltf_demo.h"
 
@@ -30,9 +31,8 @@
 #include <gltfio/TextureProvider.h>
 
 #include <filamentapp/AssetLoader.h>
-#include <filamentapp/Config.h>
 #include <filamentapp/DesktopAssetLoader.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/IBL.h>
 
 #include <filagui/ImGuiExtensions.h>
@@ -94,9 +94,10 @@ enum MaterialSource {
 };
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Engine* engine;
     ViewerGui* viewer;
-    Config config;
+    SampleConfig config;
     Camera* mainCamera;
     Entity rootTransformEntity;
 
@@ -331,14 +332,14 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 break;
             }
             case 'x': {
-                app->config.displayManager = Config::DisplayManager::WEB;
+                app->config.displayManager = SampleConfig::DisplayManager::WEB;
                 app->config.headless = true;
                 break;
             }
         }
     }
     if (app->config.headless && app->batchFile.empty() &&
-            app->config.displayManager != Config::DisplayManager::WEB) {
+            app->config.displayManager != SampleConfig::DisplayManager::WEB) {
         std::cerr << "--headless is allowed only when --batch is present." << std::endl;
         app->config.headless = false;
     }
@@ -615,7 +616,7 @@ int main(int argc, char** argv) {
     App app;
 
     app.config.title = "Filament";
-    app.config.iblDirectory = FilamentApp::getRootAssetsPath() + DEFAULT_IBL;
+    app.config.iblDirectory = FilamentApp2::getRootAssetsPath() + DEFAULT_IBL;
 
     int const optionIndex = handleCommandLineArguments(argc, argv, &app);
 
@@ -684,7 +685,7 @@ int main(int argc, char** argv) {
     };
 
     auto setupIBL = [&app]() {
-        auto ibl = FilamentApp::get().getIBL();
+        auto ibl = app.filamentApp->getIBL();
         if (ibl) {
             app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
             app.viewer->getSettings().view.fogSettings.fogColorTexture = ibl->getFogTexture();
@@ -932,7 +933,7 @@ int main(int argc, char** argv) {
                 ImGui::Indent();
                 ImGui::Text("%zu entities in the asset", app.asset->getEntityCount());
                 ImGui::Text("%zu renderables (excluding UI)", scene->getRenderableCount());
-                ImGui::Text("%zu skipped frames", FilamentApp::get().getSkippedFrameCount());
+                ImGui::Text("%zu skipped frames", app.filamentApp->getSkippedFrameCount());
                 ImGui::Unindent();
             }
 
@@ -1000,13 +1001,13 @@ int main(int argc, char** argv) {
                     }
                 }
 
-                bool cameraFrustum = FilamentApp::get().isCameraFrustumEnabled();
+                bool cameraFrustum = app.filamentApp->isCameraFrustumEnabled();
                 ImGui::Checkbox("Show Camera Frustum", &cameraFrustum);
-                FilamentApp::get().setCameraFrustumEnabled(cameraFrustum);
+                app.filamentApp->setCameraFrustumEnabled(cameraFrustum);
 
-                bool shadowFrustum = FilamentApp::get().isDirectionalShadowFrustumEnabled();
+                bool shadowFrustum = app.filamentApp->isDirectionalShadowFrustumEnabled();
                 ImGui::Checkbox("Show Shadow Frustum", &shadowFrustum);
-                FilamentApp::get().setDirectionalShadowFrustumEnabled(shadowFrustum);
+                app.filamentApp->setDirectionalShadowFrustumEnabled(shadowFrustum);
 
                 bool debugFroxelVisualization;
                 if (debug.getProperty("d.lighting.debug_froxel_visualization",
@@ -1014,7 +1015,7 @@ int main(int argc, char** argv) {
                     ImGui::Checkbox("Froxel Visualization", &debugFroxelVisualization);
                     debug.setProperty("d.lighting.debug_froxel_visualization",
                             debugFroxelVisualization);
-                    FilamentApp::get().setFroxelGridEnabled(debugFroxelVisualization);
+                    app.filamentApp->setFroxelGridEnabled(debugFroxelVisualization);
                 }
 
                 auto dataSource = debug.getDataSource("d.view.frame_info");
@@ -1152,7 +1153,7 @@ int main(int argc, char** argv) {
     auto gui = [&app](Engine*, View*) {
         app.viewer->updateUserInterface();
 
-        FilamentApp::get().setSidebarWidth(app.viewer->getSidebarWidth());
+        app.filamentApp->setSidebarWidth(app.viewer->getSidebarWidth());
     };
 
     auto preRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
@@ -1164,7 +1165,7 @@ int main(int argc, char** argv) {
 
         engine->setAutomaticInstancingEnabled(viewerOptions.autoInstancingEnabled);
 
-        if (auto* swapChain = FilamentApp::get().getPrimarySwapChain()) {
+        if (auto* swapChain = app.filamentApp->getPrimarySwapChain()) {
             if (swapChain->isFrameRateChangeSupported().is_true()) {
                 if (viewerOptions.cameraFrameRate != app.currentFrameRate) {
                     swapChain->setFrameRate(viewerOptions.cameraFrameRate,
@@ -1184,8 +1185,8 @@ int main(int argc, char** argv) {
                                   std::max(0.1f, focusDistance)) *
                           1000.0;
         }
-        FilamentApp::get().setCameraFocalLength(focalLength);
-        FilamentApp::get().setCameraNearFar(app.viewer->getSettings().camera.near,
+        app.filamentApp->setCameraFocalLength(focalLength);
+        app.filamentApp->setCameraNearFar(app.viewer->getSettings().camera.near,
                 app.viewer->getSettings().camera.far);
 
         size_t const cameraCount = app.asset->getCameraEntityCount();
@@ -1208,7 +1209,7 @@ int main(int argc, char** argv) {
         static bool stereoscopicEnabled = false;
         if (stereoscopicEnabled != view->getStereoscopicOptions().enabled) {
             // Stereo was turned on/off.
-            FilamentApp::get().reconfigureCameras();
+            app.filamentApp->reconfigureCameras();
             stereoscopicEnabled = view->getStereoscopicOptions().enabled;
         }
 
@@ -1266,7 +1267,7 @@ int main(int argc, char** argv) {
             app.screenshot = false;
         }
         if (app.automationEngine->shouldClose()) {
-            FilamentApp::get().close();
+            app.filamentApp->close();
             return;
         }
         AutomationEngine::ViewerContent const content = {
@@ -1283,34 +1284,49 @@ int main(int argc, char** argv) {
         };
         app.automationEngine->tick(engine, content, ImGui::GetIO().DeltaTime);
     };
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .iblDirectory(app.config.iblDirectory)
+                              .splitView(app.config.splitView)
+                              .backend(app.config.backend)
+                              .featureLevel(app.config.featureLevel)
+                              .cameraMode(app.config.cameraMode)
+                              .headless(app.config.headless)
+                              .stereoscopicEyeCount(app.config.stereoscopicEyeCount)
+                              .vulkanGPUHint(app.config.vulkanGPUHint)
+                              .forcedWebGPUBackend(app.config.forcedWebGPUBackend)
+                              .configDisplayManager(static_cast<FilamentApp2::DisplayManager>(
+                                      app.config.displayManager))
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui(gui)
+                              .preRender(preRender)
+                              .postRender(postRender)
+                              .animation(animate)
+                              .resize(resize)
+                              .dropHandler([&](std::string_view path) {
+                                  utils::Path filename = getPathForGLTFAsset(path);
+                                  if (!filename.isEmpty()) {
+                                      if (checkGLTFAsset(filename)) {
+                                          app.resourceLoader->asyncCancelLoad();
+                                          app.resourceLoader->evictResourceData();
+                                          app.viewer->removeAsset();
+                                          app.assetLoader->destroyAsset(app.asset);
+                                          loadAsset(filename);
+                                          loadResources(filename);
+                                          app.viewer->setAsset(app.asset, app.instance);
+                                      }
+                                      return;
+                                  }
 
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.animate(animate);
-    filamentApp.resize(resize);
-
-    filamentApp.setDropHandler([&](std::string_view path) {
-        utils::Path filename = getPathForGLTFAsset(path);
-        if (!filename.isEmpty()) {
-            if (checkGLTFAsset(filename)) {
-                app.resourceLoader->asyncCancelLoad();
-                app.resourceLoader->evictResourceData();
-                app.viewer->removeAsset();
-                app.assetLoader->destroyAsset(app.asset);
-                loadAsset(filename);
-                loadResources(filename);
-                app.viewer->setAsset(app.asset, app.instance);
-            }
-            return;
-        }
-
-        filename = getPathForIBLAsset(path);
-        if (!filename.isEmpty()) {
-            FilamentApp::get().loadIBL(path);
-            setupIBL();
-        }
-    });
-
-    filamentApp.run(app.config, setup, cleanup, gui, preRender, postRender);
+                                  filename = getPathForIBLAsset(path);
+                                  if (!filename.isEmpty()) {
+                                      app.filamentApp->loadIBL(path);
+                                      setupIBL();
+                                  }
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -36,7 +36,7 @@
 
 #include <utils/getopt.h>
 
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 
 #define STB_PERLIN_IMPLEMENTATION
 #include <stb_perlin.h>
@@ -50,6 +50,7 @@
 
 #include <imgui.h>
 
+#include "common/SampleConfig.h"
 #include "generated/resources/resources.h"
 
 using namespace filament;
@@ -61,6 +62,7 @@ using MinFilter = TextureSampler::MinFilter;
 using MagFilter = TextureSampler::MagFilter;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Skybox* skybox = nullptr;
     VertexBuffer* vb = nullptr;
     IndexBuffer* ib = nullptr;
@@ -121,7 +123,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -258,7 +260,7 @@ static void gui(Engine*, View*) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "Heightfield";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -390,44 +392,57 @@ int main(int argc, char** argv) {
         engine->destroy(app.ib);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        const size_t offset = g_params.updateSubRegion ? 64 : 0;
-        const size_t dimension = g_params.updateSubRegion ? textureSize / 2 : textureSize;
-        const size_t padding = g_params.addPadding ? 32 : 0;
-        TextureSampler sampler(MinFilter::LINEAR, MagFilter::LINEAR);
 
-        Texture* textureUpdate = nullptr;
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .imgui(gui)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        const size_t offset = g_params.updateSubRegion ? 64 : 0;
+                        const size_t dimension =
+                                g_params.updateSubRegion ? textureSize / 2 : textureSize;
+                        const size_t padding = g_params.addPadding ? 32 : 0;
+                        TextureSampler sampler(MinFilter::LINEAR, MagFilter::LINEAR);
 
-        if (g_params.textureType != g_params.currentTextureType) {
-            if (g_params.textureType == 0) {
-                textureUpdate = app.r8Tex;
-            } else if (g_params.textureType == 1) {
-                textureUpdate = app.floatTex;
-            } else if (g_params.textureType == 2) {
-                textureUpdate = app.rgbTex;
-            }
+                        Texture* textureUpdate = nullptr;
 
-            g_params.currentTextureType = g_params.textureType;
-        }
+                        if (g_params.textureType != g_params.currentTextureType) {
+                            if (g_params.textureType == 0) {
+                                textureUpdate = app.r8Tex;
+                            } else if (g_params.textureType == 1) {
+                                textureUpdate = app.floatTex;
+                            } else if (g_params.textureType == 2) {
+                                textureUpdate = app.rgbTex;
+                            }
 
-        if (textureUpdate) {
-            app.matInstance->setParameter("height", textureUpdate, sampler);
-        }
+                            g_params.currentTextureType = g_params.textureType;
+                        }
 
-        const auto n = static_cast<float>(now);
-        if (g_params.textureType == 0) {
-            populateTextureWithPerlin<uint8_t>(app.r8Tex, *engine, n * g_params.speed, g_params,
-                    offset, offset, dimension, padding);
-        } else if (g_params.textureType == 1) {
-            populateTextureWithPerlin<float>(app.floatTex, *engine, n * g_params.speed, g_params,
-                    offset, offset, dimension, padding);
-        } else if (g_params.textureType == 2) {
-            populateTextureWithPerlin<filament::math::byte3>(app.rgbTex, *engine,
-                    n * g_params.speed, g_params, offset, offset, dimension, padding);
-        }
-    });
+                        if (textureUpdate) {
+                            app.matInstance->setParameter("height", textureUpdate, sampler);
+                        }
 
-    FilamentApp::get().run(config, setup, cleanup, gui);
+                        const auto n = static_cast<float>(now);
+                        if (g_params.textureType == 0) {
+                            populateTextureWithPerlin<uint8_t>(app.r8Tex, *engine,
+                                    n * g_params.speed, g_params, offset, offset, dimension,
+                                    padding);
+                        } else if (g_params.textureType == 1) {
+                            populateTextureWithPerlin<float>(app.floatTex, *engine,
+                                    n * g_params.speed, g_params, offset, offset, dimension,
+                                    padding);
+                        } else if (g_params.textureType == 2) {
+                            populateTextureWithPerlin<filament::math::byte3>(app.rgbTex, *engine,
+                                    n * g_params.speed, g_params, offset, offset, dimension,
+                                    padding);
+                        }
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/helloasync.cpp
+++ b/samples/helloasync.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "common/arguments.h"
-#include "filament/TransformManager.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -27,25 +31,19 @@
 #include <filament/Skybox.h>
 #include <filament/Texture.h>
 #include <filament/TextureSampler.h>
+#include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-
-#include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <stb_image.h>
 
 #include <iostream> // for cerr
 #include <memory>
 #include <string>   // for printing usage/help
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -92,7 +90,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig& config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
         { "help", utils::getopt::no_argument, nullptr, 'h' },
@@ -117,6 +115,7 @@ static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
 }
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     // Global data
     Engine* engine = nullptr;
     Entity camera;
@@ -227,9 +226,9 @@ struct App {
             return;
         }
 
-        utils::Invocable<void()> command = [this](){
+        utils::Invocable<void()> command = [this]() {
             Path const path =
-                    FilamentApp::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
+                    FilamentApp2::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
             if (!path.exists()) {
                 std::cerr << "The texture " << path << " does not exist" << std::endl;
                 exit(1);
@@ -432,7 +431,7 @@ struct App {
 };
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "helloasync";
     config.asynchronousMode = backend::AsynchronousMode::THREAD_PREFERRED;
     handleCommandLineArguments(argc, argv, config);
@@ -564,19 +563,28 @@ int main(int argc, char** argv) {
         }
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        auto& tm = engine->getTransformManager();
-        for (int i = 0; i < App::OBJECT_COUNT; ++i) {
-            auto& data = app.objectData[i];
-            if (!data.renderable) {
-                continue; // Skip updating transform for renderables that are not loaded yet.
-            }
-            auto r = math::mat4f::rotation(now, math::float3(0, 0, 1));
-            tm.setTransform(tm.getInstance(data.renderable), data.baseTransform * r);
-        }
-    });
 
-    FilamentApp::get().run(config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .asynchronousMode(config.asynchronousMode)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  auto& tm = engine->getTransformManager();
+                                  for (int i = 0; i < App::OBJECT_COUNT; ++i) {
+                                      auto& data = app.objectData[i];
+                                      if (!data.renderable) {
+                                          continue; // Skip updating transform for renderables that
+                                                    // are not loaded yet.
+                                      }
+                                      auto r = math::mat4f::rotation(now, math::float3(0, 0, 1));
+                                      tm.setTransform(tm.getInstance(data.renderable),
+                                              data.baseTransform * r);
+                                  }
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hellomorphing.cpp
+++ b/samples/hellomorphing.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -22,24 +27,18 @@
 #include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/SkinningBuffer.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-#include <filament/SkinningBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
 #include <utils/getopt.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <utils/Path.h>
 
 #include <cmath>
 #include <iostream>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -48,6 +47,7 @@ using utils::Path;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -111,7 +111,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -137,7 +137,7 @@ static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "helloMorphing";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -222,24 +222,28 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
 
-        auto& rm = engine->getRenderableManager();
-        // morphTarget/blendshapes animation defined for all primitives
-        float z = (float)(sin(now)/2.f + 0.5f);
-        float weights[] = {1 - z, z/2, z/2};
-        // set global weights of all morph targets
-        rm.setMorphWeights(rm.getInstance(app.renderable), weights, 3, 0);
-    });
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  constexpr float ZOOM = 1.5f;
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                          aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
 
-    FilamentApp::get().run(config, setup, cleanup);
+                                  auto& rm = engine->getRenderableManager();
+                                  // morphTarget/blendshapes animation defined for all primitives
+                                  float z = (float) (sin(now) / 2.f + 0.5f);
+                                  float weights[] = { 1 - z, z / 2, z / 2 };
+                                  // set global weights of all morph targets
+                                  rm.setMorphWeights(rm.getInstance(app.renderable), weights, 3, 0);
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -15,6 +15,14 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/monkey.h"
+#include "generated/resources/resources.h"
+
+#include <filameshio/MeshReader.h>
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
@@ -25,19 +33,10 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-
-#include <filameshio/MeshReader.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
 
 #include <iostream>
 #include <string>// for printing usage/help
-
-#include "generated/resources/resources.h"
-#include "generated/resources/monkey.h"
 
 using namespace filament;
 using namespace filamesh;
@@ -46,7 +45,8 @@ using namespace filament::math;
 using Backend = Engine::Backend;
 
 struct App {
-    Config config;
+    std::unique_ptr<FilamentApp2> filamentApp;
+    SampleConfig config;
     utils::Entity light;
     Material* material;
     MaterialInstance* materialInstance;
@@ -105,7 +105,7 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
 int main(int argc, char** argv) {
     App app;
     app.config.title = "hellopbr";
-    app.config.iblDirectory = FilamentApp::getRootAssetsPath() + IBL_FOLDER;
+    app.config.iblDirectory = FilamentApp2::getRootAssetsPath() + IBL_FOLDER;
     handleCommandLineArguments(argc, argv, &app);
 
     auto setup = [config=app.config, &app](Engine* engine, View* view, Scene* scene) {
@@ -148,13 +148,21 @@ int main(int argc, char** argv) {
         engine->destroy(app.material);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        auto& tcm = engine->getTransformManager();
-        auto ti = tcm.getInstance(app.mesh.renderable);
-        tcm.setTransform(ti, app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
-    });
 
-    FilamentApp::get().run(app.config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .iblDirectory(app.config.iblDirectory)
+                              .backend(app.config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  auto& tcm = engine->getTransformManager();
+                                  auto ti = tcm.getInstance(app.mesh.renderable);
+                                  tcm.setTransform(ti,
+                                          app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/helloskinning.cpp
+++ b/samples/helloskinning.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -22,24 +27,18 @@
 #include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/SkinningBuffer.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-#include <filament/SkinningBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
+#include <utils/getopt.h>
 #include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
 
 #include <cmath>
 #include <iostream>
-
-#include <utils/getopt.h>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -48,6 +47,7 @@ using utils::Path;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     VertexBuffer* vb2;
     IndexBuffer* ib;
@@ -87,7 +87,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -130,7 +130,7 @@ mat4f transforms[] = {mat4f(1),
                       mat4f::translation(float3(0, 1, 0))};
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "hello skinning";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -206,28 +206,34 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
 
-        auto& rm = engine->getRenderableManager();
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        constexpr float ZOOM = 1.5f;
+                        const uint32_t w = view->getViewport().width;
+                        const uint32_t h = view->getViewport().height;
+                        const float aspect = (float) w / h;
+                        app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
 
-        // Bone skinning animation
-        float tr = (float)(sin(now));
-        mat4f trans[] = {filament::math::mat4f::translation(filament::math::float3{tr, 0, 0}),
-                         filament::math::mat4f::translation(filament::math::float3{-1, tr, 0}),
-                         filament::math::mat4f(1.f)};
-        rm.setBones(rm.getInstance(app.renderable), trans, 3, 0);
+                        auto& rm = engine->getRenderableManager();
 
-
-    });
-
-    FilamentApp::get().run(config, setup, cleanup);
+                        // Bone skinning animation
+                        float tr = (float) (sin(now));
+                        mat4f trans[] = { filament::math::mat4f::translation(
+                                                  filament::math::float3{ tr, 0, 0 }),
+                            filament::math::mat4f::translation(filament::math::float3{ -1, tr, 0 }),
+                            filament::math::mat4f(1.f) };
+                        rm.setBones(rm.getInstance(app.renderable), trans, 3, 0);
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/helloskinningbuffer.cpp
+++ b/samples/helloskinningbuffer.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -22,24 +27,18 @@
 #include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/SkinningBuffer.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-#include <filament/SkinningBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
 #include <utils/getopt.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <utils/Path.h>
 
 #include <cmath>
 #include <iostream>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -48,6 +47,7 @@ using utils::Path;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer *vb, *vb2;
     IndexBuffer* ib;
     Material* mat;
@@ -114,7 +114,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -140,7 +140,7 @@ static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "skinning buffer common for two renderables";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -240,57 +240,65 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
-        auto& tcm = engine->getTransformManager();
 
-        // Transformation of both renderables
-        tcm.setTransform(tcm.getInstance(app.renderable1),
-                filament::math::mat4f::translation(filament::math::float3{ 0.5, 0, 0 }));
-        tcm.setTransform(tcm.getInstance(app.renderable2),
-                filament::math::mat4f::translation(filament::math::float3{ 0, 0.5, 0 }));
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        constexpr float ZOOM = 1.5f;
+                        const uint32_t w = view->getViewport().width;
+                        const uint32_t h = view->getViewport().height;
+                        const float aspect = (float) w / h;
+                        app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
+                        auto& tcm = engine->getTransformManager();
 
-        auto& rm = engine->getRenderableManager();
+                        // Transformation of both renderables
+                        tcm.setTransform(tcm.getInstance(app.renderable1),
+                                filament::math::mat4f::translation(
+                                        filament::math::float3{ 0.5, 0, 0 }));
+                        tcm.setTransform(tcm.getInstance(app.renderable2),
+                                filament::math::mat4f::translation(
+                                        filament::math::float3{ 0, 0.5, 0 }));
 
-        // Bone skinning animation
-        float t = (float)(now - (int)now);
-        float s = sin(t * f::PI * 2.f);
-        float c = cos(t * f::PI * 2.f);
+                        auto& rm = engine->getRenderableManager();
 
-        mat4f translate[] = {mat4f::translation(float3(s, c, 0))};
+                        // Bone skinning animation
+                        float t = (float) (now - (int) now);
+                        float s = sin(t * f::PI * 2.f);
+                        float c = cos(t * f::PI * 2.f);
 
-        mat4f trans1of8[9] = {};
-        for (size_t i = 0; i < 9; i++) {
-            trans1of8[i] = filament::math::mat4f(1);
-        }
-        s *= 5;
-        mat4f transA[] = {
-            mat4f::translation(float3(s, 0, 0)),
-            mat4f::translation(float3(s, s, 0)),
-            mat4f::translation(float3(0, s, 0)),
-            mat4f::translation(float3(-s, s, 0)),
-            mat4f::translation(float3(-s, 0, 0)),
-            mat4f::translation(float3(-s, -s, 0)),
-            mat4f::translation(float3(0, -s, 0)),
-            mat4f::translation(float3(s, -s, 0)),
-            filament::math::mat4f(1)};
-        size_t offset = ((size_t)now) % 8;
-        trans1of8[offset] = transA[offset];
+                        mat4f translate[] = { mat4f::translation(float3(s, c, 0)) };
 
-        // Set transformation of the first bone
-        app.sb->setBones(*engine, translate, 1, 0);
+                        mat4f trans1of8[9] = {};
+                        for (size_t i = 0; i < 9; i++) {
+                            trans1of8[i] = filament::math::mat4f(1);
+                        }
+                        s *= 5;
+                        mat4f transA[] = { mat4f::translation(float3(s, 0, 0)),
+                            mat4f::translation(float3(s, s, 0)),
+                            mat4f::translation(float3(0, s, 0)),
+                            mat4f::translation(float3(-s, s, 0)),
+                            mat4f::translation(float3(-s, 0, 0)),
+                            mat4f::translation(float3(-s, -s, 0)),
+                            mat4f::translation(float3(0, -s, 0)),
+                            mat4f::translation(float3(s, -s, 0)), filament::math::mat4f(1) };
+                        size_t offset = ((size_t) now) % 8;
+                        trans1of8[offset] = transA[offset];
 
-        // Set transformation of the other bones, only 3 of them can be used, do to limitation
-        app.sb->setBones(*engine,trans1of8, 8, 1);
-    });
+                        // Set transformation of the first bone
+                        app.sb->setBones(*engine, translate, 1, 0);
 
-    FilamentApp::get().run(config, setup, cleanup);
+                        // Set transformation of the other bones, only 3 of them can be used, do to
+                        // limitation
+                        app.sb->setBones(*engine, trans1of8, 8, 1);
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/helloskinningbuffer_morebones.cpp
+++ b/samples/helloskinningbuffer_morebones.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -22,24 +27,18 @@
 #include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/SkinningBuffer.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-#include <filament/SkinningBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
 #include <utils/getopt.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <utils/Path.h>
 
 #include <cmath>
 #include <iostream>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -48,6 +47,7 @@ using utils::Path;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer *vb1, *vb2;
     IndexBuffer *ib1, *ib2;
     Material* mat;
@@ -106,7 +106,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -132,7 +132,7 @@ static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "skinning buffer common for two renderables";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -248,58 +248,64 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
-        auto& tcm = engine->getTransformManager();
 
-        // Transformation of both renderables
-        tcm.setTransform(tcm.getInstance(app.renderable1),
-                filament::math::mat4f::translation(filament::math::float3{ 0.5, 0, 0 }));
-        tcm.setTransform(tcm.getInstance(app.renderable2),
-                filament::math::mat4f::translation(filament::math::float3{ 0, 0.5, 0 }));
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        constexpr float ZOOM = 1.5f;
+                        const uint32_t w = view->getViewport().width;
+                        const uint32_t h = view->getViewport().height;
+                        const float aspect = (float) w / h;
+                        app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
+                        auto& tcm = engine->getTransformManager();
 
-        auto& rm = engine->getRenderableManager();
+                        // Transformation of both renderables
+                        tcm.setTransform(tcm.getInstance(app.renderable1),
+                                filament::math::mat4f::translation(
+                                        filament::math::float3{ 0.5, 0, 0 }));
+                        tcm.setTransform(tcm.getInstance(app.renderable2),
+                                filament::math::mat4f::translation(
+                                        filament::math::float3{ 0, 0.5, 0 }));
 
-        // Bone skinning animation
-        float t = (float)(now - (int)now);
-        float s = sin(t * f::PI * 2.f);
-        float c = cos(t * f::PI * 2.f);
+                        auto& rm = engine->getRenderableManager();
 
-        mat4f translate[] = {mat4f::translation(float3(s, c, 0))};
+                        // Bone skinning animation
+                        float t = (float) (now - (int) now);
+                        float s = sin(t * f::PI * 2.f);
+                        float c = cos(t * f::PI * 2.f);
 
-        mat4f trans[9] = {};
-        for (size_t i = 0; i < 9; i++) {
-            trans[i] = filament::math::mat4f(1);
-        }
-        s *= 8;
-        mat4f transA[] = {
-            mat4f::translation(float3(s, 0, 0)),
-            mat4f::translation(float3(s, s, 0)),
-            mat4f::translation(float3(0, s, 0)),
-            mat4f::translation(float3(-s, s, 0)),
-            mat4f::translation(float3(-s, 0, 0)),
-            mat4f::translation(float3(-s, -s, 0)),
-            mat4f::translation(float3(0, -s, 0)),
-            mat4f::translation(float3(s, -s, 0)),
-            filament::math::mat4f(1)};
-        size_t offset = ((size_t)now) % 8;
-        trans[offset] = transA[offset];
+                        mat4f translate[] = { mat4f::translation(float3(s, c, 0)) };
 
-        // Set transformation of the first bone
-        app.sb->setBones(*engine, translate, 1, 0);
+                        mat4f trans[9] = {};
+                        for (size_t i = 0; i < 9; i++) {
+                            trans[i] = filament::math::mat4f(1);
+                        }
+                        s *= 8;
+                        mat4f transA[] = { mat4f::translation(float3(s, 0, 0)),
+                            mat4f::translation(float3(s, s, 0)),
+                            mat4f::translation(float3(0, s, 0)),
+                            mat4f::translation(float3(-s, s, 0)),
+                            mat4f::translation(float3(-s, 0, 0)),
+                            mat4f::translation(float3(-s, -s, 0)),
+                            mat4f::translation(float3(0, -s, 0)),
+                            mat4f::translation(float3(s, -s, 0)), filament::math::mat4f(1) };
+                        size_t offset = ((size_t) now) % 8;
+                        trans[offset] = transA[offset];
 
-        // Set transformation of the others bones
-        app.sb->setBones(*engine,trans, 8, 1);
+                        // Set transformation of the first bone
+                        app.sb->setBones(*engine, translate, 1, 0);
 
-    });
-
-    FilamentApp::get().run(config, setup, cleanup);
+                        // Set transformation of the others bones
+                        app.sb->setBones(*engine, trans, 8, 1);
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -15,6 +15,16 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/monkey.h"
+#include "generated/resources/resources.h"
+
+#include <filameshio/MeshReader.h>
+
+#include <filamentapp/FilamentApp2.h>
+
+#include <private/filament/EngineEnums.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -30,22 +40,11 @@
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
-#include <private/filament/EngineEnums.h>
-
 #include <utils/EntityManager.h>
-
-#include <filameshio/MeshReader.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
 
 #include <iostream>
 #include <vector>
-
-#include "generated/resources/resources.h"
-#include "generated/resources/monkey.h"
 
 using namespace filament;
 using namespace filamesh;
@@ -57,7 +56,8 @@ struct Vertex {
 };
 
 struct App {
-    Config config;
+    std::unique_ptr<FilamentApp2> filamentApp;
+    SampleConfig config;
 
     Material* monkeyMaterial;
     MaterialInstance* monkeyMatInstance;
@@ -216,26 +216,28 @@ int main(int argc, char** argv) {
         app.stereoView = engine->createView();
         app.stereoView->setScene(app.stereoScene);
         app.stereoView->setPostProcessingEnabled(false);
-        app.stereoColorTexture = Texture::Builder()
-                .width(vp.width)
-                .height(vp.height)
-                .depth(eyeCount)
-                .levels(1)
-                .samples(sampleCount)
-                .sampler(Texture::Sampler::SAMPLER_2D_ARRAY)
-                .format(Texture::InternalFormat::RGBA8)
-                .usage(Texture::Usage::COLOR_ATTACHMENT | Texture::Usage::SAMPLEABLE)
-                .build(*engine);
-        app.stereoDepthTexture = Texture::Builder()
-                .width(vp.width)
-                .height(vp.height)
-                .depth(eyeCount)
-                .levels(1)
-                .samples(sampleCount)
-                .sampler(Texture::Sampler::SAMPLER_2D_ARRAY)
-                .format(Texture::InternalFormat::DEPTH32F)
-                .usage(Texture::Usage::DEPTH_ATTACHMENT | Texture::Usage::SAMPLEABLE)
-                .build(*engine);
+        app.stereoColorTexture =
+                Texture::Builder()
+                        .width(vp.width)
+                        .height(vp.height)
+                        .depth(eyeCount)
+                        .levels(1)
+                        .samples(sampleCount)
+                        .sampler(Texture::Sampler::SAMPLER_2D_ARRAY)
+                        .format(Texture::InternalFormat::RGBA8)
+                        .usage(Texture::Usage::COLOR_ATTACHMENT | Texture::Usage::SAMPLEABLE)
+                        .build(*engine);
+        app.stereoDepthTexture =
+                Texture::Builder()
+                        .width(vp.width)
+                        .height(vp.height)
+                        .depth(eyeCount)
+                        .levels(1)
+                        .samples(sampleCount)
+                        .sampler(Texture::Sampler::SAMPLER_2D_ARRAY)
+                        .format(Texture::InternalFormat::DEPTH32F)
+                        .usage(Texture::Usage::DEPTH_ATTACHMENT | Texture::Usage::SAMPLEABLE)
+                        .build(*engine);
         app.stereoRenderTarget = RenderTarget::Builder()
                 .texture(RenderTarget::AttachmentPoint::COLOR, app.stereoColorTexture)
                 .texture(RenderTarget::AttachmentPoint::DEPTH, app.stereoDepthTexture)
@@ -248,7 +250,7 @@ int main(int argc, char** argv) {
         app.stereoCamera = engine->createCamera(em.create());
         app.stereoView->setCamera(app.stereoCamera);
         app.stereoView->setStereoscopicOptions({.enabled = true});
-        FilamentApp::get().addOffscreenView(app.stereoView);
+        app.filamentApp->addOffscreenView(app.stereoView);
 
         // Camera settings for the stereo render target
         constexpr double projNear  = 0.1;
@@ -369,16 +371,29 @@ int main(int argc, char** argv) {
         renderer->setClearOptions({.clearColor = {0.1,0.2,0.4,1.0}, .clear = true});
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        auto& tcm = engine->getTransformManager();
 
-        // Animate the monkey by spinning and sliding back and forth along Z.
-        auto ti = tcm.getInstance(app.monkeyMesh.renderable);
-        mat4f xform =  app.monkeyTransform *  mat4f::rotation(now, float3{0, 1, 0 });
-        tcm.setTransform(ti, xform);
-    });
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(app.config.title)
+                    .backend(app.config.backend)
+                    .stereoscopicEyeCount(app.config.stereoscopicEyeCount)
+                    .samples(app.config.samples)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(app.config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .imgui({})
+                    .preRender(preRender)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        auto& tcm = engine->getTransformManager();
 
-    FilamentApp::get().run(app.config, setup, cleanup, FilamentApp::ImGuiCallback(), preRender);
+                        // Animate the monkey by spinning and sliding back and forth along Z.
+                        auto ti = tcm.getInstance(app.monkeyMesh.renderable);
+                        mat4f xform = app.monkeyTransform * mat4f::rotation(now, float3{ 0, 1, 0 });
+                        tcm.setTransform(ti, xform);
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hellotriangle.cpp
+++ b/samples/hellotriangle.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -29,25 +34,19 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
 
 #include <cmath>
 #include <iostream>
 #include <string>// for printing usage/help
 
-
-#include "generated/resources/resources.h"
-
 using namespace filament;
 using utils::Entity;
 using utils::EntityManager;
 
 struct App {
-    Config config;
+    std::unique_ptr<FilamentApp2> filamentApp;
+    SampleConfig config;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -170,20 +169,27 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
-        auto& tcm = engine->getTransformManager();
-        tcm.setTransform(tcm.getInstance(app.renderable),
-                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 0, 1 }));
-    });
 
-    FilamentApp::get().run(app.config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .backend(app.config.backend)
+                              .featureLevel(app.config.featureLevel)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  constexpr float ZOOM = 1.5f;
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                          aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
+                                  auto& tcm = engine->getTransformManager();
+                                  tcm.setTransform(tcm.getInstance(app.renderable),
+                                          filament::math::mat4f::rotation(now,
+                                                  filament::math::float3{ 0, 0, 1 }));
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hellouvmorphing.cpp
+++ b/samples/hellouvmorphing.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -34,17 +38,11 @@
 #include <filament/Viewport.h>
 
 #include <utils/EntityManager.h>
+#include <utils/getopt.h>
 #include <utils/Path.h>
 
-#include <utils/getopt.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
-#include <vector>
 #include <iostream>
-
-#include "generated/resources/resources.h"
+#include <vector>
 
 using namespace filament;
 using namespace filament::math;
@@ -58,7 +56,8 @@ struct Vertex {
 };
 
 struct App {
-    Config config;
+    std::unique_ptr<FilamentApp2> filamentApp;
+    SampleConfig config;
     VertexBuffer* vb = nullptr;
     IndexBuffer* ib = nullptr;
     Material* mat = nullptr;
@@ -312,19 +311,26 @@ int main(int argc, char** argv) {
         EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 2.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float)w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM, aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
 
-        auto& rm = engine->getRenderableManager();
-        float weight = (sin(now * 2.0) + 1.0f) * 0.5f;
-        rm.setMorphWeights(rm.getInstance(app.renderable), &weight, 1);
-    });
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .backend(app.config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  constexpr float ZOOM = 2.5f;
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                          aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
 
-    FilamentApp::get().run(app.config, setup, cleanup);
+                                  auto& rm = engine->getRenderableManager();
+                                  float weight = (sin(now * 2.0) + 1.0f) * 0.5f;
+                                  rm.setMorphWeights(rm.getInstance(app.renderable), &weight, 1);
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/hybrid_instancing.cpp
+++ b/samples/hybrid_instancing.cpp
@@ -35,9 +35,11 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Color.h>
@@ -56,34 +58,30 @@
 
 #include <camutils/Bookmark.h>
 
+#include <utils/EntityManager.h>
+#include <utils/getopt.h>
+#include <utils/Path.h>
+
 #include <math/mat3.h>
 #include <math/mat4.h>
+#include <math/norm.h>
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
-#include <math/norm.h>
 
-#include <utils/EntityManager.h>
-#include <utils/Path.h>
-
-#include <utils/getopt.h>
+#include <imgui.h>
 
 #include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <random>
 #include <string>
 #include <vector>
 
-#include <cmath>
-#include <cstddef>
-#include <cstdlib>
-#include <cstdint>
-
 #include <math.h>
-
-#include <imgui.h>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using namespace filament::math;
@@ -184,6 +182,7 @@ struct Emitter {
 
 // Holds all the state for this application.
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     enum class EmitterMode { CONTINUOUS, FIREWORKS };
 
     struct UiState {
@@ -197,7 +196,7 @@ struct App {
         bool moonlightEnabled = true;
     };
 
-    Config config;
+    SampleConfig config;
     UiState ui;
     int currentEmitterCount = 0;
     bool previousFireworksMode = false;
@@ -328,8 +327,17 @@ int main(int const argc, char** argv) {
         doUserInterface(app);
     };
 
-    FilamentApp::get().animate(animate);
-    FilamentApp::get().run(app.config, setup, cleanup, imgui);
+
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .backend(app.config.backend)
+                              .cameraMode(app.config.cameraMode)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui(imgui)
+                              .animation(animate)
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/image_viewer.cpp
+++ b/samples/image_viewer.cpp
@@ -15,9 +15,15 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include "generated/resources/resources.h"
+
+#include <viewer/ViewerGui.h>
+
+#include <imageio/ImageDecoder.h>
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/ColorGrading.h>
@@ -32,29 +38,22 @@
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
-#include <utils/EntityManager.h>
-
-#include <viewer/ViewerGui.h>
-
 #include <camutils/Manipulator.h>
 
+#include <utils/EntityManager.h>
 #include <utils/getopt.h>
 
 #include <math/half.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
 #include <math/mat3.h>
 #include <math/norm.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
 
 #include <imgui.h>
-
-#include <imageio/ImageDecoder.h>
 
 #include <fstream>
 #include <iostream>
 #include <string>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using namespace filament::math;
@@ -64,9 +63,10 @@ using namespace image;
 using namespace utils;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Engine* engine;
     ViewerGui* viewer;
-    Config config;
+    SampleConfig config;
     Camera* mainCamera;
 
     struct Scene {
@@ -198,12 +198,12 @@ static void createImageRenderable(Engine* engine, Scene* scene, App& app) {
     app.scene.imageMaterial = material;
 
     Texture* texture = Texture::Builder()
-            .width(1)
-            .height(1)
-            .levels(1)
-            .format(Texture::InternalFormat::RGBA8)
-            .sampler(Texture::Sampler::SAMPLER_2D)
-            .build(*engine);
+                               .width(1)
+                               .height(1)
+                               .levels(1)
+                               .format(Texture::InternalFormat::RGBA8)
+                               .sampler(Texture::Sampler::SAMPLER_2D)
+                               .build(*engine);
     static uint32_t pixel = 0;
     Texture::PixelBufferDescriptor buffer(&pixel, 4, Texture::Format::RGBA, Texture::Type::UBYTE);
     texture->setImage(*engine, 0, std::move(buffer));
@@ -239,14 +239,14 @@ static void loadImage(App& app, Engine* engine, const Path& filename) {
     uint32_t w = image->getWidth();
     uint32_t h = image->getHeight();
     Texture* texture = Texture::Builder()
-            .width(w)
-            .height(h)
-            .levels(0xff)
-            .format(channels == 3 ?
-                    Texture::InternalFormat::RGB16F : Texture::InternalFormat::RGBA16F)
-            .sampler(Texture::Sampler::SAMPLER_2D)
-            .usage(Texture::Usage::DEFAULT | Texture::Usage::GEN_MIPMAPPABLE)
-            .build(*engine);
+                               .width(w)
+                               .height(h)
+                               .levels(0xff)
+                               .format(channels == 3 ? Texture::InternalFormat::RGB16F
+                                                     : Texture::InternalFormat::RGBA16F)
+                               .sampler(Texture::Sampler::SAMPLER_2D)
+                               .usage(Texture::Usage::DEFAULT | Texture::Usage::GEN_MIPMAPPABLE)
+                               .build(*engine);
 
     Texture::PixelBufferDescriptor::Callback freeCallback = [](void* buf, size_t, void* data) {
         delete reinterpret_cast<LinearImage*>(data);
@@ -322,7 +322,7 @@ int main(int argc, char** argv) {
     auto gui = [&app](Engine* engine, View* view) {
         app.viewer->updateUserInterface();
 
-        FilamentApp::get().setSidebarWidth(app.viewer->getSidebarWidth());
+        app.filamentApp->setSidebarWidth(app.viewer->getSidebarWidth());
     };
 
     auto preRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
@@ -390,14 +390,21 @@ int main(int argc, char** argv) {
         app.scene.imageMaterial->setDefaultParameter(
                 "backgroundColor", RgbType::sRGB, app.backgroundColor);
     };
-
-    FilamentApp& filamentApp = FilamentApp::get();
-
-    filamentApp.setDropHandler([&] (std::string_view path) {
-        loadImage(app, app.engine, Path(path));
-    });
-
-    filamentApp.run(app.config, setup, cleanup, gui, preRender);
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(app.config.title)
+                    .backend(app.config.backend)
+                    .cameraMode(app.config.cameraMode)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(app.config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .imgui(gui)
+                    .preRender(preRender)
+                    .dropHandler(
+                            [&](std::string_view path) { loadImage(app, app.engine, Path(path)); })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -15,39 +15,38 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <iostream>
-#include <string>
-#include <map>
-#include <vector>
+#include "generated/resources/resources.h"
 
-#include <utils/getopt.h>
-
-#include <utils/EntityManager.h>
-#include <utils/Path.h>
+#include <filamentapp/Cube.h>
+#include <filamentapp/FilamentApp2.h>
+#include <filamentapp/IcoSphere.h>
+#include <filamentapp/MeshAssimp.h>
+#include <filamentapp/Sphere.h>
 
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
-#include <filament/Material.h>
-#include <filament/Scene.h>
 #include <filament/LightManager.h>
-#include <filament/Renderer.h>
+#include <filament/Material.h>
 #include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
+#include <filament/Scene.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-
-#include <math/norm.h>
-#include <utils/Log.h>
 #include <filament/View.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-#include <filamentapp/MeshAssimp.h>
-#include <filamentapp/Cube.h>
-#include <filamentapp/IcoSphere.h>
-#include <filamentapp/Sphere.h>
+#include <utils/EntityManager.h>
+#include <utils/getopt.h>
+#include <utils/Log.h>
+#include <utils/Path.h>
 
-#include "generated/resources/resources.h"
+#include <math/norm.h>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace filament::math;
 using namespace filament;
@@ -67,7 +66,8 @@ static Entity g_discoBallEntity;
 static float g_discoAngle = 0;
 static float g_discoAngularSpeed = 0.25f * float(M_PI);  // rad/s
 
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 static bool g_moreLights = false;
 static bool g_shadowPlane = false;
 static bool g_discoBall = false;
@@ -109,7 +109,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "hi:vs:mdcpa:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -193,10 +193,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
         filament::Renderer* renderer) {
 
     // Without an IBL, we must clear the swapchain to black before each frame.
-    renderer->setClearOptions({
-            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clear = !FilamentApp::get().getIBL()  });
-
+    renderer->setClearOptions(
+            { .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f }, .clear = !g_filamentApp->getIBL() });
 }
 
 
@@ -296,7 +294,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             scene->addEntity(light);
             const LightManager::Instance& instance = lcm.getInstance(light);
             if (!lcm.isDirectional(instance)) {
-                g_spheres.emplace_back(*engine, FilamentApp::get().getDefaultMaterial());
+                g_spheres.emplace_back(*engine, g_filamentApp->getDefaultMaterial());
                 g_spheres.back()
                          .setRadius(0.025f)
                          .setPosition(lcm.getPosition(instance));
@@ -340,7 +338,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         }
         g_discoBallEntity = discoBall;
 
-        g_spheres.emplace_back(*engine, FilamentApp::get().getDefaultMaterial());
+        g_spheres.emplace_back(*engine, g_filamentApp->getDefaultMaterial());
         g_spheres.back().setRadius(0.2f);
         auto mi = g_spheres.back().getMaterialInstance();
         mi->setParameter("baseColor", RgbaType::LINEAR, LinearColorA{ 1, 1, 1, 1 });
@@ -351,7 +349,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         tcm.setParent(tcm.getInstance(g_spheres.back().getSolidRenderable()), tcm.getInstance(discoBall));
     }
 
-    g_meshAabb.reset(new Cube(*engine, FilamentApp::get().getTransparentMaterial(), {0,0,1}));
+    g_meshAabb.reset(new Cube(*engine, g_filamentApp->getTransparentMaterial(), { 0, 0, 1 }));
 
     // First object in the scene
     Entity object = g_meshSet->getRenderables()[1];
@@ -438,6 +436,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 }
 #pragma clang diagnostic pop
 
+
 int main(int argc, char* argv[]) {
     int option_index = handleCommandLineArgments(argc, argv, &g_config);
     int num_args = argc - option_index;
@@ -456,26 +455,37 @@ int main(int argc, char* argv[]) {
     }
 
     g_config.title = "Lightbulb";
-    FilamentApp& filamentApp = FilamentApp::get();
 
+    FilamentApp2::AnimCallback animate = nullptr;
     double lastTime = 0;
     if (g_discoBall) {
-        filamentApp.animate([lastTime](filament::Engine* engine, filament::View*, double now) mutable {
+        animate = [lastTime](filament::Engine* engine, filament::View*, double now) mutable {
             auto& tcm = engine->getTransformManager();
             tcm.setTransform(tcm.getInstance(g_discoBallEntity),
-                    mat4f::translation(float3{ 0, 2, -4, }) *
-                                                            mat4f::rotation(g_discoAngle,
-                                                                    float3{ 0, 1, 0 })
-            );
+                    filament::math::mat4f::translation(filament::math::float3{
+                        0,
+                        2,
+                        -4,
+                    }) * filament::math::mat4f::rotation(g_discoAngle,
+                                 filament::math::float3{ 0, 1, 0 }));
             if (lastTime != 0) {
                 double dT = now - lastTime;
                 g_discoAngle += g_discoAngularSpeed * dT;
             }
             lastTime = now;
-        });
+        };
     }
 
-    filamentApp.run(g_config, setup, cleanup, {}, preRender);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .scale(g_config.scale)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .preRender(preRender)
+                            .animation(animate)
+                            .build();
+    g_filamentApp->run();
+
 
     return 0;
 }

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -17,9 +17,9 @@
 #include "material_sandbox.h"
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/IBL.h>
 #include <filamentapp/MeshAssimp.h>
 
@@ -71,7 +71,8 @@ static std::map<std::string, MaterialInstance*> g_meshMaterialInstances;
 static SandboxParameters g_params;
 static ColorGradingOptions g_lastColorGradingOptions;
 static ColorGrading* g_colorGrading = nullptr;
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 static bool g_shadowPlane = false;
 static bool g_singleMode = false;
 static float g_rangePlot[1024 * 3];
@@ -125,7 +126,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(const int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(const int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:vps:i:d:c:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -326,7 +327,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
                 mat4f::translation(float3{ 0, -1, -4 }));
     }
 
-    if (auto* ibl = FilamentApp::get().getIBL()) {
+    if (auto* ibl = g_filamentApp->getIBL()) {
         auto& params = g_params;
         IndirectLight* const pIndirectLight = ibl->getIndirectLight();
         // If we loaded an equirectangular IBL, we don't have spherical harmonics. In that case,
@@ -341,7 +342,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
         }
     }
 
-    g_params.bloomOptions.dirt = FilamentApp::get().getDirtTexture();
+    g_params.bloomOptions.dirt = g_filamentApp->getDirtTexture();
 }
 
 static MaterialInstance* updateInstances(SandboxParameters& params) {
@@ -614,8 +615,8 @@ static void gui(Engine* engine, View*) {
             ImGui::SliderFloat("Far", &params.cameraFar, 1.0f, 10000.0f);
             ImGui::Unindent();
 
-            FilamentApp::get().setCameraFocalLength(params.cameraFocalLength);
-            FilamentApp::get().setCameraNearFar(params.cameraNear, params.cameraFar);
+            g_filamentApp->setCameraFocalLength(params.cameraFocalLength);
+            g_filamentApp->setCameraNearFar(params.cameraNear, params.cameraFar);
         }
 
         if (ImGui::CollapsingHeader("Indirect Light")) {
@@ -942,7 +943,7 @@ static void gui(Engine* engine, View*) {
         params.hasDirectionalLight = false;
     }
 
-    if (auto* ibl = FilamentApp::get().getIBL()) {
+    if (auto* ibl = g_filamentApp->getIBL()) {
         ibl->getIndirectLight()->setIntensity(params.iblIntensity);
         ibl->getIndirectLight()->setRotation(
                 mat3f::rotation(params.iblRotation, float3{ 0, 1, 0 }));
@@ -1039,13 +1040,13 @@ static void preRender(Engine* engine, View* view, Scene*, Renderer* renderer) {
     }
 
     // Without an IBL, we must clear the swapchain to black before each frame.
-    renderer->setClearOptions({
-            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clear = !FilamentApp::get().getIBL()  });
+    renderer->setClearOptions(
+            { .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f }, .clear = !g_filamentApp->getIBL() });
 
     Camera& camera = view->getCamera();
     camera.setExposure(g_params.cameraAperture, 1.0f / g_params.cameraSpeed, g_params.cameraISO);
 }
+
 
 int main(const int argc, char* argv[]) {
     const int option_index = handleCommandLineArgments(argc, argv, &g_config);
@@ -1067,7 +1068,14 @@ int main(const int argc, char* argv[]) {
     g_params.bloomOptions.enabled = true;
 
     g_config.title = "Material Sandbox";
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.run(g_config, setup, cleanup, gui, preRender);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .scale(g_config.scale)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .imgui(gui)
+                            .preRender(preRender)
+                            .build();
+    g_filamentApp->run();
     return 0;
 }

--- a/samples/materialinstancestress.cpp
+++ b/samples/materialinstancestress.cpp
@@ -15,6 +15,14 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/monkey.h"
+#include "generated/resources/resources.h"
+
+#include <filameshio/MeshReader.h>
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
@@ -26,14 +34,8 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
-#include <filameshio/MeshReader.h>
-
 #include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <imgui.h>
 
@@ -42,15 +44,13 @@
 #include <string>
 #include <vector>
 
-#include "generated/resources/monkey.h"
-#include "generated/resources/resources.h"
-
 using namespace filament;
 using namespace filament::math;
 using namespace utils;
 using namespace filamesh;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     struct UiState {
         int objectCountSlider = 100;
         float updateRatio = 0.5f;
@@ -95,7 +95,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help", utils::getopt::no_argument, nullptr, 'h' },
@@ -197,9 +197,9 @@ static void createSceneObjects(Engine* engine, Scene* scene, App& app) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "Material Instances Stress Test";
-    config.iblDirectory = FilamentApp::getRootAssetsPath() + "assets/ibl/lightroom_14b";
+    config.iblDirectory = FilamentApp2::getRootAssetsPath() + "assets/ibl/lightroom_14b";
     handleCommandLineArguments(argc, argv, &config);
 
     App app;
@@ -300,8 +300,16 @@ int main(int argc, char** argv) {
         }
     };
 
-    FilamentApp::get().animate(animate);
-    FilamentApp::get().run(config, setup, cleanup, gui);
+
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .iblDirectory(config.iblDirectory)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui(gui)
+                              .animation(animate)
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -21,7 +21,7 @@
 
 #include <filameshio/MeshReader.h>
 
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/IBL.h>
 #include <filamentapp/NativeWindowHelper.h>
 
@@ -278,7 +278,7 @@ void resize_window(Window& w, Engine* engine) {
 }
 
 void setup_static_scene(Window& w, Engine* engine) {
-    auto iblDir = FilamentApp::getRootAssetsPath() + kIBLFolder;
+    auto iblDir = FilamentApp2::getRootAssetsPath() + kIBLFolder;
     w.ibl = load_IBL(iblDir, engine);
     if (w.ibl) {
         w.ibl->getIndirectLight()->setIntensity(10000);
@@ -311,7 +311,7 @@ void setup_static_scene(Window& w, Engine* engine) {
 }
 
 void setup_animating_scene(Window& w, Engine* engine) {
-    auto iblDir = FilamentApp::getRootAssetsPath() + kIBLFolder;
+    auto iblDir = FilamentApp2::getRootAssetsPath() + kIBLFolder;
     w.ibl = load_IBL(iblDir, engine);
     if (w.ibl) {
         w.ibl->getIndirectLight()->setIntensity(10000);

--- a/samples/point_sprites.cpp
+++ b/samples/point_sprites.cpp
@@ -15,6 +15,14 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <image/ImageSampler.h>
+#include <image/LinearImage.h>
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -24,22 +32,14 @@
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
-#include <filament/TransformManager.h>
 #include <filament/TextureSampler.h>
+#include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
 
-#include <image/ImageSampler.h>
-#include <image/LinearImage.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <cmath>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using namespace filament::math;
@@ -52,6 +52,7 @@ using MagFilter = TextureSampler::MagFilter;
 using AttributeType = VertexBuffer::AttributeType;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -189,15 +190,25 @@ void animate(App& app, Engine* engine, View* view, double now) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "point_sprites";
     config.backend = samples::parseArgumentsForBackend(argc, argv);
 
     App app;
-    FilamentApp::get().animate([&app](Engine* e, View* v, double now) { animate(app, e, v, now); });
-    FilamentApp::get().run(config,
-            [&app](Engine* engine, View* view, Scene* scene) { setup(app, engine, view, scene); },
-            [&app](Engine* engine, View*, Scene*) { cleanup(app, engine); });
+
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .backend(config.backend)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup([&app](Engine* engine, View* view, Scene* scene) {
+                        setup(app, engine, view, scene);
+                    })
+                    .cleanup([&app](Engine* engine, View*, Scene*) { cleanup(app, engine); })
+                    .animation([&app](Engine* e, View* v, double now) { animate(app, e, v, now); })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/procedural_effect.cpp
+++ b/samples/procedural_effect.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -29,19 +34,13 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <stb_image.h>
 
 #include <iostream>
 #include <string>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -51,6 +50,7 @@ using MinFilter = TextureSampler::MinFilter;
 using MagFilter = TextureSampler::MagFilter;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb = nullptr;
     Material* mat = nullptr;
     MaterialInstance* matInstance = nullptr;
@@ -83,7 +83,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig& config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
         { "help", utils::getopt::no_argument,       nullptr, 'h' },
@@ -108,7 +108,7 @@ static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "procedural_effect";
     handleCommandLineArguments(argc, argv, config);
 
@@ -157,22 +157,28 @@ int main(int argc, char** argv) {
         EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine*, View* view, double now) {
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = float(w) / float(h);
-        app.cam->setProjection(Camera::Projection::ORTHO,
-                -aspect, aspect, -1.0f, 1.0f, 0.0f, 1.0f);
 
-        static double startTime = 0.0;
-        if (startTime == 0.0) {
-            startTime = now;
-        }
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine*, View* view, double now) {
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = float(w) / float(h);
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect, aspect,
+                                          -1.0f, 1.0f, 0.0f, 1.0f);
 
-        double elapsed = now - startTime;
-        app.matInstance->setParameter("time", (float)elapsed);
-    });
+                                  static double startTime = 0.0;
+                                  if (startTime == 0.0) {
+                                      startTime = now;
+                                  }
 
-    FilamentApp::get().run(config, setup, cleanup);
+                                  double elapsed = now - startTime;
+                                  app.matInstance->setParameter("time", (float) elapsed);
+                              })
+                              .build();
+    app.filamentApp->run();
     return 0;
 }

--- a/samples/procedural_texture_quad.cpp
+++ b/samples/procedural_texture_quad.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -29,19 +34,13 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <stb_image.h>
 
 #include <iostream>
 #include <string>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -51,6 +50,7 @@ using MinFilter = TextureSampler::MinFilter;
 using MagFilter = TextureSampler::MagFilter;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb = nullptr;
     Material* mat = nullptr;
     MaterialInstance* matInstance = nullptr;
@@ -84,7 +84,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig& config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
         { "help", utils::getopt::no_argument,       nullptr, 'h' },
@@ -109,13 +109,13 @@ static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "procedural_texture_quad";
     handleCommandLineArguments(argc, argv, config);
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {
-        Path path = FilamentApp::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
+        Path path = FilamentApp2::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
         if (!path.exists()) {
             std::cerr << "The texture " << path << " does not exist" << std::endl;
             exit(1);
@@ -186,14 +186,20 @@ int main(int argc, char** argv) {
         EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine*, View* view, double) {
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = float(w) / float(h);
-        app.cam->setProjection(Camera::Projection::ORTHO,
-                -aspect, aspect, -1.0f, 1.0f, 0.0f, 1.0f);
-    });
 
-    FilamentApp::get().run(config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine*, View* view, double) {
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = float(w) / float(h);
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect, aspect,
+                                          -1.0f, 1.0f, 0.0f, 1.0f);
+                              })
+                              .build();
+    app.filamentApp->run();
     return 0;
 }

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -15,6 +15,14 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/monkey.h"
+#include "generated/resources/resources.h"
+
+#include <filameshio/MeshReader.h>
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -31,18 +39,9 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-
-#include <filameshio/MeshReader.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
 
 #include <iostream>
-
-#include "generated/resources/resources.h"
-#include "generated/resources/monkey.h"
 
 using namespace filament;
 using namespace filamesh;
@@ -54,6 +53,7 @@ struct Vertex {
 };
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     utils::Entity lightEntity;
     Material* meshMaterial;
     MaterialInstance* meshMatInstance;
@@ -74,7 +74,7 @@ struct App {
     };
 
     ReflectionMode mode = ReflectionMode::CAMERA;
-    Config config;
+    SampleConfig config;
 
     utils::Entity quadEntity;
     VertexBuffer* quadVb = nullptr;
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
         app.offscreenView->setViewport({0, 0, vp.width, vp.height});
         app.offscreenCamera = engine->createCamera(em.create());
         app.offscreenView->setCamera(app.offscreenCamera);
-        FilamentApp::get().addOffscreenView(app.offscreenView);
+        app.filamentApp->addOffscreenView(app.offscreenView);
 
         // Position and orient the mirror in an interesting way.
         float3 c = app.quadCenter = {-2, 0, -5};
@@ -337,39 +337,54 @@ int main(int argc, char** argv) {
         renderer->setClearOptions({.clearColor = {0.1,0.2,0.4,1.0}, .clear = true});
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        auto& tcm = engine->getTransformManager();
 
-        // Animate the monkey by spinning and sliding back and forth along Z.
-        auto ti = tcm.getInstance(app.monkeyMesh.renderable);
-        mat4f xlate = mat4f::translation(float3(0, 0, 0.5 + sin(now)));
-        mat4f xform =  app.transform * xlate * mat4f::rotation(now, float3{ 0, 1, 0 });
-        tcm.setTransform(ti, xform);
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(app.config.title)
+                    .backend(app.config.backend)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(app.config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .imgui({})
+                    .preRender(preRender)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        auto& tcm = engine->getTransformManager();
 
-        // Generate a reflection matrix from the plane equation Ax + By + Cz + D = 0.
-        const float3 planeNormal = app.quadNormal;
-        const float4 planeEquation(planeNormal, -dot(planeNormal, app.quadCenter));
-        const mat4f reflection = reflectionMatrix(planeEquation);
+                        // Animate the monkey by spinning and sliding back and forth along Z.
+                        auto ti = tcm.getInstance(app.monkeyMesh.renderable);
+                        mat4f xlate = mat4f::translation(float3(0, 0, 0.5 + sin(now)));
+                        mat4f xform =
+                                app.transform * xlate * mat4f::rotation(now, float3{ 0, 1, 0 });
+                        tcm.setTransform(ti, xform);
 
-        // Apply the reflection matrix to either the renderable or the camera, depending on mode.
-        Camera const& camera = view->getCamera();
-        const auto model = camera.getModelMatrix();
-        const auto renderingProjection = camera.getProjectionMatrix();
-        const auto cullingProjection = camera.getCullingProjectionMatrix();
-        app.offscreenCamera->setCustomProjection(renderingProjection, cullingProjection,
-                camera.getNear(), camera.getCullingFar());
-        switch (app.mode) {
-            case App::ReflectionMode::RENDERABLES:
-                tcm.setTransform(tcm.getInstance(app.reflectedMonkey), reflection * xform);
-                app.offscreenCamera->setModelMatrix(model);
-                break;
-            case App::ReflectionMode::CAMERA:
-                app.offscreenCamera->setModelMatrix(reflection * model);
-                break;
-        }
-    });
+                        // Generate a reflection matrix from the plane equation Ax + By + Cz + D =
+                        // 0.
+                        const float3 planeNormal = app.quadNormal;
+                        const float4 planeEquation(planeNormal, -dot(planeNormal, app.quadCenter));
+                        const mat4f reflection = reflectionMatrix(planeEquation);
 
-    FilamentApp::get().run(app.config, setup, cleanup, FilamentApp::ImGuiCallback(), preRender);
+                        // Apply the reflection matrix to either the renderable or the camera,
+                        // depending on mode.
+                        Camera const& camera = view->getCamera();
+                        const auto model = camera.getModelMatrix();
+                        const auto renderingProjection = camera.getProjectionMatrix();
+                        const auto cullingProjection = camera.getCullingProjectionMatrix();
+                        app.offscreenCamera->setCustomProjection(renderingProjection,
+                                cullingProjection, camera.getNear(), camera.getCullingFar());
+                        switch (app.mode) {
+                            case App::ReflectionMode::RENDERABLES:
+                                tcm.setTransform(tcm.getInstance(app.reflectedMonkey),
+                                        reflection * xform);
+                                app.offscreenCamera->setModelMatrix(model);
+                                break;
+                            case App::ReflectionMode::CAMERA:
+                                app.offscreenCamera->setModelMatrix(reflection * model);
+                                break;
+                        }
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -15,15 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <iostream>
-#include <string>
-#include <map>
-#include <vector>
+#include <filameshio/MeshReader.h>
 
-#include <utils/getopt.h>
-
-#include <utils/Path.h>
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
@@ -35,19 +31,22 @@
 #include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
 
+#include <filamat/MaterialBuilder.h>
+
+#include <utils/EntityManager.h>
+#include <utils/getopt.h>
+#include <utils/Path.h>
+
 #include <math/mat3.h>
 #include <math/mat4.h>
 #include <math/vec4.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <stb_image.h>
 
-#include <utils/EntityManager.h>
-
-#include <filamat/MaterialBuilder.h>
-#include <filameshio/MeshReader.h>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace filament::math;
 using namespace filament;
@@ -63,7 +62,8 @@ static const Material* g_material;
 static Entity g_light;
 static std::map<std::string, Texture*> g_maps;
 
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 
 static void printUsage(char* name) {
     std::string exec_name(Path(name).getName());
@@ -93,7 +93,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:i:vs:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",           utils::getopt::no_argument,       0, 'h' },
@@ -260,6 +260,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     scene->addEntity(g_light);
 }
 
+
 int main(int argc, char* argv[]) {
     int option_index = handleCommandLineArgments(argc, argv, &g_config);
     int num_args = argc - option_index;
@@ -278,8 +279,14 @@ int main(int argc, char* argv[]) {
     }
 
     g_config.title = "Cloth shading";
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.run(g_config, setup, cleanup);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .scale(g_config.scale)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .imgui(nullptr)
+                            .build();
+    g_filamentApp->run();
 
     return 0;
 }

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -15,40 +15,39 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <filamentapp/FilamentApp2.h>
 #include <filamentapp/MeshAssimp.h>
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
-#include <filament/Renderer.h>
 #include <filament/RenderableManager.h>
-#include <filament/TransformManager.h>
+#include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TransformManager.h>
+#include <filament/View.h>
 
 #include <filamat/MaterialBuilder.h>
 
-#include <utils/Path.h>
 #include <utils/EntityManager.h>
+#include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <math/mat3.h>
 #include <math/mat4.h>
 #include <math/vec3.h>
 
-#include <utils/getopt.h>
-
 #include <stb_image.h>
 
 #include <iostream>
-#include <memory>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <filament/View.h>
 
 using namespace filament::math;
 using namespace filament;
@@ -88,7 +87,8 @@ static std::array<PbrMap, MAP_COUNT> g_maps = {
     PbrMap { "height",     "heightMap",     false, nullptr },
 };
 
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 static struct PbrConfig {
     std::string materialDir;
     bool clearCoat = false;
@@ -138,7 +138,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:i:vs:m:cA";
     static const utils::getopt::option OPTIONS[] = {
             { "help",           utils::getopt::no_argument,       nullptr, 'h' },
@@ -453,11 +453,10 @@ static void preRender(filament::Engine*, filament::View*, filament::Scene*,
         filament::Renderer* renderer) {
 
     // Without an IBL, we must clear the swapchain to black before each frame.
-    renderer->setClearOptions({
-            .clearColor = { 0.5f, 0.5f, 0.5f, 1.0f },
-            .clear = !FilamentApp::get().getIBL()  });
-
+    renderer->setClearOptions(
+            { .clearColor = { 0.5f, 0.5f, 0.5f, 1.0f }, .clear = !g_filamentApp->getIBL() });
 }
+
 
 int main(int argc, char* argv[]) {
     int const option_index = handleCommandLineArgments(argc, argv, &g_config);
@@ -477,8 +476,15 @@ int main(int argc, char* argv[]) {
     }
 
     g_config.title = "PBR";
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.run(g_config, setup, cleanup, FilamentApp::ImGuiCallback(), preRender);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .scale(g_config.scale)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .imgui({})
+                            .preRender(preRender)
+                            .build();
+    g_filamentApp->run();
 
     return 0;
 }

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -15,38 +15,38 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
-#include <iostream>
-#include <string>
-#include <map>
-#include <vector>
+#include <filameshio/MeshReader.h>
 
-#include <utils/getopt.h>
-
-#include <utils/Path.h>
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
-#include <filament/TextureSampler.h>
-#include <filament/TransformManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
+#include <filament/TransformManager.h>
+
+#include <filamat/MaterialBuilder.h>
+
+#include <utils/EntityManager.h>
+#include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <math/mat3.h>
 #include <math/mat4.h>
 #include <math/vec4.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
 #include <stb_image.h>
 
-#include <utils/EntityManager.h>
-
-#include <filamat/MaterialBuilder.h>
-#include <filameshio/MeshReader.h>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace filament::math;
 using namespace filament;
@@ -64,7 +64,8 @@ static Texture* g_normalMap = nullptr;
 static Texture* g_clearCoatNormalMap = nullptr;
 static Texture* g_baseColorMap = nullptr;
 
-static Config g_config;
+static SampleConfig g_config;
+std::unique_ptr<FilamentApp2> g_filamentApp;
 static struct NormalConfig {
     std::string normalMap;
     std::string clearCoatNormalMap;
@@ -105,7 +106,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:i:vs:n:a:c:b:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",                   utils::getopt::no_argument,       nullptr, 'h' },
@@ -361,6 +362,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
     scene->addEntity(g_light);
 }
 
+
 int main(int argc, char* argv[]) {
     int option_index = handleCommandLineArgments(argc, argv, &g_config);
     int num_args = argc - option_index;
@@ -379,8 +381,14 @@ int main(int argc, char* argv[]) {
     }
 
     g_config.title = "Normal Mapping";
-    FilamentApp& filamentApp = FilamentApp::get();
-    filamentApp.run(g_config, setup, cleanup);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(g_config.title)
+                            .scale(g_config.scale)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .imgui(nullptr)
+                            .build();
+    g_filamentApp->run();
 
     return 0;
 }

--- a/samples/shadowtest.cpp
+++ b/samples/shadowtest.cpp
@@ -15,6 +15,12 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
+#include <filamentapp/MeshAssimp.h>
 
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
@@ -30,12 +36,6 @@
 
 #include <math/norm.h>
 
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-#include <filamentapp/MeshAssimp.h>
-
-#include "generated/resources/resources.h"
-
 using namespace filament;
 using namespace filament::math;
 using Backend = Engine::Backend;
@@ -48,6 +48,7 @@ struct GroundPlane {
 };
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Skybox* skybox;
     utils::Entity light;
     std::map<std::string, MaterialInstance*> materials;
@@ -63,12 +64,10 @@ static constexpr bool ENABLE_SHADOWS = true;
 
 static GroundPlane createGroundPlane(Engine* engine);
 
-static const Config config {
-    .title = "shadowtest",
-    .iblDirectory = FilamentApp::getRootAssetsPath() + IBL_FOLDER,
+static const SampleConfig config{ .title = "shadowtest",
+    .iblDirectory = FilamentApp2::getRootAssetsPath() + IBL_FOLDER,
     .scale = 1,
-    .splitView = false
-};
+    .splitView = false };
 
 int main(int argc, char** argv) {
     App app;
@@ -81,7 +80,7 @@ int main(int argc, char** argv) {
 
         // Add geometry into the scene.
         app.meshes = new MeshAssimp(*engine);
-        app.meshes->addFromFile(FilamentApp::getRootAssetsPath() + MODEL_FILE, app.materials);
+        app.meshes->addFromFile(FilamentApp2::getRootAssetsPath() + MODEL_FILE, app.materials);
         auto ti = tcm.getInstance(app.meshes->getRenderables()[0]);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         for (auto renderable : app.meshes->getRenderables()) {
@@ -124,13 +123,19 @@ int main(int argc, char** argv) {
         delete app.meshes;
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        auto& tcm = engine->getTransformManager();
-        auto ti = tcm.getInstance(app.meshes->getRenderables()[0]);
-        tcm.setTransform(ti, app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
-    });
 
-    FilamentApp::get().run(config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  auto& tcm = engine->getTransformManager();
+                                  auto ti = tcm.getInstance(app.meshes->getRenderables()[0]);
+                                  tcm.setTransform(ti,
+                                          app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/skinningtest.cpp
+++ b/samples/skinningtest.cpp
@@ -15,32 +15,31 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
 
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
+
+#include <filament/BufferObject.h>
 #include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/SkinningBuffer.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
-#include <filament/BufferObject.h>
-#include <filament/SkinningBuffer.h>
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Path.h>
-
 #include <utils/getopt.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <utils/Path.h>
 
 #include <cmath>
 #include <iostream>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -50,6 +49,7 @@ using utils::FixedCapacityVector;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vbs[10];
     size_t vbCount = 0;
     IndexBuffer *ib, *ib2;
@@ -158,7 +158,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArgments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -190,7 +190,7 @@ int main(int argc, char** argv) {
     app.boneDataPerPrimitiveMulti = FixedCapacityVector<FixedCapacityVector<float2>>(6);
     app.bonesPerVertex = 8;
 
-    Config config;
+    SampleConfig config;
     config.title = "skinning test with more than 4 bones per vertex";
 
     handleCommandLineArgments(argc, argv, &config);
@@ -657,56 +657,61 @@ int main(int argc, char** argv) {
         EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        constexpr float ZOOM = 1.5f;
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-            -aspect * ZOOM, aspect * ZOOM,
-            -ZOOM, ZOOM, 0, 1);
 
-        auto& rm = engine->getRenderableManager();
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .animation([&app](Engine* engine, View* view, double now) {
+                        constexpr float ZOOM = 1.5f;
+                        const uint32_t w = view->getViewport().width;
+                        const uint32_t h = view->getViewport().height;
+                        const float aspect = (float) w / h;
+                        app.cam->setProjection(Camera::Projection::ORTHO, -aspect * ZOOM,
+                                aspect * ZOOM, -ZOOM, ZOOM, 0, 1);
 
-        // Bone skinning animation for more than four bones per vertex
-        float t = (float)(now - (int)now);
-        size_t offset = ((size_t)now) % 9;
-        float s = sin(t * f::PI * 2.f) * 10;
-        mat4f trans[9] = {};
-        for (size_t i = 0; i < 9; i++) {
-            trans[i] = filament::math::mat4f(1);
-        }
-        mat4f trans2[9] = {};
-        for (size_t i = 0; i < 9; i++) {
-            trans2[i] = filament::math::mat4f(1);
-        }
-        mat4f transA[] = {
-            mat4f::scaling(float3(s / 10.f,s / 10.f, 1.f)),
-            mat4f::translation(float3(s, 0, 0)),
-            mat4f::translation(float3(s, s, 0)),
-            mat4f::translation(float3(0, s, 0)),
-            mat4f::translation(float3(-s, s, 0)),
-            mat4f::translation(float3(-s, 0, 0)),
-            mat4f::translation(float3(-s, -s, 0)),
-            mat4f::translation(float3(0, -s, 0)),
-            mat4f::translation(float3(s, -s, 0)),
-            filament::math::mat4f(1)};
-        trans[offset] = transA[offset];
-        trans2[offset] = transA[(offset + 3) % 9];
+                        auto& rm = engine->getRenderableManager();
 
-        app.sb->setBones(*engine,trans, 9, 0);
-        app.sb2->setBones(*engine,trans2, 9, 0);
+                        // Bone skinning animation for more than four bones per vertex
+                        float t = (float) (now - (int) now);
+                        size_t offset = ((size_t) now) % 9;
+                        float s = sin(t * f::PI * 2.f) * 10;
+                        mat4f trans[9] = {};
+                        for (size_t i = 0; i < 9; i++) {
+                            trans[i] = filament::math::mat4f(1);
+                        }
+                        mat4f trans2[9] = {};
+                        for (size_t i = 0; i < 9; i++) {
+                            trans2[i] = filament::math::mat4f(1);
+                        }
+                        mat4f transA[] = { mat4f::scaling(float3(s / 10.f, s / 10.f, 1.f)),
+                            mat4f::translation(float3(s, 0, 0)),
+                            mat4f::translation(float3(s, s, 0)),
+                            mat4f::translation(float3(0, s, 0)),
+                            mat4f::translation(float3(-s, s, 0)),
+                            mat4f::translation(float3(-s, 0, 0)),
+                            mat4f::translation(float3(-s, -s, 0)),
+                            mat4f::translation(float3(0, -s, 0)),
+                            mat4f::translation(float3(s, -s, 0)), filament::math::mat4f(1) };
+                        trans[offset] = transA[offset];
+                        trans2[offset] = transA[(offset + 3) % 9];
 
-        // Morph targets (blendshapes) animation
-        float z = (float)(sin(now)/2.f + 0.5f);
-        float weights[] = { 1 - z, 0, z};
-        rm.setMorphWeights(rm.getInstance(app.renderables[0]), weights, 3, 0);
-        rm.setMorphWeights(rm.getInstance(app.renderables[1]), weights, 3, 0);
-        rm.setMorphWeights(rm.getInstance(app.renderables[2]), weights, 3, 0);
-        rm.setMorphWeights(rm.getInstance(app.renderables[3]), weights, 3, 0);
-    });
+                        app.sb->setBones(*engine, trans, 9, 0);
+                        app.sb2->setBones(*engine, trans2, 9, 0);
 
-    FilamentApp::get().run(config, setup, cleanup);
+                        // Morph targets (blendshapes) animation
+                        float z = (float) (sin(now) / 2.f + 0.5f);
+                        float weights[] = { 1 - z, 0, z };
+                        rm.setMorphWeights(rm.getInstance(app.renderables[0]), weights, 3, 0);
+                        rm.setMorphWeights(rm.getInstance(app.renderables[1]), weights, 3, 0);
+                        rm.setMorphWeights(rm.getInstance(app.renderables[2]), weights, 3, 0);
+                        rm.setMorphWeights(rm.getInstance(app.renderables[3]), weights, 3, 0);
+                    })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/strobecolor.cpp
+++ b/samples/strobecolor.cpp
@@ -15,21 +15,23 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Engine.h>
-#include <filament/View.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
+#include <filament/View.h>
 
 #include <cmath>
 
 using namespace filament;
 
+std::unique_ptr<FilamentApp2> g_filamentApp;
+
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "strobecolor";
     config.backend = samples::parseArgumentsForBackend(argc, argv);
     Skybox* skybox;
@@ -43,15 +45,21 @@ int main(int argc, char** argv) {
     auto cleanup = [](Engine*, View*, Scene*) {
     };
 
-    FilamentApp::get().animate([&skybox](Engine*, View* view, double now) {
-        constexpr float SPEED = 4;
-        float r = 0.5f + 0.5f * std::sin(SPEED * now);
-        float g = 0.5f + 0.5f * std::sin(SPEED * now + M_PI * 2 / 3);
-        float b = 0.5f + 0.5f * std::sin(SPEED * now + M_PI * 4 / 3);
-        skybox->setColor({r, g, b, 1.0});
-    });
 
-    FilamentApp::get().run(config, setup, cleanup);
+    g_filamentApp = FilamentApp2::Builder()
+                            .title(config.title)
+                            .backend(config.backend)
+                            .setup(setup)
+                            .cleanup(cleanup)
+                            .animation([&skybox](Engine*, View* view, double now) {
+                                constexpr float SPEED = 4;
+                                float r = 0.5f + 0.5f * std::sin(SPEED * now);
+                                float g = 0.5f + 0.5f * std::sin(SPEED * now + M_PI * 2 / 3);
+                                float b = 0.5f + 0.5f * std::sin(SPEED * now + M_PI * 4 / 3);
+                                skybox->setColor({ r, g, b, 1.0 });
+                            })
+                            .build();
+    g_filamentApp->run();
 
     return 0;
 }

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -15,6 +15,17 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/monkey.h"
+#include "generated/resources/resources.h"
+
+#include <ktxreader/Ktx2Reader.h>
+
+#include <filameshio/MeshReader.h>
+
+#include <filamentapp/FilamentApp2.h>
+#include <filamentapp/IBL.h>
 
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
@@ -27,32 +38,20 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-#include <utils/Log.h>
-
-#include <filameshio/MeshReader.h>
-
-#include <ktxreader/Ktx2Reader.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-#include <filamentapp/IBL.h>
-
 #include <utils/getopt.h>
-
+#include <utils/Log.h>
 #include <utils/Path.h>
 
 #include <stb_image.h>
 
 #include <iostream>
 
-#include "generated/resources/resources.h"
-#include "generated/resources/monkey.h"
-
 using namespace filament;
 using namespace ktxreader;
 using namespace filament::math;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     Material* material;
     MaterialInstance* materialInstance;
     filamesh::MeshReader::Mesh mesh;
@@ -88,7 +87,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config* config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig* config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
             { "help",         utils::getopt::no_argument,       nullptr, 'h' },
@@ -131,9 +130,9 @@ static Texture* loadNormalMap(Engine* engine, const uint8_t* normals, size_t nby
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "suzanne";
-    config.iblDirectory = FilamentApp::getRootAssetsPath() + IBL_FOLDER;
+    config.iblDirectory = FilamentApp2::getRootAssetsPath() + IBL_FOLDER;
 
     handleCommandLineArguments(argc, argv, &config);
 
@@ -182,7 +181,7 @@ int main(int argc, char** argv) {
         app.materialInstance->setParameter("normal", app.normal, sampler);
         app.materialInstance->setParameter("roughness", app.roughness, sampler);
 
-        auto ibl = FilamentApp::get().getIBL()->getIndirectLight();
+        auto ibl = app.filamentApp->getIBL()->getIndirectLight();
         ibl->setIntensity(100000);
         ibl->setRotation(mat3f::rotation(0.5f, float3{ 0, 1, 0 }));
 
@@ -207,7 +206,13 @@ int main(int argc, char** argv) {
         engine->destroy(app.ao);
     };
 
-    FilamentApp::get().run(config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .iblDirectory(config.iblDirectory)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/texturedquad.cpp
+++ b/samples/texturedquad.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -30,20 +35,13 @@
 #include <filament/View.h>
 
 #include <utils/EntityManager.h>
-
-#include <utils/Path.h>
-
-#include <filamentapp/Config.h>
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/getopt.h>
+#include <utils/Path.h>
 
 #include <stb_image.h>
 
 #include <iostream> // for cerr
 #include <string>   // for printing usage/help
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 using utils::Entity;
@@ -53,6 +51,7 @@ using MinFilter = TextureSampler::MinFilter;
 using MagFilter = TextureSampler::MagFilter;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -101,7 +100,7 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
-static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
+static int handleCommandLineArguments(int argc, char* argv[], SampleConfig& config) {
     static constexpr const char* OPTSTR = "ha:";
     static const utils::getopt::option OPTIONS[] = {
         { "help", utils::getopt::no_argument, nullptr, 'h' },
@@ -126,7 +125,7 @@ static int handleCommandLineArguments(int argc, char* argv[], Config& config) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "texturedquad";
     handleCommandLineArguments(argc, argv, config);
 
@@ -134,7 +133,7 @@ int main(int argc, char** argv) {
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {
 
         // Load texture
-        Path path = FilamentApp::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
+        Path path = FilamentApp2::getRootAssetsPath() + "textures/Moss_01/Moss_01_Color.png";
         if (!path.exists()) {
             std::cerr << "The texture " << path << " does not exist" << std::endl;
             exit(1);
@@ -214,17 +213,22 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
-        const float zoom = 2.0 + 2.0 * sin(now);
-        const uint32_t w = view->getViewport().width;
-        const uint32_t h = view->getViewport().height;
-        const float aspect = (float) w / h;
-        app.cam->setProjection(Camera::Projection::ORTHO,
-                -aspect * zoom, aspect * zoom,
-                -zoom, zoom, -1, 1);
-    });
 
-    FilamentApp::get().run(config, setup, cleanup);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(config.title)
+                              .backend(config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .animation([&app](Engine* engine, View* view, double now) {
+                                  const float zoom = 2.0 + 2.0 * sin(now);
+                                  const uint32_t w = view->getViewport().width;
+                                  const uint32_t h = view->getViewport().height;
+                                  const float aspect = (float) w / h;
+                                  app.cam->setProjection(Camera::Projection::ORTHO, -aspect * zoom,
+                                          aspect * zoom, -zoom, zoom, -1, 1);
+                              })
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/vbotest.cpp
+++ b/samples/vbotest.cpp
@@ -15,6 +15,11 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include "generated/resources/resources.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/Camera.h>
 #include <filament/IndexBuffer.h>
@@ -25,15 +30,12 @@
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
-#include <filamentapp/FilamentApp.h>
-
 #include <utils/EntityManager.h>
-
-#include "generated/resources/resources.h"
 
 using namespace filament;
 
 struct App {
+    std::unique_ptr<FilamentApp2> filamentApp;
     VertexBuffer* vb;
     IndexBuffer* ib;
     Material* mat;
@@ -57,7 +59,7 @@ static void setCameraProjection(App* app, View* view) {
 }
 
 int main(int argc, char** argv) {
-    Config config;
+    SampleConfig config;
     config.title = "vbotest";
     config.backend = samples::parseArgumentsForBackend(argc, argv);
 
@@ -107,16 +109,24 @@ int main(int argc, char** argv) {
         utils::EntityManager::get().destroy(app.camera);
     };
 
-    FilamentApp::get().resize([&app](Engine* engine, View* view) {
-        setCameraProjection(&app, view);
-    });
 
-    FilamentApp::get().run(config, setup, cleanup, FilamentApp::ImGuiCallback(),
-            [](Engine*, View*, Scene*, Renderer* renderer) {
-                Renderer::ClearOptions options;
-                options.clear = true;
-                renderer->setClearOptions(options);
-            });
+    app.filamentApp =
+            FilamentApp2::Builder()
+                    .title(config.title)
+                    .backend(config.backend)
+                    .configDisplayManager(
+                            static_cast<FilamentApp2::DisplayManager>(config.displayManager))
+                    .setup(setup)
+                    .cleanup(cleanup)
+                    .imgui({})
+                    .preRender([](Engine*, View*, Scene*, Renderer* renderer) {
+                        Renderer::ClearOptions options;
+                        options.clear = true;
+                        renderer->setClearOptions(options);
+                    })
+                    .resize([&app](Engine* engine, View* view) { setCameraProjection(&app, view); })
+                    .build();
+    app.filamentApp->run();
 
     return 0;
 }

--- a/samples/viewtest.cpp
+++ b/samples/viewtest.cpp
@@ -15,19 +15,19 @@
  */
 
 #include "common/arguments.h"
+#include "common/SampleConfig.h"
+
+#include <filamentapp/FilamentApp2.h>
 
 #include <filament/IndexBuffer.h>
 #include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
-#include <filament/Renderer.h>
-
-#include <filamentapp/FilamentApp.h>
 
 #include <utils/EntityManager.h>
-
 #include <utils/getopt.h>
 
 #include <iostream>
@@ -36,7 +36,8 @@
 using namespace filament;
 
 struct App {
-    Config config;
+    std::unique_ptr<FilamentApp2> filamentApp;
+    SampleConfig config;
     VertexBuffer* vb;
     IndexBuffer* ib;
     utils::Entity camera;
@@ -140,7 +141,15 @@ int main(int argc, char** argv) {
         renderer->setClearOptions({ .clear = true });
     };
 
-    FilamentApp::get().run(app.config, setup, cleanup, {}, preRender);
+    app.filamentApp = FilamentApp2::Builder()
+                              .title(app.config.title)
+                              .backend(app.config.backend)
+                              .setup(setup)
+                              .cleanup(cleanup)
+                              .imgui({})
+                              .preRender(preRender)
+                              .build();
+    app.filamentApp->run();
 
     return 0;
 }


### PR DESCRIPTION
 - FilamentApp2 differs from FilamentApp in two aspects:
 - Not a singleton (o allow for better life-time management
 - Use Builder pattern to set parameters
 - Refactor all cpp samples to use FilamentApp2
 - Mark FilamentApp as deprecated
 - Move Config to be a sample specific class - SampleConfig