### PR TITLE
VK: Always discard transient depth/stencil attachment

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -2359,6 +2359,12 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
             discardEndVal &= ~TargetBufferFlags::STENCIL;
             clearVal &= ~TargetBufferFlags::STENCIL;
         }
+
+        VulkanAttachment& depthStencil = rt->getDepthStencil();
+        if (depthStencil.texture->isTransientAttachment()) {
+            discardEndVal |= TargetBufferFlags::DEPTH_AND_STENCIL;
+        }
+        
         currentDepthStencilLayout = VulkanLayout::DEPTH_STENCIL_ATTACHMENT;
     }
 


### PR DESCRIPTION
When a renderpass is using a depth/stencil attachment marked as transient, always set the renderpass to discard the result at the end.

BUGS = [540411825]