### PR TITLE
geometry: validate triangle indices in SurfaceOrientation (OOB read/write)

### DIFF
--- a/libs/geometry/src/SurfaceOrientation.cpp
+++ b/libs/geometry/src/SurfaceOrientation.cpp
@@ -245,7 +245,16 @@ SurfaceOrientation* OrientationBuilderImpl::buildWithUvs() {
     memset(tan2.data(), 0, sizeof(float3) * vertexCount);
     for (size_t a = 0; a < triangleCount; ++a) {
         uint3 tri = triangles16 ? uint3(triangles16[a]) : triangles32[a];
-        assert_invariant(tri.x < vertexCount && tri.y < vertexCount && tri.z < vertexCount);
+        // assert_invariant compiles to a no-op in release (NDEBUG) builds,
+        // so this check must use a release-mode precondition to prevent a
+        // heap out-of-bounds read on positions[]/uvs[] when triangle indices
+        // come from untrusted input (e.g. a malformed glTF file's index
+        // accessor via gltfio). Mirrors the fix already applied to the same
+        // pattern in TangentSpaceMesh.cpp.
+        FILAMENT_CHECK_PRECONDITION(tri.x < vertexCount && tri.y < vertexCount &&
+                tri.z < vertexCount)
+                << "Triangle index out of bounds:"
+                << " vertexCount=" << vertexCount;
         const float3& v1 = positions[tri.x];
         const float3& v2 = positions[tri.y];
         const float3& v3 = positions[tri.z];
@@ -354,7 +363,16 @@ SurfaceOrientation* OrientationBuilderImpl::buildWithFlatNormals() {
     float3* normals = new float3[vertexCount];
     for (size_t a = 0; a < triangleCount; ++a) {
         const uint3 tri = triangles16 ? uint3(triangles16[a]) : triangles32[a];
-        assert_invariant(tri.x < vertexCount && tri.y < vertexCount && tri.z < vertexCount);
+        // assert_invariant compiles to a no-op in release (NDEBUG) builds,
+        // so this check must use a release-mode precondition to prevent a
+        // heap out-of-bounds write to normals[] when triangle indices come
+        // from untrusted input (e.g. a malformed glTF file's index accessor
+        // via gltfio). Mirrors the fix already applied to the same pattern
+        // in TangentSpaceMesh.cpp.
+        FILAMENT_CHECK_PRECONDITION(tri.x < vertexCount && tri.y < vertexCount &&
+                tri.z < vertexCount)
+                << "Triangle index out of bounds:"
+                << " vertexCount=" << vertexCount;
         const float3 v1 = positions[tri.x];
         const float3 v2 = positions[tri.y];
         const float3 v3 = positions[tri.z];


### PR DESCRIPTION
## Problem

`libs/geometry/src/SurfaceOrientation.cpp` computes per-vertex tangent-space data from caller-supplied triangle index arrays. Two of its four build paths — `OrientationBuilderImpl::buildWithUvs()` and `OrientationBuilderImpl::buildWithFlatNormals()` — validated that each triangle's vertex indices are within `vertexCount` using `assert_invariant()` only, which expands to a no-op in release (`NDEBUG`) builds (`libs/utils/include/utils/debug.h`).

## Precedent

This is the same bug class already fixed in `TangentSpaceMesh.cpp` by PR #10107 ("geometry: Validate triangle indices before array access (OOB read)"), which upgraded its own `assert_invariant` guard to a release-mode `FILAMENT_CHECK_PRECONDITION`. `SurfaceOrientation.cpp` contains the identical pattern at two sites and was not covered by that fix.

## Attack Surface

`SurfaceOrientation` is used by `gltfio` (`libs/gltfio/src/TangentsJob.cpp`) to compute tangents/normals when importing glTF assets. glTF triangle indices come directly from the file's index accessor with no upstream range check against `vertexCount`. A malicious or malformed `.gltf`/`.glb` file can therefore trigger:

- **Heap out-of-bounds READ** of `positions[]`/`uvs[]` in `buildWithUvs()`
- **Heap out-of-bounds WRITE** to `normals[]` (12 bytes, `sizeof(float3)`) in `buildWithFlatNormals()`

in any application that imports untrusted 3D models through filament's glTF loader, with no other preconditions.

## Fix

Replaces `assert_invariant(tri.x < vertexCount && tri.y < vertexCount && tri.z < vertexCount)` at both sites with:
```
FILAMENT_CHECK_PRECONDITION(tri.x < vertexCount && tri.y < vertexCount &&
        tri.z < vertexCount)
        << "Triangle index out of bounds:"
        << " vertexCount=" << vertexCount;
```
— exactly mirroring the pattern and message format already used in `TangentSpaceMesh.cpp`'s fix. `<utils/Panic.h>`, which defines `FILAMENT_CHECK_PRECONDITION`, is already included in this file, so no new includes are needed.

## Testing

Verified with a standalone reproduction (compiled `SurfaceOrientation.cpp` in release mode, `-DNDEBUG`, under AddressSanitizer) that both sites previously produced heap-buffer-overflow reports with a triangle index far outside `vertexCount`. With this fix, the same inputs now trigger a clean `FILAMENT_CHECK_PRECONDITION` failure instead of an out-of-bounds access.