### PR TITLE
Add Engine::compile to support material compilation with ViewSettings

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -17,11 +17,9 @@
 #ifndef TNT_FILAMENT_ENGINE_H
 #define TNT_FILAMENT_ENGINE_H
 
-
-#include "Options.h"
-
 #include <filament/ColorGrading.h>
 #include <filament/FilamentAPI.h>
+#include <filament/Options.h>
 
 #include <backend/DriverEnums.h>
 #include <backend/Platform.h>
@@ -1394,13 +1392,13 @@ public:
      * with different rendering settings than the active one.
      */
     struct ViewSettings {
-      bool hasDirectionalLighting;
-      bool hasFog;
-      bool hasStereo;
-      bool hasPostProcessing;
-      bool hasDynamicLighting;
-      bool hasShadowing;
-      ShadowType shadowType;
+        bool hasDirectionalLighting = false;
+        bool hasFog = false;
+        bool hasStereo = false;
+        bool hasPostProcessing = false;
+        bool hasDynamicLighting = false;
+        bool hasShadowing = false;
+        ShadowType shadowType = ShadowType::PCF;
     };
 
     /**

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -1443,6 +1443,13 @@ public:
         utils::tribool skinning = utils::tribool::kIndeterminate,
         backend::CallbackHandler* UTILS_NULLABLE handler = nullptr,
         utils::Invocable<void(Material* UTILS_NONNULL)>&& callback = {});
+
+    /**
+     * @param view The View in which you want to extract the settings from.
+     * @return ViewSettings
+     */
+    ViewSettings extractViewSettings(View const* UTILS_NONNULL view) noexcept;
+
 protected:
     //! \privatesection
     Engine() noexcept = default;

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -18,6 +18,8 @@
 #define TNT_FILAMENT_ENGINE_H
 
 
+#include "Options.h"
+
 #include <filament/ColorGrading.h>
 #include <filament/FilamentAPI.h>
 
@@ -1385,7 +1387,64 @@ public:
             utils::tribool skinning,
             backend::CallbackHandler* UTILS_NULLABLE handler = nullptr,
             utils::Invocable<void(Material* UTILS_NONNULL)>&& callback = {});
+    /**
+     * View configuration settings used to pre-compile material shader variants without requiring a View instance.
+     *
+     * Useful for pre-compiling material variants ahead of time for a specific View configuration or for a View
+     * with different rendering settings than the active one.
+     */
+    struct ViewSettings {
+      bool hasDirectionalLighting;
+      bool hasFog;
+      bool hasStereo;
+      bool hasPostProcessing;
+      bool hasDynamicLighting;
+      bool hasShadowing;
+      ShadowType shadowType;
+    };
 
+    /**
+     * Asynchronously compiles the Material with the variants based on the provided ViewSettings (e.g. dynamic lighting, fog, stereo, shadowing), alongside the specified shadow receiver
+     * and skinning configurations.
+     *
+     * After issuing several Engine::compile() calls in a row, it is recommended to call
+     * Engine::flush() such that the backend can start the compilation work as soon as possible.
+     * The provided callback is guaranteed to be called on the main thread after all computed
+     * variants of the material are compiled. This can take hundreds of milliseconds.
+     *
+     * If all the needed variants are already compiled, the callback will be scheduled as
+     * soon as possible, but this might take a few dozen milliseconds, corresponding to how
+     * many previous frames are enqueued in the backend.
+     *
+     * If the same variant is scheduled for compilation multiple times, the first scheduling
+     * takes precedence; later scheduling are ignored.
+     *
+     * The callback is guaranteed to be called. If the engine is destroyed while some material
+     * variants are still compiling or in the queue, these will be discarded and the corresponding
+     * callback will be called. In that case however the Material pointer passed to the callback
+     * is guaranteed to be invalid (either because it's been destroyed by the user already, or,
+     * because it's been cleaned-up by the Engine).
+     *
+     * @param priority       Which priority queue to use, LOW or HIGH.
+     * @param material       The Material to compile.
+     * @param settings       The ViewSettings that is used to get necessary variants.
+     * @param shadowReceiver Indicates whether to compile the shadow-receiving variants.
+     *                       Pass \p utils::tribool::indeterminate to compile both permutations.
+     * @param skinning       Indicates whether to compile the skinning variants.
+     *                       Pass \p utils::tribool::indeterminate to compile both permutations.
+     * @param handler        Handler to dispatch the callback or nullptr for the default handler.
+     * @param callback       Callback called on the main thread when the compilation is done
+     *                       by the backend.
+     * @see Material::compile
+     */
+    void compile(
+        backend::CompilerPriorityQueue priority,
+        Material const* UTILS_NONNULL material,
+        ViewSettings const& settings,
+        utils::tribool shadowReceiver = utils::tribool::kIndeterminate,
+        utils::tribool skinning = utils::tribool::kIndeterminate,
+        backend::CallbackHandler* UTILS_NULLABLE handler = nullptr,
+        utils::Invocable<void(Material* UTILS_NONNULL)>&& callback = {});
 protected:
     //! \privatesection
     Engine() noexcept = default;

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -515,6 +515,19 @@ void Engine::compile(CompilerPriorityQueue priority, Material const* material, V
             handler, std::move(callback));
 }
 
+void Engine::compile(
+    CompilerPriorityQueue priority,
+    Material const* material,
+    ViewSettings const& settings,
+    tribool shadowReceiver,
+    tribool skinning,
+    CallbackHandler* handler,
+    Invocable<void(Material*)>&& callback) {
+   downcast(this)->compile(priority, downcast(material), settings,
+                          shadowReceiver, skinning, handler,
+                          std::move(callback));
+}
+
 #if defined(__EMSCRIPTEN__)
 void Engine::resetBackendState() noexcept {
     downcast(this)->resetBackendState();

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -523,9 +523,9 @@ void Engine::compile(
     tribool skinning,
     CallbackHandler* handler,
     Invocable<void(Material*)>&& callback) {
-   downcast(this)->compile(priority, downcast(material), settings,
-                          shadowReceiver, skinning, handler,
-                          std::move(callback));
+    downcast(this)->compile(priority, downcast(material), settings,
+                            shadowReceiver, skinning, handler,
+                            std::move(callback));
 }
 
 #if defined(__EMSCRIPTEN__)

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -528,6 +528,10 @@ void Engine::compile(
                             std::move(callback));
 }
 
+Engine::ViewSettings Engine::extractViewSettings(View const *view) noexcept {
+    return downcast(this)->extractViewSettings(downcast(view));
+}
+
 #if defined(__EMSCRIPTEN__)
 void Engine::resetBackendState() noexcept {
     downcast(this)->resetBackendState();

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -19,7 +19,6 @@
 #include "MaterialParser.h"
 #include "RenderPrimitive.h"
 #include "TextureCache.h"
-#include "../../../libs/viewer/include/viewer/Settings.h"
 
 #include "components/CameraManager.h"
 #include "components/LightManager.h"
@@ -156,6 +155,119 @@ Platform::DriverConfig getDriverConfig(FEngine* instance) {
                                     : AsynchronousMode::NONE,
     };
     return driverConfig;
+}
+
+Engine::ViewSettings extractViewSettings(const FView* view) noexcept {
+    return Engine::ViewSettings {
+        .hasDirectionalLighting = view->hasDirectionalLighting(),
+        .hasFog = view->hasFog(),
+        .hasStereo = view->hasStereo(),
+        .hasPostProcessing = view->hasPostProcessPass(),
+        .hasDynamicLighting = view->hasDynamicLighting(),
+        .hasShadowing = view->hasShadowing(),
+        .shadowType = view->getShadowType()
+    };
+}
+
+FixedCapacityVector<Variant> getMaterialCompileVariants(
+    FMaterial const* material,
+    Engine::ViewSettings const& settings,
+    tribool const shadowReceiver,
+    tribool const skinning) noexcept {
+
+    // the maximum possible is 6 variants (4 color + 2 depth)
+    auto variants = FixedCapacityVector<Variant>::with_capacity(6);
+
+    // apply() iteratively expands the `variants` vector by mutating existing elements
+    // in-place if `value` is determinate, or by duplicating them if `value` is indeterminate.
+    //
+    // @param start   The index in `variants` to begin the operation.
+    // @param value   The tribool state (false, true, or indeterminate) of the feature.
+    // @param setter  A pointer to a member function of Variant that sets the feature bit.
+    auto apply = [&variants](size_t const start, tribool const value, auto setter) {
+        if (value.is_indeterminate()) {
+            size_t const count = variants.size();
+            for (size_t i = start; i < count; ++i) {
+                // To maintain permutations, we first grab a copy of the variant
+                Variant v = variants[i];
+                // Mutate the original in-place for the `false` state
+                (variants[i].*setter)(false);
+                // Set the `true` state on our copy and push it as a new permutation
+                (v.*setter)(true);
+                variants.push_back(v);
+            }
+        } else {
+            // The feature is statically known, so just mutate all existing elements in-place
+            bool const b = value.is_true();
+            for (size_t i = start; i < variants.size(); ++i) {
+                (variants[i].*setter)(b);
+            }
+        }
+    };
+
+    // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
+    const bool isMaterialLit = material->getDefinition().isVariantLit;
+    Variant baseVariant{};
+    baseVariant.setDirectionalLighting(isMaterialLit && settings.hasDirectionalLighting);
+    // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
+    baseVariant.setDynamicLighting(false);
+    baseVariant.setFog(settings.hasFog);
+    baseVariant.setShadowSampler2D(isMaterialLit && settings.hasShadowing && (settings.shadowType != ShadowType::PCF));
+    baseVariant.setStereo(settings.hasStereo);
+
+    variants.push_back(baseVariant);
+    apply(0, skinning, &Variant::setSkinning);
+    // Only respect shadowReceiver variant when the shading model is lit or hasShadowMultiplier.
+    if (isMaterialLit) {
+        apply(0, shadowReceiver, &Variant::setShadowReceiver);
+    } else {
+        apply(0, tribool(false), &Variant::setShadowReceiver);
+    }
+
+    Variant depthVariant{};
+    if (isMaterialLit && settings.hasShadowing) {
+        // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
+        depthVariant = Variant{Variant::DEPTH_VARIANT};
+        depthVariant.setDepthMoments(settings.shadowType == ShadowType::VSM);
+    }
+    if (settings.hasPostProcessing) {
+        // This is needed if we're going to generate the structure pass. That is however very hard to tell
+        // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
+        // need the depth variant.
+        depthVariant = Variant{Variant::DEPTH_VARIANT};
+    }
+
+    if (Variant::isValidDepthVariant(depthVariant)) {
+        // if we have a valid depth variant, add the stereo and skinning bits
+        depthVariant.setStereo(settings.hasStereo);
+
+        size_t const depthStart = variants.size();
+        variants.push_back(depthVariant);
+        apply(depthStart, skinning, &Variant::setSkinning);
+    }
+
+    return variants;
+}
+
+FixedCapacityVector<Variant> getMaterialCompileVariants(
+        FView const* view,
+        FMaterial const* material,
+        tribool const shadowReceiver,
+        tribool const skinning) noexcept {
+    return getMaterialCompileVariants(material, extractViewSettings(view), shadowReceiver, skinning);
+}
+
+FixedCapacityVector<DynamicSpecConstKey> getMaterialCompileDynamicSpecConstKey(
+        bool hasDynamicLighting, FMaterial const* material) noexcept {
+    // Will add more as we turn more variants into spec constants
+    auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
+    DynamicSpecConstKey baseKey;
+    const bool isMaterialLit = material->getDefinition().isVariantLit;
+    baseKey.setDynamicLighting(isMaterialLit && hasDynamicLighting);
+
+    keys.push_back(baseKey);
+
+    return keys;
 }
 
 } // anonymous
@@ -1741,119 +1853,6 @@ std::optional<bool> FEngine::getFeatureFlag(char const* name) const noexcept {
 
 bool* FEngine::getFeatureFlagPtr(std::string_view name, bool const allowConstant) const noexcept {
     return FeatureFlagManager::getFeatureFlagPtr(name, allowConstant);
-}
-
-Engine::ViewSettings FEngine::extractViewSettings(const FView* view) noexcept {
-    return ViewSettings {
-        .hasDirectionalLighting = view->hasDirectionalLighting(),
-        .hasFog = view->hasFog(),
-        .hasStereo = view->hasStereo(),
-        .hasPostProcessing = view->hasPostProcessPass(),
-        .hasDynamicLighting = view->hasDynamicLighting(),
-        .hasShadowing = view->hasShadowing(),
-        .shadowType = view->getShadowType()
-    };
-}
-
-FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
-    FMaterial const* material,
-    ViewSettings const& settings,
-    tribool const shadowReceiver,
-    tribool const skinning) noexcept {
-
-    // the maximum possible is 6 variants (4 color + 2 depth)
-    auto variants = FixedCapacityVector<Variant>::with_capacity(6);
-
-    // apply() iteratively expands the `variants` vector by mutating existing elements
-    // in-place if `value` is determinate, or by duplicating them if `value` is indeterminate.
-    //
-    // @param start   The index in `variants` to begin the operation.
-    // @param value   The tribool state (false, true, or indeterminate) of the feature.
-    // @param setter  A pointer to a member function of Variant that sets the feature bit.
-    auto apply = [&variants](size_t const start, tribool const value, auto setter) {
-        if (value.is_indeterminate()) {
-            size_t const count = variants.size();
-            for (size_t i = start; i < count; ++i) {
-                // To maintain permutations, we first grab a copy of the variant
-                Variant v = variants[i];
-                // Mutate the original in-place for the `false` state
-                (variants[i].*setter)(false);
-                // Set the `true` state on our copy and push it as a new permutation
-                (v.*setter)(true);
-                variants.push_back(v);
-            }
-        } else {
-            // The feature is statically known, so just mutate all existing elements in-place
-            bool const b = value.is_true();
-            for (size_t i = start; i < variants.size(); ++i) {
-                (variants[i].*setter)(b);
-            }
-        }
-    };
-
-    // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
-    const bool isMaterialLit = material->getDefinition().isVariantLit;
-    Variant baseVariant{};
-    baseVariant.setDirectionalLighting(isMaterialLit && settings.hasDirectionalLighting);
-    // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
-    baseVariant.setDynamicLighting(false);
-    baseVariant.setFog(settings.hasFog);
-    baseVariant.setShadowSampler2D(isMaterialLit && settings.hasShadowing && (settings.shadowType != ShadowType::PCF));
-    baseVariant.setStereo(settings.hasStereo);
-
-    variants.push_back(baseVariant);
-    apply(0, skinning, &Variant::setSkinning);
-    // Only respect shadowReceiver variant when the shading model is lit or hasShadowMultiplier.
-    if (isMaterialLit) {
-        apply(0, shadowReceiver, &Variant::setShadowReceiver);
-    } else {
-        apply(0, tribool(false), &Variant::setShadowReceiver);
-    }
-
-    Variant depthVariant{};
-    if (isMaterialLit && settings.hasShadowing) {
-        // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
-        depthVariant = Variant{Variant::DEPTH_VARIANT};
-        depthVariant.setDepthMoments(settings.shadowType == ShadowType::VSM);
-    }
-    if (settings.hasPostProcessing) {
-        // This is needed if we're going to generate the structure pass. That is however very hard to tell
-        // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
-        // need the depth variant.
-        depthVariant = Variant{Variant::DEPTH_VARIANT};
-    }
-
-    if (Variant::isValidDepthVariant(depthVariant)) {
-        // if we have a valid depth variant, add the stereo and skinning bits
-        depthVariant.setStereo(settings.hasStereo);
-
-        size_t const depthStart = variants.size();
-        variants.push_back(depthVariant);
-        apply(depthStart, skinning, &Variant::setSkinning);
-    }
-
-    return variants;
-}
-
-FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
-        FView const* view,
-        FMaterial const* material,
-        tribool const shadowReceiver,
-        tribool const skinning) noexcept {
-    return getMaterialCompileVariants(material, extractViewSettings(view), shadowReceiver, skinning);
-}
-
-FixedCapacityVector<DynamicSpecConstKey> FEngine::getMaterialCompileDynamicSpecConstKey(
-        bool hasDynamicLighting, FMaterial const* material) noexcept {
-    // Will add more as we turn more variants into spec constants
-    auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
-    DynamicSpecConstKey baseKey;
-    const bool isMaterialLit = material->getDefinition().isVariantLit;
-    baseKey.setDynamicLighting(isMaterialLit && hasDynamicLighting);
-
-    keys.push_back(baseKey);
-
-    return keys;
 }
 
 void FEngine::compile(

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1743,8 +1743,13 @@ bool* FEngine::getFeatureFlagPtr(std::string_view name, bool const allowConstant
 }
 
 FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
-        FView const* view,
         FMaterial const* material,
+        bool const hasDirectionalLighting,
+        bool hasFog,
+        bool hasStereo,
+        bool hasPostProcessing,
+        bool hasShadowing,
+        ShadowType shadowType,
         tribool const shadowReceiver,
         tribool const skinning) noexcept {
 
@@ -1781,12 +1786,12 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
     const bool isMaterialLit = material->getDefinition().isVariantLit;
     Variant baseVariant{};
-    baseVariant.setDirectionalLighting(isMaterialLit && view->hasDirectionalLighting());
+    baseVariant.setDirectionalLighting(isMaterialLit && hasDirectionalLighting);
     // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
     baseVariant.setDynamicLighting(false);
-    baseVariant.setFog(view->hasFog());
-    baseVariant.setShadowSampler2D(isMaterialLit && view->hasShadowing() && (view->getShadowType() != ShadowType::PCF));
-    baseVariant.setStereo(view->hasStereo());
+    baseVariant.setFog(hasFog);
+    baseVariant.setShadowSampler2D(isMaterialLit && hasShadowing && (shadowType != ShadowType::PCF));
+    baseVariant.setStereo(hasStereo);
 
     variants.push_back(baseVariant);
     apply(0, skinning, &Variant::setSkinning);
@@ -1798,12 +1803,12 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     }
 
     Variant depthVariant{};
-    if (isMaterialLit && view->hasShadowing()) {
+    if (isMaterialLit && hasShadowing) {
         // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
         depthVariant = Variant{Variant::DEPTH_VARIANT};
-        depthVariant.setDepthMoments(view->getShadowType() == ShadowType::VSM);
+        depthVariant.setDepthMoments(shadowType == ShadowType::VSM);
     }
-    if (view->hasPostProcessPass()) {
+    if (hasPostProcessing) {
         // This is needed if we're going to generate the structure pass. That is however very hard to tell
         // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
         // need the depth variant.
@@ -1812,7 +1817,7 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
 
     if (Variant::isValidDepthVariant(depthVariant)) {
         // if we have a valid depth variant, add the stereo and skinning bits
-        depthVariant.setStereo(view->hasStereo());
+        depthVariant.setStereo(hasStereo);
 
         size_t const depthStart = variants.size();
         variants.push_back(depthVariant);
@@ -1822,13 +1827,23 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     return variants;
 }
 
+FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
+        FView const* view,
+        FMaterial const* material,
+        tribool const shadowReceiver,
+        tribool const skinning) noexcept {
+    return getMaterialCompileVariants(material, view->hasDirectionalLighting(), view->hasFog(),
+            view->hasStereo(), view->hasPostProcessPass(), view->hasShadowing(),
+            view->getShadowType(), shadowReceiver, skinning);
+}
+
 FixedCapacityVector<DynamicSpecConstKey> FEngine::getMaterialCompileDynamicSpecConstKey(
-        FView const* view, FMaterial const* material) noexcept {
+        bool const hasDynamicLighting, FMaterial const* material) noexcept {
     // Will add more as we turn more variants into spec constants
     auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
     DynamicSpecConstKey baseKey;
     const bool isMaterialLit = material->getDefinition().isVariantLit;
-    baseKey.setDynamicLighting(isMaterialLit && view->hasDynamicLighting());
+    baseKey.setDynamicLighting(isMaterialLit && hasDynamicLighting);
 
     keys.push_back(baseKey);
 
@@ -1844,7 +1859,25 @@ void FEngine::compile(
         CallbackHandler* handler,
         Invocable<void(Material*)>&& callback) {
     auto const variants = getMaterialCompileVariants(view, material, shadowReceiver, skinning);
-    auto const dynamicSpecConstKeys = getMaterialCompileDynamicSpecConstKey(view, material);
+    auto const dynamicSpecConstKeys = getMaterialCompileDynamicSpecConstKey(
+            view->hasDynamicLighting(), material);
+    const_cast<FMaterial*>(material)->compile(priority, variants, dynamicSpecConstKeys, handler,
+            std::move(callback));
+}
+
+void FEngine::compile(
+        CompilerPriorityQueue priority,
+        FMaterial const* material,
+        ViewSettings const& settings,
+        tribool shadowReceiver,
+        tribool skinning,
+        CallbackHandler* handler,
+        Invocable<void(Material*)>&& callback) {
+    auto const variants = getMaterialCompileVariants(material, settings.hasDirectionalLighting,
+            settings.hasFog, settings.hasStereo, settings.hasPostProcessing, settings.hasShadowing,
+            settings.shadowType, shadowReceiver, skinning);
+    auto const dynamicSpecConstKeys = getMaterialCompileDynamicSpecConstKey(
+            settings.hasDynamicLighting, material);
     const_cast<FMaterial*>(material)->compile(priority, variants, dynamicSpecConstKeys, handler,
             std::move(callback));
 }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -157,119 +157,6 @@ Platform::DriverConfig getDriverConfig(FEngine* instance) {
     return driverConfig;
 }
 
-Engine::ViewSettings extractViewSettings(const FView* view) noexcept {
-    return Engine::ViewSettings {
-        .hasDirectionalLighting = view->hasDirectionalLighting(),
-        .hasFog = view->hasFog(),
-        .hasStereo = view->hasStereo(),
-        .hasPostProcessing = view->hasPostProcessPass(),
-        .hasDynamicLighting = view->hasDynamicLighting(),
-        .hasShadowing = view->hasShadowing(),
-        .shadowType = view->getShadowType()
-    };
-}
-
-FixedCapacityVector<Variant> getMaterialCompileVariants(
-    FMaterial const* material,
-    Engine::ViewSettings const& settings,
-    tribool const shadowReceiver,
-    tribool const skinning) noexcept {
-
-    // the maximum possible is 6 variants (4 color + 2 depth)
-    auto variants = FixedCapacityVector<Variant>::with_capacity(6);
-
-    // apply() iteratively expands the `variants` vector by mutating existing elements
-    // in-place if `value` is determinate, or by duplicating them if `value` is indeterminate.
-    //
-    // @param start   The index in `variants` to begin the operation.
-    // @param value   The tribool state (false, true, or indeterminate) of the feature.
-    // @param setter  A pointer to a member function of Variant that sets the feature bit.
-    auto apply = [&variants](size_t const start, tribool const value, auto setter) {
-        if (value.is_indeterminate()) {
-            size_t const count = variants.size();
-            for (size_t i = start; i < count; ++i) {
-                // To maintain permutations, we first grab a copy of the variant
-                Variant v = variants[i];
-                // Mutate the original in-place for the `false` state
-                (variants[i].*setter)(false);
-                // Set the `true` state on our copy and push it as a new permutation
-                (v.*setter)(true);
-                variants.push_back(v);
-            }
-        } else {
-            // The feature is statically known, so just mutate all existing elements in-place
-            bool const b = value.is_true();
-            for (size_t i = start; i < variants.size(); ++i) {
-                (variants[i].*setter)(b);
-            }
-        }
-    };
-
-    // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
-    const bool isMaterialLit = material->getDefinition().isVariantLit;
-    Variant baseVariant{};
-    baseVariant.setDirectionalLighting(isMaterialLit && settings.hasDirectionalLighting);
-    // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
-    baseVariant.setDynamicLighting(false);
-    baseVariant.setFog(settings.hasFog);
-    baseVariant.setShadowSampler2D(isMaterialLit && settings.hasShadowing && (settings.shadowType != ShadowType::PCF));
-    baseVariant.setStereo(settings.hasStereo);
-
-    variants.push_back(baseVariant);
-    apply(0, skinning, &Variant::setSkinning);
-    // Only respect shadowReceiver variant when the shading model is lit or hasShadowMultiplier.
-    if (isMaterialLit) {
-        apply(0, shadowReceiver, &Variant::setShadowReceiver);
-    } else {
-        apply(0, tribool(false), &Variant::setShadowReceiver);
-    }
-
-    Variant depthVariant{};
-    if (isMaterialLit && settings.hasShadowing) {
-        // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
-        depthVariant = Variant{Variant::DEPTH_VARIANT};
-        depthVariant.setDepthMoments(settings.shadowType == ShadowType::VSM);
-    }
-    if (settings.hasPostProcessing) {
-        // This is needed if we're going to generate the structure pass. That is however very hard to tell
-        // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
-        // need the depth variant.
-        depthVariant = Variant{Variant::DEPTH_VARIANT};
-    }
-
-    if (Variant::isValidDepthVariant(depthVariant)) {
-        // if we have a valid depth variant, add the stereo and skinning bits
-        depthVariant.setStereo(settings.hasStereo);
-
-        size_t const depthStart = variants.size();
-        variants.push_back(depthVariant);
-        apply(depthStart, skinning, &Variant::setSkinning);
-    }
-
-    return variants;
-}
-
-FixedCapacityVector<Variant> getMaterialCompileVariants(
-        FView const* view,
-        FMaterial const* material,
-        tribool const shadowReceiver,
-        tribool const skinning) noexcept {
-    return getMaterialCompileVariants(material, extractViewSettings(view), shadowReceiver, skinning);
-}
-
-FixedCapacityVector<DynamicSpecConstKey> getMaterialCompileDynamicSpecConstKey(
-        bool hasDynamicLighting, FMaterial const* material) noexcept {
-    // Will add more as we turn more variants into spec constants
-    auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
-    DynamicSpecConstKey baseKey;
-    const bool isMaterialLit = material->getDefinition().isVariantLit;
-    baseKey.setDynamicLighting(isMaterialLit && hasDynamicLighting);
-
-    keys.push_back(baseKey);
-
-    return keys;
-}
-
 } // anonymous
 
 struct Engine::BuilderDetails {
@@ -1853,6 +1740,119 @@ std::optional<bool> FEngine::getFeatureFlag(char const* name) const noexcept {
 
 bool* FEngine::getFeatureFlagPtr(std::string_view name, bool const allowConstant) const noexcept {
     return FeatureFlagManager::getFeatureFlagPtr(name, allowConstant);
+}
+
+Engine::ViewSettings FEngine::extractViewSettings(const FView* view) noexcept {
+    return Engine::ViewSettings {
+        .hasDirectionalLighting = view->hasDirectionalLighting(),
+        .hasFog = view->hasFog(),
+        .hasStereo = view->hasStereo(),
+        .hasPostProcessing = view->hasPostProcessPass(),
+        .hasDynamicLighting = view->hasDynamicLighting(),
+        .hasShadowing = view->hasShadowing(),
+        .shadowType = view->getShadowType()
+    };
+}
+
+FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
+    FMaterial const* material,
+    Engine::ViewSettings const& settings,
+    tribool const shadowReceiver,
+    tribool const skinning) noexcept {
+
+    // the maximum possible is 6 variants (4 color + 2 depth)
+    auto variants = FixedCapacityVector<Variant>::with_capacity(6);
+
+    // apply() iteratively expands the `variants` vector by mutating existing elements
+    // in-place if `value` is determinate, or by duplicating them if `value` is indeterminate.
+    //
+    // @param start   The index in `variants` to begin the operation.
+    // @param value   The tribool state (false, true, or indeterminate) of the feature.
+    // @param setter  A pointer to a member function of Variant that sets the feature bit.
+    auto apply = [&variants](size_t const start, tribool const value, auto setter) {
+        if (value.is_indeterminate()) {
+            size_t const count = variants.size();
+            for (size_t i = start; i < count; ++i) {
+                // To maintain permutations, we first grab a copy of the variant
+                Variant v = variants[i];
+                // Mutate the original in-place for the `false` state
+                (variants[i].*setter)(false);
+                // Set the `true` state on our copy and push it as a new permutation
+                (v.*setter)(true);
+                variants.push_back(v);
+            }
+        } else {
+            // The feature is statically known, so just mutate all existing elements in-place
+            bool const b = value.is_true();
+            for (size_t i = start; i < variants.size(); ++i) {
+                (variants[i].*setter)(b);
+            }
+        }
+    };
+
+    // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
+    const bool isMaterialLit = material->getDefinition().isVariantLit;
+    Variant baseVariant{};
+    baseVariant.setDirectionalLighting(isMaterialLit && settings.hasDirectionalLighting);
+    // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
+    baseVariant.setDynamicLighting(false);
+    baseVariant.setFog(settings.hasFog);
+    baseVariant.setShadowSampler2D(isMaterialLit && settings.hasShadowing && (settings.shadowType != ShadowType::PCF));
+    baseVariant.setStereo(settings.hasStereo);
+
+    variants.push_back(baseVariant);
+    apply(0, skinning, &Variant::setSkinning);
+    // Only respect shadowReceiver variant when the shading model is lit or hasShadowMultiplier.
+    if (isMaterialLit) {
+        apply(0, shadowReceiver, &Variant::setShadowReceiver);
+    } else {
+        apply(0, tribool(false), &Variant::setShadowReceiver);
+    }
+
+    Variant depthVariant{};
+    if (isMaterialLit && settings.hasShadowing) {
+        // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
+        depthVariant = Variant{Variant::DEPTH_VARIANT};
+        depthVariant.setDepthMoments(settings.shadowType == ShadowType::VSM);
+    }
+    if (settings.hasPostProcessing) {
+        // This is needed if we're going to generate the structure pass. That is however very hard to tell
+        // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
+        // need the depth variant.
+        depthVariant = Variant{Variant::DEPTH_VARIANT};
+    }
+
+    if (Variant::isValidDepthVariant(depthVariant)) {
+        // if we have a valid depth variant, add the stereo and skinning bits
+        depthVariant.setStereo(settings.hasStereo);
+
+        size_t const depthStart = variants.size();
+        variants.push_back(depthVariant);
+        apply(depthStart, skinning, &Variant::setSkinning);
+    }
+
+    return variants;
+}
+
+FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
+        FView const* view,
+        FMaterial const* material,
+        tribool const shadowReceiver,
+        tribool const skinning) noexcept {
+    return getMaterialCompileVariants(material, extractViewSettings(view), shadowReceiver, skinning);
+}
+
+FixedCapacityVector<DynamicSpecConstKey> FEngine::getMaterialCompileDynamicSpecConstKey(
+        bool hasDynamicLighting, FMaterial const* material) noexcept {
+    // Will add more as we turn more variants into spec constants
+    auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
+    DynamicSpecConstKey baseKey;
+    const bool isMaterialLit = material->getDefinition().isVariantLit;
+    baseKey.setDynamicLighting(isMaterialLit && hasDynamicLighting);
+
+    keys.push_back(baseKey);
+
+    return keys;
 }
 
 void FEngine::compile(

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -19,6 +19,7 @@
 #include "MaterialParser.h"
 #include "RenderPrimitive.h"
 #include "TextureCache.h"
+#include "../../../libs/viewer/include/viewer/Settings.h"
 
 #include "components/CameraManager.h"
 #include "components/LightManager.h"
@@ -1742,16 +1743,23 @@ bool* FEngine::getFeatureFlagPtr(std::string_view name, bool const allowConstant
     return FeatureFlagManager::getFeatureFlagPtr(name, allowConstant);
 }
 
+Engine::ViewSettings FEngine::extractViewSettings(const FView* view) noexcept {
+    return ViewSettings {
+        .hasDirectionalLighting = view->hasDirectionalLighting(),
+        .hasFog = view->hasFog(),
+        .hasStereo = view->hasStereo(),
+        .hasPostProcessing = view->hasPostProcessPass(),
+        .hasDynamicLighting = view->hasDynamicLighting(),
+        .hasShadowing = view->hasShadowing(),
+        .shadowType = view->getShadowType()
+    };
+}
+
 FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
-        FMaterial const* material,
-        bool const hasDirectionalLighting,
-        bool hasFog,
-        bool hasStereo,
-        bool hasPostProcessing,
-        bool hasShadowing,
-        ShadowType shadowType,
-        tribool const shadowReceiver,
-        tribool const skinning) noexcept {
+    FMaterial const* material,
+    ViewSettings const& settings,
+    tribool const shadowReceiver,
+    tribool const skinning) noexcept {
 
     // the maximum possible is 6 variants (4 color + 2 depth)
     auto variants = FixedCapacityVector<Variant>::with_capacity(6);
@@ -1786,12 +1794,12 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     // isMaterialLit means shading != Shading::UNLIT || hasShadowMultiplier;
     const bool isMaterialLit = material->getDefinition().isVariantLit;
     Variant baseVariant{};
-    baseVariant.setDirectionalLighting(isMaterialLit && hasDirectionalLighting);
+    baseVariant.setDirectionalLighting(isMaterialLit && settings.hasDirectionalLighting);
     // Dynamic lighting is now handled via specialization constants. The variant bit is always 0.
     baseVariant.setDynamicLighting(false);
-    baseVariant.setFog(hasFog);
-    baseVariant.setShadowSampler2D(isMaterialLit && hasShadowing && (shadowType != ShadowType::PCF));
-    baseVariant.setStereo(hasStereo);
+    baseVariant.setFog(settings.hasFog);
+    baseVariant.setShadowSampler2D(isMaterialLit && settings.hasShadowing && (settings.shadowType != ShadowType::PCF));
+    baseVariant.setStereo(settings.hasStereo);
 
     variants.push_back(baseVariant);
     apply(0, skinning, &Variant::setSkinning);
@@ -1803,12 +1811,12 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
     }
 
     Variant depthVariant{};
-    if (isMaterialLit && hasShadowing) {
+    if (isMaterialLit && settings.hasShadowing) {
         // needsShadowMap() is no good here, because it can change based on the visibility of the shadow maps
         depthVariant = Variant{Variant::DEPTH_VARIANT};
-        depthVariant.setDepthMoments(shadowType == ShadowType::VSM);
+        depthVariant.setDepthMoments(settings.shadowType == ShadowType::VSM);
     }
-    if (hasPostProcessing) {
+    if (settings.hasPostProcessing) {
         // This is needed if we're going to generate the structure pass. That is however very hard to tell
         // because the logic exists only in the FrameGraph. For now, we assume that if postFx is enabled, we'll
         // need the depth variant.
@@ -1817,7 +1825,7 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
 
     if (Variant::isValidDepthVariant(depthVariant)) {
         // if we have a valid depth variant, add the stereo and skinning bits
-        depthVariant.setStereo(hasStereo);
+        depthVariant.setStereo(settings.hasStereo);
 
         size_t const depthStart = variants.size();
         variants.push_back(depthVariant);
@@ -1832,13 +1840,11 @@ FixedCapacityVector<Variant> FEngine::getMaterialCompileVariants(
         FMaterial const* material,
         tribool const shadowReceiver,
         tribool const skinning) noexcept {
-    return getMaterialCompileVariants(material, view->hasDirectionalLighting(), view->hasFog(),
-            view->hasStereo(), view->hasPostProcessPass(), view->hasShadowing(),
-            view->getShadowType(), shadowReceiver, skinning);
+    return getMaterialCompileVariants(material, extractViewSettings(view), shadowReceiver, skinning);
 }
 
 FixedCapacityVector<DynamicSpecConstKey> FEngine::getMaterialCompileDynamicSpecConstKey(
-        bool const hasDynamicLighting, FMaterial const* material) noexcept {
+        bool hasDynamicLighting, FMaterial const* material) noexcept {
     // Will add more as we turn more variants into spec constants
     auto keys = FixedCapacityVector<DynamicSpecConstKey>::with_capacity(1);
     DynamicSpecConstKey baseKey;
@@ -1873,9 +1879,7 @@ void FEngine::compile(
         tribool skinning,
         CallbackHandler* handler,
         Invocable<void(Material*)>&& callback) {
-    auto const variants = getMaterialCompileVariants(material, settings.hasDirectionalLighting,
-            settings.hasFog, settings.hasStereo, settings.hasPostProcessing, settings.hasShadowing,
-            settings.shadowType, shadowReceiver, skinning);
+    auto const variants = getMaterialCompileVariants(material, settings, shadowReceiver, skinning);
     auto const dynamicSpecConstKeys = getMaterialCompileDynamicSpecConstKey(
             settings.hasDynamicLighting, material);
     const_cast<FMaterial*>(material)->compile(priority, variants, dynamicSpecConstKeys, handler,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -623,21 +623,6 @@ public:
         backend::CallbackHandler* handler = nullptr,
         utils::Invocable<void(Material*)>&& callback = {});
 
-    static ViewSettings extractViewSettings(const FView* view) noexcept;
-
-    static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
-        FMaterial const* material, ViewSettings const& settings, utils::tribool shadowReceiver,
-        utils::tribool skinning) noexcept;
-
-    static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
-        FView const* view,
-        FMaterial const* material,
-        utils::tribool shadowReceiver,
-        utils::tribool skinning) noexcept;
-
-    static utils::FixedCapacityVector<DynamicSpecConstKey> getMaterialCompileDynamicSpecConstKey(
-        bool hasDynamicLighting, FMaterial const* material) noexcept;
-
 private:
     explicit FEngine(Builder const& builder);
     void init();

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -623,6 +623,21 @@ public:
         backend::CallbackHandler* handler = nullptr,
         utils::Invocable<void(Material*)>&& callback = {});
 
+    static ViewSettings extractViewSettings(const FView* view) noexcept;
+
+    static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
+        FMaterial const* material, ViewSettings const& settings, utils::tribool shadowReceiver,
+        utils::tribool skinning) noexcept;
+
+    static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
+        FView const* view,
+        FMaterial const* material,
+        utils::tribool shadowReceiver,
+        utils::tribool skinning) noexcept;
+
+    static utils::FixedCapacityVector<DynamicSpecConstKey> getMaterialCompileDynamicSpecConstKey(
+        bool hasDynamicLighting, FMaterial const* material) noexcept;
+
 private:
     explicit FEngine(Builder const& builder);
     void init();

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -623,10 +623,10 @@ public:
         backend::CallbackHandler* handler = nullptr,
         utils::Invocable<void(Material*)>&& callback = {});
 
+    static ViewSettings extractViewSettings(const FView* view) noexcept;
+
     static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
-        FMaterial const* material, bool hasDirectionalLighting, bool hasFog,
-        bool hasStereo, bool hasPostProcessing, bool hasShadowing,
-        ShadowType shadowType, utils::tribool shadowReceiver,
+        FMaterial const* material, ViewSettings const& settings, utils::tribool shadowReceiver,
         utils::tribool skinning) noexcept;
 
     static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -614,6 +614,21 @@ public:
         backend::CallbackHandler* handler = nullptr,
         utils::Invocable<void(Material*)>&& callback = {});
 
+    void compile(
+        backend::CompilerPriorityQueue priority,
+        FMaterial const* material,
+        ViewSettings const& settings,
+        utils::tribool shadowReceiver,
+        utils::tribool skinning,
+        backend::CallbackHandler* handler = nullptr,
+        utils::Invocable<void(Material*)>&& callback = {});
+
+    static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
+        FMaterial const* material, bool hasDirectionalLighting, bool hasFog,
+        bool hasStereo, bool hasPostProcessing, bool hasShadowing,
+        ShadowType shadowType, utils::tribool shadowReceiver,
+        utils::tribool skinning) noexcept;
+
     static utils::FixedCapacityVector<Variant> getMaterialCompileVariants(
         FView const* view,
         FMaterial const* material,
@@ -621,7 +636,7 @@ public:
         utils::tribool skinning) noexcept;
 
     static utils::FixedCapacityVector<DynamicSpecConstKey> getMaterialCompileDynamicSpecConstKey(
-        FView const* view, FMaterial const* material) noexcept;
+        bool hasDynamicLighting, FMaterial const* material) noexcept;
 
 private:
     explicit FEngine(Builder const& builder);

--- a/filament/test/filament_test_material.cpp
+++ b/filament/test/filament_test_material.cpp
@@ -482,3 +482,33 @@ TEST(Material, CompileUnlitMaterialShadowMultiplierWithShadowReceiverEnabled) {
     engine->destroy(material);
     Engine::destroy(engine);
 }
+
+TEST(MaterialCompile, CompileWithViewSettings) {
+    Engine* engine = Engine::create(Engine::Backend::NOOP);
+    ASSERT_NE(engine, nullptr);
+
+    Material* material = Material::Builder()
+                                 .package(FILAMENT_TEST_RESOURCES_TEST_MATERIAL_TRANSFORMNAME_DATA,
+                                         FILAMENT_TEST_RESOURCES_TEST_MATERIAL_TRANSFORMNAME_SIZE)
+                                 .build(*engine);
+    ASSERT_NE(material, nullptr);
+
+    Engine::ViewSettings settings{
+        .hasDirectionalLighting = true,
+        .hasFog = true,
+        .hasStereo = false,
+        .hasPostProcessing = true,
+        .hasDynamicLighting = false,
+        .hasShadowing = true,
+        .shadowType = ShadowType::PCF,
+    };
+
+    // Test with different configurations.
+    engine->compile(backend::CompilerPriorityQueue::HIGH, material, Engine::ViewSettings{});
+    engine->compile(backend::CompilerPriorityQueue::HIGH, material, settings);
+    engine->compile(backend::CompilerPriorityQueue::LOW, material, settings,
+                    utils::tribool(true), utils::tribool(false));
+
+    engine->destroy(material);
+    Engine::destroy(engine);
+}


### PR DESCRIPTION
There is a case where an app wants to precompile materials with view settings that are different from the current active View. To support that case, another Engine::compile is added that takes in ViewSettings.

FIXES=538287765