### PR TITLE
Add llms.txt and Markdown Android documentation to docs

### DIFF
--- a/android/filament-android/build.gradle
+++ b/android/filament-android/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "org.jetbrains.dokka" version "1.9.20"
+}
+
 android {
     namespace 'com.google.android.filament'
 
@@ -22,6 +26,16 @@ afterEvaluate { project ->
                 artifactId = POM_ARTIFACT_ID
                 from components.release
             }
+        }
+    }
+}
+
+dokkaGfm {
+    dokkaSourceSets {
+        // Use 'register' instead of 'configureEach' to force Dokka
+        // to create a new source set from scratch.
+        register("main") {
+            sourceRoots.from(file("src/main/java"))
         }
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,8 @@ function print_help {
     echo "        (debug|release|none) is meant to indicate the type of build of the resulting prebuilts,"
     echo "        or 'none' to disable the split build."
     echo "        Defaults to 'release' (tools are always prebuilt as release unless overridden)."
+    echo "    -D"
+    echo "        Build Android Markdown documentation using Dokka."
     echo ""
     echo "Build types:"
     echo "    release"
@@ -186,6 +188,8 @@ ABI_GRADLE_OPTION="all"
 
 ISSUE_ARCHIVES=false
 BUILD_JS_DOCS=false
+BUILD_DOKKA_DOCS=false
+PLATFORM_SPECIFIED=false
 
 ISSUE_CMAKE_ALWAYS=false
 
@@ -894,7 +898,7 @@ function check_debug_release_build {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
+while getopts ":hacCfgDimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
     case ${opt} in
         h)
             print_help
@@ -940,6 +944,7 @@ while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
             BUILD_COMMAND="make"
             ;;
         p)
+            PLATFORM_SPECIFIED=true
             ISSUE_DESKTOP_BUILD=false
             platforms=$(echo "${OPTARG}" | tr ',' '\n')
             for platform in ${platforms}
@@ -1071,6 +1076,9 @@ while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
             ;;
         X)  OSMESA_OPTION="-DFILAMENT_OSMESA_PATH=${OPTARG}"
             ;;
+        D)
+            BUILD_DOKKA_DOCS=true
+            ;;
         y)
             SPLIT_BUILD_TYPE=${OPTARG}
             case $(echo "${SPLIT_BUILD_TYPE}" | tr '[:upper:]' '[:lower:]') in
@@ -1103,7 +1111,7 @@ while getopts ":hacCfgimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
     esac
 done
 
-if [[ "$#" == "0" ]]; then
+if [[ "$#" == "0" ]] && [[ "${BUILD_DOKKA_DOCS}" != "true" ]]; then
     print_help
     exit 1
 fi
@@ -1119,6 +1127,11 @@ for arg; do
         BUILD_CUSTOM_TARGETS="${BUILD_CUSTOM_TARGETS} ${arg}"
     fi
 done
+
+# Prevent building desktop if only docs are requested.
+if [[ "${BUILD_DOKKA_DOCS}" == "true" ]] && [[ "${PLATFORM_SPECIFIED}" != "true" ]]; then
+    ISSUE_DESKTOP_BUILD=false
+fi
 
 validate_build_command
 
@@ -1154,6 +1167,13 @@ fi
 
 if [[ "${ISSUE_WASM_BUILD}" == "true" ]]; then
     check_debug_release_build build_wasm
+fi
+
+if [[ "${BUILD_DOKKA_DOCS}" == "true" ]]; then
+    echo "Generating Android Markdown documentation using Dokka..."
+    pushd android > /dev/null
+    ./gradlew filament-android:dokkaGfm
+    popd > /dev/null
 fi
 
 if [[ "${PRINT_MATDBG_HELP}" == "true" ]]; then

--- a/docs_src/build/copy_dokka_docs.py
+++ b/docs_src/build/copy_dokka_docs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.path.join(CUR_DIR, "../../android/filament-android/build/dokka/gfm")
+DESTINATION_DIR = os.path.join(CUR_DIR, "../src_mdbook/book/android/dokka")
+
+def run():
+    """
+    Copies the Dokka-generated GFM (Markdown) documentation files from the build output
+    into the mdbook output directory.
+    """
+    if not os.path.exists(OUT_DIR):
+        print(f"Warning: Dokka output directory does not exist: {OUT_DIR}")
+        return
+
+    print(f"Copying Dokka documentation from {OUT_DIR} to {DESTINATION_DIR}...")
+    if os.path.exists(DESTINATION_DIR):
+        shutil.rmtree(DESTINATION_DIR)
+
+    shutil.copytree(OUT_DIR, DESTINATION_DIR)
+
+if __name__ == "__main__":
+    run()

--- a/docs_src/build/postsubmit.sh
+++ b/docs_src/build/postsubmit.sh
@@ -19,7 +19,7 @@ FILAMENT_BOT_TOKEN=$2
 set -ex
 
 function update_to_main() {
-    ./build.sh -W -p wasm release
+    ./build.sh -D -W -p wasm release
     python3 docs_src/build/run.py
     mkdir -p tmp
     pushd .

--- a/docs_src/build/run.py
+++ b/docs_src/build/run.py
@@ -208,3 +208,6 @@ if __name__ == "__main__":
 
   import copy_web_docs
   copy_web_docs.run()
+
+  import copy_dokka_docs
+  copy_dokka_docs.run()

--- a/docs_src/src_raw/llms.txt
+++ b/docs_src/src_raw/llms.txt
@@ -1,0 +1,18 @@
+# Filament
+
+> Filament is a real-time physically based rendering engine for Android, iOS, Linux, macOS, Windows, and WASM.
+
+## Core Guides
+
+- [Physically Based Rendering in Filament](https://google.github.io/filament/Filament.md.html): Explains the equations and theory behind the material and lighting models used in Filament.
+- [Filament Materials](https://google.github.io/filament/Materials.md.html): Describes how to author Filament material files.
+
+## API Reference
+
+- [Android Documentation](https://google.github.io/filament/android/dokka/index.md): API documentation for the Android/Java/Kotlin bindings.
+
+## Development & Contribution
+
+- [Building Filament](https://raw.githubusercontent.com/google/filament/refs/heads/main/BUILDING.md): Build pre-requisites and compilation steps for desktop, mobile, and WASM targets.
+- [Contributing to Filament](https://raw.githubusercontent.com/google/filament/refs/heads/main/CONTRIBUTING.md): Rules for pull requests, commits, and contributing to the project.
+- [Code Style](https://raw.githubusercontent.com/google/filament/refs/heads/main/CODE_STYLE.md): Coding standards, design rules, and formatting conventions.


### PR DESCRIPTION
This PR adds a boilerplate [llms.txt](https://llmstxt.org/) to our docs root. I imagine we'll add to it as time goes on.

This PR also adds Dokka generation to our docs build step. Dokka is a documentation engine for Kotlin (although it is compatible with Java as well) that can output GitHub-flavored Markdown, which is more efficient for LLMs to parse.