### PR TITLE
renderdiff: refactor to allow other platform+backend

### DIFF
--- a/test/renderdiff/README.md
+++ b/test/renderdiff/README.md
@@ -13,7 +13,8 @@ The script `render.py` contains the core logic for taking input parameters (such
 description file) and then running `gltf_viewer` to produce the renderings.
 
 In the `test` directory is a list of test descriptions that are specified in json. Please see
-`sample.json` to glean the structure.
+`sample.json` to glean the structure. These tests declare which **renderers** they run on
+using the `platform-backend` specification format (e.g., `"desktop-opengl"`, `"desktop-vulkan"`).
 
 ## Setting up python
 
@@ -56,14 +57,15 @@ renderings, do the following step
 
 You can control the behavior of the test scripts with the following flags passed to `local_test.sh`:
 
-- `--test_filter=<filter>`: Run a subset of tests. The filter supports wildcards (`*`) to match test names.
+- `--test_filter=<filter>`: Run a subset of tests using fnmatch wildcards (`*`). It filters against
+  the pattern `{test.name}.{platform}-{backend}.{model}`.
 - `--no_rebuild`: Skip rebuilding the `gltf_viewer` executable.
 - `--num_threads=<number>`: Set the number of threads for rendering. If not set, the system's default is used.
 
-For example, to run all `MSAA` tests without rebuilding and using 8 threads:
+For example, to run all `MSAA` tests on Vulkan without rebuilding and using 8 threads:
 
 ```
-bash test/renderdiff/local_test.sh --test_filter='MSAA.*.*' --no_rebuild --num_threads=8
+bash test/renderdiff/local_test.sh --test_filter='MSAA.*vulkan*.*' --no_rebuild --num_threads=8
 ```
 
 ## Update the golden images

--- a/test/renderdiff/generate.sh
+++ b/test/renderdiff/generate.sh
@@ -83,13 +83,18 @@ esac
 done
 
 
-start_render_ && \
+start_render_ || exit 1
+
+for backend in opengl vulkan webgpu; do
+    FILAMENT_VK_ICD="${MESA_VK_ICD_PATH}" FILAMENT_OPENGL_LIB="${MESA_LIB_DIR}" \
     python3 ${RENDERDIFF_TEST_DIR}/src/render.py \
-            --gltf_viewer="$(pwd)/out/cmake-debug/samples/gltf_viewer" \
+            --executable="$(pwd)/out/cmake-debug/samples/gltf_viewer" \
+            --platform=desktop \
+            --backend=$backend \
             --test="${RENDERDIFF_TEST_DIR}/tests/presubmit.json" \
             --output_dir="${RENDER_OUTPUT_DIR}" \
-            --opengl_lib="${MESA_LIB_DIR}" \
-            --vk_icd="${MESA_VK_ICD_PATH}" \
             ${TEST_FILTER:+--test_filter="$TEST_FILTER"} \
-            ${NUM_THREADS:+--num_threads="$NUM_THREADS"} && \
-    end_render_
+            ${NUM_THREADS:+--num_threads="$NUM_THREADS"} || exit 1
+done
+
+end_render_

--- a/test/renderdiff/src/render.py
+++ b/test/renderdiff/src/render.py
@@ -15,112 +15,44 @@
 import sys
 import os
 import json
-import glob
 import shutil
-import concurrent.futures
-import fnmatch
 
-
-from utils import execute, ArgParseImpl, mkdir_p, mv_f, important_print
+from utils import ArgParseImpl, important_print
 
 import test_config
-from results import RESULT_OK, RESULT_FAILED
+from results import RESULT_OK
 
-from renderers import (
-    RenderTestCase,
-    NativeRenderer,
-    OpenGLRenderer,
-    VulkanRenderer,
-    WebGPUDesktopRenderer,
-)
-
-def _render_test_config(gltf_viewer,
-            test_config,
-            output_dir,
-            local_only=False,
-            opengl_lib=None,
-            vk_icd=None,
-            test_filter=None,
-            num_threads=None):
-  assert os.path.isdir(output_dir), f"output directory {output_dir} does not exist"
-  assert os.access(gltf_viewer, os.X_OK)
-
-  named_output_dir = os.path.join(output_dir, test_config.name)
-  mkdir_p(named_output_dir)
-
-  gltf_viewer_abs = os.path.abspath(gltf_viewer)
-
-  results = []
-  with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
-    futures = []
-    for test in test_config.tests:
-      test_json_path = os.path.abspath(
-          f'{named_output_dir}/{test.name}.simplified.json')
-
-      with open(test_json_path, 'w') as f:
-        f.write(f'[{test.to_filament_format()}]')
-
-      for backend in test.backends:
-        if backend == 'vulkan':
-          assert vk_icd, "VK ICD must be specified when testing vulkan backend"
-          renderer = VulkanRenderer(gltf_viewer_abs, vk_icd)
-        elif backend == 'opengl':
-          renderer = OpenGLRenderer(gltf_viewer_abs, opengl_lib)
-        elif backend == 'webgpu':
-          renderer = WebGPUDesktopRenderer(gltf_viewer_abs)
-        else:
-          renderer = NativeRenderer(gltf_viewer_abs)
-
-        for model in test.models:
-          test_name = f'{test.name}.{backend}.{model}'
-          if test_filter and not fnmatch.fnmatch(test_name, test_filter):
-            print(f'Skipping {test_name} because it does not match filter')
-            continue
-          model_path = os.path.abspath(test_config.models[model])
-
-          test_case = RenderTestCase(
-              test_name=test.name,
-              backend=backend,
-              model=model,
-              model_path=model_path,
-              test_json_path=test_json_path,
-              output_dir=named_output_dir
-          )
-
-          futures.append(
-            executor.submit(renderer.render, test_case))
-
-    for future in concurrent.futures.as_completed(futures):
-      results.append(future.result())
-
-  return named_output_dir, results
+from renderers import RendererFactory
 
 if __name__ == "__main__":
   parser = ArgParseImpl()
   parser.add_argument('--test', help='Configuration of the test', required=True)
-  parser.add_argument('--gltf_viewer', help='Path to the gltf_viewer', required=True)
+  parser.add_argument('--platform', help='Platform to render on (e.g. desktop)', default='desktop')
+  parser.add_argument('--backend', help='Backend to render with (e.g. vulkan)', required=True)
+  parser.add_argument('--executable', help='Path to the executable (e.g. gltf_viewer)', required=True)
   parser.add_argument('--output_dir', help='Output Directory', required=True)
-  parser.add_argument('--opengl_lib', help='Path to the folder containing OpenGL driver lib (for LD_LIBRARY_PATH)')
-  parser.add_argument('--vk_icd', help='Path to VK ICD file')
   parser.add_argument('--test_filter', help='Filter for the tests to run')
   parser.add_argument('--num_threads', help='Number of threads to use for rendering', type=int)
 
   args, _ = parser.parse_known_args(sys.argv[1:])
   test = test_config.parse_from_path(args.test)
 
-  output_dir, results = \
-    _render_test_config(args.gltf_viewer,
-                        test,
-                        args.output_dir,
-                        opengl_lib=args.opengl_lib,
-                        vk_icd=args.vk_icd,
-                        test_filter=args.test_filter,
-                        num_threads=args.num_threads)
+  renderer = RendererFactory.create(
+      platform=args.platform,
+      backend=args.backend,
+      executable=args.executable,
+      test_filter=args.test_filter,
+      num_threads=args.num_threads
+  )
 
-  with open(f'{output_dir}/render_results.json', 'w') as f:
+  results = renderer.run_tests(test, args.output_dir)
+
+  named_output_dir = os.path.join(args.output_dir, test.name)
+
+  with open(os.path.join(named_output_dir, f'render_results_{args.backend}.json'), 'w') as f:
     f.write(json.dumps(results, indent=2))
 
-  shutil.copy2(args.test, f'{output_dir}/test.json')
+  shutil.copy2(args.test, os.path.join(named_output_dir, 'test.json'))
 
   failed = [f"   {k['name']}" for k in results if k['result'] != RESULT_OK]
   success_count = len(results) - len(failed)

--- a/test/renderdiff/src/renderers.py
+++ b/test/renderdiff/src/renderers.py
@@ -14,6 +14,8 @@
 
 import abc
 import os
+import concurrent.futures
+import fnmatch
 from dataclasses import dataclass
 from utils import execute, mkdir_p, mv_f, important_print
 from results import RESULT_OK, RESULT_FAILED
@@ -28,30 +30,55 @@ class RenderTestCase:
     output_dir: str
 
 class BaseRenderer(abc.ABC):
+    def __init__(self, platform: str, backend: str, executable: str):
+        self.platform = platform
+        self.backend = backend
+        self.executable = executable
+
     @abc.abstractmethod
-    def render(self, test_case: RenderTestCase) -> dict:
+    def run_tests(self, test_config: 'RenderTestConfig', output_dir: str) -> list[dict]:
+        """Executes a suite of tests and returns a list of results."""
         pass
 
-class NativeRenderer(BaseRenderer):
-    def __init__(self, gltf_viewer: str):
-        self.gltf_viewer = gltf_viewer
+class DesktopRenderer(BaseRenderer):
+    def __init__(self, platform: str, backend: str, executable: str, num_threads: int = None, test_filter: str = None):
+        super().__init__(platform, backend, executable)
+        self.num_threads = num_threads
+        self.test_filter = test_filter
 
-    def _get_env(self, test_case: RenderTestCase) -> dict:
-        # We need to pass along the old environment because it might include vars from vulkansdk.
-        return os.environ.copy()
+    def _get_env(self) -> dict:
+        env = os.environ.copy()
+        if self.backend == 'vulkan':
+            vk_icd = os.environ.get('FILAMENT_VK_ICD')
+            if vk_icd and os.path.exists(vk_icd):
+                env.update({
+                    'VK_ICD_FILENAMES': vk_icd,
+                    'VK_DRIVER_FILES': vk_icd,
+                })
+        elif self.backend == 'opengl':
+            opengl_lib = os.environ.get('FILAMENT_OPENGL_LIB')
+            if opengl_lib and os.path.isdir(opengl_lib):
+                env.update({
+                    'LD_LIBRARY_PATH': opengl_lib,
+                    'DYLD_LIBRARY_PATH': opengl_lib,
+                })
+        return env
 
-    def render(self, test_case: RenderTestCase) -> dict:
-        env = self._get_env(test_case)
-        out_name = f'{test_case.test_name}.{test_case.backend}.{test_case.model}'
+    def render_single_test(self, test_case: RenderTestCase) -> dict:
+        env = self._get_env()
+        ext = '.tif'
+        renderer_spec = f"{self.platform}-{self.backend}"
+        out_name = f'{test_case.test_name}.{renderer_spec}.{test_case.model}'
         test_desc = out_name
 
-        working_dir = f'/tmp/renderdiff/{test_case.backend}/{test_case.model}'
+        working_dir = f'/tmp/renderdiff/{renderer_spec}/{test_case.model}'
         mkdir_p(working_dir)
 
         important_print(f'Rendering {test_desc}')
 
+        executable_abs = os.path.abspath(self.executable)
         out_code, output = execute(
-            f'{self.gltf_viewer} -a {test_case.backend} --batch={test_case.test_json_path} -e {test_case.model_path} --headless',
+            f'{executable_abs} -a {self.backend} --batch={test_case.test_json_path} -e {test_case.model_path} --headless',
             cwd=working_dir,
             env=env, capture_output=True
         )
@@ -59,7 +86,7 @@ class NativeRenderer(BaseRenderer):
         result = ''
         if out_code == 0:
             result = RESULT_OK
-            out_tif_basename = f'{out_name}.tif'
+            out_tif_basename = f'{out_name}{ext}'
             out_tif_name = f'{test_case.output_dir}/{out_tif_basename}'
             mv_f(f'{working_dir}/{test_case.test_name}0.tif', out_tif_name)
             mv_f(f'{working_dir}/{test_case.test_name}0.json', f'{test_case.output_dir}/{test_case.test_name}.json')
@@ -74,34 +101,52 @@ class NativeRenderer(BaseRenderer):
             'result_code': out_code,
         }
 
-class OpenGLRenderer(NativeRenderer):
-    def __init__(self, gltf_viewer: str, opengl_lib: str = None):
-        super().__init__(gltf_viewer)
-        self.opengl_lib = opengl_lib
+    def run_tests(self, test_config, output_dir: str) -> list[dict]:
+        named_output_dir = os.path.join(output_dir, test_config.name)
+        mkdir_p(named_output_dir)
 
-    def _get_env(self, test_case: RenderTestCase) -> dict:
-        env = super()._get_env(test_case)
-        if self.opengl_lib and os.path.isdir(self.opengl_lib):
-            env.update({
-                'LD_LIBRARY_PATH': self.opengl_lib,
-                # for macOS
-                'DYLD_LIBRARY_PATH': self.opengl_lib,
-            })
-        return env
+        results = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_threads) as executor:
+            futures = []
+            for test in test_config.tests:
+                renderer_spec = f"{self.platform}-{self.backend}"
+                if renderer_spec not in test.renderers:
+                    continue
 
-class VulkanRenderer(NativeRenderer):
-    def __init__(self, gltf_viewer: str, vk_icd: str = None):
-        super().__init__(gltf_viewer)
-        self.vk_icd = vk_icd
+                test_json_path = os.path.abspath(f'{named_output_dir}/{test.name}.simplified.json')
 
-    def _get_env(self, test_case: RenderTestCase) -> dict:
-        env = super()._get_env(test_case)
-        if self.vk_icd and os.path.exists(self.vk_icd):
-            env.update({
-                'VK_ICD_FILENAMES': self.vk_icd,
-                'VK_DRIVER_FILES': self.vk_icd,
-            })
-        return env
+                with open(test_json_path, 'w') as f:
+                    f.write(f'[{test.to_filament_format()}]')
 
-class WebGPUDesktopRenderer(NativeRenderer):
-    pass
+                for model in test.models:
+                    renderer_spec = f"{self.platform}-{self.backend}"
+                    test_name = f'{test.name}.{renderer_spec}.{model}'
+                    if self.test_filter and not fnmatch.fnmatch(test_name, self.test_filter):
+                        print(f'Skipping {test_name} because it does not match filter')
+                        continue
+                    model_path = os.path.abspath(test_config.models[model])
+
+                    test_case = RenderTestCase(
+                        test_name=test.name,
+                        backend=self.backend,
+                        model=model,
+                        model_path=model_path,
+                        test_json_path=test_json_path,
+                        output_dir=named_output_dir
+                    )
+
+                    futures.append(executor.submit(self.render_single_test, test_case))
+
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+
+        return results
+
+class RendererFactory:
+    @staticmethod
+    def create(platform: str, backend: str, executable: str, **kwargs) -> BaseRenderer:
+        if platform == 'desktop':
+            return DesktopRenderer(platform, backend, executable, **kwargs)
+        else:
+            # AndroidRenderer and others would be instantiated here.
+            raise NotImplementedError(f"Platform '{platform}' is not fully implemented yet.")

--- a/test/renderdiff/src/test_config.py
+++ b/test/renderdiff/src/test_config.py
@@ -110,14 +110,14 @@ class PresetConfig(RenderingConfig):
         assert 0 <= tolerance['maxFailingPixelsFraction'] <= 1.0, "maxFailingPixelsFraction must be 0.0-1.0"
 
 class TestConfig(RenderingConfig):
-  def __init__(self, data, existing_models, presets, backends):
+  def __init__(self, data, existing_models, presets, renderers):
     RenderingConfig.__init__(self, data)
     description = data.get('description')
     if description:
       assert _is_string(description)
       self.description = description
 
-    self.backends = data.get('backends', backends)
+    self.renderers = data.get('renderers', renderers)
 
     apply_presets = data.get('apply_presets')
     rendering = {}
@@ -179,9 +179,9 @@ class RenderTestConfig():
     assert _is_string(name)
     self.name = name
 
-    assert 'backends' in data
-    backends = data['backends']
-    assert _is_list_of_strings(backends)
+    assert 'renderers' in data
+    renderers = data['renderers']
+    assert _is_list_of_strings(renderers)
 
     assert 'model_search_paths' in data
     model_search_paths = data.get('model_search_paths')
@@ -201,7 +201,7 @@ class RenderTestConfig():
       presets = [PresetConfig(p, self.models) for p in preset_data]
 
     assert 'tests' in data
-    self.tests = [TestConfig(t, self.models, presets, backends) for t in data['tests']]
+    self.tests = [TestConfig(t, self.models, presets, renderers) for t in data['tests']]
     test_names = list([t.name for t in self.tests])
 
     # We cannot have duplicate test names

--- a/test/renderdiff/tests/presubmit.json
+++ b/test/renderdiff/tests/presubmit.json
@@ -1,6 +1,6 @@
 {
     "name": "presubmit",
-    "backends": ["opengl", "vulkan", "webgpu"],
+    "renderers": ["desktop-opengl", "desktop-vulkan", "desktop-webgpu"],
     "model_search_paths": ["third_party/models", "gltf"],
     "presets": [
         {
@@ -84,8 +84,8 @@
             "name": "Bloom",
             "description": "Bloom",
             "apply_presets": ["base", "bloom_models"],
-            // Do not include "webgpu" in the following backend since it is flaky (b/454921221)
-            "backends": ["opengl", "vulkan"],
+            // Do not include "desktop-webgpu" in the following backend since it is flaky (b/454921221)
+            "renderers": ["desktop-opengl", "desktop-vulkan"],
             "rendering": {
                 "view.bloom.enabled": true
             }
@@ -101,8 +101,8 @@
         {
             "name": "Transimssion",
             "description": "transmission",
-            // Disable transmission for webgpu because it seems flaky (b/488070152)
-            "backends": ["opengl", "vulkan"],
+            // Disable transmission for desktop-webgpu because it seems flaky (b/488070152)
+            "renderers": ["desktop-opengl", "desktop-vulkan"],
             "apply_presets": ["base", "transmission_models"],
             "rendering": {
                 "camera.focalLength": 52.0
@@ -130,8 +130,6 @@
         {
             "name": "SSR",
             "description": "Screen space reflections",
-            // Do not include "webgpu" since it is flaky (b/454921221)
-            "backends": ["opengl", "vulkan"],
             "apply_presets": ["base", "ssr_models"],
             "rendering": {
                 "view.screenSpaceReflections.enabled": true

--- a/test/renderdiff/tests/sample.json
+++ b/test/renderdiff/tests/sample.json
@@ -1,7 +1,7 @@
 {
     "name": "SampleTest" ,                            // [required]
-    "backends": ["opengl"],                           // [required] Specifies the backend that will be used to render
-                                                      //     this test
+    "renderers": ["desktop-opengl"],                  // [required] Specifies the renderer target that will be used
+                                                      //     to render this test
     "model_search_paths": ["third_party/models"],     // [optional] Base iirectory from which we will glob for
                                                       //     .glb files and try to match against names in the 'models'
                                                       //     field.


### PR DESCRIPTION
Use the renderer abstraction to describe the combination of platform+backend+executable.  This means that we can run the same test on different platforms (e.g. desktop and android) or render using one of the desktop samples.

Rename "backends" to "renderers"

Enable "SSR" for webgpu as an experiment.