### PR TITLE
Fix FL0 material compilation with bool constants.

### DIFF
--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -338,6 +338,8 @@ MaterialBuilder& MaterialBuilder::constant(const char* name, ConstantType const 
         FILAMENT_CHECK_POSTCONDITION(type == ConstantType::BOOL)
                 << "Constant " << name << " was declared with type " << toString(type)
                 << " but given a bool default value.";
+        // Zero-initialize the union to prevent garbage values.
+        constant.defaultValue.i = 0;
         constant.defaultValue.b = defaultValue;
     } else {
         assert_invariant(false);


### PR DESCRIPTION
Fix a compiler bug where union members for default values of boolean constants were not fully initialized, leading to garbage values when read.

We zero-initialize the union member before setting the boolean in MaterialBuilder.cpp.

This fix resolves compilation issues for materials using boolean constants in FL0.

FIXES=533462283