### PR TITLE
engine: support up to 4 additional shadowless directional lights

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,3 +6,6 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+- engine: support multiple directional lights; the dominant one still provides shadows and the
+  sun disc, up to 4 additional directional lights are evaluated without shadows [⚠️ **New
+  Material Version**]

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
-- engine: support multiple directional lights; the dominant one still provides shadows and the
-  sun disc, up to 4 additional directional lights are evaluated without shadows [⚠️ **New
+- engine: support multiple directional lights, opt-in via
+  `Engine::Config::enableMultipleDirectionalLights`; the dominant one still provides shadows and
+  the sun disc, up to 4 additional directional lights are evaluated without shadows [⚠️ **New
   Material Version**]

--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -665,7 +665,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
         jint preferredShaderLanguage,
         jboolean forceGLES2Context, jboolean assertNativeWindowIsValid,
         jint gpuContextPriority,
-        jlong sharedUboInitialSizeInBytes) {
+        jlong sharedUboInitialSizeInBytes,
+        jboolean enableMultipleDirectionalLights) {
     Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
     Engine::Config config = {
             .commandBufferSizeMB = (uint32_t) commandBufferSizeMB,
@@ -685,6 +686,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
             .assertNativeWindowIsValid = (bool) assertNativeWindowIsValid,
             .gpuContextPriority = (Engine::GpuContextPriority) gpuContextPriority,
             .sharedUboInitialSizeInBytes = (uint32_t) sharedUboInitialSizeInBytes,
+            .enableMultipleDirectionalLights = (bool) enableMultipleDirectionalLights,
     };
     builder->config(&config);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -274,7 +274,8 @@ public class Engine {
                     config.preferredShaderLanguage.ordinal(),
                     config.forceGLES2Context, config.assertNativeWindowIsValid,
                     config.gpuContextPriority.ordinal(),
-                    config.sharedUboInitialSizeInBytes);
+                    config.sharedUboInitialSizeInBytes,
+                    config.enableMultipleDirectionalLights);
             return this;
         }
 
@@ -489,6 +490,17 @@ public class Engine {
          * @see Engine#getMaxStereoscopicEyes
          */
         public long stereoscopicEyeCount = 2;
+
+        /**
+         * Whether a scene can contain more than one directional light.
+         *
+         * By default, only the dominant directional light (the one with the highest intensity)
+         * of a scene is evaluated. When this is enabled, up to four additional directional
+         * lights contribute lighting; they don't cast shadows and don't draw a sun's disk.
+         *
+         * @see LightManager
+         */
+        public boolean enableMultipleDirectionalLights = false;
 
         /**
          * @Deprecated This value is no longer used.
@@ -1628,7 +1640,8 @@ public class Engine {
             int preferredShaderLanguage,
             boolean forceGLES2Context, boolean assertNativeWindowIsValid,
             int gpuContextPriority,
-            long sharedUboInitialSizeInBytes);
+            long sharedUboInitialSizeInBytes,
+            boolean enableMultipleDirectionalLights);
     private static native void nSetBuilderFeatureLevel(long nativeBuilder, int ordinal);
     private static native void nSetBuilderSharedContext(long nativeBuilder, long sharedContext);
     private static native void nSetBuilderPaused(long nativeBuilder, boolean paused);

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -68,8 +68,12 @@ import androidx.annotation.Size;
  * but the later also draws a sun's disk in the sky and its reflection on glossy objects.
  * </p>
  * <p>
- * <b>warning:</b> Currently, only a single directional light is supported. If several directional lights
- * are added to the scene, the dominant one will be used.
+ * By default, only the dominant directional light (the one with the highest intensity) of a
+ * scene is evaluated. Several directional lights can be used by enabling
+ * {@link Engine.Config#enableMultipleDirectionalLights}: the dominant one is still the only one
+ * that can cast shadows and draw a sun's disk, and up to four additional directional lights are
+ * evaluated without shadows; any further directional lights are ignored. Scenes with a single
+ * directional light don't pay any cost for this feature.
  * </p>
  *
  * <h2><u>Point lights</u></h2>

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -471,6 +471,18 @@ public:
          * positive value caches up to that number of programs.
          */
         uint32_t programCacheCapacity = 0;
+
+        /**
+         * Whether a scene can contain more than one directional light.
+         *
+         * By default, and historically, only the dominant directional light (the one with the
+         * highest intensity) of a scene is evaluated. When this is enabled, up to four
+         * additional directional lights contribute lighting; they don't cast shadows and don't
+         * draw a sun's disk. Scenes with a single directional light are unaffected either way.
+         *
+         * @see LightManager
+         */
+        bool enableMultipleDirectionalLights = false;
     };
 
 

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -86,8 +86,11 @@ class FLightManager;
  * To create a directional light use Type.DIRECTIONAL or Type.SUN, both are similar, but the later
  * also draws a sun's disk in the sky and its reflection on glossy objects.
  *
- * @warning Currently, only a single directional light is supported. If several directional lights
- * are added to the scene, the dominant one will be used.
+ * Several directional lights can be added to the scene. The dominant directional light (the one
+ * with the highest intensity) is the only one that can cast shadows and draw a sun's disk; up to
+ * CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS (4) additional directional lights are evaluated without
+ * shadows, and any further directional lights are ignored. Scenes with a single directional
+ * light don't pay any cost for this feature.
  *
  * @see Builder.direction(), Builder.sunAngularRadius()
  *

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -86,11 +86,12 @@ class FLightManager;
  * To create a directional light use Type.DIRECTIONAL or Type.SUN, both are similar, but the later
  * also draws a sun's disk in the sky and its reflection on glossy objects.
  *
- * Several directional lights can be added to the scene. The dominant directional light (the one
- * with the highest intensity) is the only one that can cast shadows and draw a sun's disk; up to
- * CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS (4) additional directional lights are evaluated without
- * shadows, and any further directional lights are ignored. Scenes with a single directional
- * light don't pay any cost for this feature.
+ * By default, only the dominant directional light (the one with the highest intensity) of a
+ * scene is evaluated. Several directional lights can be used by enabling
+ * Engine::Config::enableMultipleDirectionalLights: the dominant one is still the only one that
+ * can cast shadows and draw a sun's disk, and up to CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS (4)
+ * additional directional lights are evaluated without shadows; any further directional lights
+ * are ignored. Scenes with a single directional light don't pay any cost for this feature.
  *
  * @see Builder.direction(), Builder.sunAngularRadius()
  *

--- a/filament/src/DynamicSpecConstKey.h
+++ b/filament/src/DynamicSpecConstKey.h
@@ -39,6 +39,7 @@ struct DynamicSpecConstKey {
     type_t key = 0u;
 
     static constexpr type_t DYNAMIC_LIGHTING = 0x1;
+    static constexpr type_t EXTRA_DIRECTIONAL_LIGHTS = 0x2;
 
 
     constexpr bool operator==(DynamicSpecConstKey rhs) const noexcept {
@@ -69,10 +70,21 @@ struct DynamicSpecConstKey {
         key = (key & ~DYNAMIC_LIGHTING) | (v ? DYNAMIC_LIGHTING : type_t(0));
     }
 
+    constexpr bool hasExtraDirectionalLights() const noexcept {
+        return key & EXTRA_DIRECTIONAL_LIGHTS;
+    }
+
+    constexpr void setExtraDirectionalLights(bool v) noexcept {
+        key = (key & ~EXTRA_DIRECTIONAL_LIGHTS) | (v ? EXTRA_DIRECTIONAL_LIGHTS : type_t(0));
+    }
+
     static constexpr DynamicSpecConstKey filterUserVariant(
             DynamicSpecConstKey key, UserVariantFilterMask filterMask) noexcept {
         if (filterMask & uint32_t(UserVariantFilterBit::DYNAMIC_LIGHTING)) {
             key.setDynamicLighting(false);
+        }
+        if (filterMask & uint32_t(UserVariantFilterBit::DIRECTIONAL_LIGHTING)) {
+            key.setExtraDirectionalLights(false);
         }
         return key;
     }
@@ -83,15 +95,29 @@ struct DynamicSpecConstKey {
                !Variant::isValidDepthVariant(variant) && !Variant::isSSRVariant(variant);
     }
 
+    static constexpr bool canSupportExtraDirectionalLights(Variant const variant,
+        MaterialDomain const materialDomain, bool const isLit) noexcept {
+        // the directional-lighting bit is only meaningful on standard variants
+        return materialDomain == MaterialDomain::SURFACE && isLit &&
+               !Variant::isValidDepthVariant(variant) && !Variant::isSSRVariant(variant) &&
+               variant.hasDirectionalLighting();
+    }
+
     static constexpr bool isValidProgramSpecKey(Variant const variant, DynamicSpecConstKey const specKey,
             MaterialDomain const materialDomain, bool const isLit) noexcept {
-        return !specKey.hasDynamicLighting() || canSupportDynamicLighting(variant, materialDomain, isLit);
+        return (!specKey.hasDynamicLighting() ||
+                       canSupportDynamicLighting(variant, materialDomain, isLit)) &&
+               (!specKey.hasExtraDirectionalLights() ||
+                       canSupportExtraDirectionalLights(variant, materialDomain, isLit));
     }
 
     static constexpr DynamicSpecConstKey filterProgramSpecKey(Variant const variant,
             DynamicSpecConstKey specKey, MaterialDomain const materialDomain, bool const isLit) noexcept {
         if (!canSupportDynamicLighting(variant, materialDomain, isLit)) {
             specKey.setDynamicLighting(false);
+        }
+        if (!canSupportExtraDirectionalLights(variant, materialDomain, isLit)) {
+            specKey.setExtraDirectionalLights(false);
         }
         return specKey;
     }

--- a/filament/src/MaterialDefinition.cpp
+++ b/filament/src/MaterialDefinition.cpp
@@ -579,6 +579,9 @@ void MaterialDefinition::processSpecializationConstants(FEngine& engine) {
                             +DynamicSpecializationConstants::RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING] =
             isVariantLit || hasShadowMultiplier;
 
+    specializationConstants[CONFIG_MAX_RESERVED_SPEC_CONSTANTS +
+            +DynamicSpecializationConstants::RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS] = false;
+
     // Initialize the rest of the reserved constants with a dummy value.
     for (size_t i = CONFIG_NEXT_RESERVED_SPEC_CONSTANT; i < CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
             i++) {
@@ -853,6 +856,9 @@ Program MaterialDefinition::getProgramWithVariants(FEngine const& engine,
         constants[CONFIG_MAX_RESERVED_SPEC_CONSTANTS +
                   +DynamicSpecializationConstants::RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING] =
                 specialization.specKey.hasDynamicLighting();
+        constants[CONFIG_MAX_RESERVED_SPEC_CONSTANTS +
+                  +DynamicSpecializationConstants::RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS] =
+                specialization.specKey.hasExtraDirectionalLights();
     }
     program.specializationConstants(std::move(constants));
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1829,6 +1829,7 @@ FixedCapacityVector<DynamicSpecConstKey> FEngine::getMaterialCompileDynamicSpecC
     DynamicSpecConstKey baseKey;
     const bool isMaterialLit = material->getDefinition().isVariantLit;
     baseKey.setDynamicLighting(isMaterialLit && view->hasDynamicLighting());
+    baseKey.setExtraDirectionalLights(isMaterialLit && view->hasExtraDirectionalLights());
 
     keys.push_back(baseKey);
 

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1025,6 +1025,7 @@ void FRenderer::renderJob(DriverApi& driver, RootArenaScope& rootArenaScope, FVi
 
     DynamicSpecConstKey specKey{0};
     specKey.setDynamicLighting(view.hasDynamicLighting());
+    specKey.setExtraDirectionalLights(view.hasExtraDirectionalLights());
     passBuilder.dynamicSpecConstKey(specKey);
 
     Variant variant;

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -118,13 +118,13 @@ void FScene::prepare(JobSystem& js,
 
     FILAMENT_TRACING_NAME_BEGIN(FILAMENT_TRACING_CATEGORY_FILAMENT, "InstanceLoop");
 
-    // find the max intensity directional light index in our local array
-    float maxIntensity = 0.0f;
-    std::pair<LightManager::Instance, TransformManager::Instance> directionalLightInstances{};
+    // directional lights are handled separately from the punctual lights
+    LightInstanceContainer directionalInstances{
+            LightInstanceContainer::with_capacity(entities.size(), localArenaScope.getArena()) };
 
     /*
      * First compute the exact number of renderables and lights in the scene.
-     * Also find the main directional light.
+     * Also collect the directional lights.
      */
     entities.forEachSetBit([&](uint32_t id) {
         Entity const e = Entity::import(int32_t(id));
@@ -133,13 +133,9 @@ void FScene::prepare(JobSystem& js,
             auto li = lcm.getInstance(e);
             auto ri = rcm.getInstance(e);
             if (li) {
-                // we handle the directional light here because it'd prevent multithreading below
+                // we handle the directional lights here because it'd prevent multithreading below
                 if (UTILS_UNLIKELY(lcm.isDirectionalLight(li))) {
-                    // we don't store the directional lights, because we only have a single one
-                    if (lcm.getIntensity(li) >= maxIntensity) {
-                        maxIntensity = lcm.getIntensity(li);
-                        directionalLightInstances = { li, ti };
-                    }
+                    directionalInstances.emplace_back(li, ti);
                 } else {
                     lightInstances.emplace_back(li, ti);
                 }
@@ -149,6 +145,24 @@ void FScene::prepare(JobSystem& js,
             }
         }
     });
+
+    // Sort the directional lights by decreasing intensity. The most intense one is the
+    // dominant directional light (stored at index 0 of the LightSoa); it is the only one
+    // that casts shadows and can be a sun. Up to CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS
+    // additional directional lights are evaluated without shadows; the rest are ignored.
+    if (UTILS_UNLIKELY(directionalInstances.size() > 1)) {
+        size_t const keep = std::min<size_t>(directionalInstances.size(),
+                DIRECTIONAL_LIGHTS_COUNT + CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS);
+        std::partial_sort(directionalInstances.begin(),
+                directionalInstances.begin() + keep, directionalInstances.end(),
+                [&lcm](auto const& lhs, auto const& rhs) {
+                    return lcm.getIntensity(lhs.first) > lcm.getIntensity(rhs.first);
+                });
+    }
+    std::pair<LightManager::Instance, TransformManager::Instance> const directionalLightInstances =
+            directionalInstances.empty() ?
+                    std::pair<LightManager::Instance, TransformManager::Instance>{} :
+                    directionalInstances[0];
 
     FILAMENT_TRACING_NAME_END(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
@@ -331,6 +345,28 @@ void FScene::prepare(JobSystem& js,
         lightData.elementAt<LIGHT_ENTITY>(0) = li ? lcm.getEntity(li) : utils::Entity{};
     } else {
         lightData.elementAt<LIGHT_ENTITY>(0) = utils::Entity{};
+    }
+
+    /*
+     * Handle the extra directional lights (evaluated without shadows)
+     */
+
+    cache.extraDirectionalLightCount = 0;
+    if (UTILS_UNLIKELY(directionalInstances.size() > DIRECTIONAL_LIGHTS_COUNT)) {
+        mat3 const worldTransformNormals = mat3::getTransformForNormals(worldTransform.upperLeft());
+        size_t const extraCount = std::min(directionalInstances.size() - DIRECTIONAL_LIGHTS_COUNT,
+                CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS);
+        for (size_t i = 0; i < extraCount; i++) {
+            auto const [li, ti] = directionalInstances[DIRECTIONAL_LIGHTS_COUNT + i];
+            // using mat3::getTransformForNormals handles non-uniform scaling
+            mat3 const worldDirectionTransform =
+                    mat3::getTransformForNormals(tcm.getWorldTransformAccurate(ti).upperLeft());
+            double3 const d = worldTransformNormals *
+                    (worldDirectionTransform * lcm.getLocalDirection(li));
+            cache.extraDirectionalLightDirections[i] = float3(normalize(d));
+            cache.extraDirectionalLightInstances[i] = li;
+        }
+        cache.extraDirectionalLightCount = extraCount;
     }
 
     // some elements past the end of the array will be accessed by SIMD code, we need to make

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -352,7 +352,8 @@ void FScene::prepare(JobSystem& js,
      */
 
     cache.extraDirectionalLightCount = 0;
-    if (UTILS_UNLIKELY(directionalInstances.size() > DIRECTIONAL_LIGHTS_COUNT)) {
+    if (UTILS_UNLIKELY(mEngine.getConfig().enableMultipleDirectionalLights &&
+                directionalInstances.size() > DIRECTIONAL_LIGHTS_COUNT)) {
         mat3 const worldTransformNormals = mat3::getTransformForNormals(worldTransform.upperLeft());
         size_t const extraCount = std::min(directionalInstances.size() - DIRECTIONAL_LIGHTS_COUNT,
                 CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS);
@@ -366,7 +367,7 @@ void FScene::prepare(JobSystem& js,
             cache.extraDirectionalLightDirections[i] = float3(normalize(d));
             cache.extraDirectionalLightInstances[i] = li;
         }
-        cache.extraDirectionalLightCount = extraCount;
+        cache.extraDirectionalLightCount = uint8_t(extraCount);
     }
 
     // some elements past the end of the array will be accessed by SIMD code, we need to make

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -195,7 +195,7 @@ public:
                 extraDirectionalLightDirections{};
         std::array<FLightManager::Instance, CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS>
                 extraDirectionalLightInstances{};
-        size_t extraDirectionalLightCount = 0;
+        uint8_t extraDirectionalLightCount = 0;
         bool hasContactShadows = false;
     };
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -28,6 +28,8 @@
 
 #include <filament/Scene.h>
 
+#include <private/filament/EngineEnums.h>
+
 #include <utils/Entity.h>
 #include <utils/PagedArenaBitset.h>
 #include <utils/Range.h>
@@ -36,6 +38,8 @@
 
 #include <unordered_map>
 #include <vector>
+
+#include <array>
 
 #include <stddef.h>
 
@@ -185,6 +189,14 @@ public:
     struct SceneCacheData {
         RenderableSoa renderableData;
         LightSoa lightData;
+        // Directional lights in addition to the dominant one (which is stored at index 0 of
+        // lightData). These are evaluated without shadows, so we only need their direction
+        // and LightManager instance.
+        std::array<math::float3, CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS>
+                extraDirectionalLightDirections{};
+        std::array<FLightManager::Instance, CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS>
+                extraDirectionalLightInstances{};
+        size_t extraDirectionalLightCount = 0;
         bool hasContactShadows = false;
     };
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -26,9 +26,9 @@
 
 #include "ds/DescriptorSet.h"
 
-#include <filament/Scene.h>
-
 #include <private/filament/EngineEnums.h>
+
+#include <filament/Scene.h>
 
 #include <utils/Entity.h>
 #include <utils/PagedArenaBitset.h>
@@ -36,10 +36,9 @@
 #include <utils/Slice.h>
 #include <utils/StructureOfArrays.h>
 
+#include <array>
 #include <unordered_map>
 #include <vector>
-
-#include <array>
 
 #include <stddef.h>
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -559,6 +559,15 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
     FLightManager::Instance const directionalLight = engine.getLightManager().getInstance(entity);
     const float3 sceneSpaceDirection = lightData.elementAt<FScene::DIRECTION>(0); // guaranteed normalized
     getColorPassDescriptorSet().prepareDirectionalLight(engine, exposure, sceneSpaceDirection, directionalLight);
+
+    /*
+     * Extra directional lights (evaluated without shadows)
+     */
+
+    getColorPassDescriptorSet().prepareExtraDirectionalLights(engine, exposure,
+            mSceneCache->extraDirectionalLightCount,
+            mSceneCache->extraDirectionalLightDirections.data(),
+            mSceneCache->extraDirectionalLightInstances.data());
 }
 
 /*
@@ -801,6 +810,9 @@ void FView::prepare(FEngine& engine, DriverApi& driver, RootArenaScope& rootAren
 
         // now we know if we have dynamic lighting (i.e.: dynamic lights are visible)
         mHasDynamicLighting = lightData.size() > FScene::DIRECTIONAL_LIGHTS_COUNT;
+
+        // we also know if we have extra directional lights
+        mHasExtraDirectionalLights = mSceneCache->extraDirectionalLightCount > 0;
 
         // we also know if we have a directional light
         FLightManager::Instance const directionalLight =

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -206,6 +206,7 @@ public:
 
     // ultimately decides to use the DYN variant
     bool hasDynamicLighting() const noexcept { return mHasDynamicLighting; }
+    bool hasExtraDirectionalLights() const noexcept { return mHasExtraDirectionalLights; }
 
     // ultimately decides to use the SRE variant
     bool hasShadowing() const noexcept { return mHasShadowing; }
@@ -671,6 +672,7 @@ private:
     uint32_t mRenderableUBOElementCount = 0;
     mutable bool mHasDirectionalLighting = false;
     mutable bool mHasDynamicLighting = false;
+    mutable bool mHasExtraDirectionalLights = false;
     mutable bool mHasShadowing = false;
     mutable bool mNeedsShadowMap = false;
 

--- a/filament/src/ds/ColorPassDescriptorSet.cpp
+++ b/filament/src/ds/ColorPassDescriptorSet.cpp
@@ -347,6 +347,24 @@ void ColorPassDescriptorSet::prepareDirectionalLight(FEngine& engine,
     }
 }
 
+void ColorPassDescriptorSet::prepareExtraDirectionalLights(FEngine& engine,
+        float const exposure, size_t const count,
+        float3 const* sceneSpaceDirections,
+        LightManagerInstance const* instances) noexcept {
+    assert_invariant(count <= CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS);
+    FLightManager const& lcm = engine.getLightManager();
+    auto& s = mUniforms.edit();
+    for (size_t i = 0; i < count; i++) {
+        LightManagerInstance const li = instances[i];
+        // the channel mask fits in 8 bits, so the float conversion is exact
+        s.extraLightDirection[i] = float4{
+                -sceneSpaceDirections[i], float(lcm.getLightChannels(li)) };
+        s.extraLightColorIntensity[i] = float4{
+                lcm.getColor(li), lcm.getIntensity(li) * exposure };
+    }
+    s.extraLightCount = int32_t(count);
+}
+
 void ColorPassDescriptorSet::prepareAmbientLight(FEngine const& engine, FIndirectLight const& ibl,
         float const intensity, float const exposure) noexcept {
     auto& s = mUniforms.edit();

--- a/filament/src/ds/ColorPassDescriptorSet.h
+++ b/filament/src/ds/ColorPassDescriptorSet.h
@@ -114,6 +114,13 @@ public:
     void prepareDirectionalLight(FEngine& engine, float exposure,
             math::float3 const& sceneSpaceDirection, LightManagerInstance instance) noexcept;
 
+    // Directional lights in addition to the dominant one, evaluated without shadows.
+    // `sceneSpaceDirections` and `instances` are parallel arrays of `count` elements,
+    // with count <= CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS.
+    void prepareExtraDirectionalLights(FEngine& engine, float exposure, size_t count,
+            math::float3 const* sceneSpaceDirections,
+            LightManagerInstance const* instances) noexcept;
+
     void prepareAmbientLight(FEngine const& engine,
             FIndirectLight const& ibl, float intensity, float exposure) noexcept;
 

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -14,18 +14,30 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
+#include <filament/LightManager.h>
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+#include <filament/RenderableManager.h>
 #include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
+#include <filament/VertexBuffer.h>
 #include <filament/View.h>
 #include <filament/Viewport.h>
+
+#include <filamat/MaterialBuilder.h>
 
 #include <backend/PixelBufferDescriptor.h>
 
 #include <utils/EntityManager.h>
 
 #include <gtest/gtest.h>
+
+#include <math/vec3.h>
+#include <math/vec4.h>
 
 using namespace filament;
 using namespace backend;
@@ -117,6 +129,149 @@ TEST_F(RenderingTest, ClearRed) {
         callbackCalled = true;
     });
     EXPECT_TRUE(callbackCalled);
+}
+
+// Holds a scene with a full-viewport lit quad, a dominant green directional light and a
+// weaker red one. Shared by the extra-directional-lights tests below.
+class LitQuadScene {
+public:
+    void create(Engine& engine, Scene& scene, View& view, Camera& camera) {
+        using namespace filament::math;
+        using utils::Entity;
+        using utils::EntityManager;
+
+        mEngine = &engine;
+        mScene = &scene;
+
+        view.setDithering(View::Dithering::NONE);
+        camera.setProjection(Camera::Projection::ORTHO, -1, 1, -1, 1, 0.1, 10);
+
+        // full-viewport quad at z = -1, facing the camera (normal +z, identity tangent frame)
+        static float3 const positions[4] = {
+                { -2, -2, -1 }, { 2, -2, -1 }, { 2, 2, -1 }, { -2, 2, -1 } };
+        static float4 const tangents[4] = {
+                { 0, 0, 0, 1 }, { 0, 0, 0, 1 }, { 0, 0, 0, 1 }, { 0, 0, 0, 1 } };
+        static uint16_t const indices[6] = { 0, 1, 2, 0, 2, 3 };
+
+        mVertexBuffer = VertexBuffer::Builder()
+                .vertexCount(4)
+                .bufferCount(2)
+                .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3)
+                .attribute(VertexAttribute::TANGENTS, 1, VertexBuffer::AttributeType::FLOAT4)
+                .build(engine);
+        mVertexBuffer->setBufferAt(engine, 0, { positions, sizeof(positions) });
+        mVertexBuffer->setBufferAt(engine, 1, { tangents, sizeof(tangents) });
+
+        mIndexBuffer = IndexBuffer::Builder()
+                .indexCount(6)
+                .bufferType(IndexBuffer::IndexType::USHORT)
+                .build(engine);
+        mIndexBuffer->setBuffer(engine, { indices, sizeof(indices) });
+
+        // a fully diffuse lit material
+        filamat::MaterialBuilder builder;
+        builder.init();
+        builder.shading(Shading::LIT)
+               .material("void material(inout MaterialInputs material) {"
+                         "  prepareMaterial(material);"
+                         "  material.baseColor.rgb = float3(0.8);"
+                         "  material.roughness = 1.0;"
+                         "}")
+               .targetApi(filamat::MaterialBuilder::TargetApi::ALL);
+        filamat::Package const pkg = builder.build(engine.getJobSystem());
+        ASSERT_TRUE(pkg.isValid());
+        mMaterial = Material::Builder()
+                .package(pkg.getData(), pkg.getSize())
+                .build(engine);
+        ASSERT_NE(mMaterial, nullptr);
+
+        mRenderable = EntityManager::get().create();
+        RenderableManager::Builder(1)
+                .boundingBox({{ 0, 0, -1 }, { 2, 2, 1 }})
+                .material(0, mMaterial->getDefaultInstance())
+                .geometry(0, RenderableManager::PrimitiveType::TRIANGLES,
+                        mVertexBuffer, mIndexBuffer)
+                .culling(false)
+                .receiveShadows(false)
+                .castShadows(false)
+                .build(engine, mRenderable);
+        scene.addEntity(mRenderable);
+
+        // a dominant green directional light, added to the scene right away, and a weaker
+        // red one that tests add when needed
+        mGreenLight = EntityManager::get().create();
+        LightManager::Builder(LightManager::Type::DIRECTIONAL)
+                .color({ 0.0f, 1.0f, 0.0f })
+                .intensity(100000.0f)
+                .direction({ 0.0f, 0.0f, -1.0f })
+                .build(engine, mGreenLight);
+        scene.addEntity(mGreenLight);
+
+        mRedLight = EntityManager::get().create();
+        LightManager::Builder(LightManager::Type::DIRECTIONAL)
+                .color({ 1.0f, 0.0f, 0.0f })
+                .intensity(50000.0f)
+                .direction({ 0.0f, 0.0f, -1.0f })
+                .build(engine, mRedLight);
+    }
+
+    void addRedLight() { mScene->addEntity(mRedLight); }
+
+    void destroy() {
+        using utils::EntityManager;
+        mScene->remove(mRenderable);
+        mScene->remove(mGreenLight);
+        mScene->remove(mRedLight);
+        for (auto e : { mRenderable, mGreenLight, mRedLight }) {
+            mEngine->destroy(e);
+            EntityManager::get().destroy(e);
+        }
+        mEngine->destroy(mMaterial);
+        mEngine->destroy(mVertexBuffer);
+        mEngine->destroy(mIndexBuffer);
+    }
+
+    static uint8_t const* centerPixel(uint8_t const* rgba, uint32_t width, uint32_t height) {
+        return rgba + ((height / 2) * width + width / 2) * 4;
+    }
+
+private:
+    Engine* mEngine = nullptr;
+    Scene* mScene = nullptr;
+    VertexBuffer* mVertexBuffer = nullptr;
+    IndexBuffer* mIndexBuffer = nullptr;
+    Material* mMaterial = nullptr;
+    utils::Entity mRenderable;
+    utils::Entity mGreenLight;
+    utils::Entity mRedLight;
+};
+
+TEST_F(RenderingTest, MultipleDirectionalLights) {
+    LitQuadScene quad;
+    quad.create(*mEngine, *mScene, *mView, *mCamera);
+
+    // with only the dominant light in the scene, the quad is green
+    bool callbackCalled = false;
+    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
+        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
+        EXPECT_LT(p[0], 16);
+        EXPECT_GT(p[1], 64);
+        callbackCalled = true;
+    });
+    EXPECT_TRUE(callbackCalled);
+
+    // the second (extra) directional light adds red
+    quad.addRedLight();
+    callbackCalled = false;
+    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
+        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
+        EXPECT_GT(p[0], 32);
+        EXPECT_GT(p[1], 64);
+        callbackCalled = true;
+    });
+    EXPECT_TRUE(callbackCalled);
+
+    quad.destroy();
 }
 
 TEST_F(RenderingTest, ClearGreen) {

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -34,10 +34,10 @@
 
 #include <utils/EntityManager.h>
 
-#include <gtest/gtest.h>
-
 #include <math/vec3.h>
 #include <math/vec4.h>
+
+#include <gtest/gtest.h>
 
 using namespace filament;
 using namespace backend;

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -14,28 +14,16 @@
  * limitations under the License.
  */
 
-#include <filament/Camera.h>
 #include <filament/Engine.h>
-#include <filament/IndexBuffer.h>
-#include <filament/LightManager.h>
-#include <filament/Material.h>
-#include <filament/MaterialInstance.h>
-#include <filament/RenderableManager.h>
 #include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
-#include <filament/VertexBuffer.h>
 #include <filament/View.h>
 #include <filament/Viewport.h>
-
-#include <filamat/MaterialBuilder.h>
 
 #include <backend/PixelBufferDescriptor.h>
 
 #include <utils/EntityManager.h>
-
-#include <math/vec3.h>
-#include <math/vec4.h>
 
 #include <gtest/gtest.h>
 
@@ -55,14 +43,8 @@ protected:
 
     using closure_t = std::function<void(uint8_t const* rgba, uint32_t width, uint32_t height)>;
 
-    // Tests needing a non-default engine configuration can override this.
-    virtual Engine::Config getEngineConfig() const {
-        return {};
-    }
-
     void SetUp() override {
-        Engine::Config const config = getEngineConfig();
-        mEngine = Engine::Builder().config(&config).build();
+        mEngine = Engine::create();
         mSurface = mEngine->createSwapChain(16, 16);
         mRenderer = mEngine->createRenderer();
 
@@ -135,178 +117,6 @@ TEST_F(RenderingTest, ClearRed) {
         callbackCalled = true;
     });
     EXPECT_TRUE(callbackCalled);
-}
-
-// Holds a scene with a full-viewport lit quad, a dominant green directional light and a
-// weaker red one. Shared by the extra-directional-lights tests below.
-class LitQuadScene {
-public:
-    void create(Engine& engine, Scene& scene, View& view, Camera& camera) {
-        using namespace filament::math;
-        using utils::Entity;
-        using utils::EntityManager;
-
-        mEngine = &engine;
-        mScene = &scene;
-
-        view.setDithering(View::Dithering::NONE);
-        camera.setProjection(Camera::Projection::ORTHO, -1, 1, -1, 1, 0.1, 10);
-
-        // full-viewport quad at z = -1, facing the camera (normal +z, identity tangent frame)
-        static float3 const positions[4] = {
-                { -2, -2, -1 }, { 2, -2, -1 }, { 2, 2, -1 }, { -2, 2, -1 } };
-        static float4 const tangents[4] = {
-                { 0, 0, 0, 1 }, { 0, 0, 0, 1 }, { 0, 0, 0, 1 }, { 0, 0, 0, 1 } };
-        static uint16_t const indices[6] = { 0, 1, 2, 0, 2, 3 };
-
-        mVertexBuffer = VertexBuffer::Builder()
-                .vertexCount(4)
-                .bufferCount(2)
-                .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3)
-                .attribute(VertexAttribute::TANGENTS, 1, VertexBuffer::AttributeType::FLOAT4)
-                .build(engine);
-        mVertexBuffer->setBufferAt(engine, 0, { positions, sizeof(positions) });
-        mVertexBuffer->setBufferAt(engine, 1, { tangents, sizeof(tangents) });
-
-        mIndexBuffer = IndexBuffer::Builder()
-                .indexCount(6)
-                .bufferType(IndexBuffer::IndexType::USHORT)
-                .build(engine);
-        mIndexBuffer->setBuffer(engine, { indices, sizeof(indices) });
-
-        // a fully diffuse lit material
-        filamat::MaterialBuilder builder;
-        builder.init();
-        builder.shading(Shading::LIT)
-               .material("void material(inout MaterialInputs material) {"
-                         "  prepareMaterial(material);"
-                         "  material.baseColor.rgb = float3(0.8);"
-                         "  material.roughness = 1.0;"
-                         "}")
-               .targetApi(filamat::MaterialBuilder::TargetApi::ALL);
-        filamat::Package const pkg = builder.build(engine.getJobSystem());
-        ASSERT_TRUE(pkg.isValid());
-        mMaterial = Material::Builder()
-                .package(pkg.getData(), pkg.getSize())
-                .build(engine);
-        ASSERT_NE(mMaterial, nullptr);
-
-        mRenderable = EntityManager::get().create();
-        RenderableManager::Builder(1)
-                .boundingBox({{ 0, 0, -1 }, { 2, 2, 1 }})
-                .material(0, mMaterial->getDefaultInstance())
-                .geometry(0, RenderableManager::PrimitiveType::TRIANGLES,
-                        mVertexBuffer, mIndexBuffer)
-                .culling(false)
-                .receiveShadows(false)
-                .castShadows(false)
-                .build(engine, mRenderable);
-        scene.addEntity(mRenderable);
-
-        // a dominant green directional light, added to the scene right away, and a weaker
-        // red one that tests add when needed
-        mGreenLight = EntityManager::get().create();
-        LightManager::Builder(LightManager::Type::DIRECTIONAL)
-                .color({ 0.0f, 1.0f, 0.0f })
-                .intensity(100000.0f)
-                .direction({ 0.0f, 0.0f, -1.0f })
-                .build(engine, mGreenLight);
-        scene.addEntity(mGreenLight);
-
-        mRedLight = EntityManager::get().create();
-        LightManager::Builder(LightManager::Type::DIRECTIONAL)
-                .color({ 1.0f, 0.0f, 0.0f })
-                .intensity(50000.0f)
-                .direction({ 0.0f, 0.0f, -1.0f })
-                .build(engine, mRedLight);
-    }
-
-    void addRedLight() { mScene->addEntity(mRedLight); }
-
-    void destroy() {
-        using utils::EntityManager;
-        mScene->remove(mRenderable);
-        mScene->remove(mGreenLight);
-        mScene->remove(mRedLight);
-        for (auto e : { mRenderable, mGreenLight, mRedLight }) {
-            mEngine->destroy(e);
-            EntityManager::get().destroy(e);
-        }
-        mEngine->destroy(mMaterial);
-        mEngine->destroy(mVertexBuffer);
-        mEngine->destroy(mIndexBuffer);
-    }
-
-    static uint8_t const* centerPixel(uint8_t const* rgba, uint32_t width, uint32_t height) {
-        return rgba + ((height / 2) * width + width / 2) * 4;
-    }
-
-private:
-    Engine* mEngine = nullptr;
-    Scene* mScene = nullptr;
-    VertexBuffer* mVertexBuffer = nullptr;
-    IndexBuffer* mIndexBuffer = nullptr;
-    Material* mMaterial = nullptr;
-    utils::Entity mRenderable;
-    utils::Entity mGreenLight;
-    utils::Entity mRedLight;
-};
-
-// Same as RenderingTest, but the engine opts into multiple directional lights.
-class MultipleDirectionalLightsRenderingTest : public RenderingTest {
-protected:
-    Engine::Config getEngineConfig() const override {
-        Engine::Config config{};
-        config.enableMultipleDirectionalLights = true;
-        return config;
-    }
-};
-
-TEST_F(MultipleDirectionalLightsRenderingTest, MultipleDirectionalLights) {
-    LitQuadScene quad;
-    quad.create(*mEngine, *mScene, *mView, *mCamera);
-
-    // with only the dominant light in the scene, the quad is green
-    bool callbackCalled = false;
-    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
-        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
-        EXPECT_LT(p[0], 16);
-        EXPECT_GT(p[1], 64);
-        callbackCalled = true;
-    });
-    EXPECT_TRUE(callbackCalled);
-
-    // the second (extra) directional light adds red
-    quad.addRedLight();
-    callbackCalled = false;
-    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
-        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
-        EXPECT_GT(p[0], 32);
-        EXPECT_GT(p[1], 64);
-        callbackCalled = true;
-    });
-    EXPECT_TRUE(callbackCalled);
-
-    quad.destroy();
-}
-
-TEST_F(RenderingTest, MultipleDirectionalLightsDisabledByDefault) {
-    LitQuadScene quad;
-    quad.create(*mEngine, *mScene, *mView, *mCamera);
-
-    // with the default engine configuration, only the dominant directional light is
-    // evaluated: adding a second one must not change the result
-    quad.addRedLight();
-    bool callbackCalled = false;
-    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
-        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
-        EXPECT_LT(p[0], 16);
-        EXPECT_GT(p[1], 64);
-        callbackCalled = true;
-    });
-    EXPECT_TRUE(callbackCalled);
-
-    quad.destroy();
 }
 
 TEST_F(RenderingTest, ClearGreen) {

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -55,8 +55,14 @@ protected:
 
     using closure_t = std::function<void(uint8_t const* rgba, uint32_t width, uint32_t height)>;
 
+    // Tests needing a non-default engine configuration can override this.
+    virtual Engine::Config getEngineConfig() const {
+        return {};
+    }
+
     void SetUp() override {
-        mEngine = Engine::create();
+        Engine::Config const config = getEngineConfig();
+        mEngine = Engine::Builder().config(&config).build();
         mSurface = mEngine->createSwapChain(16, 16);
         mRenderer = mEngine->createRenderer();
 
@@ -246,7 +252,17 @@ private:
     utils::Entity mRedLight;
 };
 
-TEST_F(RenderingTest, MultipleDirectionalLights) {
+// Same as RenderingTest, but the engine opts into multiple directional lights.
+class MultipleDirectionalLightsRenderingTest : public RenderingTest {
+protected:
+    Engine::Config getEngineConfig() const override {
+        Engine::Config config{};
+        config.enableMultipleDirectionalLights = true;
+        return config;
+    }
+};
+
+TEST_F(MultipleDirectionalLightsRenderingTest, MultipleDirectionalLights) {
     LitQuadScene quad;
     quad.create(*mEngine, *mScene, *mView, *mCamera);
 
@@ -266,6 +282,25 @@ TEST_F(RenderingTest, MultipleDirectionalLights) {
     runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
         uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
         EXPECT_GT(p[0], 32);
+        EXPECT_GT(p[1], 64);
+        callbackCalled = true;
+    });
+    EXPECT_TRUE(callbackCalled);
+
+    quad.destroy();
+}
+
+TEST_F(RenderingTest, MultipleDirectionalLightsDisabledByDefault) {
+    LitQuadScene quad;
+    quad.create(*mEngine, *mScene, *mView, *mCamera);
+
+    // with the default engine configuration, only the dominant directional light is
+    // evaluated: adding a second one must not change the result
+    quad.addRedLight();
+    bool callbackCalled = false;
+    runTest([&callbackCalled](uint8_t const* rgba, uint32_t width, uint32_t height) {
+        uint8_t const* p = LitQuadScene::centerPixel(rgba, width, height);
+        EXPECT_LT(p[0], 16);
         EXPECT_GT(p[1], 64);
         callbackCalled = true;
     });

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -1835,7 +1835,12 @@ TEST(FilamentTest, ECREpochBasedReclamationManagers) {
 
 
 TEST(FilamentTest, MultipleDirectionalLights) {
-    FEngine* engine = downcast(Engine::create(backend::Backend::NOOP));
+    Engine::Config config{};
+    config.enableMultipleDirectionalLights = true;
+    FEngine* engine = downcast(Engine::Builder()
+            .backend(backend::Backend::NOOP)
+            .config(&config)
+            .build());
     FScene* scene = downcast(engine->createScene());
     auto& em = engine->getEntityManager();
     FLightManager& lcm = engine->getLightManager();

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -1834,6 +1834,66 @@ TEST(FilamentTest, ECREpochBasedReclamationManagers) {
 
 
 
+TEST(FilamentTest, MultipleDirectionalLights) {
+    FEngine* engine = downcast(Engine::create(backend::Backend::NOOP));
+    FScene* scene = downcast(engine->createScene());
+    auto& em = engine->getEntityManager();
+    FLightManager& lcm = engine->getLightManager();
+
+    // create more directional lights than can be supported, with decreasing intensity,
+    // in a random-ish direction each
+    constexpr size_t EXTRA_COUNT = CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS;
+    constexpr size_t LIGHT_COUNT = FScene::DIRECTIONAL_LIGHTS_COUNT + EXTRA_COUNT + 2;
+    Entity entities[LIGHT_COUNT];
+    float3 directions[LIGHT_COUNT];
+    for (size_t i = 0; i < LIGHT_COUNT; i++) {
+        entities[i] = em.create();
+        directions[i] = normalize(float3{ float(i + 1), 1.0f, -0.5f });
+        LightManager::Builder(LightManager::Type::DIRECTIONAL)
+                .intensity(1000.0f * float(LIGHT_COUNT - i))
+                .direction(directions[i])
+                .build(*engine, entities[i]);
+        static_cast<Scene*>(scene)->addEntity(entities[i]);
+    }
+
+    LinearAllocatorArena arena("MultipleDirectionalLights test arena", 3 * 1024 * 1024);
+    RootArenaScope rootArenaScope(arena);
+    FScene::SceneCacheData cache;
+    scene->prepare(engine->getJobSystem(), rootArenaScope, mat4{}, false, cache);
+
+    // the most intense directional light is the dominant one, at index 0 of the LightSoa
+    auto const& lightData = cache.lightData;
+    EXPECT_TRUE(lightData.elementAt<FScene::LIGHT_ENTITY>(0) == entities[0]);
+
+    // the next EXTRA_COUNT lights, by decreasing intensity, are the extra directional
+    // lights; the remaining ones are ignored
+    ASSERT_EQ(EXTRA_COUNT, cache.extraDirectionalLightCount);
+    for (size_t i = 0; i < EXTRA_COUNT; i++) {
+        size_t const entity = FScene::DIRECTIONAL_LIGHTS_COUNT + i;
+        EXPECT_TRUE(cache.extraDirectionalLightInstances[i] ==
+                lcm.getInstance(entities[entity]));
+        float3 const d = cache.extraDirectionalLightDirections[i];
+        EXPECT_NEAR(directions[entity].x, d.x, 1e-6f);
+        EXPECT_NEAR(directions[entity].y, d.y, 1e-6f);
+        EXPECT_NEAR(directions[entity].z, d.z, 1e-6f);
+    }
+
+    // with a single directional light there are no extras
+    for (size_t i = 1; i < LIGHT_COUNT; i++) {
+        static_cast<Scene*>(scene)->remove(entities[i]);
+    }
+    scene->prepare(engine->getJobSystem(), rootArenaScope, mat4{}, false, cache);
+    EXPECT_TRUE(lightData.elementAt<FScene::LIGHT_ENTITY>(0) == entities[0]);
+    EXPECT_EQ(0u, cache.extraDirectionalLightCount);
+
+    engine->destroy(scene);
+    for (auto& e : entities) {
+        engine->destroy(e);
+        em.destroy(e);
+    }
+    Engine::destroy((Engine**)&engine);
+}
+
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -93,6 +93,7 @@ enum class ReservedSpecializationConstants : uint8_t {
 // users should not modify the value of these constants by themselves.
 enum class DynamicSpecializationConstants : uint8_t {
     RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING = 0,
+    RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS = 1,
     // check CONFIG_NEXT_DYNAMIC_SPEC_CONSTANT and CONFIG_MAX_DYNAMIC_SPEC_CONSTANTS below
 };
 
@@ -126,7 +127,7 @@ static_assert(CONFIG_MAX_DYNAMIC_SPEC_CONSTANTS + CONFIG_MAX_RESERVED_SPEC_CONST
 constexpr size_t CONFIG_NEXT_RESERVED_SPEC_CONSTANT = 12;
 
 // The number of the next unassigned dynamic spec constant.
-constexpr size_t CONFIG_NEXT_DYNAMIC_SPEC_CONSTANT = CONFIG_MAX_RESERVED_SPEC_CONSTANTS + 1;
+constexpr size_t CONFIG_NEXT_DYNAMIC_SPEC_CONSTANT = CONFIG_MAX_RESERVED_SPEC_CONSTANTS + 2;
 
 // The maximum number of shadow maps possible.
 // There is currently a maximum limit of 128 shadow maps.
@@ -145,6 +146,16 @@ constexpr size_t CONFIG_MAX_SHADOW_LAYERS = 64;
 
 // The maximum number of shadow cascades that can be used for directional lights.
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
+
+// The maximum number of directional lights supported in addition to the dominant one.
+// The dominant directional light supports shadows and the sun disc; the extra directional
+// lights are evaluated without shadows. This value is limited by the space available in
+// PerViewUib (each extra light uses two float4 entries). The extra directional lights code
+// path is enabled automatically via the RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS dynamic
+// specialization constant when the scene contains more than one directional light, so
+// scenes that don't use this feature don't pay for it.
+// Updating this value necessitates a material version bump.
+constexpr size_t CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS = 4;
 
 // The maximum UBO size, in bytes. This value is set to 16 KiB due to the ES3.0 spec.
 // Note that this value constrains the maximum number of skinning bones, morph targets,

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -216,8 +216,21 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved1;
     float es2Reserved2;
 
+    // --------------------------------------------------------------------------------------------
+    // Extra directional lights, in addition to the dominant one [variant: DIR]
+    // These are evaluated without shadows and without the sun disc.
+    // --------------------------------------------------------------------------------------------
+    // xyz: normalized direction towards the light, w: light channel bits
+    math::float4 extraLightDirection[CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS];
+    // rgb: color, w: intensity, premultiplied by the exposure
+    math::float4 extraLightColorIntensity[CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS];
+    int32_t extraLightCount;            // number of valid entries in the arrays above
+    int32_t extraDirReserved0;
+    int32_t extraDirReserved1;
+    int32_t extraDirReserved2;
+
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[21];
+    math::float4 reserved[12];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -217,8 +217,21 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved1;
     float es2Reserved2;
 
+    // --------------------------------------------------------------------------------------------
+    // Extra directional lights, in addition to the dominant one [variant: DIR]
+    // These are evaluated without shadows and without the sun disc.
+    // --------------------------------------------------------------------------------------------
+    // xyz: normalized direction towards the light, w: light channel bits
+    math::float4 extraLightDirection[CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS];
+    // rgb: color, w: intensity, premultiplied by the exposure
+    math::float4 extraLightColorIntensity[CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS];
+    int32_t extraLightCount;            // number of valid entries in the arrays above
+    int32_t extraDirReserved0;
+    int32_t extraDirReserved1;
+    int32_t extraDirReserved2;
+
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[18];
+    math::float4 reserved[9];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -333,6 +333,9 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
     // example), we'd run into a GPU crash.
     out << "#define CONFIG_MAX_STEREOSCOPIC_EYES " << (int) CONFIG_MAX_STEREOSCOPIC_EYES << "\n";
 
+    out << "#define CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS "
+        << (int) CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS << "\n";
+
     if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
         // On ES2 since we don't have post-processing, we need to emulate EGL_GL_COLORSPACE_KHR,
         // when it's not supported.
@@ -343,12 +346,17 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
     bool const isDepthVariant = filament::Variant::isValidDepthVariant(v);
     if (isDepthVariant) {
         out << "const bool RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING = false;\n";
+        out << "const bool RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS = false;\n";
     } else {
         bool const litVariants = material.isLit || material.hasShadowMultiplier;
         generateSpecializationConstant(out, "RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING",
                 CONFIG_MAX_RESERVED_SPEC_CONSTANTS +
                         +DynamicSpecializationConstants::RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING,
                 litVariants);
+        generateSpecializationConstant(out, "RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS",
+                CONFIG_MAX_RESERVED_SPEC_CONSTANTS + +DynamicSpecializationConstants::
+                        RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS,
+                false);
     }
 
     out << '\n';

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -89,6 +89,10 @@ UibGenerator::Binding UibGenerator::getBinding(UibGenerator::Ubo ubo) noexcept {
 static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
         "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
+static_assert(CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS == 4,
+        "Changing CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS affects PerView size and breaks materials. "
+        "It must also be kept in sync with surface_light_directional.fs.");
+
 BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     using Type = BufferInterfaceBlock::Type;
 
@@ -223,6 +227,18 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "es2Reserved0",            0, Type::FLOAT                  },
             { "es2Reserved1",            0, Type::FLOAT                  },
             { "es2Reserved2",            0, Type::FLOAT                  },
+
+            // ------------------------------------------------------------------------------------
+            // Extra directional lights [variant: DIR]
+            // ------------------------------------------------------------------------------------
+            { "extraLightDirection",      CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS,
+                                             Type::FLOAT4, Precision::HIGH },
+            { "extraLightColorIntensity", CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS,
+                                             Type::FLOAT4, Precision::DEFAULT },
+            { "extraLightCount",          0, Type::INT                     },
+            { "extraDirReserved0",        0, Type::INT                     },
+            { "extraDirReserved1",        0, Type::INT                     },
+            { "extraDirReserved2",        0, Type::INT                     },
 
             // bring PerViewUib to 2 KiB
             { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4 }

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -89,6 +89,10 @@ UibGenerator::Binding UibGenerator::getBinding(UibGenerator::Ubo ubo) noexcept {
 static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
         "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
+static_assert(CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS == 4,
+        "Changing CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS affects PerView size and breaks materials. "
+        "It must also be kept in sync with surface_light_directional.fs.");
+
 BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     using Type = BufferInterfaceBlock::Type;
 
@@ -224,6 +228,18 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "es2Reserved0",            0, Type::FLOAT                  },
             { "es2Reserved1",            0, Type::FLOAT                  },
             { "es2Reserved2",            0, Type::FLOAT                  },
+
+            // ------------------------------------------------------------------------------------
+            // Extra directional lights [variant: DIR]
+            // ------------------------------------------------------------------------------------
+            { "extraLightDirection",      CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS,
+                                             Type::FLOAT4, Precision::HIGH },
+            { "extraLightColorIntensity", CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS,
+                                             Type::FLOAT4, Precision::DEFAULT },
+            { "extraLightCount",          0, Type::INT                     },
+            { "extraDirReserved0",        0, Type::INT                     },
+            { "extraDirReserved1",        0, Type::INT                     },
+            { "extraDirReserved2",        0, Type::INT                     },
 
             // bring PerViewUib to 2 KiB
             { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4 }

--- a/shaders/src/surface_light_directional.fs
+++ b/shaders/src/surface_light_directional.fs
@@ -95,3 +95,51 @@ void evaluateDirectionalLight(const MaterialInputs material,
     color.rgb += surfaceShading(pixel, light, visibility);
 #endif
 }
+
+//------------------------------------------------------------------------------
+// Extra directional lights evaluation
+//
+// Directional lights in addition to the dominant one. These are evaluated
+// without shadows and without the sun disc.
+//------------------------------------------------------------------------------
+
+void evaluateExtraDirectionalLights(const MaterialInputs material,
+        const PixelParams pixel, inout vec3 color) {
+    int channels = object_uniforms_flagsChannels & 0xFF;
+    // RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS is a dynamic specialization constant,
+    // set automatically when the scene contains more than one directional light. It is
+    // false by default, in which case this function compiles away entirely.
+    if (!RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS) {
+        return;
+    }
+    for (int i = 0; i < CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS; i++) {
+        if (i < frameUniforms.extraLightCount) {
+            Light light;
+            // note: colorIntensity.w is always premultiplied by the exposure
+            light.colorIntensity = frameUniforms.extraLightColorIntensity[i];
+            light.l = frameUniforms.extraLightDirection[i].xyz;
+            light.attenuation = 1.0;
+            light.NoL = saturate(dot(shading_normal, light.l));
+            // the channel mask fits in 8 bits, so the float conversion is exact
+            light.channels = int(frameUniforms.extraLightDirection[i].w);
+
+            if ((light.channels & channels) != 0) {
+#if defined(MATERIAL_CAN_SKIP_LIGHTING)
+                if (light.NoL > 0.0) {
+#endif
+                    float visibility = 1.0;
+#if defined(VARIANT_HAS_SHADOWING) && defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
+                    visibility = computeMicroShadowing(light.NoL, material.ambientOcclusion);
+#endif
+#if defined(MATERIAL_HAS_CUSTOM_SURFACE_SHADING)
+                    color.rgb += customSurfaceShading(material, pixel, light, visibility);
+#else
+                    color.rgb += surfaceShading(pixel, light, visibility);
+#endif
+#if defined(MATERIAL_CAN_SKIP_LIGHTING)
+                }
+#endif
+            }
+        }
+    }
+}

--- a/shaders/src/surface_light_directional.fs
+++ b/shaders/src/surface_light_directional.fs
@@ -112,8 +112,16 @@ void evaluateExtraDirectionalLights(const MaterialInputs material,
     if (!RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS) {
         return;
     }
+    // At feature level 0, GLSL ES 1.00 only guarantees support for loops with a constant
+    // bound, and only allows indexing a uniform array with such a loop's index, so we
+    // iterate over the maximum and guard the body with the actual count. At higher feature
+    // levels the loop is simply bounded by the count.
+#if MATERIAL_FEATURE_LEVEL == 0
     for (int i = 0; i < CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS; i++) {
         if (i < frameUniforms.extraLightCount) {
+#else
+    for (int i = 0; i < frameUniforms.extraLightCount; i++) {
+#endif
             Light light;
             // note: colorIntensity.w is always premultiplied by the exposure
             light.colorIntensity = frameUniforms.extraLightColorIntensity[i];
@@ -140,6 +148,8 @@ void evaluateExtraDirectionalLights(const MaterialInputs material,
                 }
 #endif
             }
+#if MATERIAL_FEATURE_LEVEL == 0
         }
+#endif
     }
 }

--- a/shaders/src/surface_shading_lit.fs
+++ b/shaders/src/surface_shading_lit.fs
@@ -292,6 +292,7 @@ vec4 evaluateLights(const MaterialInputs material) {
 #if defined(MATERIAL_HAS_LIGHTING)
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
     evaluateDirectionalLight(material, pixel, color);
+    evaluateExtraDirectionalLights(material, pixel, color);
 #endif
 
     if (RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING) {

--- a/test/filament-unit-test/test_list.txt
+++ b/test/filament-unit-test/test_list.txt
@@ -1,5 +1,5 @@
 libs/viewer/test_settings
-filament/test/test_filament --gtest_filter=-RenderingTest.*
+filament/test/test_filament --gtest_filter=-*RenderingTest.*
 libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils

--- a/test/filament-unit-test/test_list.txt
+++ b/test/filament-unit-test/test_list.txt
@@ -1,5 +1,5 @@
 libs/viewer/test_settings
-filament/test/test_filament --gtest_filter=-*RenderingTest.*
+filament/test/test_filament --gtest_filter=-RenderingTest.*
 libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -350,7 +350,9 @@ value_object<filament::Engine::Config>("Engine$Config")
     .field("assertNativeWindowIsValid", &filament::Engine::Config::assertNativeWindowIsValid)
     .field("gpuContextPriority", &filament::Engine::Config::gpuContextPriority)
     .field("sharedUboInitialSizeInBytes", &filament::Engine::Config::sharedUboInitialSizeInBytes)
-    .field("asynchronousMode", &filament::Engine::Config::asynchronousMode);
+    .field("asynchronousMode", &filament::Engine::Config::asynchronousMode)
+    .field("enableMultipleDirectionalLights",
+            &filament::Engine::Config::enableMultipleDirectionalLights);
 
 value_object<filament::Renderer::ClearOptions>("Renderer$ClearOptions")
     .field("clearColor", &filament::Renderer::ClearOptions::clearColor)


### PR DESCRIPTION
Allow a scene to contain up to `CONFIG_MAX_EXTRA_DIRECTIONAL_LIGHTS` (4) directional lights in addition to the dominant one; the additional lights are evaluated without shadows. The dominant directional light (highest intensity) behaves exactly as before — it owns slot 0 of the light SoA, cascaded shadow maps, and the sun disc — and directional lights beyond the cap are ignored, preserving the previous dominant-light selection semantics as the degenerate case.

The feature is automatic and free for the common single-directional-light case: a new dynamic specialization constant (`RUNTIME_CONFIG_HAS_EXTRA_DIRECTIONAL_LIGHTS`, following the `RUNTIME_CONFIG_HAS_DYNAMIC_LIGHTING` pattern from #10095) is set per view when the scene contains more than one directional light, so the extra-lights loop compiles away entirely in programs specialized for single-light scenes.

Core changes:
- **Scene**: `FScene::prepare` collects all directional lights and partial-sorts them by intensity; the dominant one is stored at slot 0 as before, the next 4 are kept in `SceneCacheData` side arrays (direction + `LightManager` instance). They never enter the froxelizer or `ShadowMapManager`.
- **Uniforms**: new `extraLightDirection[4]`, `extraLightColorIntensity[4]` and `extraLightCount` fields in `PerViewUib`, carved out of the existing `reserved` slack (the struct remains exactly 2 KiB). Light channels are packed into `extraLightDirection[i].w`.
- **Shaders**: new `evaluateExtraDirectionalLights()` loop in `surface_light_directional.fs` under the existing `VARIANT_HAS_DIRECTIONAL_LIGHTING` — no new variants. The loop is gated by the dynamic specialization constant; extras skip shadowing and the sun disc.
- `DynamicSpecConstKey` gets an `EXTRA_DIRECTIONAL_LIGHTS` bit, set from `FView::hasExtraDirectionalLights()` when building render passes; `canSupportExtraDirectionalLights` limits it to lit surface variants with directional lighting, bounding the program-key growth.
- `MATERIAL_VERSION` bumped to 75 (new `PerViewUib` layout and dynamic specialization constant).
- `LightManager.h` documentation and release notes updated.

Tests:
- `FilamentTest.MultipleDirectionalLights`: dominant selection, extras ordering by intensity, direction transforms, truncation past the cap, and the single-light case.
- `RenderingTest.MultipleDirectionalLights`: headless render of a quad first lit by a single green directional light (verifying no red contribution), then with a weaker red directional light added (verifying red appears) — which also exercises the automatic program re-specialization.
