### PR TITLE
Add worldRayFromClipMatrix for stable skybox rays

### DIFF
--- a/docs_src/src_markdeep/Materials.md.html
+++ b/docs_src/src_markdeep/Materials.md.html
@@ -2768,17 +2768,18 @@ type aliases:
 
 ### Matrices
 
-                 Name                     |   Type   |            Description
-:-----------------------------------------|:--------:|:------------------------------------
-**getViewFromWorldMatrix()**              | float4x4 |  Matrix that converts from world space to view/eye space
-**getWorldFromViewMatrix()**              | float4x4 |  Matrix that converts from view/eye space to world space
-**getClipFromViewMatrix()**               | float4x4 |  Matrix that converts from view/eye space to clip (NDC) space
-**getViewFromClipMatrix()**               | float4x4 |  Matrix that converts from clip (NDC) space to view/eye space
-**getEyeFromViewMatrix()**                | float4x4 |  Matrix that converts from view space to eye space
-**getEyeFromViewMatrix(int eyeIndex)**    | float4x4 |  Matrix that converts from view space to eye space for the eye referred to by eyeIndex
-**getClipFromWorldMatrix()**              | float4x4 |  Matrix that converts from world to clip (NDC) space
-**getClipFromWorldMatrix(int eyeIndex)**  | float4x4 |  Matrix that converts from world to clip (NDC) space for the eye referred to by eyeIndex
-**getWorldFromClipMatrix()**              | float4x4 |  Matrix that converts from clip (NDC) space to world space
+                 Name                     |   Type   | ApiLevel |            Description
+:-----------------------------------------|:--------:|:--------:|:------------------------------------
+**getViewFromWorldMatrix()**              | float4x4 |     1    |  Matrix that converts from world space to view/eye space
+**getWorldFromViewMatrix()**              | float4x4 |     1    |  Matrix that converts from view/eye space to world space
+**getClipFromViewMatrix()**               | float4x4 |     1    |  Matrix that converts from view/eye space to clip (NDC) space
+**getViewFromClipMatrix()**               | float4x4 |     1    |  Matrix that converts from clip (NDC) space to view/eye space
+**getEyeFromViewMatrix()**                | float4x4 |     1    |  Matrix that converts from view space to eye space
+**getEyeFromViewMatrix(int eyeIndex)**    | float4x4 |     1    |  Matrix that converts from view space to eye space for the eye referred to by eyeIndex
+**getClipFromWorldMatrix()**              | float4x4 |     1    |  Matrix that converts from world to clip (NDC) space
+**getClipFromWorldMatrix(int eyeIndex)**  | float4x4 |     1    |  Matrix that converts from world to clip (NDC) space for the eye referred to by eyeIndex
+**getWorldFromClipMatrix()**              | float4x4 |     1    |  Matrix that converts from clip (NDC) space to world space
+**getWorldRayFromClip(float2 clipXY)**    | float3   |     2    |  Transforms a 2D clip-space position directly into an un-normalized, un-translated world-space ray direction
 
 ### Frame constants
 

--- a/filament/src/ds/PerViewDescriptorSetUtils.cpp
+++ b/filament/src/ds/PerViewDescriptorSetUtils.cpp
@@ -52,6 +52,18 @@ void PerViewDescriptorSetUtils::prepareCamera(PerViewUib& s,
     s.clipFromViewMatrix  = clipFromView;     // projection
     s.viewFromClipMatrix  = viewFromClip;     // 1/projection
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+
+    // Collapsed 3x3 clip-to-world ray matrix (strips 3D translation).
+    // This perfectly generalizes to any projection matrix shape (including asymmetric,
+    // off-axis, or orthographic) by extracting the transformation of the (x, y, 1, 1) 
+    // clip-space coordinate into a purely rotational world-space ray.
+    mat3f const worldFromView_3x3 = worldFromView.upperLeft();
+    mat3f rayFromClip;
+    rayFromClip[0] = worldFromView_3x3 * viewFromClip[0].xyz;
+    rayFromClip[1] = worldFromView_3x3 * viewFromClip[1].xyz;
+    rayFromClip[2] = worldFromView_3x3 * (viewFromClip[2].xyz + viewFromClip[3].xyz);
+
+    s.worldRayFromClipMatrix = rayFromClip;
     s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldTransform));
     s.clipTransform = camera.clipTransform;
     s.cameraFar = camera.zf;

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -27,6 +27,7 @@ material {
     shadingModel : unlit,
     variantFilter : [ skinning, shadowReceiver, vsm ],
     culling: none,
+    apiLevel: 2,
     featureLevel: 0
 }
 
@@ -62,15 +63,6 @@ fragment {
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        // This code is taken from computeWorldPosition and assumes the vertex domain is 'device'.
-        vec4 p = getPosition();
-        // GL convention to inverted DX convention
-        p.z = p.z * -0.5 + 0.5;
-        vec4 worldPosition = getWorldFromClipMatrix() * p;
-        // Getting the true world position would require dividing by w, but since this is a skybox
-        // at inifinity, this results in very large numbers for material.eyeDirection.
-        // Since the eyeDirection is only used as a direction vector in the fragment shader, we can
-        // skip that step to improve precision.
-        material.eyeDirection.xyz = worldPosition.xyz;
+        material.eyeDirection.xyz = getWorldRayFromClip(getPosition().xy);
     }
 }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -83,6 +83,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::mat4f eyeFromViewMatrix[CONFIG_MAX_STEREOSCOPIC_EYES];   // clip    eye  <- view    world
     math::mat4f clipFromWorldMatrix[CONFIG_MAX_STEREOSCOPIC_EYES]; // clip <- eye  <- view <- world
     math::mat4f worldFromClipMatrix;    // clip -> view -> world
+    std140::mat33 worldRayFromClipMatrix;
     math::mat4f userWorldFromWorldMatrix;   // userWorld <- world
     math::float4 clipTransform;             // [sx, sy, tx, ty] only used by VERTEX_DOMAIN_DEVICE
 
@@ -217,7 +218,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved2;
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[21];
+    math::float4 reserved[18];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -104,6 +104,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "clipFromWorldMatrix",    CONFIG_MAX_STEREOSCOPIC_EYES,
                                            Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldRayFromClipMatrix", 0, Type::MAT3,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -73,6 +73,20 @@ highp mat4 getWorldFromClipMatrix() {
     return frameUniforms.worldFromClipMatrix;
 }
 
+#if CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
+/**
+ * Transforms a 2D clip-space position (x, y) directly into an un-normalized, un-translated world-space ray direction.
+ * This implicitly uses a z-coordinate of 1.0 (meaning x, y on the near plane in inverted-z convention)
+ * to correctly reconstruct the un-translated world-space ray direction.
+ * Invariant to camera translation and origin-shifting modes.
+ * @api-level 2
+ * @public-api
+ */
+highp vec3 getWorldRayFromClip(highp vec2 clipXY) {
+    return frameUniforms.worldRayFromClipMatrix * vec3(clipXY, 1.0);
+}
+#endif
+
 /** @public-api */
 highp mat4 getUserWorldFromWorldMatrix() {
     return frameUniforms.userWorldFromWorldMatrix;

--- a/shaders/src/surface_getters.vs
+++ b/shaders/src/surface_getters.vs
@@ -155,6 +155,9 @@ void skinNormalTangent(inout vec3 n, inout vec3 t, const uvec4 ids, const vec4 w
 #define MAX_MORPH_TARGET_BUFFER_WIDTH 2048
 
 #if CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
+/**
+ * @api-level 2
+ */
 void morphData2(inout vec2 v, highp sampler2DArray data) {
     int index = getVertexIndex() + pushConstants.morphingBufferOffset;
     ivec3 texcoord = ivec3(index % MAX_MORPH_TARGET_BUFFER_WIDTH, index / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
@@ -168,6 +171,9 @@ void morphData2(inout vec2 v, highp sampler2DArray data) {
     }
 }
 
+/**
+ * @api-level 2
+ */
 void morphData3(inout vec3 v, highp sampler2DArray data) {
     int index = getVertexIndex() + pushConstants.morphingBufferOffset;
     ivec3 texcoord = ivec3(index % MAX_MORPH_TARGET_BUFFER_WIDTH, index / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
@@ -181,6 +187,9 @@ void morphData3(inout vec3 v, highp sampler2DArray data) {
     }
 }
 
+/**
+ * @api-level 2
+ */
 void morphData4(inout vec4 v, highp sampler2DArray data) {
     int index = getVertexIndex() + pushConstants.morphingBufferOffset;
     ivec3 texcoord = ivec3(index % MAX_MORPH_TARGET_BUFFER_WIDTH, index / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);

--- a/web/examples/materials/simulated_skybox.mat
+++ b/web/examples/materials/simulated_skybox.mat
@@ -139,21 +139,13 @@ material {
     vertexDomain : device,
     depthWrite : false,
     shadingModel : unlit,
+    apiLevel : 2,
     culling: none
 }
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        // This code is taken from computeWorldPosition and assumes the vertex domain is 'device'.
-        highp vec4 p = getPosition();
-        // GL convention to inverted DX convention
-        p.z = p.z * -0.5 + 0.5;
-        highp vec4 worldPosition = getWorldFromClipMatrix() * p;
-        // Getting the true world position would require dividing by w, but since this is a skybox
-        // at inifinity, this results in very large numbers for material.eyeDirection.
-        // Since the eyeDirection is only used as a direction vector in the fragment shader, we can
-        // skip that step to improve precision.
-        material.eyeDirection.xyz = worldPosition.xyz;
+        material.eyeDirection.xyz = getWorldRayFromClip(getPosition().xy);
     }
 }
 


### PR DESCRIPTION
Add worldRayFromClipMatrix to PerViewUib to allow for a direct 2D clip to 3D world-space ray transformation. This 3x3 matrix strips out camera translation, making the generated rays invariant to origin-shifting.

Added getWorldRayFromClip(vec2) to the unstable material API in common_getters.glsl and updated both skybox.mat and simulated_skybox.mat to use it instead of getWorldFromClipMatrix(). This resolves the skybox visual regressions that occurred when using grid-based origin shifting.

Also updated the Materials.md.html documentation to include the new API.