### PR TITLE
Add AbslStringify function to CString and CallStack

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -175,6 +175,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${TARGET} PRIVATE -Wthread-safety)
 endif()
 
+if (FILAMENT_USE_ABSEIL_LOGGING)
+    target_link_libraries(${TARGET} PUBLIC absl::log)
+endif()
+
 # ==================================================================================================
 # Installation
 # ==================================================================================================

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -22,9 +22,6 @@
 #include <utils/compiler.h>
 #include <utils/StaticString.h>
 
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-#include <iosfwd>
-#endif
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -360,10 +357,6 @@ private:
 
 #if !defined(NDEBUG)
     friend io::ostream& operator<<(io::ostream& out, const CString& rhs);
-#endif
-
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-    friend std::ostream& operator<<(std::ostream& out, const CString& rhs);
 #endif
 
     struct Data {

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -342,6 +342,12 @@ public:
         return std::string_view{data(), size()};
     }
 
+    // make CString compatible with Abseil's stringification utilities
+    template<typename Sink>
+    friend void AbslStringify(Sink& sink, CString const& str) {
+        sink.Append(str.c_str_safe());
+    }
+
 private:
     static void do_tracking(bool ctor);
     static void track(bool ctor) {

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -17,8 +17,8 @@
 #ifndef UTILS_CALLSTACK_H
 #define UTILS_CALLSTACK_H
 
-#include <utils/CString.h>
 #include <utils/compiler.h>
+#include <utils/CString.h>
 #include <utils/sstream.h>
 
 #include <typeinfo>

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -17,8 +17,9 @@
 #ifndef UTILS_CALLSTACK_H
 #define UTILS_CALLSTACK_H
 
-#include <utils/compiler.h>
 #include <utils/CString.h>
+#include <utils/compiler.h>
+#include <utils/sstream.h>
 
 #if defined(FILAMENT_USE_ABSEIL_LOGGING)
 #include <iosfwd>
@@ -96,6 +97,14 @@ public:
 #endif
     template <typename Stream>
     friend Stream& printCallStack(Stream& stream, CallStack const& callstack);
+
+    // make Callstack compatible with Abseil's stringification utilities
+    template<typename Sink>
+    friend void AbslStringify(Sink& sink, CallStack const& callstack) {
+        utils::io::sstream stream;
+        stream << callstack;
+        sink.Append(std::string_view(stream.c_str(), stream.length()));
+    }
 
     bool operator <(const CallStack& rhs) const;
 

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -21,9 +21,6 @@
 #include <utils/compiler.h>
 #include <utils/sstream.h>
 
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-#include <iosfwd>
-#endif
 #include <typeinfo>
 
 #include <stddef.h>
@@ -92,11 +89,6 @@ public:
      * program-counter recorded.
      */
     friend io::ostream& operator <<(io::ostream& stream, const CallStack& callstack);
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-    friend std::ostream& operator <<(std::ostream& stream, const CallStack& callstack);
-#endif
-    template <typename Stream>
-    friend Stream& printCallStack(Stream& stream, CallStack const& callstack);
 
     // make Callstack compatible with Abseil's stringification utilities
     template<typename Sink>

--- a/libs/utils/src/CString.cpp
+++ b/libs/utils/src/CString.cpp
@@ -163,12 +163,6 @@ io::ostream& operator<<(io::ostream& out, const CString& rhs) {
 }
 #endif
 
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-std::ostream& operator<<(std::ostream& out, const CString& rhs) {
-    return out << rhs.c_str_safe();
-}
-#endif
-
 namespace {
 
 // use a C-style variadic function to avoid code bloat from templates

--- a/libs/utils/src/CallStack.cpp
+++ b/libs/utils/src/CallStack.cpp
@@ -140,8 +140,7 @@ CString CallStack::demangleTypeName(const char* mangled) {
 
 // ------------------------------------------------------------------------------------------------
 
-template <typename Stream>
-Stream& printCallStack(Stream& stream, CallStack const& UTILS_UNUSED callstack) {
+io::ostream& operator<<(io::ostream& stream, CallStack const& UTILS_UNUSED callstack) {
 #if HAS_EXECINFO
     size_t const size = callstack.getFrameCount();
     char buf[1024];
@@ -169,18 +168,9 @@ Stream& printCallStack(Stream& stream, CallStack const& UTILS_UNUSED callstack) 
             free((void*)symbols);
         }
     }
+    stream << io::endl;
 #endif
     return stream;
 }
-
-io::ostream& operator<<(io::ostream& stream, CallStack const& callstack) {
-    return printCallStack(stream, callstack) << io::endl;
-}
-
-#if defined(FILAMENT_USE_ABSEIL_LOGGING)
-std::ostream& operator<<(std::ostream& stream, CallStack const& callstack) {
-    return printCallStack(stream, callstack) << '\n' << std::flush;
-}
-#endif
 
 } // namespace utils


### PR DESCRIPTION
This reverts the change made in https://github.com/google/filament/pull/10218 in favor of defining `AbslStringify` friend functions for `utils::CString` and `utils::CallStack`. This has the advantage that it doesn't incur a dependency on `std::ostream`.

BUGS=[537502416]