### PR TITLE
Support SINGLE_THREADED mode in JobSystem

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -372,6 +372,11 @@ public class Engine {
                 FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB * 3;
 
         /**
+         * Special value for jobSystemThreadCount, forcing the JobSystem to be single-threaded.
+         */
+        public static final long SINGLE_THREADED = 0xFFFFFFFFL;
+
+        /**
          * Size in MiB of the low-level command buffer arena.
          *
          * Each new command buffer is allocated from here. If this buffer is too small the program

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -296,17 +296,26 @@ public:
         uint32_t perFrameCommandsSizeMB = FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB;
 
         /**
+         * Special value for jobSystemThreadCount, forcing the JobSystem to be single-threaded.
+         */
+        static constexpr uint32_t SINGLE_THREADED = std::numeric_limits<uint32_t>::max();
+
+        /**
          * Number of threads to use in Engine's JobSystem.
          *
-         * Engine uses a utils::JobSystem to carry out paralleization of Engine workloads. This
+         * Engine uses a utils::JobSystem to carry out parallelization of Engine workloads. This
          * value sets the number of threads allocated for JobSystem. Configuring this value can be
          * helpful in CPU-constrained environments where too many threads can cause contention of
          * CPU and reduce performance.
          *
          * The default value is 0, which implies that the Engine will use a heuristic to determine
          * the number of threads to use.
+         *
+         * The special value SINGLE_THREADED forces the JobSystem to be single-threaded and not use
+         * a thread pool (jobs are executed on the calling thread).
          */
         uint32_t jobSystemThreadCount = 0;
+
 
         /**
          * When uploading vertex or index data, the Filament Metal backend copies data

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -97,7 +97,19 @@ public:
     static_assert(sizeof(Job) == 64);
 #endif
 
-    explicit JobSystem(size_t threadCount = 0, size_t adoptableThreadsCount = 1) noexcept;
+    /**
+     * Special value for userThreadCount to configure the JobSystem in single-threaded mode.
+     */
+    static constexpr uint32_t SINGLE_THREADED = std::numeric_limits<uint32_t>::max();
+
+    /**
+     * Create a JobSystem and initializes its thread pool. The pool can have zero threads if SINGLE_THREADED is used
+     * as the userThreadCount, in that case adoptableThreadsCount is forced to 1.
+     *
+     * @param userThreadCount number of threads in the JobSystem thread pool.
+     * @param adoptableThreadsCount number of calling threads outside the thread pool.
+     */
+    explicit JobSystem(uint32_t userThreadCount = 0, uint32_t adoptableThreadsCount = 1) noexcept;
 
     ~JobSystem();
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -33,6 +33,7 @@
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Log.h>
+#include <utils/Logger.h>
 #include <utils/ostream.h>
 #include <utils/Panic.h>
 
@@ -96,17 +97,17 @@
 
 namespace utils {
 
-void JobSystem::setThreadName(const char* name) noexcept {
+void JobSystem::setThreadName(const char* threadName) noexcept {
 #if defined(__linux__)
     constexpr size_t MAX_PTHREAD_NAME_LEN = 16;
     char buf[MAX_PTHREAD_NAME_LEN];
-    strncpy(buf, name, MAX_PTHREAD_NAME_LEN - 1);
+    strncpy(buf, threadName, MAX_PTHREAD_NAME_LEN - 1);
     buf[MAX_PTHREAD_NAME_LEN - 1] = '\0';
     pthread_setname_np(pthread_self(), buf);
 #elif defined(__APPLE__)
-    pthread_setname_np(name);
+    pthread_setname_np(threadName);
 #elif defined(WIN32)
-    std::string_view u8name(name);
+    std::string_view u8name(threadName);
     size_t size = MultiByteToWideChar(CP_UTF8, 0, u8name.data(), u8name.size(), nullptr, 0);
 
     std::wstring u16name;
@@ -117,7 +118,7 @@ void JobSystem::setThreadName(const char* name) noexcept {
 #endif
 }
 
-void JobSystem::setThreadPriority(Priority priority) noexcept {
+void JobSystem::setThreadPriority(Priority const priority) noexcept {
 #ifdef __ANDROID__
     int androidPriority = 0;
     switch (priority) {
@@ -163,7 +164,7 @@ void JobSystem::setThreadPriority(Priority priority) noexcept {
     error = pthread_set_qos_class_self_np(qosClass, 0);
 #ifndef NDEBUG
     if (UTILS_UNLIKELY(error)) {
-        slog.w << "pthread_set_qos_class_self_np failed: " << strerror(errno) << io::endl;
+        LOG(WARNING) << "pthread_set_qos_class_self_np failed: " << strerror(errno);
     }
 #endif
 #endif
@@ -178,33 +179,40 @@ void JobSystem::setThreadAffinityById(size_t id) noexcept {
 #endif
 }
 
-JobSystem::JobSystem(const size_t userThreadCount, const size_t adoptableThreadsCount) noexcept
+UTILS_NOINLINE
+JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCount) noexcept
     : mJobPool("JobSystem Job pool", MAX_JOB_COUNT * sizeof(Job)),
       mJobStorageBase(static_cast<Job *>(mJobPool.getAllocator().getCurrent()))
 {
     FILAMENT_TRACING_ENABLE(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
 
     unsigned int threadPoolCount = userThreadCount;
-    if (threadPoolCount == 0) {
-        // default value, system dependant
-        unsigned int hwThreads = std::thread::hardware_concurrency();
-        if (UTILS_HAS_HYPER_THREADING) {
-            // For now we avoid using HT, this simplifies profiling.
-            // TODO: figure-out what to do with Hyper-threading
-            // since we assumed HT, always round-up to an even number of cores (to play it safe)
-            hwThreads = (hwThreads + 1) / 2;
+
+    if (userThreadCount != SINGLE_THREADED) {
+        if (threadPoolCount == 0) {
+            // default value, system dependant
+            unsigned int hwThreads = std::thread::hardware_concurrency();
+            if constexpr (UTILS_HAS_HYPER_THREADING) {
+                // For now we avoid using HT, this simplifies profiling.
+                // TODO: figure-out what to do with Hyper-threading
+                // since we assumed HT, always round-up to an even number of cores (to play it safe)
+                hwThreads = (hwThreads + 1) / 2;
+            }
+            // one of the thread will be the user thread
+            threadPoolCount = hwThreads - 1;
         }
-        // one of the thread will be the user thread
-        threadPoolCount = hwThreads - 1;
+        // make sure we have at least one thread in the thread pool
+        threadPoolCount = std::max(1u, threadPoolCount);
+        // and also limit the pool to 32 threads
+        threadPoolCount = std::min(UTILS_HAS_THREADING ? 32u : 0u, threadPoolCount);
+    } else {
+        threadPoolCount = 0;
+        adoptableThreadsCount = 1;
     }
-    // make sure we have at least one thread in the thread pool
-    threadPoolCount = std::max(1u, threadPoolCount);
-    // and also limit the pool to 32 threads
-    threadPoolCount = std::min(UTILS_HAS_THREADING ? 32u : 0u, threadPoolCount);
 
     mThreadStates = aligned_vector<ThreadState>(threadPoolCount + adoptableThreadsCount);
     mThreadCount = uint16_t(threadPoolCount);
-    mParallelSplitCount = (uint8_t)std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount)));
+    mParallelSplitCount = uint8_t(std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount))));
 
     static_assert(std::atomic<bool>::is_always_lock_free);
     static_assert(std::atomic<uint16_t>::is_always_lock_free);
@@ -248,7 +256,7 @@ JobSystem::~JobSystem() {
 inline void JobSystem::incRef(Job const* job) noexcept {
     // no action is taken when incrementing the reference counter, therefore we can safely use
     // memory_order_relaxed.
-    UTILS_UNUSED_IN_RELEASE auto c = job->refCount.fetch_add(1, std::memory_order_relaxed);
+    UTILS_UNUSED_IN_RELEASE auto const c = job->refCount.fetch_add(1, std::memory_order_relaxed);
     assert_invariant(c < 255);
 }
 
@@ -429,8 +437,7 @@ JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     Job* job = nullptr;
     do {
-        ThreadState* const stateToStealFrom = getStateToStealFrom(state);
-        if (stateToStealFrom) {
+        if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
             job = steal(stateToStealFrom->workQueue);
         }
         // nullptr -> nothing to steal in that queue either, if there are active jobs,
@@ -447,7 +454,7 @@ bool JobSystem::execute(ThreadState& state) noexcept {
     // It is beneficial for some benchmarks to poll on steal() for a bit, because going back to
     // sleep and waking up is pretty expensive. However, it is unclear it helps in practice with
     // larger jobs or when parallel_for is used.
-    constexpr size_t const STEAL_TRY_COUNT = 1;
+    constexpr size_t STEAL_TRY_COUNT = 1;
     for (size_t i = 0; UTILS_UNLIKELY(!job && i < STEAL_TRY_COUNT); i++) {
         // our queue is empty, try to steal a job
         job = steal(state);
@@ -531,7 +538,7 @@ void JobSystem::finish(Job* job) noexcept {
 // public API...
 
 
-JobSystem::Job* JobSystem::create(Job* parent, JobFunc func) noexcept {
+JobSystem::Job* JobSystem::create(Job* parent, JobFunc const func) noexcept {
     parent = (parent == nullptr) ? mRootJob : parent;
     Job* const job = allocateJob();
     if (UTILS_LIKELY(job)) {
@@ -582,7 +589,7 @@ void JobSystem::run(Job*& job) noexcept {
     job = nullptr;
 }
 
-void JobSystem::run(Job*& job, uint8_t id) noexcept {
+void JobSystem::run(Job*& job, uint8_t const id) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
 
     ThreadState& state = mThreadStates[id];

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -88,6 +88,8 @@ Filament.loadClassExtensions = function() {
 
     /// Engine ::core class::
 
+    Filament.Engine.SINGLE_THREADED = 0xFFFFFFFF;
+
     /// create ::static method:: Creates an Engine instance for the given canvas.
     /// canvas ::argument:: the canvas DOM element
     /// options ::argument:: optional WebGL 2.0 context configuration

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -815,6 +815,7 @@ export class DecodedImage {
 }
 
 export class Engine {
+    public static readonly SINGLE_THREADED: number;
     public static create(canvas: HTMLCanvasElement, options?: { backend?: Backend }): Engine;
     public static destroy(engine: Engine): void;
     public execute(): void;


### PR DESCRIPTION
Introduce a JobSystem::SINGLE_THREADED constant to allow explicitly configuring the job system in single-threaded mode. When this special value is passed as the userThreadCount, the job system guarantees zero worker threads are spawned and the adoptableThreadsCount is forced to 1, ensuring all jobs safely execute on the calling thread.

Additional changes:
- Change constructor parameters from size_t to uint32_t.
- Replace slog.w with standard LOG(WARNING).
- Fix variable shadowing in setThreadName().
- Improve const correctness for internal method parameters.
- Simplify getStateToStealFrom logic.