### PR TITLE
web: expand JS bindings coverage, part 2

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,3 +6,5 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- web: expand JS bindings coverage for View and Material getters, TextureSampler accessors, the ToneMapper hierarchy, integer material parameters, and other previously unbound APIs

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,5 +6,7 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- web: expand JS bindings coverage for View and Material getters, TextureSampler accessors, the ToneMapper hierarchy, integer material parameters, and other previously unbound APIs
 - backend: re-enable the `backend_test` build on iOS (opt-in via `INSTALL_BACKEND_TEST`) and record its golden-image hashes
 - vulkan: fix very slow `readPixels` on devices without host-cached staging memory (e.g. PowerVR)

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -430,7 +430,13 @@ ViewerGui::ViewerGui(filament::Engine* engine, filament::Scene* scene, filament:
     mSettings.view.bloom.enabled = true;
 
     DebugRegistry& debug = mEngine->getDebugRegistry();
-    *debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images") = true;
+    // Registered by the first Renderer the engine creates, which may not exist yet: a viewer can
+    // be constructed before anything has been rendered. Writing through the null this returns
+    // corrupts the bottom of the heap, which surfaces much later and somewhere else entirely.
+    if (bool* combineMultiviewImages =
+            debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images")) {
+        *combineMultiviewImages = true;
+    }
 
     using namespace filament;
     LightManager::Builder(LightManager::Type::SUN)
@@ -1127,7 +1133,7 @@ void ViewerGui::updateUserInterface() {
             ImGui::SliderFloat("Strength", &mSettings.viewer.groundShadowStrength, 0.0f, 1.0f);
             ImGui::Unindent();
 
-            if (mAsset->getSceneCount() > 1) {
+            if (mAsset && mAsset->getSceneCount() > 1) {
                 ImGui::Separator();
                 sceneSelectionUI();
             }
@@ -1180,7 +1186,7 @@ void ViewerGui::updateUserInterface() {
 
         // We do not yet support camera selection in the remote UI. To support this feature, we
         // would need to send a message from DebugServer to the WebSockets client.
-        if (!isRemoteMode()) {
+        if (!isRemoteMode() && mAsset) {
 
             const utils::Entity* cameras = mAsset->getCameraEntities();
             const size_t cameraCount = mAsset->getCameraEntityCount();
@@ -1257,7 +1263,10 @@ void ViewerGui::updateUserInterface() {
     // TODO(prideout): add support for hierarchy, animation and variant selection in remote mode. To
     // support these features, we will need to send a message (list of strings) from DebugServer to
     // the WebSockets client.
-    if (!isRemoteMode()) {
+    //
+    // Everything below reads the asset and its instance, which are only set once setAsset has
+    // been called; a viewer that draws its UI before loading anything has neither.
+    if (!isRemoteMode() && mAsset && mInstance) {
         if (ImGui::CollapsingHeader("Hierarchy")) {
             ImGui::Indent();
             ImGui::Checkbox("Show bounds", &mEnableWireframe);

--- a/tools/web-binding-audit/run.py
+++ b/tools/web-binding-audit/run.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report public C++ APIs that the Java/JNI bindings expose but the JS bindings do not.
+
+The web (embind) surface is maintained by hand, so it drifts from the C++ headers silently: a
+method that is never registered simply does not exist in JavaScript, and nothing fails at build
+time. This tool makes that drift visible.
+
+How it works
+------------
+Three surfaces are parsed and diffed:
+
+  C++    filament/include/filament/*.h and libs/gltfio/include/gltfio/*.h -- the API that exists.
+  web    web/filament-js/{jsbindings,jsbindings_generated,jsenums,jsenums_generated}.cpp plus
+         extensions.js -- the API JavaScript can actually reach. filament.d.ts is excluded on
+         purpose; see collect_web().
+  Java   android/**/src/main/java/.../*.java -- the API Android exposes.
+
+A C++ method is reported when it is absent from the web surface *and* present on the Java one.
+Requiring the Java side keeps the report actionable: it filters out APIs that no binding layer
+has ever exposed, and it means acting on a finding never makes the web surface wider than
+Android's.
+
+Deliberate omissions live in EXCLUSIONS below, each with the reason. Anything not excluded and
+not bound is reported, and the tool exits 1, so this can gate CI.
+
+Usage
+-----
+    ./tools/web-binding-audit/run.py            # report unexplained gaps, exit 1 if any
+    ./tools/web-binding-audit/run.py --all      # also list the deliberate exclusions
+    ./tools/web-binding-audit/run.py --verbose  # include the C++ declaration for each gap
+
+Known limitations
+-----------------
+Matching is by *name*, not by signature, so a method bound with fewer parameters than C++
+declares (an overload gap) is reported as covered. setMorphWeights was such a case: bound, but
+without its offset argument. Signature-level checking would need a real C++ parser; until then,
+treat a clean run as "no missing names" rather than "no missing functionality".
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+
+ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
+HEADER_DIRS = [
+    ("filament/include/filament", ""),
+    ("libs/gltfio/include/gltfio", "gltfio$"),
+]
+
+WEB_SOURCES = [
+    "web/filament-js/jsbindings.cpp",
+    "web/filament-js/jsbindings_generated.cpp",
+    "web/filament-js/jsenums.cpp",
+    "web/filament-js/jsenums_generated.cpp",
+]
+
+JAVA_DIRS = [
+    "android/filament-android/src/main/java/com/google/android/filament",
+    "android/gltfio-android/src/main/java/com/google/android/filament/gltfio",
+    "android/filament-utils-android/src/main/java/com/google/android/filament/utils",
+]
+
+# Classes that are not part of the JS surface by design.
+SKIPPED_CLASSES = {
+    # CRTP/infrastructure helpers, not real API.
+    "BuilderNameMixin", "FilamentAPI",
+    # Math and geometry value types, bound as value_array/value_object rather than classes.
+    "Aabb", "Aabb$Corners", "Box", "Viewport", "Color", "ColorSpace", "Gamut", "TransferFunction",
+    # Iterator plumbing.
+    "TransformManager$children_iterator", "TransformManager$children_range",
+    # Frame pacing and history: driven by requestAnimationFrame on the web.
+    "FrameHistoryStream", "FrameHistoryStream$NewFramesRange", "FrameHistoryStream$Result",
+    "FramePacer", "FramePacer$Builder", "FramePipelineEstimator", "Sync",
+    "gltfio$AssetConfigurationExtended",
+}
+
+# A C++ name that covers many overloads is usually bound as a family of typed entry points
+# (setParameter -> setBoolParameter, setInt2Parameter, ...). Rather than hand-listing those names,
+# derive the family from the *Java* bindings, which spell every overload out with concrete types:
+#
+#   public void setParameter(String name, int x, int y)  ->  an int2 overload must be reachable
+#
+# Each Java overload is turned into a type token (Int2) and checked against the web surface under
+# the naming conventions the bindings actually use, infix (setInt2Parameter) or suffix
+# (setParameterInt2). A family that covers only some overloads then reports the specific ones that
+# are missing, instead of hiding behind a comment claiming the family is complete.
+JAVA_TYPE_TOKENS = {
+    "boolean": "Bool", "float": "Float", "int": "Int", "double": "Double", "long": "Long",
+}
+
+# Methods whose family should be derived, keyed by "Class.method". The value is the Java class file
+# to read the overloads from (usually the same class).
+DERIVED_FAMILIES = {
+    "MaterialInstance.setParameter": "MaterialInstance",
+    "MaterialInstance.setConstant": "MaterialInstance",
+}
+
+# Overload shapes that the derivation cannot name on its own, because the web binding uses a name
+# unrelated to the Java parameter types (textures, colour spaces, matrices).
+IRREGULAR_FAMILY_MEMBERS = {
+    "MaterialInstance.setParameter": ["setMat3Parameter", "setMat4Parameter",
+                                      "setTextureParameter", "setColor3Parameter",
+                                      "setColor4Parameter"],
+}
+
+
+def java_overload_tokens(java_src, method):
+    """Turn `method(String name, int x, int y)` declarations into type tokens like "Int2"."""
+    tokens = set()
+    pattern = re.compile(r"public\s+void\s+" + re.escape(method) + r"\s*\(([^)]*)\)")
+    for params in pattern.findall(java_src):
+        params = params.replace("@NonNull", " ").replace("@Nullable", " ")
+        parts = [p.strip() for p in params.split(",") if p.strip()]
+        # Drop the leading `String name` argument.
+        if parts and parts[0].split()[0] == "String":
+            parts = parts[1:]
+        if not parts:
+            continue
+        types = [p.split()[0] for p in parts]
+        if len(set(types)) != 1 or types[0] not in JAVA_TYPE_TOKENS:
+            continue  # irregular shape; covered by IRREGULAR_FAMILY_MEMBERS
+        token = JAVA_TYPE_TOKENS[types[0]]
+        tokens.add(token + (str(len(types)) if len(types) > 1 else ""))
+    return tokens
+
+
+def candidate_names(method, token):
+    """The naming conventions the bindings use: infix after the verb, or suffix."""
+    for verb in ("set", "get", "is", "has"):
+        if method.startswith(verb):
+            rest = method[len(verb):]
+            return {f"{verb}{token}{rest}", f"{method}{token}"}
+    return {f"{method}{token}"}
+
+# Methods intentionally left unbound, keyed by "Class.method" or "Class.*" -> reason.
+# Each entry below was checked against the implementation, not just the header.
+EXCLUSIONS = {
+    # FFence::wait opens with FILAMENT_CHECK_PRECONDITION(UTILS_HAS_THREADING || timeout == 0),
+    # so on the single-threaded wasm build any non-zero timeout aborts. FFence::waitAndDestroy has
+    # no UTILS_HAS_THREADING guard of its own: it calls wait(mode, FENCE_WAIT_FOR_EVER) directly,
+    # which trips that precondition. It is unusable on the web and has no timeout parameter to fix
+    # it with; the bound Fence._wait with a timeout of 0 is the supported path.
+    #
+    # Not to be confused with FEngine::flushAndWait, which *does* guard on
+    # `if constexpr (UTILS_HAS_THREADING)` and calls execute() instead of fencing. That one is safe
+    # on the web and is bound.
+    "Fence.waitAndDestroy": "calls Fence::wait with FENCE_WAIT_FOR_EVER, which requires threads",
+    "Engine.isValid": "bound as the per-type isValidX overloads instead",
+    "IndirectLight$Builder.irradiance": "bound as irradianceSh and irradianceTex",
+    "IndirectLight$Builder.radiance": "bound as radianceSh",
+    "gltfio$ResourceLoader.addTextureProvider": "bound as addStbProvider/addKtx2Provider/addWebpProvider",
+
+    # Threading and engine lifecycle the browser owns.
+    "Engine.setPaused": "render-thread pausing is meaningless without a render thread",
+    "Engine.isPaused": "render-thread pausing is meaningless without a render thread",
+    "Engine.getJobSystem": "returns utils::JobSystem&, an internal type with no JS representation",
+    "Engine.compile": "CompilerPriorityQueue scheduling has no effect without a backend thread",
+    "Engine.getFeatureFlag": "returns std::optional<bool>; needs a marshalling decision first",
+    "Engine.setFeatureFlag": "paired with getFeatureFlag; experimental debug surface",
+    "Engine.hasFeatureFlag": "paired with getFeatureFlag; experimental debug surface",
+    "Engine$Builder.*": "the web constructs the Engine through Engine.create",
+
+    # No web equivalent for external/native video streams or native window handles.
+    "Stream.*": "no web equivalent for external/native video streams",
+    "Stream$Builder.*": "no web equivalent for external/native video streams",
+    "Texture.setExternalImage": "requires Stream",
+    "Texture.setExternalStream": "requires Stream",
+    "SwapChain.*": "native-window handles, frame callbacks, protected content and frame-rate "
+                   "control have no web equivalent; the canvas owns presentation",
+
+    # Material::Builder is not registered; the web creates materials through Engine.createMaterial,
+    # whose options object already carries uboBatching. The other two Builder options are simply
+    # not plumbed through that entry point yet.
+    "Material$Builder.uboBatching": "already reachable via Engine.createMaterial's options object",
+    "Material$Builder.*": "Material::Builder is not bound; extend Engine.createMaterial's options "
+                          "object to reach these",
+    "Material.compile": "CompilerPriorityQueue scheduling has no effect without a backend thread",
+    "MaterialInstance.compile": "CompilerPriorityQueue scheduling has no effect without a backend thread",
+
+    # Blocked on marshalling, not on cost. gltfio::MaterialKey is a bitfield-packed POD, and
+    # embind's value_object binds members by pointer-to-member, which cannot be formed for a
+    # bitfield. Needs per-field accessors or a plain-object converter first.
+    "gltfio$MaterialProvider.*": "blocked on marshalling the bitfield-packed gltfio::MaterialKey",
+
+    # Frame pacing and vsync, owned by the browser via requestAnimationFrame.
+    "Renderer.setDisplayInfo": "the browser owns vsync scheduling",
+    "Renderer.setFrameRateOptions": "the browser owns vsync scheduling",
+    "Renderer.setFrameScheduleTime": "the browser owns vsync scheduling",
+    "Renderer.getFrameInfoHistory": "returns FixedCapacityVector<FrameInfo>, an unbound type",
+    "Renderer.getMaxFrameHistorySize": "paired with getFrameInfoHistory",
+    "Renderer.hasGpuFallenBehind": "paired with getFrameInfoHistory",
+
+    # Templated or callback-shaped APIs covered by a hand-written typed family instead.
+    "Material.setDefaultParameter": "templated; would need one binding per parameter type",
+    "Scene.forEach": "needs a JS callback marshalling layer",
+}
+
+# Method names that are never bound directly on any class.
+SKIPPED_METHODS = {"getEngine", "operator", "begin", "end", "size", "empty", "data", "getName",
+                   "name"}
+
+
+def read(path):
+    with open(os.path.join(ROOT, path), encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+# --------------------------------------------------------------------------------------------
+# C++ headers
+# --------------------------------------------------------------------------------------------
+
+DECL_RE = re.compile(
+    r"^\s*(?!return|if|for|while|else|using|typedef|friend|static_assert)"
+    r"(?:UTILS_PUBLIC\s+)?"
+    r"(?:static\s+|virtual\s+|inline\s+|constexpr\s+)*"
+    r"(?P<ret>[A-Za-z_][\w:<>,\s\*&\[\]]*?)\s+"
+    r"(?P<name>[a-zA-Z_]\w*)\s*\(")
+OPEN_RE = re.compile(r"^\s*(?:class|struct)\s+(?:UTILS_PUBLIC\s+)?(\w+)\b(?![^{;]*;)")
+ACCESS_RE = re.compile(r"^\s*(public|protected|private)\s*:")
+
+
+def parse_header(path, prefix):
+    """Return {qualified class name: {method: declaration}} for public methods only."""
+    out = defaultdict(dict)
+    src = read(path)
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    src = re.sub(r"//[^\n]*", "", src)
+
+    stack, access, depth = [], ["public"], 0
+    for line in src.splitlines():
+        opened = OPEN_RE.match(line)
+        if opened:
+            stack.append((opened.group(1), depth))
+            # `class` members default to private, `struct` members to public.
+            access.append("private" if line.strip().startswith("class") else "public")
+        access_change = ACCESS_RE.match(line)
+        if access_change:
+            access[-1] = access_change.group(1)
+        if stack and access[-1] == "public":
+            decl = DECL_RE.match(line)
+            if decl and decl.group("name") not in ("operator", "if", "return"):
+                cls = prefix + "$".join(name for name, _ in stack)
+                out[cls][decl.group("name")] = line.strip()
+        depth += line.count("{") - line.count("}")
+        while stack and depth <= stack[-1][1]:
+            stack.pop()
+            access.pop()
+    return out
+
+
+def collect_headers():
+    headers = defaultdict(dict)
+    for rel, prefix in HEADER_DIRS:
+        directory = os.path.join(ROOT, rel)
+        for name in sorted(os.listdir(directory)):
+            if name.endswith(".h"):
+                for cls, methods in parse_header(os.path.join(rel, name), prefix).items():
+                    headers[cls].update(methods)
+    return headers
+
+
+# --------------------------------------------------------------------------------------------
+# Web (embind) surface
+# --------------------------------------------------------------------------------------------
+
+REGISTRATION_RE = re.compile(
+    r'(?:class_|value_object|value_array|enum_)<[^;]*?>\s*\(\s*"([^"]+)"')
+MEMBER_RE = re.compile(
+    r'\.(?:function|class_function|property|field|value|element'
+    r'|BUILDER_FUNCTION|EMBIND_LAMBDA|constructor)\s*\(\s*"([^"]+)"')
+
+
+def collect_web():
+    """Return {embind class name: {member names}}.
+
+    Two conventions matter. Registrations chain across many lines, so the current class persists
+    until the next registration opens. And entry points registered as `_foo` are re-exposed as
+    `foo` by extensions.js, so the leading underscore is stripped.
+    """
+    web = defaultdict(set)
+    for source in WEB_SOURCES:
+        current = None
+        for line in read(source).splitlines():
+            opened = REGISTRATION_RE.search(line)
+            if opened:
+                current = opened.group(1)
+                web.setdefault(current, set())
+            for member in MEMBER_RE.finditer(line):
+                if current:
+                    web[current].add(member.group(1).lstrip("_"))
+
+    extensions = read("web/filament-js/extensions.js")
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.prototype\.([A-Za-z0-9_]+)\s*=", extensions):
+        web[cls].add(method)
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.([A-Za-z0-9_]+)\s*=\s*function", extensions):
+        web[cls].add(method)
+
+    # filament.d.ts is deliberately NOT consulted here. It is a declaration, not a registration:
+    # a stale or aspirational entry there would mask a genuinely missing embind binding, which is
+    # exactly how filament.d.ts came to declare setMorphWeights with a signature the bindings had
+    # not exposed for some time. The authoritative web surface is the embind registrations plus
+    # the extensions.js wrappers that re-expose them.
+    return web
+
+
+# --------------------------------------------------------------------------------------------
+# Java surface
+# --------------------------------------------------------------------------------------------
+
+JAVA_METHOD_RE = re.compile(
+    r"^[ \t]*public\s+(?:static\s+|final\s+|native\s+|synchronized\s+)*"
+    r"[\w<>\[\],.@\s]+?[\s\]>]+(\w+)\s*\(", re.M)
+JAVA_NATIVE_RE = re.compile(
+    r"^[ \t]*(?:private|public)\s+static\s+native\s+.*?\bn(\w+)\s*\(", re.M)
+
+
+def collect_java():
+    """Return {java class name: {method names}}, one flat bucket per file.
+
+    Nested Builders live in the same file as their outer class, so folding per file rather than
+    per class keeps Builder methods reachable without modelling Java nesting.
+    """
+    java, sources = defaultdict(set), {}
+    for rel in JAVA_DIRS:
+        directory = os.path.join(ROOT, rel)
+        if not os.path.isdir(directory):
+            continue
+        for dirpath, _, files in os.walk(directory):
+            for name in sorted(files):
+                if not name.endswith(".java"):
+                    continue
+                src = open(os.path.join(dirpath, name), encoding="utf-8",
+                           errors="replace").read()
+                found = set(JAVA_METHOD_RE.findall(src))
+                found |= {n[0].lower() + n[1:] for n in JAVA_NATIVE_RE.findall(src)}
+                java[name[:-5]] |= found
+                sources[name[:-5]] = src
+    return java, sources
+
+
+# --------------------------------------------------------------------------------------------
+# Diff
+# --------------------------------------------------------------------------------------------
+
+def excluded_reason(cls, method):
+    return EXCLUSIONS.get(f"{cls}.{method}") or EXCLUSIONS.get(f"{cls}.*")
+
+
+def audit():
+    headers, web = collect_headers(), collect_web()
+    java, java_sources = collect_java()
+    gaps, excluded = [], []
+
+    for cls in sorted(headers):
+        if cls in SKIPPED_CLASSES:
+            continue
+        bound = set(web.get(cls, []))
+        java_bucket = java.get(cls.replace("gltfio$", "").split("$")[0], set())
+
+        for method, declaration in sorted(headers[cls].items()):
+            if method in SKIPPED_METHODS or method == cls.split("$")[-1]:
+                continue
+            if method in bound:
+                continue
+            # embind commonly renames getX/setX to the property "x".
+            if method[:3] in ("get", "set") and (method[3:4].lower() + method[4:]) in bound:
+                continue
+            # Only report what Android already exposes.
+            if method not in java_bucket and \
+                    ("n" + method[0].upper() + method[1:]) not in java_bucket:
+                continue
+            key = f"{cls}.{method}"
+            if key in DERIVED_FAMILIES:
+                java_src = java_sources.get(DERIVED_FAMILIES[key], "")
+                tokens = java_overload_tokens(java_src, method)
+                missing, present = [], []
+                for token in sorted(tokens):
+                    names = candidate_names(method, token)
+                    (present if (names & bound) else missing).append(
+                            sorted(names)[0])
+                for name in IRREGULAR_FAMILY_MEMBERS.get(key, []):
+                    (present if name in bound else missing).append(name)
+                if missing:
+                    gaps.append((cls, method, declaration,
+                                 f"typed family incomplete ({len(present)} of "
+                                 f"{len(present) + len(missing)} bound), missing: "
+                                 + ", ".join(missing)))
+                else:
+                    excluded.append((cls, method, declaration,
+                                     f"bound as a typed family of {len(present)}, derived from "
+                                     f"the Java overloads"))
+                continue
+
+            reason = excluded_reason(cls, method)
+            (excluded if reason else gaps).append((cls, method, declaration, reason))
+    return gaps, excluded
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--all", action="store_true",
+                        help="also list deliberate exclusions and their reasons")
+    parser.add_argument("--verbose", action="store_true",
+                        help="print the C++ declaration for each gap")
+    args = parser.parse_args()
+
+    gaps, excluded = audit()
+
+    if gaps:
+        print(f"Unbound on the web but present in the Java bindings ({len(gaps)}):\n")
+        current = None
+        for cls, method, declaration, detail in gaps:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {method}")
+            if detail:
+                print(f"        {detail}")
+            if args.verbose:
+                print(f"        {declaration}")
+        print("\nBind these in web/filament-js/jsbindings.cpp and declare them in filament.d.ts,")
+        print("or add them to EXCLUSIONS in this script with the reason they cannot be bound.")
+    else:
+        print("No unexplained gaps: every Java-exposed C++ method is reachable from JavaScript.")
+
+    if args.all:
+        print(f"\nDeliberately unbound ({len(excluded)}):\n")
+        current = None
+        for cls, method, _, reason in excluded:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {method:<34} {reason}")
+
+    return 1 if gaps else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/web-binding-audit/unbound_apis.py
+++ b/tools/web-binding-audit/unbound_apis.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report public C++ APIs that the Java/JNI bindings expose but the JS bindings do not.
+
+The web (embind) surface is maintained by hand, so it drifts from the C++ headers silently: a
+method that is never registered simply does not exist in JavaScript, and nothing fails at build
+time. This tool makes that drift visible.
+
+How it works
+------------
+Three surfaces are parsed and diffed:
+
+  C++    filament/include/filament/*.h and libs/gltfio/include/gltfio/*.h -- the API that exists.
+  web    web/filament-js/{jsbindings,jsbindings_generated,jsenums,jsenums_generated}.cpp plus
+         extensions.js -- the API JavaScript can actually reach. filament.d.ts is excluded on
+         purpose; see collect_web().
+  Java   android/**/src/main/java/.../*.java -- the API Android exposes.
+
+A C++ method is reported when it is absent from the web surface *and* present on the Java one.
+Requiring the Java side keeps the report actionable: it filters out APIs that no binding layer
+has ever exposed, and it means acting on a finding never makes the web surface wider than
+Android's.
+
+Deliberate omissions live in EXCLUSIONS below, each with the reason. Anything not excluded and
+not bound is reported, and the tool exits 1, so this can gate CI.
+
+Usage
+-----
+    ./tools/web-binding-audit/unbound_apis.py            # report unexplained gaps, exit 1 if any
+    ./tools/web-binding-audit/unbound_apis.py --all      # also list the deliberate exclusions
+    ./tools/web-binding-audit/unbound_apis.py --verbose  # print the C++ declaration for each gap
+
+Its counterpart, untested_bindings.py, starts from the other end: it reports bindings that exist
+but that no test exercises.
+
+Known limitations
+-----------------
+Matching is by *name*, not by signature, so a method bound with fewer parameters than C++
+declares (an overload gap) is reported as covered. setMorphWeights was such a case: bound, but
+without its offset argument. Signature-level checking would need a real C++ parser; until then,
+treat a clean run as "no missing names" rather than "no missing functionality".
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+
+ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
+HEADER_DIRS = [
+    ("filament/include/filament", ""),
+    ("libs/gltfio/include/gltfio", "gltfio$"),
+]
+
+WEB_SOURCES = [
+    "web/filament-js/jsbindings.cpp",
+    "web/filament-js/jsbindings_generated.cpp",
+    "web/filament-js/jsenums.cpp",
+    "web/filament-js/jsenums_generated.cpp",
+]
+
+JAVA_DIRS = [
+    "android/filament-android/src/main/java/com/google/android/filament",
+    "android/gltfio-android/src/main/java/com/google/android/filament/gltfio",
+    "android/filament-utils-android/src/main/java/com/google/android/filament/utils",
+]
+
+# Classes that are not part of the JS surface by design.
+SKIPPED_CLASSES = {
+    # CRTP/infrastructure helpers, not real API.
+    "BuilderNameMixin", "FilamentAPI",
+    # Math and geometry value types, bound as value_array/value_object rather than classes.
+    "Aabb", "Aabb$Corners", "Box", "Viewport", "Color", "ColorSpace", "Gamut", "TransferFunction",
+    # Iterator plumbing.
+    "TransformManager$children_iterator", "TransformManager$children_range",
+    # Frame pacing and history: driven by requestAnimationFrame on the web.
+    "FrameHistoryStream", "FrameHistoryStream$NewFramesRange", "FrameHistoryStream$Result",
+    "FramePacer", "FramePacer$Builder", "FramePipelineEstimator", "Sync",
+    "gltfio$AssetConfigurationExtended",
+}
+
+# A C++ name that covers many overloads is usually bound as a family of typed entry points
+# (setParameter -> setBoolParameter, setInt2Parameter, ...). Rather than hand-listing those names,
+# derive the family from the *Java* bindings, which spell every overload out with concrete types:
+#
+#   public void setParameter(String name, int x, int y)  ->  an int2 overload must be reachable
+#
+# Each Java overload is turned into a type token (Int2) and checked against the web surface under
+# the naming conventions the bindings actually use, infix (setInt2Parameter) or suffix
+# (setParameterInt2). A family that covers only some overloads then reports the specific ones that
+# are missing, instead of hiding behind a comment claiming the family is complete.
+JAVA_TYPE_TOKENS = {
+    "boolean": "Bool", "float": "Float", "int": "Int", "double": "Double", "long": "Long",
+}
+
+# Methods whose family should be derived, keyed by "Class.method". The value is the Java class file
+# to read the overloads from (usually the same class).
+DERIVED_FAMILIES = {
+    "MaterialInstance.setParameter": "MaterialInstance",
+    "MaterialInstance.setConstant": "MaterialInstance",
+    "LightManager$Builder.intensity": "LightManager",
+}
+
+# Overload shapes that the derivation cannot name on its own, because the web binding uses a name
+# unrelated to the Java parameter types (textures, colour spaces, matrices).
+IRREGULAR_FAMILY_MEMBERS = {
+    "MaterialInstance.setParameter": ["setMat3Parameter", "setMat4Parameter",
+                                      "setTextureParameter", "setColor3Parameter",
+                                      "setColor4Parameter"],
+    "LightManager$Builder.intensity": ["intensity", "intensityEnergy"],
+}
+
+
+def java_overload_tokens(java_src, method):
+    """Turn `method(String name, int x, int y)` declarations into type tokens like "Int2"."""
+    tokens = set()
+    pattern = re.compile(r"public\s+void\s+" + re.escape(method) + r"\s*\(([^)]*)\)")
+    for params in pattern.findall(java_src):
+        params = params.replace("@NonNull", " ").replace("@Nullable", " ")
+        parts = [p.strip() for p in params.split(",") if p.strip()]
+        # Drop the leading `String name` argument.
+        if parts and parts[0].split()[0] == "String":
+            parts = parts[1:]
+        if not parts:
+            continue
+        types = [p.split()[0] for p in parts]
+        if len(set(types)) != 1 or types[0] not in JAVA_TYPE_TOKENS:
+            continue  # irregular shape; covered by IRREGULAR_FAMILY_MEMBERS
+        token = JAVA_TYPE_TOKENS[types[0]]
+        tokens.add(token + (str(len(types)) if len(types) > 1 else ""))
+    return tokens
+
+
+def candidate_names(method, token):
+    """The naming conventions the bindings use: infix after the verb, or suffix."""
+    for verb in ("set", "get", "is", "has"):
+        if method.startswith(verb):
+            rest = method[len(verb):]
+            return {f"{verb}{token}{rest}", f"{method}{token}"}
+    return {f"{method}{token}"}
+
+# Methods intentionally left unbound, keyed by "Class.method" or "Class.*" -> reason.
+# Each entry below was checked against the implementation, not just the header.
+EXCLUSIONS = {
+    # FFence::wait opens with FILAMENT_CHECK_PRECONDITION(UTILS_HAS_THREADING || timeout == 0),
+    # so on the single-threaded wasm build any non-zero timeout aborts. FFence::waitAndDestroy has
+    # no UTILS_HAS_THREADING guard of its own: it calls wait(mode, FENCE_WAIT_FOR_EVER) directly,
+    # which trips that precondition. It is unusable on the web and has no timeout parameter to fix
+    # it with; the bound Fence._wait with a timeout of 0 is the supported path.
+    #
+    # Not to be confused with FEngine::flushAndWait, which *does* guard on
+    # `if constexpr (UTILS_HAS_THREADING)` and calls execute() instead of fencing. That one is safe
+    # on the web and is bound.
+    "Fence.waitAndDestroy": "calls Fence::wait with FENCE_WAIT_FOR_EVER, which requires threads",
+    # embind picks an overload by argument count, so same-arity overloads are the ones that need a
+    # name each. Engine::isValid is overloaded on resource type with one argument throughout.
+    "Engine.isValid": "overloaded per resource type, all taking one argument; bound as the "
+                      "isValidX family, which embind can tell apart",
+
+    # Threading and engine lifecycle the browser owns.
+    "Engine.setPaused": "render-thread pausing is meaningless without a render thread",
+    "Engine.isPaused": "render-thread pausing is meaningless without a render thread",
+    "Engine.getJobSystem": "returns utils::JobSystem&, an internal type with no JS representation",
+    "Engine.compile": "takes a backend::CallbackHandler, and CompilerPriorityQueue scheduling has "
+                      "no effect without a backend thread",
+    "Engine$Builder.sharedContext": "the canvas passed to Engine.create owns the context",
+    "Engine$Builder.paused": "render-thread pausing is meaningless without a render thread",
+
+    # No web equivalent for external/native video streams or native window handles.
+    "Stream.*": "no web equivalent for external/native video streams",
+    "Stream$Builder.*": "no web equivalent for external/native video streams",
+    "Texture.setExternalImage": "requires Stream",
+    "Texture.setExternalStream": "requires Stream",
+    # The static capability queries are bound; what is left is the instance surface.
+    "SwapChain.getNativeWindow": "the canvas is the window, and it is not a native handle",
+    "SwapChain.setFrameRate": "the browser owns vsync scheduling",
+    "SwapChain.isFrameRateChangeSupported": "returns utils::tribool, an unbound type, and pairs "
+                                            "with setFrameRate",
+    "SwapChain.setFrameScheduledCallback": "needs a backend::CallbackHandler marshalling layer",
+    "SwapChain.setFrameCompletedCallback": "needs a backend::CallbackHandler marshalling layer",
+    "SwapChain.isFrameScheduledCallbackSet": "paired with setFrameScheduledCallback",
+
+    # Material::Builder is not registered; the web creates materials through Engine.createMaterial,
+    # whose options object already carries uboBatching. The other two Builder options are simply
+    # not plumbed through that entry point yet.
+    "Material$Builder.uboBatching": "already reachable via Engine.createMaterial's options object",
+    "Material$Builder.*": "Material::Builder is not bound; extend Engine.createMaterial's options "
+                          "object to reach these",
+    "Material.compile": "takes a backend::CallbackHandler, and CompilerPriorityQueue scheduling "
+                        "has no effect without a backend thread",
+    "MaterialInstance.compile": "takes a backend::CallbackHandler, and CompilerPriorityQueue "
+                                "scheduling has no effect without a backend thread",
+
+    # Blocked on marshalling, not on cost. embind's value_object binds members by
+    # pointer-to-member, which C++ does not allow for a bitfield, and 39 of gltfio::MaterialKey's
+    # 46 fields are bitfields. Binding it means a class_ with a getter/setter lambda per field,
+    # plus UvMap and constrainMaterial, which is a piece of work worth its own change rather than
+    # a footnote to one. The rest of MaterialProvider takes no MaterialKey and is bound on the
+    # UbershaderProvider wrapper.
+    "gltfio$MaterialProvider.createMaterialInstance": "takes a MaterialKey, whose bitfield members "
+                                                      "value_object cannot bind",
+    "gltfio$MaterialProvider.getMaterial": "takes a MaterialKey, whose bitfield members "
+                                           "value_object cannot bind",
+    # MaterialProvider is polymorphic, and embind reaches a base class through RTTI, which this
+    # build compiles without. Its key-free members are bound on the one concrete provider the web
+    # constructs instead.
+    "gltfio$MaterialProvider.destroyMaterials": "bound on gltfio$UbershaderProvider",
+    "gltfio$MaterialProvider.getMaterials": "bound on gltfio$UbershaderProvider",
+    "gltfio$MaterialProvider.getMaterialsCount": "bound on gltfio$UbershaderProvider",
+    "gltfio$MaterialProvider.needsDummyData": "bound on gltfio$UbershaderProvider",
+
+    # Frame pacing and vsync, owned by the browser via requestAnimationFrame.
+    "Renderer.setDisplayInfo": "the browser owns vsync scheduling",
+    "Renderer.setFrameRateOptions": "the browser owns vsync scheduling",
+    "Renderer.setFrameScheduleTime": "the browser owns vsync scheduling",
+    "Renderer.getFrameInfoHistory": "returns FixedCapacityVector<FrameInfo>, an unbound type",
+    "Renderer.getMaxFrameHistorySize": "sizes getFrameInfoHistory's out-parameter, which is unbound",
+
+    # A template over the parameter type, and no more than sugar for
+    # getDefaultInstance()->setParameter(). Both halves of that are bound, so JavaScript reaches
+    # the same thing as material.getDefaultInstance().setFloatParameter(name, value).
+    "Material.setDefaultParameter": "sugar for getDefaultInstance()->setParameter(), and both of "
+                                    "those are bound",
+    "Scene.forEach": "needs a JS callback marshalling layer",
+}
+
+# Method names that are never bound directly on any class.
+SKIPPED_METHODS = {"getEngine", "operator", "begin", "end", "size", "empty", "data", "getName",
+                   "name"}
+
+
+def read(path):
+    with open(os.path.join(ROOT, path), encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+# --------------------------------------------------------------------------------------------
+# C++ headers
+# --------------------------------------------------------------------------------------------
+
+DECL_RE = re.compile(
+    r"^\s*(?!return|if|for|while|else|using|typedef|friend|static_assert)"
+    r"(?:UTILS_PUBLIC\s+)?"
+    r"(?:static\s+|virtual\s+|inline\s+|constexpr\s+)*"
+    r"(?P<ret>[A-Za-z_][\w:<>,\s\*&\[\]]*?)\s+"
+    r"(?P<name>[a-zA-Z_]\w*)\s*\(")
+OPEN_RE = re.compile(r"^\s*(?:class|struct)\s+(?:UTILS_PUBLIC\s+)?(\w+)\b(?![^{;]*;)")
+ACCESS_RE = re.compile(r"^\s*(public|protected|private)\s*:")
+
+
+def parse_header(path, prefix):
+    """Return {qualified class name: {method: declaration}} for public methods only."""
+    out = defaultdict(dict)
+    src = read(path)
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    src = re.sub(r"//[^\n]*", "", src)
+
+    stack, access, depth = [], ["public"], 0
+    for line in src.splitlines():
+        opened = OPEN_RE.match(line)
+        if opened:
+            stack.append((opened.group(1), depth))
+            # `class` members default to private, `struct` members to public.
+            access.append("private" if line.strip().startswith("class") else "public")
+        access_change = ACCESS_RE.match(line)
+        if access_change:
+            access[-1] = access_change.group(1)
+        if stack and access[-1] == "public":
+            decl = DECL_RE.match(line)
+            if decl and decl.group("name") not in ("operator", "if", "return"):
+                cls = prefix + "$".join(name for name, _ in stack)
+                out[cls][decl.group("name")] = line.strip()
+        depth += line.count("{") - line.count("}")
+        while stack and depth <= stack[-1][1]:
+            stack.pop()
+            access.pop()
+    return out
+
+
+def collect_headers():
+    headers = defaultdict(dict)
+    for rel, prefix in HEADER_DIRS:
+        directory = os.path.join(ROOT, rel)
+        for name in sorted(os.listdir(directory)):
+            if name.endswith(".h"):
+                for cls, methods in parse_header(os.path.join(rel, name), prefix).items():
+                    headers[cls].update(methods)
+    return headers
+
+
+# --------------------------------------------------------------------------------------------
+# Web (embind) surface
+# --------------------------------------------------------------------------------------------
+
+REGISTRATION_RE = re.compile(
+    r'(?:class_|value_object|value_array|enum_)<[^;]*?>\s*\(\s*"([^"]+)"')
+MEMBER_RE = re.compile(
+    r'\.(?:function|class_function|property|field|value|element'
+    r'|BUILDER_FUNCTION|EMBIND_LAMBDA|constructor)\s*\(\s*"([^"]+)"')
+
+
+def collect_web():
+    """Return {embind class name: {member names}}.
+
+    Two conventions matter. Registrations chain across many lines, so the current class persists
+    until the next registration opens. And entry points registered as `_foo` are re-exposed as
+    `foo` by extensions.js, so the leading underscore is stripped.
+    """
+    web = defaultdict(set)
+    for source in WEB_SOURCES:
+        current = None
+        for line in read(source).splitlines():
+            opened = REGISTRATION_RE.search(line)
+            if opened:
+                current = opened.group(1)
+                web.setdefault(current, set())
+            for member in MEMBER_RE.finditer(line):
+                if current:
+                    web[current].add(member.group(1).lstrip("_"))
+
+    extensions = read("web/filament-js/extensions.js")
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.prototype\.([A-Za-z0-9_]+)\s*=", extensions):
+        web[cls].add(method)
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.([A-Za-z0-9_]+)\s*=\s*function", extensions):
+        web[cls].add(method)
+
+    # filament.d.ts is deliberately NOT consulted here. It is a declaration, not a registration:
+    # a stale or aspirational entry there would mask a genuinely missing embind binding, which is
+    # exactly how filament.d.ts came to declare setMorphWeights with a signature the bindings had
+    # not exposed for some time. The authoritative web surface is the embind registrations plus
+    # the extensions.js wrappers that re-expose them.
+    return web
+
+
+# --------------------------------------------------------------------------------------------
+# Java surface
+# --------------------------------------------------------------------------------------------
+
+JAVA_METHOD_RE = re.compile(
+    r"^[ \t]*public\s+(?:static\s+|final\s+|native\s+|synchronized\s+)*"
+    r"[\w<>\[\],.@\s]+?[\s\]>]+(\w+)\s*\(", re.M)
+JAVA_NATIVE_RE = re.compile(
+    r"^[ \t]*(?:private|public)\s+static\s+native\s+.*?\bn(\w+)\s*\(", re.M)
+
+
+def collect_java():
+    """Return {java class name: {method names}}, one flat bucket per file.
+
+    Nested Builders live in the same file as their outer class, so folding per file rather than
+    per class keeps Builder methods reachable without modelling Java nesting.
+    """
+    java, sources = defaultdict(set), {}
+    for rel in JAVA_DIRS:
+        directory = os.path.join(ROOT, rel)
+        if not os.path.isdir(directory):
+            continue
+        for dirpath, _, files in os.walk(directory):
+            for name in sorted(files):
+                if not name.endswith(".java"):
+                    continue
+                src = open(os.path.join(dirpath, name), encoding="utf-8",
+                           errors="replace").read()
+                found = set(JAVA_METHOD_RE.findall(src))
+                found |= {n[0].lower() + n[1:] for n in JAVA_NATIVE_RE.findall(src)}
+                java[name[:-5]] |= found
+                sources[name[:-5]] = src
+    return java, sources
+
+
+# --------------------------------------------------------------------------------------------
+# Diff
+# --------------------------------------------------------------------------------------------
+
+def excluded_reason(cls, method):
+    return EXCLUSIONS.get(f"{cls}.{method}") or EXCLUSIONS.get(f"{cls}.*")
+
+
+def audit():
+    headers, web = collect_headers(), collect_web()
+    java, java_sources = collect_java()
+    gaps, excluded = [], []
+
+    for cls in sorted(headers):
+        if cls in SKIPPED_CLASSES:
+            continue
+        bound = set(web.get(cls, []))
+        java_bucket = java.get(cls.replace("gltfio$", "").split("$")[0], set())
+
+        for method, declaration in sorted(headers[cls].items()):
+            if method in SKIPPED_METHODS or method == cls.split("$")[-1]:
+                continue
+            key = f"{cls}.{method}"
+            if key not in DERIVED_FAMILIES:
+                if method in bound:
+                    continue
+                # embind commonly renames getX/setX to the property "x".
+                if method[:3] in ("get", "set") and (method[3:4].lower() + method[4:]) in bound:
+                    continue
+                # Only report what Android already exposes.
+                if method not in java_bucket and \
+                        ("n" + method[0].upper() + method[1:]) not in java_bucket:
+                    continue
+            if key in DERIVED_FAMILIES:
+                java_src = java_sources.get(DERIVED_FAMILIES[key], "")
+                tokens = java_overload_tokens(java_src, method)
+                missing, present = [], []
+                for token in sorted(tokens):
+                    names = candidate_names(method, token)
+                    (present if (names & bound) else missing).append(
+                            sorted(names)[0])
+                for name in IRREGULAR_FAMILY_MEMBERS.get(key, []):
+                    (present if name in bound else missing).append(name)
+                if missing:
+                    gaps.append((cls, method, declaration,
+                                 f"typed family incomplete ({len(present)} of "
+                                 f"{len(present) + len(missing)} bound), missing: "
+                                 + ", ".join(missing)))
+                else:
+                    excluded.append((cls, method, declaration,
+                                     f"bound as a typed family of {len(present)}, derived from "
+                                     f"the Java overloads"))
+                continue
+
+            reason = excluded_reason(cls, method)
+            (excluded if reason else gaps).append((cls, method, declaration, reason))
+    return gaps, excluded
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--all", action="store_true",
+                        help="also list deliberate exclusions and their reasons")
+    parser.add_argument("--verbose", action="store_true",
+                        help="print the C++ declaration for each gap")
+    args = parser.parse_args()
+
+    gaps, excluded = audit()
+
+    if gaps:
+        print(f"Unbound on the web but present in the Java bindings ({len(gaps)}):\n")
+        current = None
+        for cls, method, declaration, detail in gaps:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {method}")
+            if detail:
+                print(f"        {detail}")
+            if args.verbose:
+                print(f"        {declaration}")
+        print("\nBind these in web/filament-js/jsbindings.cpp and declare them in filament.d.ts,")
+        print("or add them to EXCLUSIONS in this script with the reason they cannot be bound.")
+    else:
+        print("No unexplained gaps: every Java-exposed C++ method is reachable from JavaScript.")
+
+    if args.all:
+        print(f"\nDeliberately unbound ({len(excluded)}):\n")
+        current = None
+        for cls, method, _, reason in excluded:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {method:<34} {reason}")
+
+    return 1 if gaps else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/web-binding-audit/untested_bindings.py
+++ b/tools/web-binding-audit/untested_bindings.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report JS bindings that exist but that no test exercises.
+
+unbound_apis.py asks whether the bindings cover the C++ API. This asks the opposite question:
+whether the tests cover the bindings. A binding nobody calls is a binding nobody notices breaking,
+which is how filament.d.ts came to declare methods the bindings had never exposed.
+
+The suite is three files, each covering what the one before it cannot:
+
+  web/filament-js/test.ts            type-checked, never run. Proves filament.d.ts describes the
+                                     bindings, including the calls that would abort at runtime.
+  web/filament-js/test-runtime.js    run under Node on the NOOP backend. Proves the bindings exist
+                                     and marshal, for everything that does not need a GPU.
+  web/filament-js/test-browser.html  run in a browser on WebGL. Covers what is left: rendering,
+                                     pixel readback, picking and image decoding.
+
+A member is covered when its name appears in any of the three, so the default report is the union.
+Pass --target to check one file on its own.
+
+Usage
+-----
+    ./tools/web-binding-audit/untested_bindings.py           # report untested members, exit 1 if any
+    ./tools/web-binding-audit/untested_bindings.py --all     # also list the deliberate exclusions
+    ./tools/web-binding-audit/untested_bindings.py --target runtime   # ts | runtime | browser
+
+Known limitations
+-----------------
+Matching is by name: a member counts as covered when its name appears anywhere in a test file, so
+a mention in a comment counts, and one call covers every overload. Treat a clean run as "every
+binding is named by a test" rather than "every binding is verified".
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import unbound_apis
+from unbound_apis import ROOT, MEMBER_RE, WEB_SOURCES, read
+
+TESTS = {
+    "ts": "web/filament-js/test.ts",
+    "runtime": "web/filament-js/test-runtime.js",
+    "browser": "web/filament-js/test-browser.html",
+}
+
+# Only class members are audited. Enum values and value_object fields are bound by the thousand and
+# are exercised in bulk: a test that round-trips an options struct covers every field in it without
+# naming one.
+REGISTRATION_RE = re.compile(
+    r'(class_|value_object|value_array|enum_)<[^;]*?>\s*\(\s*"([^"]+)"')
+
+# Members intentionally left untested, keyed by "Class.member" or "Class.*" -> reason.
+EXCLUSIONS = {
+    # Internal entry points that a wrapper in extensions.js calls on the caller's behalf. The
+    # underscore prefix is stripped when the surface is collected, so they show up under the name
+    # of the wrapper that hides them.
+    "Engine.createSwapChainForCanvas": "internal; Engine.createSwapChain calls it when the engine "
+                                       "was created on a canvas",
+
+    # filament::Stream is not bound at all (see Stream.* in unbound_apis.py), so there is no way to
+    # obtain the argument this validity check takes.
+    "Engine.isValidStream": "no Stream can be constructed from JS, so this cannot be called",
+}
+
+
+def excluded_reason(cls, member):
+    return EXCLUSIONS.get(f"{cls}.{member}") or EXCLUSIONS.get(f"{cls}.*")
+
+
+def collect_class_members():
+    """Return {embind class name: {member names}}, classes only."""
+    web = defaultdict(set)
+    for source in WEB_SOURCES:
+        kind, current = None, None
+        for line in read(source).splitlines():
+            opened = REGISTRATION_RE.search(line)
+            if opened:
+                kind, current = opened.group(1), opened.group(2)
+                if kind == "class_":
+                    web.setdefault(current, set())
+            if kind != "class_" or not current:
+                continue
+            for member in MEMBER_RE.finditer(line):
+                web[current].add(member.group(1).lstrip("_"))
+
+    # extensions.js both wraps bound entry points and adds members of its own; either way what it
+    # defines is part of the surface a test can reach.
+    extensions = read("web/filament-js/extensions.js")
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.prototype\.([A-Za-z0-9_]+)\s*=", extensions):
+        web[cls].add(method)
+    for cls, method in re.findall(
+            r"Filament\.([A-Za-z0-9_$]+)\.([A-Za-z0-9_]+)\s*=\s*function", extensions):
+        web[cls].add(method)
+    return web
+
+
+def identifiers(path):
+    return set(re.findall(r"[A-Za-z_$][A-Za-z0-9_$]*", read(path)))
+
+
+def audit(targets):
+    exercised = set()
+    for target in targets:
+        exercised |= identifiers(TESTS[target])
+
+    surface = collect_class_members()
+    gaps, excluded, total = [], [], 0
+    for cls in sorted(surface):
+        for member in sorted(surface[cls]):
+            total += 1
+            if member in exercised:
+                continue
+            reason = excluded_reason(cls, member)
+            (excluded if reason else gaps).append((cls, member, reason))
+    return gaps, excluded, total
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--target", choices=sorted(TESTS), action="append",
+                        help="check one test file rather than the union of all three; repeatable")
+    parser.add_argument("--all", action="store_true",
+                        help="also list the deliberate exclusions and their reasons")
+    args = parser.parse_args()
+
+    targets = args.target or sorted(TESTS)
+    gaps, excluded, total = audit(targets)
+    covered = total - len(gaps) - len(excluded)
+
+    where = ", ".join(os.path.basename(TESTS[t]) for t in targets)
+    if gaps:
+        print(f"Bound but not exercised by {where} ({len(gaps)} of {total}):\n")
+        current = None
+        for cls, member, _ in gaps:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {member}")
+        print("\nCall these from a test, or add them to EXCLUSIONS in this script with the reason")
+        print("they cannot be called.")
+    else:
+        print(f"Every binding is exercised by {where}.")
+
+    print(f"\n{covered}/{total} bound class members covered, {len(excluded)} deliberately not.")
+
+    if args.all:
+        print(f"\nDeliberately untested ({len(excluded)}):\n")
+        current = None
+        for cls, member, reason in excluded:
+            if cls != current:
+                print(f"  {cls}")
+                current = cls
+            print(f"    {member:<34} {reason}")
+
+    return 1 if gaps else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -90,9 +90,18 @@ Filament.loadClassExtensions = function() {
 
     Filament.Engine.SINGLE_THREADED = 0xFFFFFFFF;
 
+    Filament.Engine$Builder.prototype.build = function() {
+        const result = this._build();
+        this.delete();
+        return result;
+    };
+
     /// create ::static method:: Creates an Engine instance for the given canvas.
     /// canvas ::argument:: the canvas DOM element
-    /// options ::argument:: optional WebGL 2.0 context configuration
+    /// options ::argument:: optional WebGL 2.0 context configuration. Also accepts the
+    /// [Engine$Builder] settings `backend`, `featureLevel`, `features` (an object of engine
+    /// feature name -> boolean) and `colorGrading` (a [ColorGrading$Builder]).
+    /// config ::argument:: optional [Engine$Config]
     /// ::retval:: an instance of [Engine]
     Filament.Engine.create = function (canvas, options, config) {
         if (!canvas.id) {
@@ -103,7 +112,12 @@ Filament.loadClassExtensions = function() {
         const backend = (options && options.backend !== undefined) ?
               options.backend : Filament.Backend.DEFAULT;
 
-        if (backend !== Filament.Backend.WEBGPU) {
+        // Only the GL backends consume the emscripten-registered context; leaving the transient
+        // globals unset is what tells Engine$Builder._build to skip registration.
+        const usesGl = backend === Filament.Backend.DEFAULT ||
+              backend === Filament.Backend.OPENGL;
+
+        if (usesGl) {
             const defaults = {
                 majorVersion: 2,
                 minorVersion: 0,
@@ -127,22 +141,35 @@ Filament.loadClassExtensions = function() {
             window.filament_glContext = ctx;
         }
 
-        // Register the GL context with emscripten and create the Engine.
-        const defaultConfig = Filament.Engine.createDefaultConfig();
-        const finalConfig = Object.assign(defaultConfig, config);
-        const engine = Filament.Engine._create(backend, finalConfig);
+        const builder = new Filament.Engine$Builder();
+        builder.backend(backend);
+        builder.config(Object.assign(Filament.Engine.createDefaultConfig(), config));
+        if (options) {
+            if (options.featureLevel !== undefined) {
+                builder.featureLevel(options.featureLevel);
+            }
+            for (const name in options.features || {}) {
+                builder.feature(name, options.features[name]);
+            }
+            if (options.colorGrading) {
+                builder.colorGrading(options.colorGrading);
+            }
+        }
+        // Registers the GL context with emscripten, then builds.
+        const engine = builder.build();
 
-        // Annotate the engine with the GL context to support multiple canvases.
-        if (backend !== Filament.Backend.WEBGPU) {
+        // Annotate the engine with the GL context to support multiple canvases. Only the GL
+        // backends set the transient globals, so only they have any to read back or clean up.
+        if (usesGl) {
             engine.context = window.filament_glContext;
             engine.handle = window.filament_contextHandle;
+
+            // Ensure that we do not pollute the global namespace.
+            delete window.filament_glOptions;
+            delete window.filament_glContext;
+            delete window.filament_contextHandle;
         }
         engine.canvasId = canvasId;
-
-        // Ensure that we do not pollute the global namespace.
-        delete window.filament_glOptions;
-        delete window.filament_glContext;
-        delete window.filament_contextHandle;
 
         return engine;
     };
@@ -324,6 +351,18 @@ Filament.loadClassExtensions = function() {
         this._setClearOptions(options);
     };
 
+    /// setDynamicResolutionOptions ::method::
+    Filament.View.prototype.setDynamicResolutionOptions = function(overrides) {
+        const options = this.setDynamicResolutionOptionsDefaults(overrides);
+        this._setDynamicResolutionOptions(options);
+    };
+
+    /// setRenderQuality ::method::
+    Filament.View.prototype.setRenderQuality = function(overrides) {
+        const options = this.setRenderQualityDefaults(overrides);
+        this._setRenderQuality(options);
+    };
+
     /// setAmbientOcclusionOptions ::method::
     Filament.View.prototype.setAmbientOcclusionOptions = function(overrides) {
         const options = this.setAmbientOcclusionOptionsDefaults(overrides);
@@ -476,6 +515,7 @@ Filament.loadClassExtensions = function() {
     Filament.RenderTarget$Builder.prototype.build =
     Filament.VertexBuffer$Builder.prototype.build =
     Filament.IndexBuffer$Builder.prototype.build =
+    Filament.BufferObject$Builder.prototype.build =
     Filament.Texture$Builder.prototype.build =
     Filament.IndirectLight$Builder.prototype.build =
     Filament.Skybox$Builder.prototype.build =
@@ -501,9 +541,9 @@ Filament.loadClassExtensions = function() {
         return result;
     }
 
-    Filament.Texture.prototype.setImage = function(engine, level, pbd) {
-        this._setImage(engine, level, pbd);
-        pbd.delete();
+    Filament.Texture.prototype.setImage = function(engine, level, ...args) {
+        this._setImage(engine, level, ...args);
+        args[args.length - 1].delete();
     }
 
     Filament.Texture.prototype.getWidth = function(engine, level = 0) {
@@ -522,11 +562,14 @@ Filament.loadClassExtensions = function() {
         return this._getLevels(engine);
     }
 
+    // These copy their argument into the heap, so they cannot be bound directly. Each returns the
+    // builder, like every other builder setter and like filament.d.ts declares.
     Filament.SurfaceOrientation$Builder.prototype.normals = function(buffer, stride = 0) {
         buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
         this.norPointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.norPointer);
         this._normals(this.norPointer, stride);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.tangents = function(buffer, stride = 0) {
@@ -534,6 +577,7 @@ Filament.loadClassExtensions = function() {
         this.tanPointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.tanPointer);
         this._tangents(this.tanPointer, stride);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.uvs = function(buffer, stride = 0) {
@@ -541,6 +585,7 @@ Filament.loadClassExtensions = function() {
         this.uvsPointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.uvsPointer);
         this._uvs(this.uvsPointer, stride);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.positions = function(buffer, stride = 0) {
@@ -548,6 +593,7 @@ Filament.loadClassExtensions = function() {
         this.posPointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.posPointer);
         this._positions(this.posPointer, stride);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.triangles16 = function(buffer) {
@@ -555,6 +601,7 @@ Filament.loadClassExtensions = function() {
         this.t16Pointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.t16Pointer);
         this._triangles16(this.t16Pointer);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.triangles32 = function(buffer) {
@@ -562,6 +609,7 @@ Filament.loadClassExtensions = function() {
         this.t32Pointer = Filament._malloc(buffer.byteLength);
         Filament.HEAPU8.set(buffer, this.t32Pointer);
         this._triangles32(this.t32Pointer);
+        return this;
     };
 
     Filament.SurfaceOrientation$Builder.prototype.build = function() {
@@ -674,12 +722,12 @@ Filament.loadClassExtensions = function() {
         const resourceLoader = new Filament.gltfio$ResourceLoader(engine,
                 config.normalizeSkinningWeights);
 
-        const stbProvider = new Filament.gltfio$StbProvider(engine);
-        const ktx2Provider = new Filament.gltfio$Ktx2Provider(engine);
+        const stbProvider = Filament.gltfio$TextureProvider.createStbProvider(engine);
+        const ktx2Provider = Filament.gltfio$TextureProvider.createKtx2Provider(engine);
 
-        resourceLoader.addStbProvider("image/jpeg", stbProvider);
-        resourceLoader.addStbProvider("image/png", stbProvider);
-        resourceLoader.addKtx2Provider("image/ktx2", ktx2Provider);
+        resourceLoader.addTextureProvider("image/jpeg", stbProvider);
+        resourceLoader.addTextureProvider("image/png", stbProvider);
+        resourceLoader.addTextureProvider("image/ktx2", ktx2Provider);
 
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -75,6 +75,12 @@ export const assets: {[url: string]: Uint8Array};
  */
 export type BufferReference = string | ArrayBufferView;
 
+export type int2 = number[];
+export type int3 = number[];
+export type int4 = number[];
+export type bool2 = boolean[];
+export type bool3 = boolean[];
+export type bool4 = boolean[];
 export type float2 = glm.vec2|number[];
 export type float3 = glm.vec3|number[];
 export type float4 = glm.vec4|number[];
@@ -93,6 +99,10 @@ export interface Vector<T> {
 
 export class SwapChain {
     public static isSRGBSwapChainSupported(engine: Engine): boolean;
+    public static isProtectedContentSupported(engine: Engine): boolean;
+    public static isMSAASwapChainSupported(engine: Engine, samples: number): boolean;
+    public setFrameScheduledCallback(callback?: () => void): void;
+    public isFrameScheduledCallbackSet(): boolean;
 }
 
 export class Fence {
@@ -178,9 +188,22 @@ export class Texture$Builder {
     public height(height: number): Texture$Builder;
     public depth(depth: number): Texture$Builder;
     public levels(levels: number): Texture$Builder;
+    public samples(samples: number): Texture$Builder;
     public sampler(sampler: Texture$Sampler): Texture$Builder;
     public format(format: Texture$InternalFormat): Texture$Builder;
     public usage(usage: number): Texture$Builder;
+    /**
+     * Marks the texture as external. The web has no external image or stream source to attach to
+     * it, so a texture built this way stays empty; the binding exists for parity.
+     */
+    public external(): Texture$Builder;
+    /**
+     * @throws on the WebGL backend, where build() rejects a swizzled texture with
+     * "WebGL does not support texture swizzling" (WebGL 2.0 spec 5.19). Guard with
+     * Texture.isTextureSwizzleSupported(engine), which returns false on the web.
+     */
+    public swizzle(r: Texture$Swizzle, g: Texture$Swizzle, b: Texture$Swizzle,
+            a: Texture$Swizzle): Texture$Builder;
     public build(engine: Engine) : Texture;
 }
 
@@ -188,6 +211,12 @@ export class Texture {
     public static Builder(): Texture$Builder;
     public setImage(
         engine: Engine, level: number, pbd: driver$PixelBufferDescriptor): void;
+    public setImage(
+        engine: Engine, level: number, xoffset: number, yoffset: number,
+        width: number, height: number, pbd: driver$PixelBufferDescriptor): void;
+    public setImage(
+        engine: Engine, level: number, xoffset: number, yoffset: number, zoffset: number,
+        width: number, height: number, depth: number, pbd: driver$PixelBufferDescriptor): void;
     public getWidth(engine: Engine, level?: number) : number;
     public getHeight(engine: Engine, level?: number) : number;
     public getDepth(engine: Engine, level?: number) : number;
@@ -197,6 +226,12 @@ export class Texture {
     public static validatePixelFormatAndType(internalFormat: Texture$InternalFormat,
             format: PixelDataFormat, type: PixelDataType): boolean;
     public static isTextureSwizzleSupported(engine: Engine): boolean;
+    public static isTextureFormatSupported(engine: Engine,
+            format: Texture$InternalFormat): boolean;
+    public static getMaxTextureSize(engine: Engine, type: Texture$Sampler): number;
+    public static getMaxArrayTextureLayers(engine: Engine): number;
+    public getTarget(): Texture$Sampler;
+    public getFormat(): Texture$InternalFormat;
 }
 
 export class SkinningBuffer$Builder {
@@ -250,6 +285,13 @@ export class Skybox {
     public static Builder(): Skybox$Builder;
 }
 
+export class LightManager$ShadowCascades {
+    public static computeUniformSplits(cascades: number): number[];
+    public static computeLogSplits(cascades: number, near: number, far: number): number[];
+    public static computePracticalSplits(cascades: number, near: number, far: number,
+            lambda: number): number[];
+}
+
 export class LightManager$Instance {
     public delete(): void;
 }
@@ -265,7 +307,20 @@ export class TransformManager$Instance {
 export class TextureSampler {
     constructor(minfilter: MinFilter, magfilter: MagFilter, wrapmode: WrapMode);
     public setAnisotropy(value: number): void;
+    public getAnisotropy(): number;
     public setCompareMode(mode: CompareMode, func: CompareFunc): void;
+    public getCompareMode(): CompareMode;
+    public getCompareFunc(): CompareFunc;
+    public setMinFilter(filter: MinFilter): void;
+    public getMinFilter(): MinFilter;
+    public setMagFilter(filter: MagFilter): void;
+    public getMagFilter(): MagFilter;
+    public setWrapModeS(mode: WrapMode): void;
+    public getWrapModeS(): WrapMode;
+    public setWrapModeT(mode: WrapMode): void;
+    public getWrapModeT(): WrapMode;
+    public setWrapModeR(mode: WrapMode): void;
+    public getWrapModeR(): WrapMode;
 }
 
 export class MaterialInstance {
@@ -274,6 +329,13 @@ export class MaterialInstance {
     public duplicate(): MaterialInstance;
     public duplicateNamed(name: string): MaterialInstance;
     public setBoolParameter(name: string, value: boolean): void;
+    public setBool2Parameter(name: string, value: bool2): void;
+    public setBool3Parameter(name: string, value: bool3): void;
+    public setBool4Parameter(name: string, value: bool4): void;
+    public setIntParameter(name: string, value: number): void;
+    public setInt2Parameter(name: string, value: int2): void;
+    public setInt3Parameter(name: string, value: int3): void;
+    public setInt4Parameter(name: string, value: int4): void;
     public setFloatParameter(name: string, value: number): void;
     public setFloat2Parameter(name: string, value: float2): void;
     public setFloat3Parameter(name: string, value: float3): void;
@@ -287,6 +349,9 @@ export class MaterialInstance {
     public setMaskThreshold(threshold: number): void;
     public setScissor(left: number, bottom: number, width: number, height: number): void;
     public unsetScissor(): void;
+    public setConstantBool(name: string, value: boolean): void;
+    public setConstantFloat(name: string, value: number): void;
+    public setConstantInt(name: string, value: number): void;
     public getConstantBool(name: string): boolean;
     public getConstantFloat(name: string): number;
     public getConstantInt(name: string): number;
@@ -304,6 +369,7 @@ export class MaterialInstance {
     public setStencilReferenceValue(value: Number, face?: StencilFace): void;
     public setStencilReadMask(readMask: Number, face?: StencilFace): void;
     public setStencilWriteMask(writeMask: Number, face?: StencilFace): void;
+    public isStencilWriteEnabled(): boolean;
     public getMaskThreshold(): number;
     public setSpecularAntiAliasingVariance(variance: number): void;
     public getSpecularAntiAliasingVariance(): number;
@@ -323,8 +389,16 @@ export class MaterialInstance {
 
 export class EntityManager {
     public static get(): EntityManager;
+    public static getMaxEntityCount(): number;
     public create(): Entity;
+    public destroy(entity: Entity): void;
+    public getEntityCount(): number;
+    /**
+     * Only bound in builds compiled with FILAMENT_UTILS_TRACK_ENTITIES, which the release wasm
+     * build is not. Check for the method before calling it.
+     */
     public getActiveEntityCount(): number;
+    public advanceEpoch(): void;
 }
 
 export class VertexBuffer$Builder {
@@ -406,6 +480,8 @@ export class LightManager$Builder {
     public color(rgb: float3): LightManager$Builder;
     public direction(value: float3): LightManager$Builder;
     public intensity(value: number): LightManager$Builder;
+    public intensityEnergy(watts: number, efficiency: number): LightManager$Builder;
+    public intensityCandela(value: number): LightManager$Builder;
     public falloff(value: number): LightManager$Builder;
     public position(value: float3): LightManager$Builder;
     public spotLightCone(inner: number, outer: number): LightManager$Builder;
@@ -419,6 +495,7 @@ export class Skybox$Builder {
     public build(engine: Engine): Skybox;
     public color(rgba: float4): Skybox$Builder;
     public environment(envmap: Texture): Skybox$Builder;
+    public intensity(envIntensity: number): Skybox$Builder;
     public showSun(show: boolean): Skybox$Builder;
     public priority(priority: number): Skybox$Builder;
 }
@@ -441,10 +518,14 @@ export class LightManager {
     public setIntensity(instance: LightManager$Instance, intensity: number): void;
     public setIntensityEnergy(instance: LightManager$Instance, watts: number, efficiency: number): void;
     public getIntensity(instance: LightManager$Instance): number;
+    public destroy(entity: Entity): void;
+    public setIntensityCandela(instance: LightManager$Instance, intensity: number): void;
     public setFalloff(instance: LightManager$Instance, radius: number): void;
     public getFalloff(instance: LightManager$Instance): number;
     public setShadowOptions(instance: LightManager$Instance, options: LightManager$ShadowOptions): void;
     public setSpotLightCone(instance: LightManager$Instance, inner: number, outer: number): void;
+    public getSpotLightInnerCone(instance: LightManager$Instance): number;
+    public getSpotLightOuterCone(instance: LightManager$Instance): number;
     public setSunAngularRadius(instance: LightManager$Instance, angularRadius: number): void;
     public getSunAngularRadius(instance: LightManager$Instance): number;
     public setSunHaloSize(instance: LightManager$Instance, haloSize: number): void;
@@ -478,8 +559,14 @@ export class RenderableManager {
             offset: number): void
     public setBonesFromMatrices(instance: RenderableManager$Instance, transforms: mat4[],
             offset: number): void
-    public setMorphWeights(instance: RenderableManager$Instance, a: number, b: number, c: number,
-            d: number): void;
+    public setMorphWeights(instance: RenderableManager$Instance, weights: number[]): void;
+    public setMorphWeightsOffset(instance: RenderableManager$Instance, weights: number[],
+            offset: number): void;
+    public getMorphTargetCount(instance: RenderableManager$Instance): number;
+    public setMorphTargetBufferOffsetAt(instance: RenderableManager$Instance, level: number,
+            primitiveIndex: number, offset: number): void;
+    public setSkinningBuffer(instance: RenderableManager$Instance, skinningBuffer: SkinningBuffer,
+            count: number, offset: number): void;
     public getAxisAlignedBoundingBox(instance: RenderableManager$Instance): Box;
     public getPrimitiveCount(instance: RenderableManager$Instance): number;
     public setMaterialInstanceAt(instance: RenderableManager$Instance,
@@ -519,6 +606,7 @@ export class RenderableManager {
 
 export class VertexBuffer {
     public static Builder(): VertexBuffer$Builder;
+    public getVertexCount(): number;
     public setBufferAt(engine: Engine, bufindex: number, f32array: BufferReference,
             byteOffset?: number): void;
     public setBufferObjectAt(engine: Engine, bufindex: number, bo: BufferObject): void;
@@ -532,6 +620,7 @@ export class BufferObject {
 
 export class IndexBuffer {
     public static Builder(): IndexBuffer$Builder;
+    public getIndexCount(): number;
     public setBuffer(engine: Engine, u16array: BufferReference, byteOffset?: number): void;
 }
 
@@ -545,6 +634,9 @@ export class Renderer {
     public getClearOptions(): Renderer$ClearOptions;
     public getUserTime(): number;
     public resetUserTime(): void;
+    public getMaterialTime(): number;
+    public setMaterialTimeEpoch(epoch: number): void;
+    public pauseRenderThread(pauseDurationNs: number): void;
     public skipNextFrames(frameCount: number): void;
     public getFrameToSkipCount(): number;
     public setPresentationTime(monotonicClockNs: number): void;
@@ -553,6 +645,7 @@ export class Renderer {
     public setVsyncTime(steadyClockTimeNano: number): void;
     public skipFrame(vsyncSteadyClockTimeNano: number): void;
     public shouldRenderFrame(): boolean;
+    public hasGpuFallenBehind(): boolean;
     public copyFrame(dstSwapChain: SwapChain, dstViewport: float4, srcViewport: float4,
             flags: number): void;
     // The Uint8Array passed to the callback is only valid for the duration of the callback,
@@ -565,12 +658,48 @@ export class Renderer {
             callback: (pixels: Uint8Array) => void): void;
 }
 
+export interface Material$ParameterInfo {
+    name: string;
+    isSampler: boolean;
+    isSubpass: boolean;
+    /** Present when neither isSampler nor isSubpass. */
+    type?: number;
+    /** Present when isSampler. */
+    samplerType?: number;
+    /** Present when isSubpass. */
+    subpassType?: number;
+    count: number;
+    precision: number;
+}
+
 export class Material {
     public createInstance(): MaterialInstance;
     public createNamedInstance(name: string): MaterialInstance;
     public getDefaultInstance(): MaterialInstance;
     public getName(): string;
     public getParameterTransformName(samplerName: string): string;
+    public hasParameter(name: string): boolean;
+    public getParameterCount(): number;
+    public getParameters(): Material$ParameterInfo[];
+    public getShading(): Shading;
+    public getInterpolation(): Interpolation;
+    public getBlendingMode(): BlendingMode;
+    public getRefractionMode(): RefractionMode;
+    public getRefractionType(): RefractionType;
+    public getReflectionMode(): ReflectionMode;
+    public getVertexDomain(): VertexDomain;
+    public getCullingMode(): CullingMode;
+    public getTransparencyMode(): TransparencyMode;
+    public getFeatureLevel(): FeatureLevel;
+    public getMaskThreshold(): number;
+    public getSpecularAntiAliasingVariance(): number;
+    public getSpecularAntiAliasingThreshold(): number;
+    public getRequiredAttributes(): number;
+    public isDoubleSided(): boolean;
+    public isAlphaToCoverageEnabled(): boolean;
+    public isColorWriteEnabled(): boolean;
+    public isDepthWriteEnabled(): boolean;
+    public isDepthCullingEnabled(): boolean;
 }
 
 export enum Material$UboBatchingMode {
@@ -619,20 +748,57 @@ export class Camera {
     public setFocusDistance(distance: number): void;
     public setShift(shift: double2): void;
     public getShift(): double2;
+    public getEntity(): Entity;
+    public setEyeModelMatrix(eyeId: number, model: mat4): void;
+    public setCustomEyeProjection(projections: mat4[], projectionForCulling: mat4,
+            near: number, far: number): void;
     public static inverseProjection(p: mat4): mat4;
     public static computeEffectiveFocalLength(focalLength: number, focusDistance: number) : number;
     public static computeEffectiveFov(fovInDegrees: number, focusDistance: number) : number;
+}
+
+export class ToneMapper {
+    public delete(): void;
+}
+
+export class LinearToneMapper extends ToneMapper { constructor(); }
+export class ACESToneMapper extends ToneMapper { constructor(); }
+export class ACESLegacyToneMapper extends ToneMapper { constructor(); }
+export class FilmicToneMapper extends ToneMapper { constructor(); }
+export class PBRNeutralToneMapper extends ToneMapper { constructor(); }
+export class GT7ToneMapper extends ToneMapper { constructor(); }
+export class DisplayRangeToneMapper extends ToneMapper { constructor(); }
+
+export class AgxToneMapper extends ToneMapper {
+    constructor(look: AgxToneMapper$AgxLook);
+}
+
+export class GenericToneMapper extends ToneMapper {
+    constructor(contrast: number, midGrayIn: number, midGrayOut: number, hdrMax: number);
+    public getContrast(): number;
+    public setContrast(contrast: number): void;
+    public getMidGrayIn(): number;
+    public setMidGrayIn(midGrayIn: number): void;
+    public getMidGrayOut(): number;
+    public setMidGrayOut(midGrayOut: number): void;
+    public getHdrMax(): number;
+    public setHdrMax(hdrMax: number): void;
 }
 
 export class ColorGrading$Builder {
     public quality(qualityLevel: ColorGrading$QualityLevel): ColorGrading$Builder;
     public format(format: ColorGrading$LutFormat): ColorGrading$Builder;
     public dimensions(dim: number): ColorGrading$Builder;
+    /**
+     * @deprecated Use toneMapper(ToneMapper) instead. The ToneMapping enum has only five values
+     * and cannot select the PBRNeutral, GT7, AgX or Generic operators.
+     */
     public toneMapping(toneMapping: ColorGrading$ToneMapping): ColorGrading$Builder;
+    public toneMapper(toneMapper: ToneMapper): ColorGrading$Builder;
     public luminanceScaling(luminanceScaling: boolean): ColorGrading$Builder;
     public gamutMapping(gamutMapping: boolean): ColorGrading$Builder;
     public exposure(exposure: number): ColorGrading$Builder;
-    public nightAdaptation(adaptation: boolean): ColorGrading$Builder;
+    public nightAdaptation(adaptation: number): ColorGrading$Builder;
     public whiteBalance(temperature: number, tint: number): ColorGrading$Builder;
     public channelMixer(outRed: float3, outGreen: float3, outBlue: float3): ColorGrading$Builder;
     public shadowsMidtonesHighlights(shadows: float4, midtones: float4, highlights: float4,
@@ -663,8 +829,11 @@ export class IndirectLight {
 
 export class IndirectLight$Builder {
     public reflections(cubemap: Texture): IndirectLight$Builder;
-    public irradianceTex(cubemap: Texture): IndirectLight$Builder;
-    public irradianceSh(nbands: number, f32array: any): IndirectLight$Builder;
+    /** Sets the irradiance from spherical harmonics coefficients. */
+    public irradiance(nbands: number, f32array: any): IndirectLight$Builder;
+    /** Sets the irradiance from a cubemap. embind dispatches the two on argument count. */
+    public irradiance(cubemap: Texture): IndirectLight$Builder;
+    public radiance(nbands: number, f32array: any): IndirectLight$Builder;
     public intensity(value: number): IndirectLight$Builder;
     public rotation(value: mat3): IndirectLight$Builder;
     public build(engine: Engine): IndirectLight;
@@ -705,28 +874,51 @@ export class RenderTarget {
 export class View {
     public pick(x: number, y: number, cb: PickCallback): void;
     public setCamera(camera: Camera): void;
+    public getCamera(): Camera;
     public setColorGrading(colorGrading: ColorGrading): void;
     public getColorGrading(): ColorGrading;
     public setScene(scene: Scene): void;
+    public getScene(): Scene;
+    public setName(name: string): void;
+    public getName(): string;
     public setViewport(viewport: float4): void;
     public setVisibleLayers(select: number, values: number): void;
+    public getVisibleLayers(): number;
+    public setLayerEnabled(layer: number, enabled: boolean): void;
     public setRenderTarget(renderTarget: RenderTarget): void;
+    public getRenderTarget(): RenderTarget;
     public setAmbientOcclusionOptions(options: View$AmbientOcclusionOptions): void;
+    public getAmbientOcclusionOptions(): View$AmbientOcclusionOptions;
     public setDepthOfFieldOptions(options: View$DepthOfFieldOptions): void;
+    public getDepthOfFieldOptions(): View$DepthOfFieldOptions;
     public setMultiSampleAntiAliasingOptions(options: View$MultiSampleAntiAliasingOptions): void;
+    public getMultiSampleAntiAliasingOptions(): View$MultiSampleAntiAliasingOptions;
     public setTemporalAntiAliasingOptions(options: View$TemporalAntiAliasingOptions): void;
+    public getTemporalAntiAliasingOptions(): View$TemporalAntiAliasingOptions;
     public setScreenSpaceReflectionsOptions(options: View$ScreenSpaceReflectionsOptions): void;
+    public getScreenSpaceReflectionsOptions(): View$ScreenSpaceReflectionsOptions;
+    public setScreenSpaceRefractionEnabled(enabled: boolean): void;
+    public isScreenSpaceRefractionEnabled(): boolean;
     public setBloomOptions(options: View$BloomOptions): void;
+    public getBloomOptions(): View$BloomOptions;
     public setFogOptions(options: View$FogOptions): void;
+    public getFogOptions(): View$FogOptions;
     public setVignetteOptions(options: View$VignetteOptions): void;
+    public getVignetteOptions(): View$VignetteOptions;
     public setGuardBandOptions(options: View$GuardBandOptions): void;
+    public getGuardBandOptions(): View$GuardBandOptions;
     public setStereoscopicOptions(options: View$StereoscopicOptions): void;
+    public getStereoscopicOptions(): View$StereoscopicOptions;
+    public setRenderQuality(renderQuality: View$RenderQuality): void;
+    public getRenderQuality(): View$RenderQuality;
     public setAmbientOcclusion(ambientOcclusion: View$AmbientOcclusion): void;
     public getAmbientOcclusion(): View$AmbientOcclusion;
     public setBlendMode(mode: View$BlendMode): void;
     public getBlendMode(): View$BlendMode;
     public setPostProcessingEnabled(enabled: boolean): void;
+    public isPostProcessingEnabled(): boolean;
     public setAntiAliasing(antialiasing: View$AntiAliasing): void;
+    public getAntiAliasing(): View$AntiAliasing;
     public setStencilBufferEnabled(enabled: boolean): void;
     public isStencilBufferEnabled(): boolean;
     public setTransparentPickingEnabled(enabled: boolean): void;
@@ -745,9 +937,11 @@ export class View {
     public isFrustumCullingEnabled(): boolean;
     public setChannelDepthClearEnabled(channel: number, enabled: boolean): void;
     public isChannelDepthClearEnabled(channel: number): boolean;
+    public setSampleCount(count: number): void;
     public getSampleCount(): number;
     public getVisibleRenderableCount(): number;
     public setDithering(dithering: View$Dithering): void;
+    public getDithering(): View$Dithering;
     public setDynamicResolutionOptions(options: View$DynamicResolutionOptions): void;
     public getDynamicResolutionOptions(): View$DynamicResolutionOptions;
     public getLastDynamicResolutionScale(): float2;
@@ -772,6 +966,9 @@ export class TransformManager {
     public setTransform(instance: TransformManager$Instance, xform: mat4): void;
     public getTransform(instance: TransformManager$Instance): mat4;
     public getWorldTransform(instance: TransformManager$Instance): mat4;
+    public getChildCount(instance: TransformManager$Instance): number;
+    public setAccurateTranslationsEnabled(enable: boolean): void;
+    public isAccurateTranslationsEnabled(): boolean;
     public openLocalTransformTransaction(): void;
     public commitLocalTransformTransaction(): void;
     public getParent(instance: TransformManager$Instance): Entity;
@@ -814,11 +1011,62 @@ export class DecodedImage {
     public data: any;
 }
 
+export interface EngineCreateOptions extends WebGLContextAttributes {
+    backend?: Backend;
+    majorVersion?: number;
+    minorVersion?: number;
+    featureLevel?: FeatureLevel;
+    /** Engine feature flags, keyed by name. */
+    features?: Record<string, boolean>;
+    colorGrading?: ColorGrading$Builder;
+}
+
+export class Engine$Builder {
+    public backend(backend: Backend): Engine$Builder;
+    public config(config: Engine$Config): Engine$Builder;
+    public featureLevel(featureLevel: FeatureLevel): Engine$Builder;
+    public feature(name: string, value: boolean): Engine$Builder;
+    public colorGrading(colorGrading: ColorGrading$Builder): Engine$Builder;
+    /**
+     * Prefer Engine.create, which creates the canvas' WebGL context and registers it before
+     * building. Calling this directly builds an engine with no context to render into.
+     */
+    public build(): Engine;
+}
+
+export interface Engine$Config {
+    commandBufferSizeMB?: number;
+    perRenderPassArenaSizeMB?: number;
+    driverHandleArenaSizeMB?: number;
+    minCommandBufferSizeMB?: number;
+    perFrameCommandsSizeMB?: number;
+    jobSystemThreadCount?: number;
+    metalUploadBufferSizeBytes?: number;
+    metalDisablePanicOnDrawableFailure?: boolean;
+    disableParallelShaderCompile?: boolean;
+    stereoscopicType?: StereoscopicType;
+    stereoscopicEyeCount?: number;
+    resourceAllocatorCacheSizeMB?: number;
+    resourceAllocatorCacheMaxAge?: number;
+    disableHandleUseAfterFreeCheck?: boolean;
+    preferredShaderLanguage?: ShaderLanguage;
+    forceGLES2Context?: boolean;
+    assertNativeWindowIsValid?: boolean;
+    gpuContextPriority?: GpuContextPriority;
+    sharedUboInitialSizeInBytes?: number;
+    asynchronousMode?: AsynchronousMode;
+}
+
 export class Engine {
     public static readonly SINGLE_THREADED: number;
-    public static create(canvas: HTMLCanvasElement, options?: { backend?: Backend }): Engine;
+    public static create(canvas: HTMLCanvasElement, options?: EngineCreateOptions,
+        config?: Engine$Config): Engine;
+    public static createDefaultConfig(): Engine$Config;
+    public getConfig(): Engine$Config;
     public static destroy(engine: Engine): void;
     public execute(): void;
+    public flush(): void;
+    public flushAndWait(): void;
     public createCamera(entity: Entity): Camera;
     public createMaterial(urlOrBuffer: BufferReference, options?: { uboBatching?: Material$UboBatchingMode }): Material;
     public createRenderer(): Renderer;
@@ -876,6 +1124,9 @@ export class Engine {
     public isValidSkinningBuffer(skinningBuffer: SkinningBuffer): boolean;
     public isValidMorphTargetBuffer(morphTargetBuffer: MorphTargetBuffer): boolean;
     public getSupportedFeatureLevel(): FeatureLevel;
+    public setFeatureFlag(name: string, value: boolean): boolean;
+    public hasFeatureFlag(name: string): boolean;
+    public getFeatureFlag(name: string): boolean|undefined;
     public setActiveFeatureLevel(featureLevel: FeatureLevel): FeatureLevel;
     public getActiveFeatureLevel(): FeatureLevel;
     public static getSteadyClockTimeNano(): number;
@@ -899,7 +1150,8 @@ export class Ktx2Reader {
     constructor(engine: Engine, quiet: boolean)
     public requestFormat(format: Texture$InternalFormat): void;
     public unrequestFormat(format: Texture$InternalFormat): void;
-    public load(urlOrBuffer: BufferReference, transfer: TransferFunction): Texture|null;
+    public load(urlOrBuffer: BufferReference,
+            transfer: Ktx2Reader$TransferFunction): Texture|null;
 }
 
 // [mipLevel, arrayIndex, cubeFace] index into a KTX1 bundle's blobs.
@@ -940,6 +1192,10 @@ export class gltfio$AssetLoader {
             instances: (gltfio$FilamentInstance | null)[]): gltfio$FilamentAsset;
     public destroyAsset(asset: gltfio$FilamentAsset): void;
     public createInstance(asset: gltfio$FilamentAsset): (gltfio$FilamentInstance | null);
+    public enableDiagnostics(enable: boolean): void;
+    /** Frees the materials and textures that no live asset references anymore. */
+    public gc(): void;
+    public static destroy(loader: gltfio$AssetLoader): void;
     public delete(): void;
 }
 
@@ -948,16 +1204,24 @@ export class gltfio$FilamentAsset {
             basePath: string|null, asyncInterval: number|null, options?: object): void;
     public getEntities(): Entity[];
     public getEntitiesByName(name: string): Entity[];
-    public getEntityByName(name: string): Entity;
     public getEntitiesByPrefix(name: string): Entity[];
     public getLightEntities(): Entity[];
     public getRenderableEntities(): Entity[];
     public getCameraEntities(): Entity[];
     public getRoot(): Entity;
     public popRenderable(): Entity;
+    public popRenderables(count: number): Vector<Entity>;
     public getInstance(): gltfio$FilamentInstance;
     public getAssetInstances(): gltfio$FilamentInstance[];
     public getResourceUris(): string[];
+    public getEntityCount(): number;
+    public getLightEntityCount(): number;
+    public getRenderableEntityCount(): number;
+    public getCameraEntityCount(): number;
+    public getResourceUriCount(): number;
+    public getMorphTargetCountAt(entity: Entity): number;
+    public getSceneCount(): number;
+    public getAssetInstanceCount(): number;
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
     public getExtras(entity: Entity): string;
@@ -974,6 +1238,9 @@ export class gltfio$FilamentInstance {
     public getRoot(): Entity;
     public getAnimator(): gltfio$Animator;
     public getSkinNames(): Vector<string>;
+    public getEntityCount(): number;
+    public getMaterialVariantCount(): number;
+    public getMaterialInstanceCount(): number;
     public getSkinCount(): number;
     public getJointCountAt(skinIndex: number): number;
     public getJointsAt(skinIndex: number): Entity[];
@@ -998,32 +1265,37 @@ export class gltfio$Animator {
 export class gltfio$UbershaderProvider {
     constructor(engine: Engine);
     public destroyMaterials(): void;
+    public getMaterialsCount(): number;
+    /** A weak reference to the provider's material cache; it stays the provider's to destroy. */
+    public getMaterials(): Vector<Material>;
+    public needsDummyData(attribute: VertexAttribute): boolean;
 }
 
-export class gltfio$StbProvider {
-    constructor(engine: Engine);
-}
-
-export class gltfio$Ktx2Provider {
-    constructor(engine: Engine);
-}
-
-export class gltfio$WebpProvider {
-    constructor(engine: Engine);
+/**
+ * Decodes texture data on behalf of a [gltfio$ResourceLoader]. gltfio::TextureProvider is
+ * polymorphic and embind reaches a base class through RTTI, which this build compiles without, so
+ * the three providers share one type here rather than deriving from it.
+ */
+export class gltfio$TextureProvider {
+    /** Decodes PNG and JPEG. */
+    public static createStbProvider(engine: Engine): gltfio$TextureProvider;
+    public static createKtx2Provider(engine: Engine): gltfio$TextureProvider;
+    /** Returns a provider that does nothing where WebP is unsupported. */
+    public static createWebpProvider(engine: Engine): gltfio$TextureProvider;
     public static isWebpSupported(): boolean;
 }
 
 export class gltfio$ResourceLoader {
     constructor(engine: Engine, normalizeSkinningWeights: boolean);
     public addResourceData(url: string, buffer: driver$BufferDescriptor): void;
-    public addStbProvider(mimeType: string, provider: gltfio$StbProvider): void;
-    public addKtx2Provider(mimeType: string, provider: gltfio$Ktx2Provider): void;
-    public addWebpProvider(mimeType: string, provider: gltfio$WebpProvider): void;
+    public addTextureProvider(mimeType: string, provider: gltfio$TextureProvider): void;
     public hasResourceData(url: string): boolean;
     public loadResources(asset: gltfio$FilamentAsset): boolean;
     public asyncBeginLoad(asset: gltfio$FilamentAsset): boolean;
     public asyncGetLoadProgress(): number;
     public asyncUpdateLoad(): void;
+    public asyncCancelLoad(): void;
+    public evictResourceData(): void;
 }
 
 export class SurfaceOrientation$Builder {
@@ -1196,10 +1468,92 @@ export enum TransparencyMode {
     TWO_PASSES_TWO_SIDES,
 }
 
+export enum Shading {
+    UNLIT,
+    LIT,
+    SUBSURFACE,
+    CLOTH,
+    SPECULAR_GLOSSINESS,
+}
+
+export enum Interpolation {
+    SMOOTH,
+    FLAT,
+}
+
+export enum BlendingMode {
+    OPAQUE,
+    TRANSPARENT,
+    ADD,
+    MASKED,
+    FADE,
+    MULTIPLY,
+    SCREEN,
+    CUSTOM,
+}
+
+export enum VertexDomain {
+    OBJECT,
+    WORLD,
+    VIEW,
+    DEVICE,
+}
+
+export enum RefractionMode {
+    NONE,
+    CUBEMAP,
+    SCREEN_SPACE,
+}
+
+export enum RefractionType {
+    SOLID,
+    THIN,
+}
+
+export enum ReflectionMode {
+    DEFAULT,
+    SCREEN_SPACE,
+}
+
+export enum Texture$Swizzle {
+    SUBSTITUTE_ZERO,
+    SUBSTITUTE_ONE,
+    CHANNEL_0,
+    CHANNEL_1,
+    CHANNEL_2,
+    CHANNEL_3,
+}
+
 export enum FeatureLevel {
     FEATURE_LEVEL_1 = 1,
     FEATURE_LEVEL_2,
     FEATURE_LEVEL_3,
+}
+
+export enum StereoscopicType {
+    NONE,
+    INSTANCED,
+    MULTIVIEW,
+}
+
+export enum GpuContextPriority {
+    DEFAULT,
+    LOW,
+    MEDIUM,
+    HIGH,
+    REALTIME,
+}
+
+export enum ShaderLanguage {
+    DEFAULT,
+    MSL,
+    METAL_LIBRARY,
+}
+
+export enum AsynchronousMode {
+    NONE,
+    THREAD_PREFERRED,
+    AMORTIZATION,
 }
 
 export enum StencilOperation {
@@ -1388,6 +1742,11 @@ export const enum TextureUsage {
     UPLOADABLE = 8,
     SAMPLEABLE = 16,
     SUBPASS_INPUT = 32,
+    BLIT_SRC = 64,
+    BLIT_DST = 128,
+    PROTECTED = 256,
+    /** Required by Texture.generateMipmaps. */
+    GEN_MIPMAPPABLE = 512,
     DEFAULT = UPLOADABLE | SAMPLEABLE,
 }
 

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -75,6 +75,12 @@ export const assets: {[url: string]: Uint8Array};
  */
 export type BufferReference = string | ArrayBufferView;
 
+export type int2 = number[];
+export type int3 = number[];
+export type int4 = number[];
+export type bool2 = boolean[];
+export type bool3 = boolean[];
+export type bool4 = boolean[];
 export type float2 = glm.vec2|number[];
 export type float3 = glm.vec3|number[];
 export type float4 = glm.vec4|number[];
@@ -178,9 +184,17 @@ export class Texture$Builder {
     public height(height: number): Texture$Builder;
     public depth(depth: number): Texture$Builder;
     public levels(levels: number): Texture$Builder;
+    public samples(samples: number): Texture$Builder;
     public sampler(sampler: Texture$Sampler): Texture$Builder;
     public format(format: Texture$InternalFormat): Texture$Builder;
     public usage(usage: number): Texture$Builder;
+    /**
+     * @throws on the WebGL backend, where build() rejects a swizzled texture with
+     * "WebGL does not support texture swizzling" (WebGL 2.0 spec 5.19). Guard with
+     * Texture.isTextureSwizzleSupported(engine), which returns false on the web.
+     */
+    public swizzle(r: Texture$Swizzle, g: Texture$Swizzle, b: Texture$Swizzle,
+            a: Texture$Swizzle): Texture$Builder;
     public build(engine: Engine) : Texture;
 }
 
@@ -197,6 +211,12 @@ export class Texture {
     public static validatePixelFormatAndType(internalFormat: Texture$InternalFormat,
             format: PixelDataFormat, type: PixelDataType): boolean;
     public static isTextureSwizzleSupported(engine: Engine): boolean;
+    public static isTextureFormatSupported(engine: Engine,
+            format: Texture$InternalFormat): boolean;
+    public static getMaxTextureSize(engine: Engine, type: Texture$Sampler): number;
+    public static getMaxArrayTextureLayers(engine: Engine): number;
+    public getTarget(): Texture$Sampler;
+    public getFormat(): Texture$InternalFormat;
 }
 
 export class SkinningBuffer$Builder {
@@ -250,6 +270,13 @@ export class Skybox {
     public static Builder(): Skybox$Builder;
 }
 
+export class LightManager$ShadowCascades {
+    public static computeUniformSplits(cascades: number): number[];
+    public static computeLogSplits(cascades: number, near: number, far: number): number[];
+    public static computePracticalSplits(cascades: number, near: number, far: number,
+            lambda: number): number[];
+}
+
 export class LightManager$Instance {
     public delete(): void;
 }
@@ -265,7 +292,20 @@ export class TransformManager$Instance {
 export class TextureSampler {
     constructor(minfilter: MinFilter, magfilter: MagFilter, wrapmode: WrapMode);
     public setAnisotropy(value: number): void;
+    public getAnisotropy(): number;
     public setCompareMode(mode: CompareMode, func: CompareFunc): void;
+    public getCompareMode(): CompareMode;
+    public getCompareFunc(): CompareFunc;
+    public setMinFilter(filter: MinFilter): void;
+    public getMinFilter(): MinFilter;
+    public setMagFilter(filter: MagFilter): void;
+    public getMagFilter(): MagFilter;
+    public setWrapModeS(mode: WrapMode): void;
+    public getWrapModeS(): WrapMode;
+    public setWrapModeT(mode: WrapMode): void;
+    public getWrapModeT(): WrapMode;
+    public setWrapModeR(mode: WrapMode): void;
+    public getWrapModeR(): WrapMode;
 }
 
 export class MaterialInstance {
@@ -274,6 +314,13 @@ export class MaterialInstance {
     public duplicate(): MaterialInstance;
     public duplicateNamed(name: string): MaterialInstance;
     public setBoolParameter(name: string, value: boolean): void;
+    public setBool2Parameter(name: string, value: bool2): void;
+    public setBool3Parameter(name: string, value: bool3): void;
+    public setBool4Parameter(name: string, value: bool4): void;
+    public setIntParameter(name: string, value: number): void;
+    public setInt2Parameter(name: string, value: int2): void;
+    public setInt3Parameter(name: string, value: int3): void;
+    public setInt4Parameter(name: string, value: int4): void;
     public setFloatParameter(name: string, value: number): void;
     public setFloat2Parameter(name: string, value: float2): void;
     public setFloat3Parameter(name: string, value: float3): void;
@@ -287,6 +334,9 @@ export class MaterialInstance {
     public setMaskThreshold(threshold: number): void;
     public setScissor(left: number, bottom: number, width: number, height: number): void;
     public unsetScissor(): void;
+    public setConstantBool(name: string, value: boolean): void;
+    public setConstantFloat(name: string, value: number): void;
+    public setConstantInt(name: string, value: number): void;
     public getConstantBool(name: string): boolean;
     public getConstantFloat(name: string): number;
     public getConstantInt(name: string): number;
@@ -304,6 +354,7 @@ export class MaterialInstance {
     public setStencilReferenceValue(value: Number, face?: StencilFace): void;
     public setStencilReadMask(readMask: Number, face?: StencilFace): void;
     public setStencilWriteMask(writeMask: Number, face?: StencilFace): void;
+    public isStencilWriteEnabled(): boolean;
     public getMaskThreshold(): number;
     public setSpecularAntiAliasingVariance(variance: number): void;
     public getSpecularAntiAliasingVariance(): number;
@@ -406,6 +457,7 @@ export class LightManager$Builder {
     public color(rgb: float3): LightManager$Builder;
     public direction(value: float3): LightManager$Builder;
     public intensity(value: number): LightManager$Builder;
+    public intensityCandela(value: number): LightManager$Builder;
     public falloff(value: number): LightManager$Builder;
     public position(value: float3): LightManager$Builder;
     public spotLightCone(inner: number, outer: number): LightManager$Builder;
@@ -419,6 +471,7 @@ export class Skybox$Builder {
     public build(engine: Engine): Skybox;
     public color(rgba: float4): Skybox$Builder;
     public environment(envmap: Texture): Skybox$Builder;
+    public intensity(envIntensity: number): Skybox$Builder;
     public showSun(show: boolean): Skybox$Builder;
     public priority(priority: number): Skybox$Builder;
 }
@@ -441,6 +494,8 @@ export class LightManager {
     public setIntensity(instance: LightManager$Instance, intensity: number): void;
     public setIntensityEnergy(instance: LightManager$Instance, watts: number, efficiency: number): void;
     public getIntensity(instance: LightManager$Instance): number;
+    public destroy(entity: Entity): void;
+    public setIntensityCandela(instance: LightManager$Instance, intensity: number): void;
     public setFalloff(instance: LightManager$Instance, radius: number): void;
     public getFalloff(instance: LightManager$Instance): number;
     public setShadowOptions(instance: LightManager$Instance, options: LightManager$ShadowOptions): void;
@@ -478,8 +533,14 @@ export class RenderableManager {
             offset: number): void
     public setBonesFromMatrices(instance: RenderableManager$Instance, transforms: mat4[],
             offset: number): void
-    public setMorphWeights(instance: RenderableManager$Instance, a: number, b: number, c: number,
-            d: number): void;
+    public setMorphWeights(instance: RenderableManager$Instance, weights: number[]): void;
+    public setMorphWeightsOffset(instance: RenderableManager$Instance, weights: number[],
+            offset: number): void;
+    public getMorphTargetCount(instance: RenderableManager$Instance): number;
+    public setMorphTargetBufferOffsetAt(instance: RenderableManager$Instance, level: number,
+            primitiveIndex: number, offset: number): void;
+    public setSkinningBuffer(instance: RenderableManager$Instance, skinningBuffer: SkinningBuffer,
+            count: number, offset: number): void;
     public getAxisAlignedBoundingBox(instance: RenderableManager$Instance): Box;
     public getPrimitiveCount(instance: RenderableManager$Instance): number;
     public setMaterialInstanceAt(instance: RenderableManager$Instance,
@@ -519,6 +580,7 @@ export class RenderableManager {
 
 export class VertexBuffer {
     public static Builder(): VertexBuffer$Builder;
+    public getVertexCount(): number;
     public setBufferAt(engine: Engine, bufindex: number, f32array: BufferReference,
             byteOffset?: number): void;
     public setBufferObjectAt(engine: Engine, bufindex: number, bo: BufferObject): void;
@@ -532,6 +594,7 @@ export class BufferObject {
 
 export class IndexBuffer {
     public static Builder(): IndexBuffer$Builder;
+    public getIndexCount(): number;
     public setBuffer(engine: Engine, u16array: BufferReference, byteOffset?: number): void;
 }
 
@@ -565,12 +628,48 @@ export class Renderer {
             callback: (pixels: Uint8Array) => void): void;
 }
 
+export interface Material$ParameterInfo {
+    name: string;
+    isSampler: boolean;
+    isSubpass: boolean;
+    /** Present when neither isSampler nor isSubpass. */
+    type?: number;
+    /** Present when isSampler. */
+    samplerType?: number;
+    /** Present when isSubpass. */
+    subpassType?: number;
+    count: number;
+    precision: number;
+}
+
 export class Material {
     public createInstance(): MaterialInstance;
     public createNamedInstance(name: string): MaterialInstance;
     public getDefaultInstance(): MaterialInstance;
     public getName(): string;
     public getParameterTransformName(samplerName: string): string;
+    public hasParameter(name: string): boolean;
+    public getParameterCount(): number;
+    public getParameters(): Material$ParameterInfo[];
+    public getShading(): Shading;
+    public getInterpolation(): Interpolation;
+    public getBlendingMode(): BlendingMode;
+    public getRefractionMode(): RefractionMode;
+    public getRefractionType(): RefractionType;
+    public getReflectionMode(): ReflectionMode;
+    public getVertexDomain(): VertexDomain;
+    public getCullingMode(): CullingMode;
+    public getTransparencyMode(): TransparencyMode;
+    public getFeatureLevel(): FeatureLevel;
+    public getMaskThreshold(): number;
+    public getSpecularAntiAliasingVariance(): number;
+    public getSpecularAntiAliasingThreshold(): number;
+    public getRequiredAttributes(): number;
+    public isDoubleSided(): boolean;
+    public isAlphaToCoverageEnabled(): boolean;
+    public isColorWriteEnabled(): boolean;
+    public isDepthWriteEnabled(): boolean;
+    public isDepthCullingEnabled(): boolean;
 }
 
 export enum Material$UboBatchingMode {
@@ -619,16 +718,53 @@ export class Camera {
     public setFocusDistance(distance: number): void;
     public setShift(shift: double2): void;
     public getShift(): double2;
+    public getEntity(): Entity;
+    public setEyeModelMatrix(eyeId: number, model: mat4): void;
+    public setCustomEyeProjection(projections: mat4[], projectionForCulling: mat4,
+            near: number, far: number): void;
     public static inverseProjection(p: mat4): mat4;
     public static computeEffectiveFocalLength(focalLength: number, focusDistance: number) : number;
     public static computeEffectiveFov(fovInDegrees: number, focusDistance: number) : number;
+}
+
+export class ToneMapper {
+    public delete(): void;
+}
+
+export class LinearToneMapper extends ToneMapper { constructor(); }
+export class ACESToneMapper extends ToneMapper { constructor(); }
+export class ACESLegacyToneMapper extends ToneMapper { constructor(); }
+export class FilmicToneMapper extends ToneMapper { constructor(); }
+export class PBRNeutralToneMapper extends ToneMapper { constructor(); }
+export class GT7ToneMapper extends ToneMapper { constructor(); }
+export class DisplayRangeToneMapper extends ToneMapper { constructor(); }
+
+export class AgxToneMapper extends ToneMapper {
+    constructor(look: AgxToneMapper$AgxLook);
+}
+
+export class GenericToneMapper extends ToneMapper {
+    constructor(contrast: number, midGrayIn: number, midGrayOut: number, hdrMax: number);
+    public getContrast(): number;
+    public setContrast(contrast: number): void;
+    public getMidGrayIn(): number;
+    public setMidGrayIn(midGrayIn: number): void;
+    public getMidGrayOut(): number;
+    public setMidGrayOut(midGrayOut: number): void;
+    public getHdrMax(): number;
+    public setHdrMax(hdrMax: number): void;
 }
 
 export class ColorGrading$Builder {
     public quality(qualityLevel: ColorGrading$QualityLevel): ColorGrading$Builder;
     public format(format: ColorGrading$LutFormat): ColorGrading$Builder;
     public dimensions(dim: number): ColorGrading$Builder;
+    /**
+     * @deprecated Use toneMapper(ToneMapper) instead. The ToneMapping enum has only five values
+     * and cannot select the PBRNeutral, GT7, AgX or Generic operators.
+     */
     public toneMapping(toneMapping: ColorGrading$ToneMapping): ColorGrading$Builder;
+    public toneMapper(toneMapper: ToneMapper): ColorGrading$Builder;
     public luminanceScaling(luminanceScaling: boolean): ColorGrading$Builder;
     public gamutMapping(gamutMapping: boolean): ColorGrading$Builder;
     public exposure(exposure: number): ColorGrading$Builder;
@@ -665,6 +801,7 @@ export class IndirectLight$Builder {
     public reflections(cubemap: Texture): IndirectLight$Builder;
     public irradianceTex(cubemap: Texture): IndirectLight$Builder;
     public irradianceSh(nbands: number, f32array: any): IndirectLight$Builder;
+    public radianceSh(nbands: number, f32array: any): IndirectLight$Builder;
     public intensity(value: number): IndirectLight$Builder;
     public rotation(value: mat3): IndirectLight$Builder;
     public build(engine: Engine): IndirectLight;
@@ -705,27 +842,49 @@ export class RenderTarget {
 export class View {
     public pick(x: number, y: number, cb: PickCallback): void;
     public setCamera(camera: Camera): void;
+    public getCamera(): Camera;
     public setColorGrading(colorGrading: ColorGrading): void;
     public getColorGrading(): ColorGrading;
     public setScene(scene: Scene): void;
+    public getScene(): Scene;
+    public setName(name: string): void;
+    public getName(): string;
     public setViewport(viewport: float4): void;
     public setVisibleLayers(select: number, values: number): void;
+    public getVisibleLayers(): number;
+    public setLayerEnabled(layer: number, enabled: boolean): void;
     public setRenderTarget(renderTarget: RenderTarget): void;
+    public getRenderTarget(): RenderTarget;
     public setAmbientOcclusionOptions(options: View$AmbientOcclusionOptions): void;
+    public getAmbientOcclusionOptions(): View$AmbientOcclusionOptions;
     public setDepthOfFieldOptions(options: View$DepthOfFieldOptions): void;
+    public getDepthOfFieldOptions(): View$DepthOfFieldOptions;
     public setMultiSampleAntiAliasingOptions(options: View$MultiSampleAntiAliasingOptions): void;
+    public getMultiSampleAntiAliasingOptions(): View$MultiSampleAntiAliasingOptions;
     public setTemporalAntiAliasingOptions(options: View$TemporalAntiAliasingOptions): void;
+    public getTemporalAntiAliasingOptions(): View$TemporalAntiAliasingOptions;
     public setScreenSpaceReflectionsOptions(options: View$ScreenSpaceReflectionsOptions): void;
+    public getScreenSpaceReflectionsOptions(): View$ScreenSpaceReflectionsOptions;
+    public setScreenSpaceRefractionEnabled(enabled: boolean): void;
+    public isScreenSpaceRefractionEnabled(): boolean;
     public setBloomOptions(options: View$BloomOptions): void;
+    public getBloomOptions(): View$BloomOptions;
     public setFogOptions(options: View$FogOptions): void;
+    public getFogOptions(): View$FogOptions;
     public setVignetteOptions(options: View$VignetteOptions): void;
+    public getVignetteOptions(): View$VignetteOptions;
     public setGuardBandOptions(options: View$GuardBandOptions): void;
+    public getGuardBandOptions(): View$GuardBandOptions;
     public setStereoscopicOptions(options: View$StereoscopicOptions): void;
+    public getStereoscopicOptions(): View$StereoscopicOptions;
+    public setRenderQuality(renderQuality: View$RenderQuality): void;
+    public getRenderQuality(): View$RenderQuality;
     public setAmbientOcclusion(ambientOcclusion: View$AmbientOcclusion): void;
     public getAmbientOcclusion(): View$AmbientOcclusion;
     public setBlendMode(mode: View$BlendMode): void;
     public getBlendMode(): View$BlendMode;
     public setPostProcessingEnabled(enabled: boolean): void;
+    public isPostProcessingEnabled(): boolean;
     public setAntiAliasing(antialiasing: View$AntiAliasing): void;
     public setStencilBufferEnabled(enabled: boolean): void;
     public isStencilBufferEnabled(): boolean;
@@ -748,6 +907,7 @@ export class View {
     public getSampleCount(): number;
     public getVisibleRenderableCount(): number;
     public setDithering(dithering: View$Dithering): void;
+    public getDithering(): View$Dithering;
     public setDynamicResolutionOptions(options: View$DynamicResolutionOptions): void;
     public getDynamicResolutionOptions(): View$DynamicResolutionOptions;
     public getLastDynamicResolutionScale(): float2;
@@ -772,6 +932,9 @@ export class TransformManager {
     public setTransform(instance: TransformManager$Instance, xform: mat4): void;
     public getTransform(instance: TransformManager$Instance): mat4;
     public getWorldTransform(instance: TransformManager$Instance): mat4;
+    public getChildCount(instance: TransformManager$Instance): number;
+    public setAccurateTranslationsEnabled(enable: boolean): void;
+    public isAccurateTranslationsEnabled(): boolean;
     public openLocalTransformTransaction(): void;
     public commitLocalTransformTransaction(): void;
     public getParent(instance: TransformManager$Instance): Entity;
@@ -819,6 +982,8 @@ export class Engine {
     public static create(canvas: HTMLCanvasElement, options?: { backend?: Backend }): Engine;
     public static destroy(engine: Engine): void;
     public execute(): void;
+    public flush(): void;
+    public flushAndWait(): void;
     public createCamera(entity: Entity): Camera;
     public createMaterial(urlOrBuffer: BufferReference, options?: { uboBatching?: Material$UboBatchingMode }): Material;
     public createRenderer(): Renderer;
@@ -940,6 +1105,8 @@ export class gltfio$AssetLoader {
             instances: (gltfio$FilamentInstance | null)[]): gltfio$FilamentAsset;
     public destroyAsset(asset: gltfio$FilamentAsset): void;
     public createInstance(asset: gltfio$FilamentAsset): (gltfio$FilamentInstance | null);
+    public enableDiagnostics(enable: boolean): void;
+    public static destroy(loader: gltfio$AssetLoader): void;
     public delete(): void;
 }
 
@@ -955,9 +1122,18 @@ export class gltfio$FilamentAsset {
     public getCameraEntities(): Entity[];
     public getRoot(): Entity;
     public popRenderable(): Entity;
+    public popRenderables(count: number): Vector<Entity>;
     public getInstance(): gltfio$FilamentInstance;
     public getAssetInstances(): gltfio$FilamentInstance[];
     public getResourceUris(): string[];
+    public getEntityCount(): number;
+    public getLightEntityCount(): number;
+    public getRenderableEntityCount(): number;
+    public getCameraEntityCount(): number;
+    public getResourceUriCount(): number;
+    public getMorphTargetCountAt(entity: Entity): number;
+    public getSceneCount(): number;
+    public getAssetInstanceCount(): number;
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
     public getExtras(entity: Entity): string;
@@ -974,6 +1150,9 @@ export class gltfio$FilamentInstance {
     public getRoot(): Entity;
     public getAnimator(): gltfio$Animator;
     public getSkinNames(): Vector<string>;
+    public getEntityCount(): number;
+    public getMaterialVariantCount(): number;
+    public getMaterialInstanceCount(): number;
     public getSkinCount(): number;
     public getJointCountAt(skinIndex: number): number;
     public getJointsAt(skinIndex: number): Entity[];
@@ -1024,6 +1203,8 @@ export class gltfio$ResourceLoader {
     public asyncBeginLoad(asset: gltfio$FilamentAsset): boolean;
     public asyncGetLoadProgress(): number;
     public asyncUpdateLoad(): void;
+    public asyncCancelLoad(): void;
+    public evictResourceData(): void;
 }
 
 export class SurfaceOrientation$Builder {
@@ -1194,6 +1375,62 @@ export enum TransparencyMode {
     DEFAULT,
     TWO_PASSES_ONE_SIDE,
     TWO_PASSES_TWO_SIDES,
+}
+
+export enum Shading {
+    UNLIT,
+    LIT,
+    SUBSURFACE,
+    CLOTH,
+    SPECULAR_GLOSSINESS,
+}
+
+export enum Interpolation {
+    SMOOTH,
+    FLAT,
+}
+
+export enum BlendingMode {
+    OPAQUE,
+    TRANSPARENT,
+    ADD,
+    MASKED,
+    FADE,
+    MULTIPLY,
+    SCREEN,
+    CUSTOM,
+}
+
+export enum VertexDomain {
+    OBJECT,
+    WORLD,
+    VIEW,
+    DEVICE,
+}
+
+export enum RefractionMode {
+    NONE,
+    CUBEMAP,
+    SCREEN_SPACE,
+}
+
+export enum RefractionType {
+    SOLID,
+    THIN,
+}
+
+export enum ReflectionMode {
+    DEFAULT,
+    SCREEN_SPACE,
+}
+
+export enum Texture$Swizzle {
+    SUBSTITUTE_ZERO,
+    SUBSTITUTE_ONE,
+    CHANNEL_0,
+    CHANNEL_1,
+    CHANNEL_2,
+    CHANNEL_3,
 }
 
 export enum FeatureLevel {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -32,6 +32,8 @@
  * this explicit rather than mysterious.
  */
 
+#include <optional>
+
 #include <viewer/AutomationEngine.h>
 #include <viewer/AutomationSpec.h>
 #include <viewer/Settings.h>
@@ -72,6 +74,7 @@
 #include <filament/Skybox.h>
 #include <filament/SwapChain.h>
 #include <filament/Texture.h>
+#include <filament/ToneMapper.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
@@ -164,6 +167,7 @@ namespace {
 // For convenience, declare terse private aliases to nested types. This lets us avoid extremely
 // verbose binding declarations.
 using ColorBuilder = ColorGrading::Builder;
+using EngineBuilder = Engine::Builder;
 using IblBuilder = IndirectLight::Builder;
 using IndexBuilder = IndexBuffer::Builder;
 using LightBuilder = LightManager::Builder;
@@ -283,6 +287,38 @@ value_array<filament::math::float4>("float4")
     .element(&filament::math::float4::y)
     .element(&filament::math::float4::z)
     .element(&filament::math::float4::w);
+
+// Integer and boolean vectors, needed by MaterialInstance::setParameter for materials that
+// declare int/bool vector parameters.
+value_array<filament::math::int2>("int2")
+    .element(&filament::math::int2::x)
+    .element(&filament::math::int2::y);
+
+value_array<filament::math::int3>("int3")
+    .element(&filament::math::int3::x)
+    .element(&filament::math::int3::y)
+    .element(&filament::math::int3::z);
+
+value_array<filament::math::int4>("int4")
+    .element(&filament::math::int4::x)
+    .element(&filament::math::int4::y)
+    .element(&filament::math::int4::z)
+    .element(&filament::math::int4::w);
+
+value_array<filament::math::bool2>("bool2")
+    .element(&filament::math::bool2::x)
+    .element(&filament::math::bool2::y);
+
+value_array<filament::math::bool3>("bool3")
+    .element(&filament::math::bool3::x)
+    .element(&filament::math::bool3::y)
+    .element(&filament::math::bool3::z);
+
+value_array<filament::math::bool4>("bool4")
+    .element(&filament::math::bool4::x)
+    .element(&filament::math::bool4::y)
+    .element(&filament::math::bool4::z)
+    .element(&filament::math::bool4::w);
 
 value_array<filament::math::double2>("double2")
     .element(&filament::math::double2::x)
@@ -443,6 +479,14 @@ class_<std::vector<FilamentInstance*>>("AssetInstanceVector")
         return (*self)[i];
     }), allow_raw_pointers());
 
+class_<std::vector<Material*>>("MaterialVector")
+    .function("size", EMBIND_LAMBDA(size_t, (std::vector<Material*>* self), {
+        return self->size();
+    }), allow_raw_pointers())
+    .function("get", EMBIND_LAMBDA(Material*, (std::vector<Material*>* self, size_t i), {
+        return (*self)[i];
+    }), allow_raw_pointers());
+
 class_<std::vector<MaterialInstance*>>("MaterialInstanceVector")
     .function("size", EMBIND_LAMBDA(size_t, (std::vector<MaterialInstance*>* self), {
         return self->size();
@@ -476,21 +520,50 @@ enum_<Engine::Config::ShaderLanguage>("ShaderLanguage")
     .value("MSL", Engine::Config::ShaderLanguage::MSL)
     .value("METAL_LIBRARY", Engine::Config::ShaderLanguage::METAL_LIBRARY);
 
+/// Engine$Builder ::class:: Builds an [Engine].
+/// Engine::Builder::platform and ::sharedContext are omitted: on the web the canvas owns the
+/// context, and it is registered with emscripten by Engine.create before build() runs.
+class_<EngineBuilder>("Engine$Builder")
+    .constructor<>()
+
+    .BUILDER_FUNCTION("backend", EngineBuilder, (EngineBuilder* builder,
+            backend::Backend backend), {
+        return &builder->backend(backend); })
+
+    .BUILDER_FUNCTION("config", EngineBuilder, (EngineBuilder* builder, Engine::Config config), {
+        // Builder::config copies through its pimpl, so the local is safe to take the address of.
+        return &builder->config(&config); })
+
+    .BUILDER_FUNCTION("featureLevel", EngineBuilder, (EngineBuilder* builder,
+            backend::FeatureLevel featureLevel), {
+        return &builder->featureLevel(featureLevel); })
+
+    .BUILDER_FUNCTION("feature", EngineBuilder, (EngineBuilder* builder, std::string name,
+            bool value), {
+        return &builder->feature(name.c_str(), value); })
+
+    .BUILDER_FUNCTION("colorGrading", EngineBuilder, (EngineBuilder* builder,
+            ColorBuilder* colorGrading), {
+        return &builder->colorGrading(*colorGrading); })
+
+    // Engine.create stashes the canvas' WebGL context in a transient global before calling this;
+    // it has to be handed to emscripten's GL layer here, after the context exists and before the
+    // engine is built. Backends that do not use it (WebGPU) leave the global unset.
+    .function("_build", EMBIND_LAMBDA(Engine*, (EngineBuilder* builder), {
+        EM_ASM_INT({
+            // No window outside a browser, and no context for the backends that do not use one.
+            if (typeof window === 'undefined' || !window.filament_glContext) {
+                return;
+            }
+            const handle = GL.registerContext(window.filament_glContext, window.filament_glOptions);
+            window.filament_contextHandle = handle;
+            GL.makeContextCurrent(handle);
+        });
+        return builder->build();
+    }), allow_raw_pointers());
+
 /// Engine ::core class:: Central manager and resource owner.
 class_<Engine>("Engine")
-    .class_function("_create", (Engine* (*)(backend::Backend, Engine::Config)) [] (backend::Backend backend, Engine::Config config) {
-        if (backend == backend::Backend::DEFAULT || backend == backend::Backend::OPENGL) {
-            EM_ASM_INT({
-                const options = window.filament_glOptions;
-                const context = window.filament_glContext;
-                const handle = GL.registerContext(context, options);
-                window.filament_contextHandle = handle;
-                GL.makeContextCurrent(handle);
-            });
-        }
-        return Engine::create(backend, nullptr, nullptr, &config);
-    }, allow_raw_pointers())
-
     // Create a default Engine configuration. This is for internal use to ensure that engine
     // creation logic in 'extensions.js' does not have to populate the default configuration
     // variables manually.
@@ -516,6 +589,30 @@ class_<Engine>("Engine")
 
     .function("getActiveFeatureLevel", &Engine::getActiveFeatureLevel)
 
+    // These take a char const*, which embind has no conversion for, so each takes a std::string
+    // and hands over its data.
+
+    /// setFeatureFlag ::method:: Sets an engine feature flag by name, after construction.
+    /// The same flags can be set before construction with [Engine$Builder] `feature`.
+    /// ::retval:: false if no flag by that name exists, or if it can only be set at build time
+    .function("setFeatureFlag", EMBIND_LAMBDA(bool, (Engine* engine, std::string name, bool value), {
+        return engine->setFeatureFlag(name.c_str(), value);
+    }), allow_raw_pointers())
+
+    /// hasFeatureFlag ::method:: True if an engine feature flag by this name exists.
+    .function("hasFeatureFlag", EMBIND_LAMBDA(bool, (Engine* engine, std::string name), {
+        return engine->hasFeatureFlag(name.c_str());
+    }), allow_raw_pointers())
+
+    /// getFeatureFlag ::method:: The value of an engine feature flag.
+    /// ::retval:: the boolean value, or undefined if no flag by that name exists
+    .function("getFeatureFlag", EMBIND_LAMBDA(emscripten::val,
+            (Engine* engine, std::string name), {
+        // std::optional has no embind representation, so the empty case becomes undefined.
+        std::optional<bool> const value = engine->getFeatureFlag(name.c_str());
+        return value.has_value() ? emscripten::val(*value) : emscripten::val::undefined();
+    }), allow_raw_pointers())
+
     .function("getBackend", &Engine::getBackend)
 
     .class_function("getMaxStereoscopicEyes", &Engine::getMaxStereoscopicEyes)
@@ -528,6 +625,15 @@ class_<Engine>("Engine")
             GL.makeContextCurrent(handle);
         });
         engine->execute();
+    }), allow_raw_pointers())
+
+    .function("flush", &Engine::flush)
+
+    /// flushAndWait ::method:: Flushes the command stream and waits for it to drain.
+    /// On the single-threaded web build this drains the queue directly rather than
+    /// creating a fence, so it does not block the page.
+    .function("flushAndWait", EMBIND_LAMBDA(void, (Engine* engine), {
+        engine->flushAndWait();
     }), allow_raw_pointers())
 
     /// destroy ::static method:: Destroys an engine instance and cleans up resources.
@@ -756,7 +862,30 @@ class_<Engine>("Engine")
 /// SwapChain ::core class:: Represents the platform's native rendering surface.
 /// See also the [Engine] methods `createSwapChain` and `destroySwapChain`.
 class_<SwapChain>("SwapChain")
-        .class_function("isSRGBSwapChainSupported", &SwapChain::isSRGBSwapChainSupported);
+        .class_function("isSRGBSwapChainSupported", &SwapChain::isSRGBSwapChainSupported)
+        .class_function("isProtectedContentSupported", &SwapChain::isProtectedContentSupported)
+        .class_function("isMSAASwapChainSupported", &SwapChain::isMSAASwapChainSupported)
+        /// setFrameScheduledCallback ::method:: Sets the callback Filament fires once the frame's
+        /// CPU work is done, latched at [Renderer] `endFrame`. The `PresentCallable` is not passed
+        /// through: it is `noopPresent` on both web backends.
+        /// callback ::argument:: called with no arguments, or omitted to clear
+        .function("setFrameScheduledCallback", EMBIND_LAMBDA(void, (SwapChain* self,
+                val callback), {
+            if (callback.isUndefined() || callback.isNull()) {
+                self->setFrameScheduledCallback();
+                return;
+            }
+            // val is refcounted, so capturing by value keeps the JS function alive exactly as
+            // long as the std::function the driver holds.
+            self->setFrameScheduledCallback(nullptr,
+                    [callback](backend::PresentCallable) { callback(); });
+        }), allow_raw_pointers())
+        /// isFrameScheduledCallbackSet ::method:: Whether the last `setFrameScheduledCallback`
+        /// set a callback rather than clearing it.
+        /// ::retval:: boolean
+        .function("isFrameScheduledCallbackSet", &SwapChain::isFrameScheduledCallbackSet);
+        // setFrameCompletedCallback is deliberately unbound: OpenGLDriver implements it as an
+        // empty function, so it could never fire here.
 
 /// Fence ::core class:: A synchronization primitive that can be waited on.
 /// See also the [Engine] methods `createFence` and `destroyFence`.
@@ -770,6 +899,10 @@ class_<Fence>("Fence")
             double timeout), {
         return self->wait(mode, (uint64_t) timeout);
     }), allow_raw_pointers());
+
+// Fence::waitAndDestroy is deliberately not bound: it hardcodes FENCE_WAIT_FOR_EVER, and the web
+// build is single-threaded, so an unbounded wait can never be satisfied. Use _wait with a timeout
+// of 0 followed by Engine::destroyFence instead.
 
 /// Renderer ::core class:: Represents the platform's native window.
 /// See also the [Engine] methods `createRenderer` and `destroyRenderer`.
@@ -802,6 +935,7 @@ class_<Renderer>("Renderer")
     .function("setVsyncTime", &Renderer::setVsyncTime)
     .function("skipFrame", &Renderer::skipFrame)
     .function("shouldRenderFrame", &Renderer::shouldRenderFrame)
+    .function("hasGpuFallenBehind", &Renderer::hasGpuFallenBehind)
     .function("beginFrame", EMBIND_LAMBDA(bool, (Renderer* self, SwapChain* swapChain), {
         return self->beginFrame(swapChain);
     }), allow_raw_pointers())
@@ -875,8 +1009,21 @@ class_<View>("View")
     }), allow_raw_pointers())
 
     .function("setScene", &View::setScene, allow_raw_pointers())
+    .function("getScene", EMBIND_LAMBDA(Scene*, (View* self), {
+        return self->getScene();
+    }), allow_raw_pointers())
     .function("setCamera", &View::setCamera, allow_raw_pointers())
+    .function("getCamera", EMBIND_LAMBDA(Camera*, (View* self), {
+        return &self->getCamera();
+    }), allow_raw_pointers())
     .function("hasCamera", &View::hasCamera)
+    .function("setName", EMBIND_LAMBDA(void, (View* self, std::string name), {
+        self->setName(name.c_str());
+    }), allow_raw_pointers())
+    .function("getName", EMBIND_LAMBDA(std::string, (View* self), {
+        const char* name = self->getName();
+        return name ? std::string(name) : std::string();
+    }), allow_raw_pointers())
     .function("setColorGrading", &View::setColorGrading, allow_raw_pointers())
     .function("getColorGrading", EMBIND_LAMBDA(ColorGrading*, (View* self), {
         return const_cast<ColorGrading*>(self->getColorGrading());
@@ -891,14 +1038,38 @@ class_<View>("View")
     .function("getGridSize", &View::getGridSize)
     .function("getEffectiveGridSize", &View::getEffectiveGridSize)
     .function("setVisibleLayers", &View::setVisibleLayers)
+    .function("getVisibleLayers", &View::getVisibleLayers)
+    .function("setLayerEnabled", &View::setLayerEnabled)
     .function("setPostProcessingEnabled", &View::setPostProcessingEnabled)
+    .function("isPostProcessingEnabled", &View::isPostProcessingEnabled)
+    .function("setScreenSpaceRefractionEnabled", &View::setScreenSpaceRefractionEnabled)
+    .function("isScreenSpaceRefractionEnabled", &View::isScreenSpaceRefractionEnabled)
     .function("setDithering", &View::setDithering)
+    .function("getDithering", &View::getDithering)
     .function("_setAmbientOcclusionOptions", &View::setAmbientOcclusionOptions)
+    .function("getAmbientOcclusionOptions", EMBIND_LAMBDA(View::AmbientOcclusionOptions,
+            (View* self), {
+        return self->getAmbientOcclusionOptions();
+    }), allow_raw_pointers())
     .function("_setDepthOfFieldOptions", &View::setDepthOfFieldOptions)
+    .function("getDepthOfFieldOptions", &View::getDepthOfFieldOptions)
     .function("_setMultiSampleAntiAliasingOptions", &View::setMultiSampleAntiAliasingOptions)
+    .function("getMultiSampleAntiAliasingOptions", EMBIND_LAMBDA(
+            View::MultiSampleAntiAliasingOptions, (View* self), {
+        return self->getMultiSampleAntiAliasingOptions();
+    }), allow_raw_pointers())
     .function("_setTemporalAntiAliasingOptions", &View::setTemporalAntiAliasingOptions)
+    .function("getTemporalAntiAliasingOptions", EMBIND_LAMBDA(
+            View::TemporalAntiAliasingOptions, (View* self), {
+        return self->getTemporalAntiAliasingOptions();
+    }), allow_raw_pointers())
     .function("_setScreenSpaceReflectionsOptions", &View::setScreenSpaceReflectionsOptions)
+    .function("getScreenSpaceReflectionsOptions", EMBIND_LAMBDA(
+            View::ScreenSpaceReflectionsOptions, (View* self), {
+        return self->getScreenSpaceReflectionsOptions();
+    }), allow_raw_pointers())
     .function("_setBloomOptions", &View::setBloomOptions)
+    .function("getBloomOptions", &View::getBloomOptions)
     .function("setShadowingEnabled", &View::setShadowingEnabled)
     .function("isShadowingEnabled", &View::isShadowingEnabled)
     .function("setShadowType", &View::setShadowType)
@@ -912,13 +1083,22 @@ class_<View>("View")
     .function("setFrontFaceWindingInverted", &View::setFrontFaceWindingInverted)
     .function("isFrontFaceWindingInverted", &View::isFrontFaceWindingInverted)
     .function("setDynamicLightingOptions", &View::setDynamicLightingOptions)
-    .function("setRenderQuality", &View::setRenderQuality)
-    .function("setDynamicResolutionOptions", &View::setDynamicResolutionOptions)
+    .function("_setRenderQuality", &View::setRenderQuality)
+    .function("getRenderQuality", &View::getRenderQuality)
+    .function("_setDynamicResolutionOptions", &View::setDynamicResolutionOptions)
     .function("getDynamicResolutionOptions", &View::getDynamicResolutionOptions)
     .function("_setFogOptions", &View::setFogOptions)
+    .function("getFogOptions", &View::getFogOptions)
     .function("_setVignetteOptions", &View::setVignetteOptions)
+    .function("getVignetteOptions", &View::getVignetteOptions)
     .function("_setGuardBandOptions", &View::setGuardBandOptions)
+    .function("getGuardBandOptions", EMBIND_LAMBDA(View::GuardBandOptions, (View* self), {
+        return self->getGuardBandOptions();
+    }), allow_raw_pointers())
     .function("_setStereoscopicOptions", &View::setStereoscopicOptions)
+    .function("getStereoscopicOptions", EMBIND_LAMBDA(View::StereoscopicOptions, (View* self), {
+        return self->getStereoscopicOptions();
+    }), allow_raw_pointers())
     .function("setAmbientOcclusion", &View::setAmbientOcclusion)
     .function("getAmbientOcclusion", &View::getAmbientOcclusion)
     .function("setAntiAliasing", &View::setAntiAliasing)
@@ -929,6 +1109,7 @@ class_<View>("View")
     .function("setRenderTarget", EMBIND_LAMBDA(void, (View* self, RenderTarget* renderTarget), {
         self->setRenderTarget(renderTarget);
     }), allow_raw_pointers())
+    .function("getRenderTarget", &View::getRenderTarget, allow_raw_pointers())
     .function("setTransparentPickingEnabled", &View::setTransparentPickingEnabled)
     .function("isTransparentPickingEnabled", &View::isTransparentPickingEnabled)
     .function("setStencilBufferEnabled", &View::setStencilBufferEnabled)
@@ -1002,6 +1183,11 @@ class_<Camera>("Camera")
         self->setCustomProjection(filament::math::mat4(m.m), near, far);
     }), allow_raw_pointers())
 
+    .function("setCustomProjection", EMBIND_LAMBDA(void, (Camera* self,
+            flatmat4 m, flatmat4 mCull, double near, double far), {
+        self->setCustomProjection(filament::math::mat4(m.m), filament::math::mat4(mCull.m), near, far);
+    }), allow_raw_pointers())
+
     .function("setScaling", EMBIND_LAMBDA(void, (Camera* self, math::double2 scaling), {
         self->setScaling(scaling);
     }), allow_raw_pointers())
@@ -1017,6 +1203,25 @@ class_<Camera>("Camera")
     .function("getScaling", &Camera::getScaling)
     .function("setShift", &Camera::setShift)
     .function("getShift", &Camera::getShift)
+    .function("getEntity", &Camera::getEntity)
+    // setEyeModelMatrix has no mat4f overload (unlike setModelMatrix), so widen explicitly.
+    .function("setEyeModelMatrix", EMBIND_LAMBDA(void, (Camera* self, uint8_t eyeId, flatmat4 m), {
+        self->setEyeModelMatrix(eyeId, filament::math::mat4(m.m));
+    }), allow_raw_pointers())
+
+    /// setCustomEyeProjection ::method:: Sets a per-eye projection for stereoscopic rendering.
+    /// projections ::argument:: array of mat4, one per eye
+    /// projectionForCulling ::argument:: a mat4 encompassing all eye frustums
+    .function("setCustomEyeProjection", EMBIND_LAMBDA(void, (Camera* self, val projections,
+            flatmat4 projectionForCulling, double near, double far), {
+        size_t const count = projections["length"].as<size_t>();
+        std::vector<filament::math::mat4> matrices(count);
+        for (size_t i = 0; i < count; i++) {
+            matrices[i] = filament::math::mat4(projections[i].as<flatmat4>().m);
+        }
+        self->setCustomEyeProjection(matrices.data(), count,
+                filament::math::mat4(projectionForCulling.m), near, far);
+    }), allow_raw_pointers())
 
     .function("getNear", &Camera::getNear)
     .function("getCullingFar", &Camera::getCullingFar)
@@ -1062,6 +1267,47 @@ class_<Camera>("Camera")
         return flatmat4 { filament::math::mat4f(Camera::inverseProjection(m.m)) };
     }, allow_raw_pointers());
 
+// ToneMapper hierarchy. ColorGrading$Builder::toneMapper supersedes the deprecated
+// toneMapping(ToneMapping) enum, whose 5 values cannot reach PBRNeutral, GT7, AgX or the tunable
+// Generic operator. Each subclass is bound as its own class so JS can construct one and hand it to
+// the builder; build() consumes it synchronously, so it is safe to delete afterwards.
+class_<ToneMapper>("ToneMapper");
+
+class_<LinearToneMapper, base<ToneMapper>>("LinearToneMapper")
+    .constructor<>();
+
+class_<ACESToneMapper, base<ToneMapper>>("ACESToneMapper")
+    .constructor<>();
+
+class_<ACESLegacyToneMapper, base<ToneMapper>>("ACESLegacyToneMapper")
+    .constructor<>();
+
+class_<FilmicToneMapper, base<ToneMapper>>("FilmicToneMapper")
+    .constructor<>();
+
+class_<PBRNeutralToneMapper, base<ToneMapper>>("PBRNeutralToneMapper")
+    .constructor<>();
+
+class_<GT7ToneMapper, base<ToneMapper>>("GT7ToneMapper")
+    .constructor<>();
+
+class_<DisplayRangeToneMapper, base<ToneMapper>>("DisplayRangeToneMapper")
+    .constructor<>();
+
+class_<AgxToneMapper, base<ToneMapper>>("AgxToneMapper")
+    .constructor<AgxToneMapper::AgxLook>();
+
+class_<GenericToneMapper, base<ToneMapper>>("GenericToneMapper")
+    .constructor<float, float, float, float>()
+    .function("getContrast", &GenericToneMapper::getContrast)
+    .function("setContrast", &GenericToneMapper::setContrast)
+    .function("getMidGrayIn", &GenericToneMapper::getMidGrayIn)
+    .function("setMidGrayIn", &GenericToneMapper::setMidGrayIn)
+    .function("getMidGrayOut", &GenericToneMapper::getMidGrayOut)
+    .function("setMidGrayOut", &GenericToneMapper::setMidGrayOut)
+    .function("getHdrMax", &GenericToneMapper::getHdrMax)
+    .function("setHdrMax", &GenericToneMapper::setHdrMax);
+
 class_<ColorGrading>("ColorGrading")
     .class_function("Builder", (ColorBuilder (*)()) [] { return ColorBuilder(); });
 
@@ -1087,6 +1333,11 @@ class_<ColorBuilder>("ColorGrading$Builder")
     .BUILDER_FUNCTION("toneMapping", ColorBuilder, (ColorBuilder* builder,
             ColorGrading::ToneMapping tm), {
         return &builder->toneMapping(tm);
+    })
+
+    .BUILDER_FUNCTION("toneMapper", ColorBuilder, (ColorBuilder* builder,
+            ToneMapper const* toneMapper), {
+        return &builder->toneMapper(toneMapper);
     })
 
     .BUILDER_FUNCTION("luminanceScaling", ColorBuilder, (ColorBuilder* builder,
@@ -1411,6 +1662,24 @@ class_<RenderableManager>("RenderableManager")
         self->setMorphWeights(instance, floats.data(), nfloats);
     }), allow_raw_pointers())
 
+    // Same as setMorphWeights, but writes into the target buffer at the given offset. embind
+    // cannot overload on arity, so this follows the "geometry"/"geometryOffset" naming precedent.
+    .function("setMorphWeightsOffset", EMBIND_LAMBDA(void, (RenderableManager* self,
+            RenderableManager::Instance instance, emscripten::val weights, size_t offset), {
+        auto nfloats = weights["length"].as<size_t>();
+        std::vector<float> floats(nfloats);
+        for (size_t i = 0; i < nfloats; i++) {
+            floats[i] = weights[i].as<float>();
+        }
+        self->setMorphWeights(instance, floats.data(), nfloats, offset);
+    }), allow_raw_pointers())
+
+    .function("getMorphTargetCount", &RenderableManager::getMorphTargetCount)
+
+    .function("setMorphTargetBufferOffsetAt", &RenderableManager::setMorphTargetBufferOffsetAt)
+
+    .function("setSkinningBuffer", &RenderableManager::setSkinningBuffer, allow_raw_pointers())
+
     .function("getAxisAlignedBoundingBox", &RenderableManager::getAxisAlignedBoundingBox)
     .function("getPrimitiveCount", &RenderableManager::getPrimitiveCount)
     .function("getInstanceCount", &RenderableManager::getInstanceCount)
@@ -1579,6 +1848,13 @@ class_<TransformManager>("TransformManager")
             (TransformManager* self, TransformManager::Instance instance), {
         return flatmat4 { self->getWorldTransform(instance) } ; }), allow_raw_pointers())
 
+    .function("getChildCount", &TransformManager::getChildCount)
+
+    .function("setAccurateTranslationsEnabled",
+            &TransformManager::setAccurateTranslationsEnabled)
+    .function("isAccurateTranslationsEnabled",
+            &TransformManager::isAccurateTranslationsEnabled)
+
     .function("openLocalTransformTransaction", &TransformManager::openLocalTransformTransaction)
     .function("commitLocalTransformTransaction",
             &TransformManager::commitLocalTransformTransaction);
@@ -1608,6 +1884,11 @@ class_<LightBuilder>("LightManager$Builder")
         return &builder->color(value); })
     .BUILDER_FUNCTION("intensity", LightBuilder, (LightBuilder* builder, float value), {
         return &builder->intensity(value); })
+    .BUILDER_FUNCTION("intensityEnergy", LightBuilder,
+            (LightBuilder* builder, float watts, float efficiency), {
+        return &builder->intensity(watts, efficiency); })
+    .BUILDER_FUNCTION("intensityCandela", LightBuilder, (LightBuilder* builder, float value), {
+        return &builder->intensityCandela(value); })
     .BUILDER_FUNCTION("falloff", LightBuilder, (LightBuilder* builder, float value), {
         return &builder->falloff(value); })
     .BUILDER_FUNCTION("spotLightCone", LightBuilder,
@@ -1656,11 +1937,15 @@ class_<LightManager>("LightManager")
         self->setIntensity(instance, watts, efficiency);
     }), allow_raw_pointers())
 
+    .function("destroy", &LightManager::destroy)
+    .function("setIntensityCandela", &LightManager::setIntensityCandela)
     .function("getIntensity", &LightManager::getIntensity)
     .function("setFalloff", &LightManager::setFalloff)
     .function("getFalloff", &LightManager::getFalloff)
     .function("_setShadowOptions", &LightManager::setShadowOptions)
     .function("setSpotLightCone", &LightManager::setSpotLightCone)
+    .function("getSpotLightInnerCone", &LightManager::getSpotLightInnerCone)
+    .function("getSpotLightOuterCone", &LightManager::getSpotLightOuterCone)
     .function("setSunAngularRadius", &LightManager::setSunAngularRadius)
     .function("getSunAngularRadius", &LightManager::getSunAngularRadius)
     .function("setSunHaloSize", &LightManager::setSunHaloSize)
@@ -1672,6 +1957,34 @@ class_<LightManager>("LightManager")
     .function("setLightChannel", &LightManager::setLightChannel)
     .function("getLightChannel", &LightManager::getLightChannel)
     ;
+
+/// LightManager$ShadowCascades ::class:: Utilities for computing cascade split positions.
+/// These take an out-parameter array in C++; the JS forms return a (cascades - 1) length array
+/// suitable for LightManager$ShadowOptions.cascadeSplitPositions.
+class_<LightManager::ShadowCascades>("LightManager$ShadowCascades")
+    .class_function("computeUniformSplits", EMBIND_LAMBDA(val, (uint8_t cascades), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computeUniformSplits(splits, cascades);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }))
+    .class_function("computeLogSplits", EMBIND_LAMBDA(val, (uint8_t cascades, float near,
+            float far), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computeLogSplits(splits, cascades, near, far);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }))
+    .class_function("computePracticalSplits", EMBIND_LAMBDA(val, (uint8_t cascades, float near,
+            float far, float lambda), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computePracticalSplits(splits, cascades, near, far, lambda);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }));
 
 /// LightManager$Instance ::class:: Component instance returned by [LightManager]
 /// Be sure to call the instance's `delete` method when you're done with it.
@@ -1724,6 +2037,7 @@ class_<VertexBuilder>("VertexBuffer$Builder")
 /// VertexBuffer ::core class:: Bundle of buffers and associated vertex attributes.
 class_<VertexBuffer>("VertexBuffer")
     .class_function("Builder", (VertexBuilder (*)()) [] { return VertexBuilder(); })
+    .function("getVertexCount", &VertexBuffer::getVertexCount)
     .function("setBufferObjectAt", &VertexBuffer::setBufferObjectAt, allow_raw_pointers())
     .function("_setBufferAt", EMBIND_LAMBDA(void, (VertexBuffer* self,
             Engine* engine, uint8_t bufferIndex, BufferDescriptor vbd, uint32_t byteOffset), {
@@ -1743,6 +2057,7 @@ class_<IndexBuilder>("IndexBuffer$Builder")
 /// IndexBuffer ::core class:: Array of 16-bit or 32-bit unsigned integers consumed by the GPU.
 class_<IndexBuffer>("IndexBuffer")
     .class_function("Builder", (IndexBuilder (*)()) [] { return IndexBuilder(); })
+    .function("getIndexCount", &IndexBuffer::getIndexCount)
     .function("_setBuffer", EMBIND_LAMBDA(void, (IndexBuffer* self,
             Engine* engine, BufferDescriptor ibd, uint32_t byteOffset), {
         self->setBuffer(*engine, std::move(*ibd.bd), byteOffset);
@@ -1763,7 +2078,61 @@ class_<Material>("Material")
     .function("getParameterTransformName", EMBIND_LAMBDA(std::string, (Material* self, std::string samplerName), {
         const char* transformName = self->getParameterTransformName(samplerName.c_str());
         return transformName ? std::string(transformName) : std::string();
-    }), allow_raw_pointers());
+    }), allow_raw_pointers())
+
+    .function("hasParameter", EMBIND_LAMBDA(bool, (Material* self, std::string name), {
+        return self->hasParameter(name.c_str());
+    }), allow_raw_pointers())
+    .function("getParameterCount", &Material::getParameterCount)
+
+    // ParameterInfo holds a union and a const char*, so it cannot be a value_object. Return an
+    // array of plain JS objects instead, reading the union member that isSampler/isSubpass selects.
+    .function("getParameters", EMBIND_LAMBDA(val, (Material* self), {
+        const size_t count = self->getParameterCount();
+        std::vector<Material::ParameterInfo> info(count);
+        const size_t written = self->getParameters(info.data(), count);
+        val result = val::array();
+        for (size_t i = 0; i < written; i++) {
+            const auto& p = info[i];
+            val entry = val::object();
+            entry.set("name", std::string(p.name));
+            entry.set("isSampler", p.isSampler);
+            entry.set("isSubpass", p.isSubpass);
+            if (p.isSampler) {
+                entry.set("samplerType", int(p.samplerType));
+            } else if (p.isSubpass) {
+                entry.set("subpassType", int(p.subpassType));
+            } else {
+                entry.set("type", int(p.type));
+            }
+            entry.set("count", p.count);
+            entry.set("precision", int(p.precision));
+            result.set(i, entry);
+        }
+        return result;
+    }), allow_raw_pointers())
+
+    .function("getShading", &Material::getShading)
+    .function("getInterpolation", &Material::getInterpolation)
+    .function("getBlendingMode", &Material::getBlendingMode)
+    .function("getRefractionMode", &Material::getRefractionMode)
+    .function("getRefractionType", &Material::getRefractionType)
+    .function("getReflectionMode", &Material::getReflectionMode)
+    .function("getVertexDomain", &Material::getVertexDomain)
+    .function("getCullingMode", &Material::getCullingMode)
+    .function("getTransparencyMode", &Material::getTransparencyMode)
+    .function("getFeatureLevel", &Material::getFeatureLevel)
+    .function("getMaskThreshold", &Material::getMaskThreshold)
+    .function("getSpecularAntiAliasingVariance", &Material::getSpecularAntiAliasingVariance)
+    .function("getSpecularAntiAliasingThreshold", &Material::getSpecularAntiAliasingThreshold)
+    .function("getRequiredAttributes", EMBIND_LAMBDA(uint32_t, (Material* self), {
+        return self->getRequiredAttributes().getValue();
+    }), allow_raw_pointers())
+    .function("isDoubleSided", &Material::isDoubleSided)
+    .function("isAlphaToCoverageEnabled", &Material::isAlphaToCoverageEnabled)
+    .function("isColorWriteEnabled", &Material::isColorWriteEnabled)
+    .function("isDepthWriteEnabled", &Material::isDepthWriteEnabled)
+    .function("isDepthCullingEnabled", &Material::isDepthCullingEnabled);
 
 enum_<Material::UboBatchingMode>("Material$UboBatchingMode")
     .value("DISABLED", Material::UboBatchingMode::DISABLED)
@@ -1802,11 +2171,44 @@ class_<MaterialInstance>("MaterialInstance")
             std::string name), {
         return self->getConstant<int32_t>(name.c_str(), name.size());
     }), allow_raw_pointers())
+    .function("setConstantBool", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, bool value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
+    .function("setConstantFloat", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, float value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
+    .function("setConstantInt", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, int32_t value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
     .function("setBoolParameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, bool value), {
         self->setParameter(name.c_str(), value); }), allow_raw_pointers())
     .function("setFloatParameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, float value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool2Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool2 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool3Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool3 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool4Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool4 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setIntParameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, int32_t value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt2Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int2 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt3Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int3 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt4Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int4 value), {
         self->setParameter(name.c_str(), value); }), allow_raw_pointers())
     .function("setFloat2Parameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, filament::math::float2 value), {
@@ -1890,6 +2292,7 @@ class_<MaterialInstance>("MaterialInstance")
             (MaterialInstance* self, uint8_t readMask), {
                 self->setStencilReadMask(readMask, backend::StencilFace::FRONT_AND_BACK);
             }), allow_raw_pointers())
+    .function("isStencilWriteEnabled", &MaterialInstance::isStencilWriteEnabled)
     .function("setStencilWriteMask", &MaterialInstance::setStencilWriteMask)
     .function("setStencilWriteMask", EMBIND_LAMBDA(void,
             (MaterialInstance* self, uint8_t writeMask), {
@@ -1899,7 +2302,20 @@ class_<MaterialInstance>("MaterialInstance")
 class_<TextureSampler>("TextureSampler")
     .constructor<backend::SamplerMinFilter, backend::SamplerMagFilter, backend::SamplerWrapMode>()
     .function("setAnisotropy", &TextureSampler::setAnisotropy)
-    .function("setCompareMode", &TextureSampler::setCompareMode);
+    .function("getAnisotropy", &TextureSampler::getAnisotropy)
+    .function("setCompareMode", &TextureSampler::setCompareMode)
+    .function("getCompareMode", &TextureSampler::getCompareMode)
+    .function("getCompareFunc", &TextureSampler::getCompareFunc)
+    .function("setMinFilter", &TextureSampler::setMinFilter)
+    .function("getMinFilter", &TextureSampler::getMinFilter)
+    .function("setMagFilter", &TextureSampler::setMagFilter)
+    .function("getMagFilter", &TextureSampler::getMagFilter)
+    .function("setWrapModeS", &TextureSampler::setWrapModeS)
+    .function("getWrapModeS", &TextureSampler::getWrapModeS)
+    .function("setWrapModeT", &TextureSampler::setWrapModeT)
+    .function("getWrapModeT", &TextureSampler::getWrapModeT)
+    .function("setWrapModeR", &TextureSampler::setWrapModeR)
+    .function("getWrapModeR", &TextureSampler::getWrapModeR);
 
 /// Texture ::core class:: 2D image or cubemap that can be sampled by the GPU, possibly mipmapped.
 class_<Texture>("Texture")
@@ -1909,10 +2325,35 @@ class_<Texture>("Texture")
     .class_function("isTextureSwizzleSupported", (bool (*)(Engine*)) [] (Engine* engine) {
         return Texture::isTextureSwizzleSupported(*engine);
     }, allow_raw_pointers())
+    .class_function("isTextureFormatSupported",
+            (bool (*)(Engine*, Texture::InternalFormat)) [] (Engine* engine,
+                    Texture::InternalFormat format) {
+        return Texture::isTextureFormatSupported(*engine, format);
+    }, allow_raw_pointers())
+    .class_function("getMaxTextureSize",
+            (size_t (*)(Engine*, Texture::Sampler)) [] (Engine* engine, Texture::Sampler type) {
+        return Texture::getMaxTextureSize(*engine, type);
+    }, allow_raw_pointers())
+    .class_function("getMaxArrayTextureLayers",
+            (size_t (*)(Engine*)) [] (Engine* engine) {
+        return Texture::getMaxArrayTextureLayers(*engine);
+    }, allow_raw_pointers())
+    .function("getTarget", &Texture::getTarget)
+    .function("getFormat", &Texture::getFormat)
     .function("generateMipmaps", &Texture::generateMipmaps)
     .function("_setImage", EMBIND_LAMBDA(void, (Texture* self,
             Engine* engine, uint8_t level, PixelBufferDescriptor pbd), {
         self->setImage(*engine, level, std::move(*pbd.pbd));
+    }), allow_raw_pointers())
+    .function("_setImage", EMBIND_LAMBDA(void, (Texture* self,
+            Engine* engine, uint8_t level, uint32_t xoffset, uint32_t yoffset,
+            uint32_t width, uint32_t height, PixelBufferDescriptor pbd), {
+        self->setImage(*engine, level, xoffset, yoffset, width, height, std::move(*pbd.pbd));
+    }), allow_raw_pointers())
+    .function("_setImage", EMBIND_LAMBDA(void, (Texture* self,
+            Engine* engine, uint8_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
+            uint32_t width, uint32_t height, uint32_t depth, PixelBufferDescriptor pbd), {
+        self->setImage(*engine, level, xoffset, yoffset, zoffset, width, height, depth, std::move(*pbd.pbd));
     }), allow_raw_pointers())
     .function("_getWidth", EMBIND_LAMBDA(size_t, (Texture* self,
             Engine* engine, uint8_t level), {
@@ -1943,12 +2384,20 @@ class_<TexBuilder>("Texture$Builder")
         return &builder->depth(depth); })
     .BUILDER_FUNCTION("levels", TexBuilder, (TexBuilder* builder, uint8_t levels), {
         return &builder->levels(levels); })
+    .BUILDER_FUNCTION("samples", TexBuilder, (TexBuilder* builder, uint8_t samples), {
+        return &builder->samples(samples); })
     .BUILDER_FUNCTION("sampler", TexBuilder, (TexBuilder* builder, Texture::Sampler target), {
         return &builder->sampler(target); })
     .BUILDER_FUNCTION("format", TexBuilder, (TexBuilder* builder, Texture::InternalFormat fmt), {
         return &builder->format(fmt); })
     .BUILDER_FUNCTION("external", TexBuilder, (TexBuilder* builder), {
         return &builder->external(); })
+    // Note build() rejects a swizzled texture on WebGL, which has no texture swizzle; the binding
+    // exists so callers get that explicit error rather than a missing method. Pair with
+    // isTextureSwizzleSupported, which is already bound and returns false here.
+    .BUILDER_FUNCTION("swizzle", TexBuilder, (TexBuilder* builder, Texture::Swizzle r,
+            Texture::Swizzle g, Texture::Swizzle b, Texture::Swizzle a), {
+        return &builder->swizzle(r, g, b, a); })
 
     // This takes a bitfield that can be composed by or'ing constants.
     // - JS clients should use the value member, as in: "Texture$Usage.SAMPLEABLE.value".
@@ -1996,9 +2445,9 @@ class_<IblBuilder>("IndirectLight$Builder")
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("reflections", IblBuilder, (IblBuilder* builder, Texture const* cubemap), {
         return &builder->reflections(cubemap); })
-    .BUILDER_FUNCTION("irradianceTex", IblBuilder, (IblBuilder* builder, Texture const* cubemap), {
+    .BUILDER_FUNCTION("irradiance", IblBuilder, (IblBuilder* builder, Texture const* cubemap), {
         return &builder->irradiance(cubemap); })
-    .BUILDER_FUNCTION("irradianceSh", IblBuilder, (IblBuilder* builder, uint8_t nbands, val ta), {
+    .BUILDER_FUNCTION("irradiance", IblBuilder, (IblBuilder* builder, uint8_t nbands, val ta), {
         // This is not efficient but consuming a BufferDescriptor would be overkill.
         size_t nfloats = ta["length"].as<size_t>();
         if (nfloats != nbands * nbands * 3) {
@@ -2010,6 +2459,17 @@ class_<IblBuilder>("IndirectLight$Builder")
             floats[i] = ta[i].as<float>();
         }
         return &builder->irradiance(nbands, (filament::math::float3 const*) floats.data()); })
+    .BUILDER_FUNCTION("radiance", IblBuilder, (IblBuilder* builder, uint8_t nbands, val ta), {
+        size_t nfloats = ta["length"].as<size_t>();
+        if (nfloats != nbands * nbands * 3) {
+            printf("Received %zu floats for spherical harmonics, expected %d.", nfloats, nbands);
+            return builder;
+        }
+        std::vector<float> floats(nfloats);
+        for (size_t i = 0; i < nfloats; i++) {
+            floats[i] = ta[i].as<float>();
+        }
+        return &builder->radiance(nbands, (filament::math::float3 const*) floats.data()); })
     .BUILDER_FUNCTION("intensity", IblBuilder, (IblBuilder* builder, float value), {
         return &builder->intensity(value); })
     .BUILDER_FUNCTION("rotation", IblBuilder, (IblBuilder* builder, flatmat3 value), {
@@ -2035,6 +2495,10 @@ class_<SkyBuilder>("Skybox$Builder")
         return &builder->color(color); })
     .BUILDER_FUNCTION("environment", SkyBuilder, (SkyBuilder* builder, Texture* cubemap), {
         return &builder->environment(cubemap); })
+    .BUILDER_FUNCTION("intensity", SkyBuilder, (SkyBuilder* builder, float envIntensity), {
+        return &builder->intensity(envIntensity); })
+    .BUILDER_FUNCTION("intensity", SkyBuilder, (SkyBuilder* builder, float envIntensity), {
+        return &builder->intensity(envIntensity); })
     .BUILDER_FUNCTION("showSun", SkyBuilder, (SkyBuilder* builder, bool show), {
         return &builder->showSun(show); });
 
@@ -2188,7 +2652,8 @@ class_<Ktx1Bundle>("Ktx1Bundle")
     /// key ::argument:: string
     /// ::retval:: string
     .function("getMetadata", EMBIND_LAMBDA(std::string, (Ktx1Bundle* self, std::string key), {
-        return std::string(self->getMetadata(key.c_str()));
+        const char* res = self->getMetadata(key.c_str());
+        return res ? std::string(res) : std::string();
     }), allow_raw_pointers());
 
 function("ktx1reader$createTexture", EMBIND_LAMBDA(Texture*,
@@ -2234,7 +2699,8 @@ class_<MeshReader::MaterialRegistry>("MeshReader$MaterialRegistry")
     .function("keys", EMBIND_LAMBDA(std::vector<std::string>, (MeshReader::MaterialRegistry* self), {
         std::vector<utils::CString> names(self->numRegistered());
         self->getRegisteredMaterialNames(names.data());
-        std::vector<std::string> result(self->numRegistered());
+        std::vector<std::string> result;
+        result.reserve(self->numRegistered());
         for (const auto& name : names) {
             result.emplace_back(name.c_str());
         }
@@ -2364,7 +2830,8 @@ class_<Animator>("gltfio$Animator")
     .function("getAnimationCount", &Animator::getAnimationCount)
     .function("getAnimationDuration", &Animator::getAnimationDuration)
     .function("getAnimationName", EMBIND_LAMBDA(std::string, (Animator* self, size_t index), {
-        return std::string(self->getAnimationName(index));
+        const char* name = self->getAnimationName(index);
+        return name ? std::string(name) : std::string();
     }), allow_raw_pointers());
 
 class_<FilamentAsset>("gltfio$FilamentAsset")
@@ -2379,9 +2846,11 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         return result;
     }), allow_raw_pointers())
 
+    // Unlike getEntitiesByName, this cannot be asked for a count first: it returns 0 as soon as
+    // maxCount is 0, so it has to be handed room for every entity in the asset and trimmed after.
     .function("_getEntitiesByPrefix", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self, std::string prefix), {
-        EntityVector result(self->getEntitiesByPrefix(prefix.c_str(), nullptr, 0));
-        self->getEntitiesByPrefix(prefix.c_str(), result.data(), result.size());
+        EntityVector result(self->getEntityCount());
+        result.resize(self->getEntitiesByPrefix(prefix.c_str(), result.data(), result.size()));
         return result;
     }), allow_raw_pointers())
 
@@ -2408,6 +2877,14 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
 
     .function("popRenderable", &FilamentAsset::popRenderable)
 
+    // Batched form of popRenderable; returns up to `count` entities (fewer when the queue drains).
+    .function("popRenderables", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self, size_t count), {
+        EntityVector result(count);
+        const size_t popped = self->popRenderables(result.data(), count);
+        result.resize(popped);
+        return result;
+    }), allow_raw_pointers())
+
     .function("getInstance", &FilamentAsset::getInstance, allow_raw_pointers())
 
     .function("_getAssetInstances", EMBIND_LAMBDA(std::vector<FilamentInstance*>,
@@ -2425,12 +2902,24 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         return retval;
     }), allow_raw_pointers())
 
+    // Count accessors, so callers can size a buffer without materializing the entity vector.
+    .function("getEntityCount", &FilamentAsset::getEntityCount)
+    .function("getLightEntityCount", &FilamentAsset::getLightEntityCount)
+    .function("getRenderableEntityCount", &FilamentAsset::getRenderableEntityCount)
+    .function("getCameraEntityCount", &FilamentAsset::getCameraEntityCount)
+    .function("getResourceUriCount", &FilamentAsset::getResourceUriCount)
+    .function("getMorphTargetCountAt", &FilamentAsset::getMorphTargetCountAt)
+    .function("getSceneCount", &FilamentAsset::getSceneCount)
+    .function("getAssetInstanceCount", &FilamentAsset::getAssetInstanceCount)
+
     .function("getBoundingBox", &FilamentAsset::getBoundingBox)
     .function("getName", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
-        return std::string(self->getName(entity));
+        const char* name = self->getName(entity);
+        return name ? std::string(name) : std::string();
     }), allow_raw_pointers())
     .function("getExtras", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
-        return std::string(self->getExtras(entity));
+        const char* extras = self->getExtras(entity);
+        return extras ? std::string(extras) : std::string();
     }), allow_raw_pointers())
     .function("getWireframe", &FilamentAsset::getWireframe)
     .function("getEngine", &FilamentAsset::getEngine, allow_raw_pointers())
@@ -2467,6 +2956,9 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
     .function("attachSkin", &FilamentInstance::attachSkin)
     .function("detachSkin", &FilamentInstance::detachSkin)
 
+    .function("getEntityCount", &FilamentInstance::getEntityCount)
+    .function("getMaterialVariantCount", &FilamentInstance::getMaterialVariantCount)
+    .function("getMaterialInstanceCount", &FilamentInstance::getMaterialInstanceCount)
     .function("getSkinCount", &FilamentInstance::getSkinCount)
     .function("getJointCountAt", &FilamentInstance::getJointCountAt)
 
@@ -2484,6 +2976,8 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
         return std::vector<MaterialInstance*>(ptr, ptr + self->getMaterialInstanceCount());
     }), allow_raw_pointers())
 
+    .function("detachMaterialInstances", &FilamentInstance::detachMaterialInstances)
+
     .function("_getMaterialVariantNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentInstance* self), {
         std::vector<std::string> retval(self->getMaterialVariantCount());
         for (size_t i = 0, len = retval.size(); i < len; ++i) {
@@ -2497,33 +2991,47 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
 struct UbershaderProvider {
     MaterialProvider* provider;
     void destroyMaterials() { provider->destroyMaterials(); }
+    size_t getMaterialsCount() const { return provider->getMaterialsCount(); }
+    bool needsDummyData(VertexAttribute attrib) const {
+        return provider->needsDummyData(attrib);
+    }
+    std::vector<Material*> getMaterials() const {
+        // A weak reference to the provider's cache, which stays const in C++ only because the
+        // provider still owns it.
+        Material* const* materials = const_cast<Material* const*>(provider->getMaterials());
+        return std::vector<Material*>(materials, materials + provider->getMaterialsCount());
+    }
 };
 
-struct StbProvider { TextureProvider* provider; };
-struct Ktx2Provider { TextureProvider* provider; };
-struct WebpProvider { TextureProvider* provider; };
+// TextureProvider is polymorphic, and embind reaches a base class through RTTI, which this build
+// compiles without. Carrying the provider as an opaque handle avoids the base class entirely,
+// which keeps one JS type for all three providers, and so one addTextureProvider that takes any of
+// them, exactly as C++ and Java have it.
+struct TextureProviderHandle { TextureProvider* provider; };
 
 class_<UbershaderProvider>("gltfio$UbershaderProvider")
     .constructor(EMBIND_LAMBDA(UbershaderProvider, (Engine* engine), {
         return UbershaderProvider { createUbershaderProvider(engine,
                 UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE) };
     }))
-    .function("destroyMaterials", &UbershaderProvider::destroyMaterials);
+    .function("destroyMaterials", &UbershaderProvider::destroyMaterials)
+    .function("getMaterialsCount", &UbershaderProvider::getMaterialsCount)
+    .function("needsDummyData", &UbershaderProvider::needsDummyData)
+    .function("getMaterials", &UbershaderProvider::getMaterials);
 
-class_<StbProvider>("gltfio$StbProvider")
-    .constructor(EMBIND_LAMBDA(StbProvider, (Engine* engine), {
-        return StbProvider { createStbProvider(engine) };
-    }));
-
-class_<Ktx2Provider>("gltfio$Ktx2Provider")
-    .constructor(EMBIND_LAMBDA(Ktx2Provider, (Engine* engine), {
-        return Ktx2Provider { createKtx2Provider(engine) };
-    }));
-
-class_<WebpProvider>("gltfio$WebpProvider")
-    .constructor(EMBIND_LAMBDA(WebpProvider, (Engine* engine), {
-        return WebpProvider { createWebpProvider(engine) };
-    }))
+/// TextureProvider ::core class:: Decodes texture data for [gltfio$ResourceLoader].
+/// The three factories mirror gltfio's createStbProvider, createKtx2Provider and
+/// createWebpProvider; whichever one is used, the result goes to `addTextureProvider`.
+class_<TextureProviderHandle>("gltfio$TextureProvider")
+    .class_function("createStbProvider", EMBIND_LAMBDA(TextureProviderHandle, (Engine* engine), {
+        return TextureProviderHandle { createStbProvider(engine) };
+    }), allow_raw_pointers())
+    .class_function("createKtx2Provider", EMBIND_LAMBDA(TextureProviderHandle, (Engine* engine), {
+        return TextureProviderHandle { createKtx2Provider(engine) };
+    }), allow_raw_pointers())
+    .class_function("createWebpProvider", EMBIND_LAMBDA(TextureProviderHandle, (Engine* engine), {
+        return TextureProviderHandle { createWebpProvider(engine) };
+    }), allow_raw_pointers())
     .class_function("isWebpSupported", &isWebpSupported);
 
 class_<AssetLoader>("gltfio$AssetLoader")
@@ -2547,7 +3055,7 @@ class_<AssetLoader>("gltfio$AssetLoader")
     .function("_createInstancedAsset", EMBIND_LAMBDA(FilamentAsset*,
             (AssetLoader* self, BufferDescriptor buffer, int numInstances), {
         // Ignore the returned instances, they can be extracted from the asset.
-        std::vector<FilamentInstance*> instances;
+        std::vector<FilamentInstance*> instances(numInstances);
         return self->createInstancedAsset((const uint8_t*) buffer.bd->buffer,
                 buffer.bd->size, instances.data(), numInstances);
     }), allow_raw_pointers())
@@ -2564,7 +3072,16 @@ class_<AssetLoader>("gltfio$AssetLoader")
     
     // gc ::method::
     // Performs a Garbage Collection sweep over all internal component managers.
-    .function("gc", &AssetLoader::gc, allow_raw_pointers());
+    .function("gc", &AssetLoader::gc, allow_raw_pointers())
+
+    // enableDiagnostics ::method:: Enables the diagnostic "wireframe" renderable.
+    .function("enableDiagnostics", &AssetLoader::enableDiagnostics, allow_raw_pointers())
+
+    // destroy ::method:: Frees the loader itself (not its assets or material cache).
+    // The embind raw_destructor for AssetLoader is a no-op, so `delete` does not release it.
+    .class_function("destroy", EMBIND_LAMBDA(void, (AssetLoader* loader), {
+        AssetLoader::destroy(&loader);
+    }), allow_raw_pointers());
 
 class_<ResourceLoader>("gltfio$ResourceLoader")
     .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine, bool normalizeSkinningWeights), {
@@ -2580,18 +3097,13 @@ class_<ResourceLoader>("gltfio$ResourceLoader")
         self->addResourceData(url.c_str(), std::move(*buffer.bd));
     }), allow_raw_pointers())
 
-    .function("addStbProvider", EMBIND_LAMBDA(void, (ResourceLoader* self, std::string mime,
-            StbProvider provider), {
-        self->addTextureProvider(mime.c_str(), provider.provider);
-    }), allow_raw_pointers())
-
-    .function("addKtx2Provider", EMBIND_LAMBDA(void, (ResourceLoader* self, std::string mime,
-            Ktx2Provider provider), {
-        self->addTextureProvider(mime.c_str(), provider.provider);
-    }), allow_raw_pointers())
-
-    .function("addWebpProvider", EMBIND_LAMBDA(void, (ResourceLoader* self, std::string mime,
-            WebpProvider provider), {
+    /// addTextureProvider ::method:: Registers a provider for one MIME type.
+    /// mimeType ::argument:: e.g. "image/png"
+    /// provider ::argument:: a [gltfio$TextureProvider]
+    .function("addTextureProvider", EMBIND_LAMBDA(void, (ResourceLoader* self, std::string mime,
+            TextureProviderHandle provider), {
+        // createWebpProvider returns null where WebP is unsupported, and a null provider would
+        // abort the loader rather than fall back.
         if (provider.provider) {
             self->addTextureProvider(mime.c_str(), provider.provider);
         }
@@ -2610,7 +3122,9 @@ class_<ResourceLoader>("gltfio$ResourceLoader")
     }), allow_raw_pointers())
 
     .function("asyncGetLoadProgress", &ResourceLoader::asyncGetLoadProgress)
-    .function("asyncUpdateLoad", &ResourceLoader::asyncUpdateLoad);
+    .function("asyncUpdateLoad", &ResourceLoader::asyncUpdateLoad)
+    .function("asyncCancelLoad", &ResourceLoader::asyncCancelLoad)
+    .function("evictResourceData", &ResourceLoader::evictResourceData);
 
 class_<Settings>("Settings");
 
@@ -2777,7 +3291,8 @@ class_<AutomationSpec>("AutomationSpec")
     .function("size", &AutomationSpec::size)
     .function("get", &AutomationSpec::get, allow_raw_pointers())
     .function("getName", EMBIND_LAMBDA(std::string, (AutomationSpec* self, size_t index), {
-        return std::string(self->getName(index));
+        const char* name = self->getName(index);
+        return name ? std::string(name) : std::string();
     }), allow_raw_pointers());
 
 value_object<AutomationEngine::Options>("AutomationEngine$Options")
@@ -2859,7 +3374,8 @@ class_<AutomationEngine>("AutomationEngine")
     .function("currentTest", &AutomationEngine::currentTest)
     .function("testCount", &AutomationEngine::testCount)
     .function("getStatusMessage", EMBIND_LAMBDA(std::string, (AutomationEngine* self), {
-        return std::string(self->getStatusMessage());
+        const char* msg = self->getStatusMessage();
+        return msg ? std::string(msg) : std::string();
     }), allow_raw_pointers());
 
 class_<ViewerGui>("ViewerGui")

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -72,6 +72,7 @@
 #include <filament/Skybox.h>
 #include <filament/SwapChain.h>
 #include <filament/Texture.h>
+#include <filament/ToneMapper.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
@@ -283,6 +284,38 @@ value_array<filament::math::float4>("float4")
     .element(&filament::math::float4::y)
     .element(&filament::math::float4::z)
     .element(&filament::math::float4::w);
+
+// Integer and boolean vectors, needed by MaterialInstance::setParameter for materials that
+// declare int/bool vector parameters.
+value_array<filament::math::int2>("int2")
+    .element(&filament::math::int2::x)
+    .element(&filament::math::int2::y);
+
+value_array<filament::math::int3>("int3")
+    .element(&filament::math::int3::x)
+    .element(&filament::math::int3::y)
+    .element(&filament::math::int3::z);
+
+value_array<filament::math::int4>("int4")
+    .element(&filament::math::int4::x)
+    .element(&filament::math::int4::y)
+    .element(&filament::math::int4::z)
+    .element(&filament::math::int4::w);
+
+value_array<filament::math::bool2>("bool2")
+    .element(&filament::math::bool2::x)
+    .element(&filament::math::bool2::y);
+
+value_array<filament::math::bool3>("bool3")
+    .element(&filament::math::bool3::x)
+    .element(&filament::math::bool3::y)
+    .element(&filament::math::bool3::z);
+
+value_array<filament::math::bool4>("bool4")
+    .element(&filament::math::bool4::x)
+    .element(&filament::math::bool4::y)
+    .element(&filament::math::bool4::z)
+    .element(&filament::math::bool4::w);
 
 value_array<filament::math::double2>("double2")
     .element(&filament::math::double2::x)
@@ -528,6 +561,15 @@ class_<Engine>("Engine")
         engine->execute();
     }), allow_raw_pointers())
 
+    .function("flush", &Engine::flush)
+
+    /// flushAndWait ::method:: Flushes the command stream and waits for it to drain.
+    /// On the single-threaded web build this drains the queue directly rather than
+    /// creating a fence, so it does not block the page.
+    .function("flushAndWait", EMBIND_LAMBDA(void, (Engine* engine), {
+        engine->flushAndWait();
+    }), allow_raw_pointers())
+
     /// destroy ::static method:: Destroys an engine instance and cleans up resources.
     /// engine ::argument:: the instance to destroy
     .class_function("destroy", (void (*)(Engine*)) []
@@ -769,6 +811,10 @@ class_<Fence>("Fence")
         return self->wait(mode, (uint64_t) timeout);
     }), allow_raw_pointers());
 
+// Fence::waitAndDestroy is deliberately not bound: it hardcodes FENCE_WAIT_FOR_EVER, and the web
+// build is single-threaded, so an unbounded wait can never be satisfied. Use _wait with a timeout
+// of 0 followed by Engine::destroyFence instead.
+
 /// Renderer ::core class:: Represents the platform's native window.
 /// See also the [Engine] methods `createRenderer` and `destroyRenderer`.
 class_<Renderer>("Renderer")
@@ -873,8 +919,21 @@ class_<View>("View")
     }), allow_raw_pointers())
 
     .function("setScene", &View::setScene, allow_raw_pointers())
+    .function("getScene", EMBIND_LAMBDA(Scene*, (View* self), {
+        return self->getScene();
+    }), allow_raw_pointers())
     .function("setCamera", &View::setCamera, allow_raw_pointers())
+    .function("getCamera", EMBIND_LAMBDA(Camera*, (View* self), {
+        return &self->getCamera();
+    }), allow_raw_pointers())
     .function("hasCamera", &View::hasCamera)
+    .function("setName", EMBIND_LAMBDA(void, (View* self, std::string name), {
+        self->setName(name.c_str());
+    }), allow_raw_pointers())
+    .function("getName", EMBIND_LAMBDA(std::string, (View* self), {
+        const char* name = self->getName();
+        return name ? std::string(name) : std::string();
+    }), allow_raw_pointers())
     .function("setColorGrading", &View::setColorGrading, allow_raw_pointers())
     .function("getColorGrading", EMBIND_LAMBDA(ColorGrading*, (View* self), {
         return const_cast<ColorGrading*>(self->getColorGrading());
@@ -889,14 +948,38 @@ class_<View>("View")
     .function("getGridSize", &View::getGridSize)
     .function("getEffectiveGridSize", &View::getEffectiveGridSize)
     .function("setVisibleLayers", &View::setVisibleLayers)
+    .function("getVisibleLayers", &View::getVisibleLayers)
+    .function("setLayerEnabled", &View::setLayerEnabled)
     .function("setPostProcessingEnabled", &View::setPostProcessingEnabled)
+    .function("isPostProcessingEnabled", &View::isPostProcessingEnabled)
+    .function("setScreenSpaceRefractionEnabled", &View::setScreenSpaceRefractionEnabled)
+    .function("isScreenSpaceRefractionEnabled", &View::isScreenSpaceRefractionEnabled)
     .function("setDithering", &View::setDithering)
+    .function("getDithering", &View::getDithering)
     .function("_setAmbientOcclusionOptions", &View::setAmbientOcclusionOptions)
+    .function("getAmbientOcclusionOptions", EMBIND_LAMBDA(View::AmbientOcclusionOptions,
+            (View* self), {
+        return self->getAmbientOcclusionOptions();
+    }), allow_raw_pointers())
     .function("_setDepthOfFieldOptions", &View::setDepthOfFieldOptions)
+    .function("getDepthOfFieldOptions", &View::getDepthOfFieldOptions)
     .function("_setMultiSampleAntiAliasingOptions", &View::setMultiSampleAntiAliasingOptions)
+    .function("getMultiSampleAntiAliasingOptions", EMBIND_LAMBDA(
+            View::MultiSampleAntiAliasingOptions, (View* self), {
+        return self->getMultiSampleAntiAliasingOptions();
+    }), allow_raw_pointers())
     .function("_setTemporalAntiAliasingOptions", &View::setTemporalAntiAliasingOptions)
+    .function("getTemporalAntiAliasingOptions", EMBIND_LAMBDA(
+            View::TemporalAntiAliasingOptions, (View* self), {
+        return self->getTemporalAntiAliasingOptions();
+    }), allow_raw_pointers())
     .function("_setScreenSpaceReflectionsOptions", &View::setScreenSpaceReflectionsOptions)
+    .function("getScreenSpaceReflectionsOptions", EMBIND_LAMBDA(
+            View::ScreenSpaceReflectionsOptions, (View* self), {
+        return self->getScreenSpaceReflectionsOptions();
+    }), allow_raw_pointers())
     .function("_setBloomOptions", &View::setBloomOptions)
+    .function("getBloomOptions", &View::getBloomOptions)
     .function("setShadowingEnabled", &View::setShadowingEnabled)
     .function("isShadowingEnabled", &View::isShadowingEnabled)
     .function("setShadowType", &View::setShadowType)
@@ -911,12 +994,21 @@ class_<View>("View")
     .function("isFrontFaceWindingInverted", &View::isFrontFaceWindingInverted)
     .function("setDynamicLightingOptions", &View::setDynamicLightingOptions)
     .function("setRenderQuality", &View::setRenderQuality)
+    .function("getRenderQuality", &View::getRenderQuality)
     .function("setDynamicResolutionOptions", &View::setDynamicResolutionOptions)
     .function("getDynamicResolutionOptions", &View::getDynamicResolutionOptions)
     .function("_setFogOptions", &View::setFogOptions)
+    .function("getFogOptions", &View::getFogOptions)
     .function("_setVignetteOptions", &View::setVignetteOptions)
+    .function("getVignetteOptions", &View::getVignetteOptions)
     .function("_setGuardBandOptions", &View::setGuardBandOptions)
+    .function("getGuardBandOptions", EMBIND_LAMBDA(View::GuardBandOptions, (View* self), {
+        return self->getGuardBandOptions();
+    }), allow_raw_pointers())
     .function("_setStereoscopicOptions", &View::setStereoscopicOptions)
+    .function("getStereoscopicOptions", EMBIND_LAMBDA(View::StereoscopicOptions, (View* self), {
+        return self->getStereoscopicOptions();
+    }), allow_raw_pointers())
     .function("setAmbientOcclusion", &View::setAmbientOcclusion)
     .function("getAmbientOcclusion", &View::getAmbientOcclusion)
     .function("setAntiAliasing", &View::setAntiAliasing)
@@ -927,6 +1019,7 @@ class_<View>("View")
     .function("setRenderTarget", EMBIND_LAMBDA(void, (View* self, RenderTarget* renderTarget), {
         self->setRenderTarget(renderTarget);
     }), allow_raw_pointers())
+    .function("getRenderTarget", &View::getRenderTarget, allow_raw_pointers())
     .function("setTransparentPickingEnabled", &View::setTransparentPickingEnabled)
     .function("isTransparentPickingEnabled", &View::isTransparentPickingEnabled)
     .function("setStencilBufferEnabled", &View::setStencilBufferEnabled)
@@ -1015,6 +1108,25 @@ class_<Camera>("Camera")
     .function("getScaling", &Camera::getScaling)
     .function("setShift", &Camera::setShift)
     .function("getShift", &Camera::getShift)
+    .function("getEntity", &Camera::getEntity)
+    // setEyeModelMatrix has no mat4f overload (unlike setModelMatrix), so widen explicitly.
+    .function("setEyeModelMatrix", EMBIND_LAMBDA(void, (Camera* self, uint8_t eyeId, flatmat4 m), {
+        self->setEyeModelMatrix(eyeId, filament::math::mat4(m.m));
+    }), allow_raw_pointers())
+
+    /// setCustomEyeProjection ::method:: Sets a per-eye projection for stereoscopic rendering.
+    /// projections ::argument:: array of mat4, one per eye
+    /// projectionForCulling ::argument:: a mat4 encompassing all eye frustums
+    .function("setCustomEyeProjection", EMBIND_LAMBDA(void, (Camera* self, val projections,
+            flatmat4 projectionForCulling, double near, double far), {
+        size_t const count = projections["length"].as<size_t>();
+        std::vector<filament::math::mat4> matrices(count);
+        for (size_t i = 0; i < count; i++) {
+            matrices[i] = filament::math::mat4(projections[i].as<flatmat4>().m);
+        }
+        self->setCustomEyeProjection(matrices.data(), count,
+                filament::math::mat4(projectionForCulling.m), near, far);
+    }), allow_raw_pointers())
 
     .function("getNear", &Camera::getNear)
     .function("getCullingFar", &Camera::getCullingFar)
@@ -1060,6 +1172,47 @@ class_<Camera>("Camera")
         return flatmat4 { filament::math::mat4f(Camera::inverseProjection(m.m)) };
     }, allow_raw_pointers());
 
+// ToneMapper hierarchy. ColorGrading$Builder::toneMapper supersedes the deprecated
+// toneMapping(ToneMapping) enum, whose 5 values cannot reach PBRNeutral, GT7, AgX or the tunable
+// Generic operator. Each subclass is bound as its own class so JS can construct one and hand it to
+// the builder; build() consumes it synchronously, so it is safe to delete afterwards.
+class_<ToneMapper>("ToneMapper");
+
+class_<LinearToneMapper, base<ToneMapper>>("LinearToneMapper")
+    .constructor<>();
+
+class_<ACESToneMapper, base<ToneMapper>>("ACESToneMapper")
+    .constructor<>();
+
+class_<ACESLegacyToneMapper, base<ToneMapper>>("ACESLegacyToneMapper")
+    .constructor<>();
+
+class_<FilmicToneMapper, base<ToneMapper>>("FilmicToneMapper")
+    .constructor<>();
+
+class_<PBRNeutralToneMapper, base<ToneMapper>>("PBRNeutralToneMapper")
+    .constructor<>();
+
+class_<GT7ToneMapper, base<ToneMapper>>("GT7ToneMapper")
+    .constructor<>();
+
+class_<DisplayRangeToneMapper, base<ToneMapper>>("DisplayRangeToneMapper")
+    .constructor<>();
+
+class_<AgxToneMapper, base<ToneMapper>>("AgxToneMapper")
+    .constructor<AgxToneMapper::AgxLook>();
+
+class_<GenericToneMapper, base<ToneMapper>>("GenericToneMapper")
+    .constructor<float, float, float, float>()
+    .function("getContrast", &GenericToneMapper::getContrast)
+    .function("setContrast", &GenericToneMapper::setContrast)
+    .function("getMidGrayIn", &GenericToneMapper::getMidGrayIn)
+    .function("setMidGrayIn", &GenericToneMapper::setMidGrayIn)
+    .function("getMidGrayOut", &GenericToneMapper::getMidGrayOut)
+    .function("setMidGrayOut", &GenericToneMapper::setMidGrayOut)
+    .function("getHdrMax", &GenericToneMapper::getHdrMax)
+    .function("setHdrMax", &GenericToneMapper::setHdrMax);
+
 class_<ColorGrading>("ColorGrading")
     .class_function("Builder", (ColorBuilder (*)()) [] { return ColorBuilder(); });
 
@@ -1085,6 +1238,11 @@ class_<ColorBuilder>("ColorGrading$Builder")
     .BUILDER_FUNCTION("toneMapping", ColorBuilder, (ColorBuilder* builder,
             ColorGrading::ToneMapping tm), {
         return &builder->toneMapping(tm);
+    })
+
+    .BUILDER_FUNCTION("toneMapper", ColorBuilder, (ColorBuilder* builder,
+            ToneMapper const* toneMapper), {
+        return &builder->toneMapper(toneMapper);
     })
 
     .BUILDER_FUNCTION("luminanceScaling", ColorBuilder, (ColorBuilder* builder,
@@ -1409,6 +1567,24 @@ class_<RenderableManager>("RenderableManager")
         self->setMorphWeights(instance, floats.data(), nfloats);
     }), allow_raw_pointers())
 
+    // Same as setMorphWeights, but writes into the target buffer at the given offset. embind
+    // cannot overload on arity, so this follows the "geometry"/"geometryOffset" naming precedent.
+    .function("setMorphWeightsOffset", EMBIND_LAMBDA(void, (RenderableManager* self,
+            RenderableManager::Instance instance, emscripten::val weights, size_t offset), {
+        auto nfloats = weights["length"].as<size_t>();
+        std::vector<float> floats(nfloats);
+        for (size_t i = 0; i < nfloats; i++) {
+            floats[i] = weights[i].as<float>();
+        }
+        self->setMorphWeights(instance, floats.data(), nfloats, offset);
+    }), allow_raw_pointers())
+
+    .function("getMorphTargetCount", &RenderableManager::getMorphTargetCount)
+
+    .function("setMorphTargetBufferOffsetAt", &RenderableManager::setMorphTargetBufferOffsetAt)
+
+    .function("setSkinningBuffer", &RenderableManager::setSkinningBuffer, allow_raw_pointers())
+
     .function("getAxisAlignedBoundingBox", &RenderableManager::getAxisAlignedBoundingBox)
     .function("getPrimitiveCount", &RenderableManager::getPrimitiveCount)
     .function("getInstanceCount", &RenderableManager::getInstanceCount)
@@ -1577,6 +1753,13 @@ class_<TransformManager>("TransformManager")
             (TransformManager* self, TransformManager::Instance instance), {
         return flatmat4 { self->getWorldTransform(instance) } ; }), allow_raw_pointers())
 
+    .function("getChildCount", &TransformManager::getChildCount)
+
+    .function("setAccurateTranslationsEnabled",
+            &TransformManager::setAccurateTranslationsEnabled)
+    .function("isAccurateTranslationsEnabled",
+            &TransformManager::isAccurateTranslationsEnabled)
+
     .function("openLocalTransformTransaction", &TransformManager::openLocalTransformTransaction)
     .function("commitLocalTransformTransaction",
             &TransformManager::commitLocalTransformTransaction);
@@ -1606,6 +1789,8 @@ class_<LightBuilder>("LightManager$Builder")
         return &builder->color(value); })
     .BUILDER_FUNCTION("intensity", LightBuilder, (LightBuilder* builder, float value), {
         return &builder->intensity(value); })
+    .BUILDER_FUNCTION("intensityCandela", LightBuilder, (LightBuilder* builder, float value), {
+        return &builder->intensityCandela(value); })
     .BUILDER_FUNCTION("falloff", LightBuilder, (LightBuilder* builder, float value), {
         return &builder->falloff(value); })
     .BUILDER_FUNCTION("spotLightCone", LightBuilder,
@@ -1654,6 +1839,8 @@ class_<LightManager>("LightManager")
         self->setIntensity(instance, watts, efficiency);
     }), allow_raw_pointers())
 
+    .function("destroy", &LightManager::destroy)
+    .function("setIntensityCandela", &LightManager::setIntensityCandela)
     .function("getIntensity", &LightManager::getIntensity)
     .function("setFalloff", &LightManager::setFalloff)
     .function("getFalloff", &LightManager::getFalloff)
@@ -1670,6 +1857,34 @@ class_<LightManager>("LightManager")
     .function("setLightChannel", &LightManager::setLightChannel)
     .function("getLightChannel", &LightManager::getLightChannel)
     ;
+
+/// LightManager$ShadowCascades ::class:: Utilities for computing cascade split positions.
+/// These take an out-parameter array in C++; the JS forms return a (cascades - 1) length array
+/// suitable for LightManager$ShadowOptions.cascadeSplitPositions.
+class_<LightManager::ShadowCascades>("LightManager$ShadowCascades")
+    .class_function("computeUniformSplits", EMBIND_LAMBDA(val, (uint8_t cascades), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computeUniformSplits(splits, cascades);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }))
+    .class_function("computeLogSplits", EMBIND_LAMBDA(val, (uint8_t cascades, float near,
+            float far), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computeLogSplits(splits, cascades, near, far);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }))
+    .class_function("computePracticalSplits", EMBIND_LAMBDA(val, (uint8_t cascades, float near,
+            float far, float lambda), {
+        float splits[3] = {};
+        LightManager::ShadowCascades::computePracticalSplits(splits, cascades, near, far, lambda);
+        val result = val::array();
+        for (uint8_t i = 0; i + 1 < cascades; i++) { result.set(i, splits[i]); }
+        return result;
+    }));
 
 /// LightManager$Instance ::class:: Component instance returned by [LightManager]
 /// Be sure to call the instance's `delete` method when you're done with it.
@@ -1722,6 +1937,7 @@ class_<VertexBuilder>("VertexBuffer$Builder")
 /// VertexBuffer ::core class:: Bundle of buffers and associated vertex attributes.
 class_<VertexBuffer>("VertexBuffer")
     .class_function("Builder", (VertexBuilder (*)()) [] { return VertexBuilder(); })
+    .function("getVertexCount", &VertexBuffer::getVertexCount)
     .function("setBufferObjectAt", &VertexBuffer::setBufferObjectAt, allow_raw_pointers())
     .function("_setBufferAt", EMBIND_LAMBDA(void, (VertexBuffer* self,
             Engine* engine, uint8_t bufferIndex, BufferDescriptor vbd, uint32_t byteOffset), {
@@ -1741,6 +1957,7 @@ class_<IndexBuilder>("IndexBuffer$Builder")
 /// IndexBuffer ::core class:: Array of 16-bit or 32-bit unsigned integers consumed by the GPU.
 class_<IndexBuffer>("IndexBuffer")
     .class_function("Builder", (IndexBuilder (*)()) [] { return IndexBuilder(); })
+    .function("getIndexCount", &IndexBuffer::getIndexCount)
     .function("_setBuffer", EMBIND_LAMBDA(void, (IndexBuffer* self,
             Engine* engine, BufferDescriptor ibd, uint32_t byteOffset), {
         self->setBuffer(*engine, std::move(*ibd.bd), byteOffset);
@@ -1761,7 +1978,61 @@ class_<Material>("Material")
     .function("getParameterTransformName", EMBIND_LAMBDA(std::string, (Material* self, std::string samplerName), {
         const char* transformName = self->getParameterTransformName(samplerName.c_str());
         return transformName ? std::string(transformName) : std::string();
-    }), allow_raw_pointers());
+    }), allow_raw_pointers())
+
+    .function("hasParameter", EMBIND_LAMBDA(bool, (Material* self, std::string name), {
+        return self->hasParameter(name.c_str());
+    }), allow_raw_pointers())
+    .function("getParameterCount", &Material::getParameterCount)
+
+    // ParameterInfo holds a union and a const char*, so it cannot be a value_object. Return an
+    // array of plain JS objects instead, reading the union member that isSampler/isSubpass selects.
+    .function("getParameters", EMBIND_LAMBDA(val, (Material* self), {
+        const size_t count = self->getParameterCount();
+        std::vector<Material::ParameterInfo> info(count);
+        const size_t written = self->getParameters(info.data(), count);
+        val result = val::array();
+        for (size_t i = 0; i < written; i++) {
+            const auto& p = info[i];
+            val entry = val::object();
+            entry.set("name", std::string(p.name));
+            entry.set("isSampler", p.isSampler);
+            entry.set("isSubpass", p.isSubpass);
+            if (p.isSampler) {
+                entry.set("samplerType", int(p.samplerType));
+            } else if (p.isSubpass) {
+                entry.set("subpassType", int(p.subpassType));
+            } else {
+                entry.set("type", int(p.type));
+            }
+            entry.set("count", p.count);
+            entry.set("precision", int(p.precision));
+            result.set(i, entry);
+        }
+        return result;
+    }), allow_raw_pointers())
+
+    .function("getShading", &Material::getShading)
+    .function("getInterpolation", &Material::getInterpolation)
+    .function("getBlendingMode", &Material::getBlendingMode)
+    .function("getRefractionMode", &Material::getRefractionMode)
+    .function("getRefractionType", &Material::getRefractionType)
+    .function("getReflectionMode", &Material::getReflectionMode)
+    .function("getVertexDomain", &Material::getVertexDomain)
+    .function("getCullingMode", &Material::getCullingMode)
+    .function("getTransparencyMode", &Material::getTransparencyMode)
+    .function("getFeatureLevel", &Material::getFeatureLevel)
+    .function("getMaskThreshold", &Material::getMaskThreshold)
+    .function("getSpecularAntiAliasingVariance", &Material::getSpecularAntiAliasingVariance)
+    .function("getSpecularAntiAliasingThreshold", &Material::getSpecularAntiAliasingThreshold)
+    .function("getRequiredAttributes", EMBIND_LAMBDA(uint32_t, (Material* self), {
+        return self->getRequiredAttributes().getValue();
+    }), allow_raw_pointers())
+    .function("isDoubleSided", &Material::isDoubleSided)
+    .function("isAlphaToCoverageEnabled", &Material::isAlphaToCoverageEnabled)
+    .function("isColorWriteEnabled", &Material::isColorWriteEnabled)
+    .function("isDepthWriteEnabled", &Material::isDepthWriteEnabled)
+    .function("isDepthCullingEnabled", &Material::isDepthCullingEnabled);
 
 enum_<Material::UboBatchingMode>("Material$UboBatchingMode")
     .value("DISABLED", Material::UboBatchingMode::DISABLED)
@@ -1800,11 +2071,44 @@ class_<MaterialInstance>("MaterialInstance")
             std::string name), {
         return self->getConstant<int32_t>(name.c_str(), name.size());
     }), allow_raw_pointers())
+    .function("setConstantBool", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, bool value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
+    .function("setConstantFloat", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, float value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
+    .function("setConstantInt", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, int32_t value), {
+        self->setConstant(name.c_str(), name.size(), value);
+    }), allow_raw_pointers())
     .function("setBoolParameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, bool value), {
         self->setParameter(name.c_str(), value); }), allow_raw_pointers())
     .function("setFloatParameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, float value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool2Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool2 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool3Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool3 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setBool4Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::bool4 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setIntParameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, int32_t value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt2Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int2 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt3Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int3 value), {
+        self->setParameter(name.c_str(), value); }), allow_raw_pointers())
+    .function("setInt4Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, filament::math::int4 value), {
         self->setParameter(name.c_str(), value); }), allow_raw_pointers())
     .function("setFloat2Parameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, filament::math::float2 value), {
@@ -1888,6 +2192,7 @@ class_<MaterialInstance>("MaterialInstance")
             (MaterialInstance* self, uint8_t readMask), {
                 self->setStencilReadMask(readMask, backend::StencilFace::FRONT_AND_BACK);
             }), allow_raw_pointers())
+    .function("isStencilWriteEnabled", &MaterialInstance::isStencilWriteEnabled)
     .function("setStencilWriteMask", &MaterialInstance::setStencilWriteMask)
     .function("setStencilWriteMask", EMBIND_LAMBDA(void,
             (MaterialInstance* self, uint8_t writeMask), {
@@ -1897,7 +2202,20 @@ class_<MaterialInstance>("MaterialInstance")
 class_<TextureSampler>("TextureSampler")
     .constructor<backend::SamplerMinFilter, backend::SamplerMagFilter, backend::SamplerWrapMode>()
     .function("setAnisotropy", &TextureSampler::setAnisotropy)
-    .function("setCompareMode", &TextureSampler::setCompareMode);
+    .function("getAnisotropy", &TextureSampler::getAnisotropy)
+    .function("setCompareMode", &TextureSampler::setCompareMode)
+    .function("getCompareMode", &TextureSampler::getCompareMode)
+    .function("getCompareFunc", &TextureSampler::getCompareFunc)
+    .function("setMinFilter", &TextureSampler::setMinFilter)
+    .function("getMinFilter", &TextureSampler::getMinFilter)
+    .function("setMagFilter", &TextureSampler::setMagFilter)
+    .function("getMagFilter", &TextureSampler::getMagFilter)
+    .function("setWrapModeS", &TextureSampler::setWrapModeS)
+    .function("getWrapModeS", &TextureSampler::getWrapModeS)
+    .function("setWrapModeT", &TextureSampler::setWrapModeT)
+    .function("getWrapModeT", &TextureSampler::getWrapModeT)
+    .function("setWrapModeR", &TextureSampler::setWrapModeR)
+    .function("getWrapModeR", &TextureSampler::getWrapModeR);
 
 /// Texture ::core class:: 2D image or cubemap that can be sampled by the GPU, possibly mipmapped.
 class_<Texture>("Texture")
@@ -1907,6 +2225,21 @@ class_<Texture>("Texture")
     .class_function("isTextureSwizzleSupported", (bool (*)(Engine*)) [] (Engine* engine) {
         return Texture::isTextureSwizzleSupported(*engine);
     }, allow_raw_pointers())
+    .class_function("isTextureFormatSupported",
+            (bool (*)(Engine*, Texture::InternalFormat)) [] (Engine* engine,
+                    Texture::InternalFormat format) {
+        return Texture::isTextureFormatSupported(*engine, format);
+    }, allow_raw_pointers())
+    .class_function("getMaxTextureSize",
+            (size_t (*)(Engine*, Texture::Sampler)) [] (Engine* engine, Texture::Sampler type) {
+        return Texture::getMaxTextureSize(*engine, type);
+    }, allow_raw_pointers())
+    .class_function("getMaxArrayTextureLayers",
+            (size_t (*)(Engine*)) [] (Engine* engine) {
+        return Texture::getMaxArrayTextureLayers(*engine);
+    }, allow_raw_pointers())
+    .function("getTarget", &Texture::getTarget)
+    .function("getFormat", &Texture::getFormat)
     .function("generateMipmaps", &Texture::generateMipmaps)
     .function("_setImage", EMBIND_LAMBDA(void, (Texture* self,
             Engine* engine, uint8_t level, PixelBufferDescriptor pbd), {
@@ -1941,12 +2274,20 @@ class_<TexBuilder>("Texture$Builder")
         return &builder->depth(depth); })
     .BUILDER_FUNCTION("levels", TexBuilder, (TexBuilder* builder, uint8_t levels), {
         return &builder->levels(levels); })
+    .BUILDER_FUNCTION("samples", TexBuilder, (TexBuilder* builder, uint8_t samples), {
+        return &builder->samples(samples); })
     .BUILDER_FUNCTION("sampler", TexBuilder, (TexBuilder* builder, Texture::Sampler target), {
         return &builder->sampler(target); })
     .BUILDER_FUNCTION("format", TexBuilder, (TexBuilder* builder, Texture::InternalFormat fmt), {
         return &builder->format(fmt); })
     .BUILDER_FUNCTION("external", TexBuilder, (TexBuilder* builder), {
         return &builder->external(); })
+    // Note build() rejects a swizzled texture on WebGL, which has no texture swizzle; the binding
+    // exists so callers get that explicit error rather than a missing method. Pair with
+    // isTextureSwizzleSupported, which is already bound and returns false here.
+    .BUILDER_FUNCTION("swizzle", TexBuilder, (TexBuilder* builder, Texture::Swizzle r,
+            Texture::Swizzle g, Texture::Swizzle b, Texture::Swizzle a), {
+        return &builder->swizzle(r, g, b, a); })
 
     // This takes a bitfield that can be composed by or'ing constants.
     // - JS clients should use the value member, as in: "Texture$Usage.SAMPLEABLE.value".
@@ -2008,6 +2349,17 @@ class_<IblBuilder>("IndirectLight$Builder")
             floats[i] = ta[i].as<float>();
         }
         return &builder->irradiance(nbands, (filament::math::float3 const*) floats.data()); })
+    .BUILDER_FUNCTION("radianceSh", IblBuilder, (IblBuilder* builder, uint8_t nbands, val ta), {
+        size_t nfloats = ta["length"].as<size_t>();
+        if (nfloats != nbands * nbands * 3) {
+            printf("Received %zu floats for spherical harmonics, expected %d.", nfloats, nbands);
+            return builder;
+        }
+        std::vector<float> floats(nfloats);
+        for (size_t i = 0; i < nfloats; i++) {
+            floats[i] = ta[i].as<float>();
+        }
+        return &builder->radiance(nbands, (filament::math::float3 const*) floats.data()); })
     .BUILDER_FUNCTION("intensity", IblBuilder, (IblBuilder* builder, float value), {
         return &builder->intensity(value); })
     .BUILDER_FUNCTION("rotation", IblBuilder, (IblBuilder* builder, flatmat3 value), {
@@ -2033,6 +2385,10 @@ class_<SkyBuilder>("Skybox$Builder")
         return &builder->color(color); })
     .BUILDER_FUNCTION("environment", SkyBuilder, (SkyBuilder* builder, Texture* cubemap), {
         return &builder->environment(cubemap); })
+    .BUILDER_FUNCTION("intensity", SkyBuilder, (SkyBuilder* builder, float envIntensity), {
+        return &builder->intensity(envIntensity); })
+    .BUILDER_FUNCTION("intensity", SkyBuilder, (SkyBuilder* builder, float envIntensity), {
+        return &builder->intensity(envIntensity); })
     .BUILDER_FUNCTION("showSun", SkyBuilder, (SkyBuilder* builder, bool show), {
         return &builder->showSun(show); });
 
@@ -2406,6 +2762,14 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
 
     .function("popRenderable", &FilamentAsset::popRenderable)
 
+    // Batched form of popRenderable; returns up to `count` entities (fewer when the queue drains).
+    .function("popRenderables", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self, size_t count), {
+        EntityVector result(count);
+        const size_t popped = self->popRenderables(result.data(), count);
+        result.resize(popped);
+        return result;
+    }), allow_raw_pointers())
+
     .function("getInstance", &FilamentAsset::getInstance, allow_raw_pointers())
 
     .function("_getAssetInstances", EMBIND_LAMBDA(std::vector<FilamentInstance*>,
@@ -2422,6 +2786,16 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         }
         return retval;
     }), allow_raw_pointers())
+
+    // Count accessors, so callers can size a buffer without materializing the entity vector.
+    .function("getEntityCount", &FilamentAsset::getEntityCount)
+    .function("getLightEntityCount", &FilamentAsset::getLightEntityCount)
+    .function("getRenderableEntityCount", &FilamentAsset::getRenderableEntityCount)
+    .function("getCameraEntityCount", &FilamentAsset::getCameraEntityCount)
+    .function("getResourceUriCount", &FilamentAsset::getResourceUriCount)
+    .function("getMorphTargetCountAt", &FilamentAsset::getMorphTargetCountAt)
+    .function("getSceneCount", &FilamentAsset::getSceneCount)
+    .function("getAssetInstanceCount", &FilamentAsset::getAssetInstanceCount)
 
     .function("getBoundingBox", &FilamentAsset::getBoundingBox)
     .function("getName", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
@@ -2465,6 +2839,9 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
     .function("attachSkin", &FilamentInstance::attachSkin)
     .function("detachSkin", &FilamentInstance::detachSkin)
 
+    .function("getEntityCount", &FilamentInstance::getEntityCount)
+    .function("getMaterialVariantCount", &FilamentInstance::getMaterialVariantCount)
+    .function("getMaterialInstanceCount", &FilamentInstance::getMaterialInstanceCount)
     .function("getSkinCount", &FilamentInstance::getSkinCount)
     .function("getJointCountAt", &FilamentInstance::getJointCountAt)
 
@@ -2562,7 +2939,16 @@ class_<AssetLoader>("gltfio$AssetLoader")
     
     // gc ::method::
     // Performs a Garbage Collection sweep over all internal component managers.
-    .function("gc", &AssetLoader::gc, allow_raw_pointers());
+    .function("gc", &AssetLoader::gc, allow_raw_pointers())
+
+    // enableDiagnostics ::method:: Enables the diagnostic "wireframe" renderable.
+    .function("enableDiagnostics", &AssetLoader::enableDiagnostics, allow_raw_pointers())
+
+    // destroy ::method:: Frees the loader itself (not its assets or material cache).
+    // The embind raw_destructor for AssetLoader is a no-op, so `delete` does not release it.
+    .class_function("destroy", EMBIND_LAMBDA(void, (AssetLoader* loader), {
+        AssetLoader::destroy(&loader);
+    }), allow_raw_pointers());
 
 class_<ResourceLoader>("gltfio$ResourceLoader")
     .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine, bool normalizeSkinningWeights), {
@@ -2608,7 +2994,9 @@ class_<ResourceLoader>("gltfio$ResourceLoader")
     }), allow_raw_pointers())
 
     .function("asyncGetLoadProgress", &ResourceLoader::asyncGetLoadProgress)
-    .function("asyncUpdateLoad", &ResourceLoader::asyncUpdateLoad);
+    .function("asyncUpdateLoad", &ResourceLoader::asyncUpdateLoad)
+    .function("asyncCancelLoad", &ResourceLoader::asyncCancelLoad)
+    .function("evictResourceData", &ResourceLoader::evictResourceData);
 
 class_<Settings>("Settings");
 

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -27,6 +27,7 @@
 #include <filament/Frustum.h>
 #include <filament/IndexBuffer.h>
 #include <filament/LightManager.h>
+#include <filament/MaterialEnums.h>
 #include <filament/RenderableManager.h>
 #include <filament/RenderTarget.h>
 #include <filament/Texture.h>
@@ -499,5 +500,55 @@ enum_<ktxreader::Ktx2Reader::Result>("Ktx2Reader$Result")
     enum_<filament::viewer::AutomationEngine::Options::ExportFormat>("AutomationEngine$ExportFormat")
         .value("TIFF", filament::viewer::AutomationEngine::Options::ExportFormat::TIFF)
         .value("PPM", filament::viewer::AutomationEngine::Options::ExportFormat::PPM);
+
+    // Material introspection return types (Material::getShading, getBlendingMode, etc.)
+    enum_<filament::Shading>("Shading")
+        .value("UNLIT", filament::Shading::UNLIT)
+        .value("LIT", filament::Shading::LIT)
+        .value("SUBSURFACE", filament::Shading::SUBSURFACE)
+        .value("CLOTH", filament::Shading::CLOTH)
+        .value("SPECULAR_GLOSSINESS", filament::Shading::SPECULAR_GLOSSINESS);
+
+    enum_<filament::Interpolation>("Interpolation")
+        .value("SMOOTH", filament::Interpolation::SMOOTH)
+        .value("FLAT", filament::Interpolation::FLAT);
+
+    enum_<filament::BlendingMode>("BlendingMode")
+        .value("OPAQUE", filament::BlendingMode::OPAQUE)
+        .value("TRANSPARENT", filament::BlendingMode::TRANSPARENT)
+        .value("ADD", filament::BlendingMode::ADD)
+        .value("MASKED", filament::BlendingMode::MASKED)
+        .value("FADE", filament::BlendingMode::FADE)
+        .value("MULTIPLY", filament::BlendingMode::MULTIPLY)
+        .value("SCREEN", filament::BlendingMode::SCREEN)
+        .value("CUSTOM", filament::BlendingMode::CUSTOM);
+
+    enum_<filament::VertexDomain>("VertexDomain")
+        .value("OBJECT", filament::VertexDomain::OBJECT)
+        .value("WORLD", filament::VertexDomain::WORLD)
+        .value("VIEW", filament::VertexDomain::VIEW)
+        .value("DEVICE", filament::VertexDomain::DEVICE);
+
+    enum_<filament::RefractionMode>("RefractionMode")
+        .value("NONE", filament::RefractionMode::NONE)
+        .value("CUBEMAP", filament::RefractionMode::CUBEMAP)
+        .value("SCREEN_SPACE", filament::RefractionMode::SCREEN_SPACE);
+
+    enum_<filament::RefractionType>("RefractionType")
+        .value("SOLID", filament::RefractionType::SOLID)
+        .value("THIN", filament::RefractionType::THIN);
+
+    enum_<filament::ReflectionMode>("ReflectionMode")
+        .value("DEFAULT", filament::ReflectionMode::DEFAULT)
+        .value("SCREEN_SPACE", filament::ReflectionMode::SCREEN_SPACE);
+
+    // Texture::Builder::swizzle; isTextureSwizzleSupported was already bound without it.
+    enum_<backend::TextureSwizzle>("Texture$Swizzle")
+        .value("SUBSTITUTE_ZERO", backend::TextureSwizzle::SUBSTITUTE_ZERO)
+        .value("SUBSTITUTE_ONE", backend::TextureSwizzle::SUBSTITUTE_ONE)
+        .value("CHANNEL_0", backend::TextureSwizzle::CHANNEL_0)
+        .value("CHANNEL_1", backend::TextureSwizzle::CHANNEL_1)
+        .value("CHANNEL_2", backend::TextureSwizzle::CHANNEL_2)
+        .value("CHANNEL_3", backend::TextureSwizzle::CHANNEL_3);
 
 }

--- a/web/filament-js/test-browser.html
+++ b/web/filament-js/test-browser.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<!--
+ Copyright (C) 2026 The Android Open Source Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Filament JS bindings: GPU tests</title>
+<!--
+ GPU counterpart to test-runtime.js.
+
+ test-runtime.js covers the bindings that run on the NOOP backend under Node. What is left over
+ needs a real backend: creating an engine on a canvas' WebGL context, reading pixels back out of a
+ rendered frame, picking, and decoding images into mipmapped textures. Those live here.
+
+ The page builds its own test images with a 2D canvas, so it needs no assets beyond the module.
+
+ Usage:
+   cp web/filament-js/test-browser.html out/cmake-wasm-release/web/filament-js/
+   cd out/cmake-wasm-release/web/filament-js && python3 -m http.server 8080
+   open http://localhost:8080/test-browser.html
+
+ Results are printed to the page and to the console, and are left in window.filamentTestResults
+ as { passed, failed, results } for a headless runner to pick up.
+-->
+<style>
+body { font-family: ui-monospace, monospace; margin: 2rem; background: #fff; color: #111; }
+#results { list-style: none; padding: 0; }
+#results li { padding: 0.15rem 0; white-space: pre-wrap; }
+.ok::before { content: "ok   "; color: #0a0; }
+.fail::before { content: "FAIL "; color: #c00; }
+.fail { color: #c00; }
+#summary { margin-top: 1rem; font-weight: bold; }
+canvas { display: none; }
+</style>
+</head>
+<body>
+<h1>Filament JS bindings: GPU tests</h1>
+<ul id="results"></ul>
+<div id="summary">running…</div>
+<script src="filament.js"></script>
+<script>
+'use strict';
+
+const TESTS = [];
+function test(name, fn) {
+    TESTS.push([name, fn]);
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message || 'assertion failed');
+    }
+}
+
+function assertEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(`${message || 'assertion failed'}: ${actual} !== ${expected}`);
+    }
+}
+
+// Renderer.render opens and closes a frame of its own, so anything that has to happen inside the
+// frame — readPixels among them — goes through beginFrame/renderView/endFrame instead.
+function renderFrame(engine, renderer, swapChain, view, insideFrame) {
+    if (renderer.beginFrame(swapChain)) {
+        renderer.renderView(view);
+        if (insideFrame) {
+            insideFrame();
+        }
+        renderer.endFrame();
+    }
+    engine.flushAndWait();
+    engine.execute();
+}
+
+// Keeps rendering frames, yielding to the event loop between them, until `isDone` says the driver
+// has answered. Pixel readback and picking are both resolved a few frames after they are asked
+// for, and only while the command buffer keeps being pumped.
+async function renderUntil(engine, renderer, swapChain, view, isDone, what) {
+    for (let frame = 0; frame < 60; frame++) {
+        if (isDone()) {
+            return;
+        }
+        renderFrame(engine, renderer, swapChain, view);
+        // A timer rather than requestAnimationFrame: headless runs throttle animation frames, and
+        // the driver only needs the event loop to turn over, not a real display refresh.
+        await new Promise((resolve) => setTimeout(resolve, 16));
+    }
+    if (!isDone()) {
+        throw new Error(`the ${what} callback never fired`);
+    }
+}
+
+// Renders until readPixels hands back the pixels it was asked for.
+async function renderAndReadPixels(engine, renderer, swapChain, view, readFrom) {
+    let pixels = null;
+    // The Uint8Array handed to the callback is only valid for the duration of the call, so it has
+    // to be copied before it can be asserted on.
+    const done = (result) => { pixels = result.slice(); };
+    renderFrame(engine, renderer, swapChain, view, () => {
+        if (readFrom) {
+            renderer.readPixels(readFrom, 0, 0, 1, 1, Filament.PixelDataFormat.RGBA,
+                    Filament.PixelDataType.UBYTE, done);
+        } else {
+            renderer.readPixels(0, 0, 1, 1, Filament.PixelDataFormat.RGBA,
+                    Filament.PixelDataType.UBYTE, done);
+        }
+    });
+    await renderUntil(engine, renderer, swapChain, view, () => pixels !== null, 'readPixels');
+    return pixels;
+}
+
+// A solid-colour image, encoded by the browser, so the decoding tests need no assets on disk.
+function encodeImage(mimeType, r, g, b) {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 8;
+    const context = canvas.getContext('2d');
+    context.fillStyle = `rgb(${r}, ${g}, ${b})`;
+    context.fillRect(0, 0, 8, 8);
+    const dataUrl = canvas.toDataURL(mimeType);
+    const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1);
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+function textureUsage(...names) {
+    return names.reduce((bits, name) => bits | Filament.Texture$Usage[name].value, 0);
+}
+
+// A canvas hands out one WebGL context for its lifetime, and destroying the engine that owns it
+// does not hand it back, so every engine gets a canvas of its own.
+let canvasCount = 0;
+function newCanvas() {
+    const canvas = document.createElement('canvas');
+    canvas.id = `test-canvas-${canvasCount++}`;
+    canvas.width = canvas.height = 64;
+    document.body.appendChild(canvas);
+    return canvas;
+}
+
+// Each test gets an engine on a real canvas, and the engine owns that canvas' GL context.
+function withEngine(fn) {
+    const engine = Filament.Engine.create(newCanvas());
+    return Promise.resolve(fn(engine)).finally(() => Filament.Engine.destroy(engine));
+}
+
+function simpleView(engine, clearColor) {
+    const view = engine.createView();
+    view.setScene(engine.createScene());
+    view.setCamera(engine.createCamera(Filament.EntityManager.get().create()));
+    view.setViewport([0, 0, 64, 64]);
+    // Post-processing would resolve through a tone mapper and change the pixels being asserted on.
+    view.setPostProcessingEnabled(false);
+    if (clearColor) {
+        view.setBlendMode(Filament.View$BlendMode.OPAQUE);
+    }
+    return view;
+}
+
+// ---------------------------------------------------------------------------
+// Engine.create over a WebGL context
+// ---------------------------------------------------------------------------
+
+test('Engine.create takes over the canvas WebGL context', () => {
+    const canvas = newCanvas();
+    const engine = Filament.Engine.create(canvas);
+
+    assertEqual(engine.getBackend(), Filament.Backend.OPENGL, 'backend');
+    assertEqual(engine.canvasId, '#' + canvas.id, 'canvasId');
+    assert(engine.context, 'the engine kept no GL context');
+    assert(engine.handle !== undefined, 'the engine kept no emscripten context handle');
+
+    // Engine.create has to clean up after itself: the context is handed to the backend through
+    // globals on window, which must not outlive the call.
+    assertEqual(window.filament_glOptions, undefined, 'window.filament_glOptions leaked');
+    assertEqual(window.filament_glContext, undefined, 'window.filament_glContext leaked');
+    assertEqual(window.filament_contextHandle, undefined, 'window.filament_contextHandle leaked');
+
+    Filament.Engine.destroy(engine);
+});
+
+test('Engine.create honours WebGL context attributes', () => {
+    const engine = Filament.Engine.create(newCanvas(), {
+        antialias: false,
+        alpha: false,
+    });
+    const attributes = engine.context.getContextAttributes();
+    assertEqual(attributes.antialias, false, 'antialias');
+    assertEqual(attributes.alpha, false, 'alpha');
+    Filament.Engine.destroy(engine);
+});
+
+test('A second engine gets its own context', () => {
+    const first = Filament.Engine.create(newCanvas());
+    const second = Filament.Engine.create(newCanvas());
+    assert(first.context !== second.context, 'both engines share one GL context');
+    assert(first.handle !== second.handle, 'both engines share one context handle');
+    Filament.Engine.destroy(second);
+    Filament.Engine.destroy(first);
+});
+
+// ---------------------------------------------------------------------------
+// Rendering and pixel readback
+// ---------------------------------------------------------------------------
+
+test('readPixels returns the colour the frame was cleared to', () => withEngine(async (engine) => {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = simpleView(engine, true);
+    renderer.setClearOptions({ clearColor: [1, 0, 0, 1], clear: true, discard: false });
+
+    const pixels = await renderAndReadPixels(engine, renderer, swapChain, view);
+    assert(pixels, 'the readPixels callback never fired');
+    assertEqual(pixels.length, 4, 'one RGBA pixel');
+    assertEqual(pixels[0], 255, 'red channel');
+    assertEqual(pixels[1], 0, 'green channel');
+    assertEqual(pixels[2], 0, 'blue channel');
+    assertEqual(pixels[3], 255, 'alpha channel');
+}));
+
+// NoopDriver never dispatches, so only a real backend can prove the callback fires.
+test('the frame-scheduled callback fires once per frame', () => withEngine(async (engine) => {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = simpleView(engine, true);
+
+    let calls = 0;
+    swapChain.setFrameScheduledCallback(() => { calls++; });
+    assert(swapChain.isFrameScheduledCallbackSet(), 'the callback did not take');
+
+    await renderUntil(engine, renderer, swapChain, view, () => calls > 0, 'frame-scheduled');
+
+    // It is not one-shot: it stays latched and fires again on the next frame.
+    const afterFirst = calls;
+    await renderUntil(engine, renderer, swapChain, view, () => calls > afterFirst,
+            'second frame-scheduled');
+
+    // Clearing stops it. Render a few more frames and the count must not move.
+    swapChain.setFrameScheduledCallback();
+    assert(!swapChain.isFrameScheduledCallbackSet(), 'the callback did not clear');
+    const afterClear = calls;
+    for (let frame = 0; frame < 3; frame++) {
+        renderFrame(engine, renderer, swapChain, view);
+        await new Promise((resolve) => setTimeout(resolve, 16));
+    }
+    assertEqual(calls, afterClear, 'the cleared callback still fired');
+}));
+
+test('readPixels reads back a RenderTarget', () => withEngine(async (engine) => {
+    const color = Filament.Texture.Builder()
+        .width(64).height(64).levels(1)
+        .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('COLOR_ATTACHMENT', 'SAMPLEABLE'))
+        .build(engine);
+    const renderTarget = Filament.RenderTarget.Builder()
+        .texture(Filament.RenderTarget$AttachmentPoint.COLOR, color)
+        .build(engine);
+
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = simpleView(engine, true);
+    view.setRenderTarget(renderTarget);
+    renderer.setClearOptions({ clearColor: [0, 0, 1, 1], clear: true, discard: false });
+
+    const pixels = await renderAndReadPixels(engine, renderer, swapChain, view, renderTarget);
+    assert(pixels, 'the readPixels callback never fired');
+    assertEqual(pixels[0], 0, 'red channel');
+    assertEqual(pixels[2], 255, 'blue channel');
+}));
+
+test('Renderer draws a renderable and reports it as visible', () =>
+        withEngine(async (engine) => {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = simpleView(engine, true);
+    const scene = view.getScene();
+
+    // A full-screen triangle in front of an orthographic camera.
+    const vertexBuffer = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+                Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .build(engine);
+    vertexBuffer.setBufferAt(engine, 0,
+            new Float32Array([-3, -3, -1, 3, -3, -1, 0, 3, -1]));
+    const indexBuffer = Filament.IndexBuffer.Builder()
+        .indexCount(3)
+        .bufferType(Filament.IndexBuffer$IndexType.USHORT)
+        .build(engine);
+    indexBuffer.setBuffer(engine, new Uint16Array([0, 1, 2]));
+
+    const entity = Filament.EntityManager.get().create();
+    Filament.RenderableManager.Builder(1)
+        .boundingBox({ center: [0, 0, 0], halfExtent: [10, 10, 10] })
+        .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer, indexBuffer)
+        .culling(false)
+        .build(engine, entity);
+    scene.addEntity(entity);
+
+    const camera = view.getCamera();
+    camera.setProjection(Filament.Camera$Projection.ORTHO, -1, 1, -1, 1, 0.1, 10);
+    camera.lookAt([0, 0, 0], [0, 0, -1], [0, 1, 0]);
+
+    renderer.setClearOptions({ clearColor: [0, 0, 0, 1], clear: true, discard: false });
+    renderFrame(engine, renderer, swapChain, view);
+
+    assertEqual(view.getVisibleRenderableCount(), 1, 'visible renderable count');
+
+    // The triangle covers the whole viewport, so the frame is no longer the clear colour.
+    const pixels = await renderAndReadPixels(engine, renderer, swapChain, view);
+    assert(pixels[0] !== 0 || pixels[1] !== 0 || pixels[2] !== 0,
+            `nothing was drawn, the frame is still ${Array.from(pixels)}`);
+}));
+
+test('View.pick returns the renderable under the cursor', () => withEngine(async (engine) => {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = simpleView(engine, true);
+    const scene = view.getScene();
+
+    const vertexBuffer = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+                Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .build(engine);
+    vertexBuffer.setBufferAt(engine, 0,
+            new Float32Array([-3, -3, -1, 3, -3, -1, 0, 3, -1]));
+    const indexBuffer = Filament.IndexBuffer.Builder()
+        .indexCount(3)
+        .bufferType(Filament.IndexBuffer$IndexType.USHORT)
+        .build(engine);
+    indexBuffer.setBuffer(engine, new Uint16Array([0, 1, 2]));
+
+    const entity = Filament.EntityManager.get().create();
+    Filament.RenderableManager.Builder(1)
+        .boundingBox({ center: [0, 0, 0], halfExtent: [10, 10, 10] })
+        .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer, indexBuffer)
+        .culling(false)
+        .build(engine, entity);
+    scene.addEntity(entity);
+
+    const camera = view.getCamera();
+    camera.setProjection(Filament.Camera$Projection.ORTHO, -1, 1, -1, 1, 0.1, 10);
+    camera.lookAt([0, 0, 0], [0, 0, -1], [0, 1, 0]);
+
+    // The pick query is issued inside a frame and answered a frame or two later.
+    let picked = null;
+    renderFrame(engine, renderer, swapChain, view,
+            () => view.pick(32, 32, (result) => { picked = result; }));
+    await renderUntil(engine, renderer, swapChain, view, () => picked !== null, 'pick');
+
+    assert(picked, 'the pick callback never fired');
+    assertEqual(picked.renderable.getId(), entity.getId(), 'picked entity');
+    assertEqual(picked.fragCoords.length, 3, 'fragCoords');
+}));
+
+// ---------------------------------------------------------------------------
+// Image decoding and mipmap generation
+// ---------------------------------------------------------------------------
+
+test('createTextureFromPng decodes and mipmaps an image', () => withEngine((engine) => {
+    const texture = engine.createTextureFromPng(encodeImage('image/png', 255, 0, 0));
+    assertEqual(texture.getWidth(engine), 8, 'width');
+    assertEqual(texture.getHeight(engine), 8, 'height');
+    // levels(0xff) asks for a full mip chain, which an 8x8 image caps at four levels.
+    assertEqual(texture.getLevels(engine), 4, 'levels');
+    assert(engine.isValidTexture(texture), 'texture is not valid');
+}));
+
+test('createTextureFromJpeg decodes an image', () => withEngine((engine) => {
+    const texture = engine.createTextureFromJpeg(encodeImage('image/jpeg', 0, 255, 0),
+            { srgb: true });
+    assertEqual(texture.getWidth(engine), 8, 'width');
+    assertEqual(texture.getFormat(), Filament.Texture$InternalFormat.SRGB8_A8, 'format');
+}));
+
+test('generateMipmaps fills the mip chain', () => withEngine((engine) => {
+    const texture = Filament.Texture.Builder()
+        .width(8).height(8).levels(4)
+        .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('UPLOADABLE', 'SAMPLEABLE', 'GEN_MIPMAPPABLE'))
+        .build(engine);
+    texture.setImage(engine, 0, Filament.PixelBuffer(new Uint8Array(8 * 8 * 4),
+            Filament.PixelDataFormat.RGBA, Filament.PixelDataType.UBYTE));
+    texture.generateMipmaps(engine);
+    assertEqual(texture.getWidth(engine, 3), 1, 'the smallest mip is one texel');
+    assert(Filament.Texture.isTextureFormatMipmappable(engine,
+            Filament.Texture$InternalFormat.RGBA8), 'RGBA8 should be mipmappable on WebGL');
+}));
+
+// ---------------------------------------------------------------------------
+// Capabilities WebGL does not have
+// ---------------------------------------------------------------------------
+
+test('Texture swizzling is rejected on WebGL', () => withEngine((engine) => {
+    assertEqual(Filament.Texture.isTextureSwizzleSupported(engine), false,
+            'WebGL 2.0 has no texture swizzle');
+    let threw = false;
+    try {
+        Filament.Texture.Builder()
+            .width(8).height(8)
+            .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+            .format(Filament.Texture$InternalFormat.RGBA8)
+            .swizzle(Filament.Texture$Swizzle.CHANNEL_0, Filament.Texture$Swizzle.CHANNEL_1,
+                    Filament.Texture$Swizzle.CHANNEL_2, Filament.Texture$Swizzle.SUBSTITUTE_ONE)
+            .build(engine);
+    } catch (e) {
+        threw = true;
+    }
+    assert(threw, 'building a swizzled texture should have thrown');
+}));
+
+test('SwapChain reports whether sRGB is available', () => withEngine((engine) => {
+    assertEqual(typeof Filament.SwapChain.isSRGBSwapChainSupported(engine), 'boolean', 'type');
+}));
+
+test('getSupportedFormats queries the compressed texture extensions', () => {
+    const formats = Filament.getSupportedFormats();
+    for (const key of ['s3tc', 's3tc_srgb', 'astc', 'etc']) {
+        assertEqual(typeof formats[key], 'boolean', key);
+    }
+    assertEqual(typeof Filament.getSupportedFormatSuffix('etc s3tc'), 'string', 'suffix');
+});
+
+// ---------------------------------------------------------------------------
+
+Filament.init([], async () => {
+    const list = document.getElementById('results');
+    const results = [];
+    let failed = 0;
+
+    for (const [name, fn] of TESTS) {
+        let error = null;
+        try {
+            await fn();
+        } catch (e) {
+            error = (e && e.message) ? e.message : String(e);
+            failed++;
+        }
+        const item = document.createElement('li');
+        item.className = error ? 'fail' : 'ok';
+        item.textContent = error ? `${name}\n       ${error}` : name;
+        list.appendChild(item);
+        results.push({ name, error });
+        console.log(`${error ? 'FAIL' : 'ok  '} ${name}${error ? ': ' + error : ''}`);
+    }
+
+    const summary = `${TESTS.length - failed}/${TESTS.length} passed`;
+    document.getElementById('summary').textContent = summary;
+    console.log(summary);
+    window.filamentTestResults = { passed: TESTS.length - failed, failed, results };
+});
+</script>
+</body>
+</html>

--- a/web/filament-js/test-runtime.js
+++ b/web/filament-js/test-runtime.js
@@ -1,0 +1,1885 @@
+/*
+* Copyright (C) 2026 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+ * Runtime counterpart to test.ts.
+ *
+ * test.ts is only type-checked, never executed, so it proves the declarations in filament.d.ts
+ * compile — not that the bindings behind them exist or marshal correctly. This script loads the
+ * built module under Node and exercises the same surface against a real engine, using the NOOP
+ * backend. A missing registration, a wrong embind signature, a builder setter that forgets to
+ * return the builder, or a value_object field that does not round-trip fails here instead of in a
+ * browser.
+ *
+ * The sections below follow test.ts one for one. What is missing from them is the part of the API
+ * that needs a GPU: pixel readback, mipmap generation, image decoding and picking all need a real
+ * backend, and live in test-browser.html instead.
+ *
+ * Usage:
+ *   node test-runtime.js [path/to/filament.js]
+ *
+ * Defaults to the standard wasm release output. Exits non-zero on the first failure.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+const modulePath = path.resolve(process.argv[2] ||
+    path.join(ROOT, 'out', 'cmake-wasm-release', 'web', 'filament-js', 'filament.js'));
+
+if (!fs.existsSync(modulePath)) {
+    console.error(`No module at ${modulePath}. Build it with: ./build.sh -p wasm release`);
+    process.exit(1);
+}
+
+// filament.js declares `var Filament = ...` at global scope, so it has to be loaded by indirect
+// eval rather than require(). That scope has none of CommonJS's module-locals, and emscripten's
+// Node branch uses all three to find filament.wasm, so hand them over first.
+globalThis.__filename = modulePath;
+globalThis.__dirname = path.dirname(modulePath);
+globalThis.require = require;
+// extensions.js passes the GL context to the backend through globals on `window`. The NOOP backend
+// never reads them, but Engine.execute writes them unconditionally, so give it somewhere to write.
+globalThis.window = globalThis;
+(0, eval)(fs.readFileSync(modulePath, 'utf8'));
+
+// Committed assets, used where a binding needs real content to chew on. test_material.filamat is
+// a lit opaque material with twelve scalar and vector parameters; textured.filamat is the only
+// committed material with sampler parameters; lightroom_ibl.ktx is a cubemap with SH metadata.
+const MATERIAL = 'filament/test/test_material.filamat';
+const TEXTURED_MATERIAL = 'docs/web/assets/suzanne/textured.filamat';
+const IBL_KTX = 'libs/ktxreader/tests/lightroom_ibl.ktx';
+
+function asset(relativePath) {
+    return new Uint8Array(fs.readFileSync(path.join(ROOT, relativePath)));
+}
+
+// A single-triangle glTF with its vertex data inline, so gltfio can be exercised without pulling
+// in a model from third_party.
+function triangleGltf() {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const base64 = Buffer.from(new Uint8Array(positions.buffer)).toString('base64');
+    return new TextEncoder().encode(JSON.stringify({
+        asset: { version: '2.0' },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ mesh: 0, name: 'triangle' }],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+        accessors: [{
+            bufferView: 0, componentType: 5126, count: 3, type: 'VEC3',
+            min: [0, 0, 0], max: [1, 1, 0]
+        }],
+        bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }],
+        buffers: [{
+            byteLength: positions.byteLength,
+            uri: 'data:application/octet-stream;base64,' + base64
+        }],
+    }));
+}
+
+const TESTS = [];
+function test(name, fn) {
+    TESTS.push([name, fn]);
+}
+
+// Most tests want an engine and nothing else. NOOP needs no canvas context, so Engine.create only
+// reads the id off the object it is handed.
+let Filament = null;
+function withEngine(fn) {
+    const engine = Filament.Engine.create({ id: 'runtime-test-canvas' },
+        { backend: Filament.Backend.NOOP });
+    try {
+        return fn(engine);
+    } finally {
+        Filament.Engine.destroy(engine);
+    }
+}
+
+function newEntity() {
+    return Filament.EntityManager.get().create();
+}
+
+function material(engine) {
+    return engine.createMaterial(asset(MATERIAL));
+}
+
+// Textures default to UPLOADABLE | SAMPLEABLE, which the Texture$Usage enum spells out one flag
+// at a time on the JS side (TypeScript clients get the folded TextureUsage constants instead).
+function textureUsage(...names) {
+    return names.reduce((bits, name) => bits | Filament.Texture$Usage[name].value, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Engine$Builder
+// ---------------------------------------------------------------------------
+
+test('Engine$Builder is registered with its full setter surface', () => {
+    assert.strictEqual(typeof Filament.Engine$Builder, 'function');
+    for (const method of ['backend', 'config', 'featureLevel', 'feature', 'colorGrading',
+        'build', '_build']) {
+        assert.strictEqual(typeof Filament.Engine$Builder.prototype[method], 'function',
+            `Engine$Builder.${method} is not registered`);
+    }
+});
+
+test('Engine$Config round-trips through the builder', () => {
+    const config = Filament.Engine.createDefaultConfig();
+
+    // Defaults must match Engine::Config, since every binding layer mirrors them.
+    assert.strictEqual(config.jobSystemThreadCount, 0);
+    assert.strictEqual(config.stereoscopicEyeCount, 2);
+    assert.strictEqual(config.resourceAllocatorCacheMaxAge, 1);
+    assert.strictEqual(config.disableParallelShaderCompile, false);
+    assert.strictEqual(config.disableHandleUseAfterFreeCheck, false);
+    assert.strictEqual(config.assertNativeWindowIsValid, false);
+
+    config.perRenderPassArenaSizeMB = 5;
+    config.jobSystemThreadCount = 1;
+    config.disableParallelShaderCompile = true;
+    config.disableHandleUseAfterFreeCheck = true;
+    config.stereoscopicEyeCount = 2;
+    config.sharedUboInitialSizeInBytes = 32768;
+
+    const builder = new Filament.Engine$Builder();
+    builder.backend(Filament.Backend.NOOP);
+    builder.config(config);
+    const engine = builder.build();
+    assert.ok(engine, 'Engine$Builder.build returned null');
+
+    const readBack = engine.getConfig();
+    assert.strictEqual(readBack.perRenderPassArenaSizeMB, 5);
+    assert.strictEqual(readBack.jobSystemThreadCount, 1);
+    assert.strictEqual(readBack.disableParallelShaderCompile, true);
+    assert.strictEqual(readBack.disableHandleUseAfterFreeCheck, true);
+    assert.strictEqual(readBack.sharedUboInitialSizeInBytes, 32768);
+    assert.strictEqual(engine.getBackend(), Filament.Backend.NOOP);
+
+    Filament.Engine.destroy(engine);
+});
+
+test('Engine$Builder accepts feature flags and a ColorGrading$Builder', () => {
+    const builder = new Filament.Engine$Builder();
+    builder.backend(Filament.Backend.NOOP);
+    builder.featureLevel(Filament.FeatureLevel.FEATURE_LEVEL_1);
+    // Unknown names are ignored by the engine; this asserts the string marshalling works.
+    builder.feature('backend.disable_parallel_shader_compile', true);
+    builder.colorGrading(Filament.ColorGrading.Builder());
+    const engine = builder.build();
+    assert.ok(engine);
+    Filament.Engine.destroy(engine);
+});
+
+test('Engine.create forwards options through to the builder', () => {
+    const config = Filament.Engine.createDefaultConfig();
+    config.driverHandleArenaSizeMB = 4;
+
+    // NOOP needs no WebGL context, so Engine.create skips canvas.getContext entirely and only
+    // reads the id. That is the whole non-GL path of Engine.create, exercised for real.
+    const engine = Filament.Engine.create({ id: 'runtime-test-canvas' }, {
+        backend: Filament.Backend.NOOP,
+        featureLevel: Filament.FeatureLevel.FEATURE_LEVEL_1,
+        features: { 'backend.disable_parallel_shader_compile': true },
+        colorGrading: Filament.ColorGrading.Builder(),
+    }, config);
+
+    assert.strictEqual(engine.getBackend(), Filament.Backend.NOOP);
+    assert.strictEqual(engine.getConfig().driverHandleArenaSizeMB, 4);
+    assert.strictEqual(engine.canvasId, '#runtime-test-canvas');
+    Filament.Engine.destroy(engine);
+});
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+test('Engine exposes its feature level, clocks and instancing toggle', () => withEngine((engine) => {
+    assert.strictEqual(engine.getSupportedFeatureLevel(), Filament.FeatureLevel.FEATURE_LEVEL_1);
+    assert.strictEqual(engine.getActiveFeatureLevel(), Filament.FeatureLevel.FEATURE_LEVEL_1);
+    engine.setActiveFeatureLevel(Filament.FeatureLevel.FEATURE_LEVEL_1);
+
+    engine.setAutomaticInstancingEnabled(true);
+    assert.strictEqual(engine.isAutomaticInstancingEnabled(), true);
+    engine.setAutomaticInstancingEnabled(false);
+    assert.strictEqual(engine.isAutomaticInstancingEnabled(), false);
+
+    assert.strictEqual(engine.hasUnrecoverableFailure(), false);
+    assert.ok(Filament.Engine.getMaxStereoscopicEyes() >= 1);
+    assert.ok(Filament.Engine.getSteadyClockTimeNano() > 0);
+
+    engine.enableAccurateTranslations();
+    engine.unprotected();
+    engine.flush();
+    engine.flushAndWait();
+    engine.execute();
+}));
+
+test('Engine feature flags can be read and written after construction', () => withEngine((engine) => {
+    // The flag Engine$Builder.feature sets before construction is reachable afterwards too.
+    const name = 'backend.disable_parallel_shader_compile';
+    assert.strictEqual(engine.hasFeatureFlag(name), true, `${name} is not a known flag`);
+    assert.strictEqual(typeof engine.getFeatureFlag(name), 'boolean');
+
+    const accepted = engine.setFeatureFlag(name, true);
+    assert.strictEqual(typeof accepted, 'boolean');
+    if (accepted) {
+        assert.strictEqual(engine.getFeatureFlag(name), true, 'setFeatureFlag did not take');
+    }
+
+    // An unknown flag is absent rather than false, which is why the getter is optional-shaped.
+    assert.strictEqual(engine.hasFeatureFlag('no.such.flag'), false);
+    assert.strictEqual(engine.getFeatureFlag('no.such.flag'), undefined);
+    assert.strictEqual(engine.setFeatureFlag('no.such.flag', true), false);
+}));
+
+test('Engine hands back every object type and validates it', () => withEngine((engine) => {
+    const swapChain = engine.createSwapChain();
+    const renderer = engine.createRenderer();
+    const view = engine.createView();
+    const scene = engine.createScene();
+    const texture = Filament.Texture.Builder().width(1).height(1).build(engine);
+    const renderTarget = Filament.RenderTarget.Builder()
+        .texture(Filament.RenderTarget$AttachmentPoint.COLOR, Filament.Texture.Builder()
+            .width(8).height(8)
+            .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+            .format(Filament.Texture$InternalFormat.RGBA8)
+            .usage(textureUsage('COLOR_ATTACHMENT', 'SAMPLEABLE'))
+            .build(engine))
+        .build(engine);
+    const colorGrading = Filament.ColorGrading.Builder().build(engine);
+    const indirectLight = Filament.IndirectLight.Builder().build(engine);
+    const skybox = Filament.Skybox.Builder().color([0, 0, 0, 1]).build(engine);
+    const vertexBuffer = Filament.VertexBuffer.Builder().vertexCount(1).bufferCount(1)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+            Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .build(engine);
+    const indexBuffer = Filament.IndexBuffer.Builder().indexCount(1).build(engine);
+    const mat = material(engine);
+    const matinst = mat.createInstance();
+
+    assert.ok(engine.isValidSwapChain(swapChain));
+    assert.ok(engine.isValidRenderer(renderer));
+    assert.ok(engine.isValidView(view));
+    assert.ok(engine.isValidScene(scene));
+    assert.ok(engine.isValidTexture(texture));
+    assert.ok(engine.isValidRenderTarget(renderTarget));
+    assert.ok(engine.isValidColorGrading(colorGrading));
+    assert.ok(engine.isValidIndirectLight(indirectLight));
+    assert.ok(engine.isValidSkybox(skybox));
+    assert.ok(engine.isValidVertexBuffer(vertexBuffer));
+    assert.ok(engine.isValidIndexBuffer(indexBuffer));
+    assert.ok(engine.isValidMaterial(mat));
+    assert.ok(engine.isValidMaterialInstance(mat, matinst));
+    assert.ok(engine.isValidExpensiveMaterialInstance(matinst));
+
+    const cameraEntity = newEntity();
+    engine.createCamera(cameraEntity);
+    assert.ok(engine.getCameraComponent(cameraEntity), 'getCameraComponent returned null');
+
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyMaterial(mat);
+    engine.destroyIndexBuffer(indexBuffer);
+    engine.destroyVertexBuffer(vertexBuffer);
+    engine.destroySkybox(skybox);
+    engine.destroyIndirectLight(indirectLight);
+    engine.destroyColorGrading(colorGrading);
+    engine.destroyRenderTarget(renderTarget);
+    engine.destroyTexture(texture);
+    engine.destroyScene(scene);
+    engine.destroyView(view);
+    engine.destroyRenderer(renderer);
+    engine.destroySwapChain(swapChain);
+    engine.destroyCameraComponent(cameraEntity);
+    engine.destroyEntity(cameraEntity);
+
+    // The validity checks have to notice the destruction, not just the creation.
+    assert.strictEqual(engine.isValidSwapChain(swapChain), false);
+    assert.strictEqual(engine.isValidTexture(texture), false);
+}));
+
+test('Engine creates and waits on a fence', () => withEngine((engine) => {
+    const fence = engine.createFence();
+    assert.ok(engine.isValidFence(fence));
+    // Any non-zero timeout aborts on a build without threads, so 0 is the only supported wait.
+    const status = fence.wait(Filament.Fence$Mode.FLUSH, 0);
+    assert.ok(status === Filament.FenceStatus.CONDITION_SATISFIED ||
+        status === Filament.FenceStatus.TIMEOUT_EXPIRED, `unexpected status ${status}`);
+    engine.destroyFence(fence);
+    assert.strictEqual(engine.isValidFence(fence), false);
+}));
+
+test('Engine decodes a KTX1 environment into an IBL and a skybox', () => withEngine((engine) => {
+    const ibl = engine.createIblFromKtx1(asset(IBL_KTX));
+    assert.ok(ibl.getIntensity() > 0);
+    // createIblFromKtx1 parses the "sh" metadata into 27 floats hanging off the IBL.
+    assert.strictEqual(ibl.shfloats.length, 27);
+
+    const skybox = engine.createSkyFromKtx1(asset(IBL_KTX));
+    assert.ok(skybox.getTexture(), 'skybox has no texture');
+}));
+
+// ---------------------------------------------------------------------------
+// EntityManager
+// ---------------------------------------------------------------------------
+
+test('EntityManager creates and destroys entities', () => {
+    const em = Filament.EntityManager.get();
+    const before = em.getEntityCount();
+    const entity = em.create();
+    assert.ok(entity.getId() > 0);
+    assert.strictEqual(em.getEntityCount(), before + 1);
+    assert.ok(Filament.EntityManager.getMaxEntityCount() > 0);
+    em.advanceEpoch();
+    em.destroy(entity);
+    assert.strictEqual(em.getEntityCount(), before);
+    // getActiveEntityCount is compiled in only when FILAMENT_UTILS_TRACK_ENTITIES is set, which
+    // the release build does not do; filament.d.ts documents that it has to be feature-detected.
+    assert.strictEqual(typeof em.getActiveEntityCount, 'undefined');
+});
+
+// ---------------------------------------------------------------------------
+// Camera + frustum
+// ---------------------------------------------------------------------------
+
+test('Camera projections and the view basis round-trip', () => withEngine((engine) => {
+    const camera = engine.createCamera(newEntity());
+    camera.setProjection(Filament.Camera$Projection.PERSPECTIVE, -1, 1, -1, 1, 0.1, 100);
+    assert.strictEqual(camera.getNear(), 0.1);
+    assert.strictEqual(camera.getCullingFar(), 100);
+    assert.strictEqual(camera.getProjectionMatrix().length, 16);
+    assert.strictEqual(camera.getCullingProjectionMatrix().length, 16);
+    assert.strictEqual(Filament.Camera.inverseProjection(camera.getProjectionMatrix()).length, 16);
+
+    camera.setProjectionFov(45, 1.0, 0.1, 100, Filament.Camera$Fov.HORIZONTAL);
+    assert.ok(Math.abs(camera.getFieldOfViewInDegrees(Filament.Camera$Fov.HORIZONTAL) - 45) < 1e-3);
+    camera.setLensProjection(0.05, 1, 0.1, 100);
+    camera.setCustomProjection([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], 0.1, 100);
+    // One projection per eye; Engine$Config.stereoscopicEyeCount defaults to two.
+    const identity4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    camera.setCustomEyeProjection([identity4, identity4], identity4, 0.1, 100);
+    camera.setEyeModelMatrix(0, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+    // An identity model matrix leaves the camera at the origin looking down -Z.
+    camera.setModelMatrix([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+    assert.deepStrictEqual(Array.from(camera.getPosition()), [0, 0, 0]);
+    assert.deepStrictEqual(Array.from(camera.getLeftVector()), [1, 0, 0]);
+    assert.deepStrictEqual(Array.from(camera.getUpVector()), [0, 1, 0]);
+    assert.deepStrictEqual(Array.from(camera.getForwardVector()).map((v) => v === 0 ? 0 : v), [0, 0, -1]);
+    assert.strictEqual(camera.getModelMatrix().length, 16);
+    assert.strictEqual(camera.getViewMatrix().length, 16);
+
+    camera.lookAt([0, 0, 1], [0, 0, 0], [0, 1, 0]);
+    camera.setScaling([2, 2]);
+    assert.deepStrictEqual(Array.from(camera.getScaling()).slice(0, 2), [2, 2]);
+    assert.ok(camera.getEntity().getId() > 0);
+}));
+
+test('Camera exposure controls round-trip', () => withEngine((engine) => {
+    const camera = engine.createCamera(newEntity());
+    camera.setExposure(16, 1 / 125, 100);
+    assert.strictEqual(camera.getAperture(), 16);
+    assert.ok(Math.abs(camera.getShutterSpeed() - 1 / 125) < 1e-5);
+    assert.strictEqual(camera.getSensitivity(), 100);
+    camera.setExposureDirect(1.0);
+
+    camera.setFocusDistance(5);
+    assert.strictEqual(camera.getFocusDistance(), 5);
+    camera.setShift([0.1, 0.2]);
+    const shift = camera.getShift();
+    assert.ok(Math.abs(shift[0] - 0.1) < 1e-6 && Math.abs(shift[1] - 0.2) < 1e-6);
+    assert.ok(camera.getFocalLength() > 0);
+    assert.ok(Filament.Camera.computeEffectiveFov(45, 5) > 0);
+    assert.ok(Filament.Camera.computeEffectiveFocalLength(0.05, 1) > 0);
+}));
+
+test('Frustum intersects the volumes in front of the camera', () => withEngine((engine) => {
+    const camera = engine.createCamera(newEntity());
+    camera.setProjection(Filament.Camera$Projection.PERSPECTIVE, -1, 1, -1, 1, 0.1, 100);
+    const frustum = camera.getFrustum();
+    assert.strictEqual(frustum.getNormalizedPlane(Filament.Frustum$Plane.BOTTOM).length, 4);
+    // The camera looks down -Z, so a unit box one unit ahead is inside and one behind is not.
+    assert.strictEqual(frustum.intersectsBox({ center: [0, 0, -1], halfExtent: [1, 1, 1] }), true);
+    assert.strictEqual(frustum.intersectsBox({ center: [0, 0, 50], halfExtent: [1, 1, 1] }), false);
+    assert.strictEqual(frustum.intersectsSphere([0, 0, -1, 1]), true);
+    assert.strictEqual(frustum.intersectsSphere([0, 0, 50, 1]), false);
+
+    const standalone = new Filament.Frustum(camera.getProjectionMatrix());
+    standalone.setProjection(camera.getProjectionMatrix());
+    assert.ok(standalone);
+}));
+
+// ---------------------------------------------------------------------------
+// View / Scene / Renderer
+// ---------------------------------------------------------------------------
+
+test('View toggles and scalar getters round-trip', () => withEngine((engine) => {
+    const view = engine.createView();
+    view.setName('runtime view');
+    assert.strictEqual(view.getName(), 'runtime view');
+
+    view.setViewport([0, 0, 64, 32]);
+    assert.deepStrictEqual(Array.from(view.getViewport()), [0, 0, 64, 32]);
+
+    for (const [set, get, value] of [
+        ['setShadowingEnabled', 'isShadowingEnabled', false],
+        ['setPostProcessingEnabled', 'isPostProcessingEnabled', false],
+        ['setScreenSpaceRefractionEnabled', 'isScreenSpaceRefractionEnabled', false],
+        ['setFrustumCullingEnabled', 'isFrustumCullingEnabled', false],
+        ['setFrontFaceWindingInverted', 'isFrontFaceWindingInverted', true],
+        ['setStencilBufferEnabled', 'isStencilBufferEnabled', true],
+        ['setTransparentPickingEnabled', 'isTransparentPickingEnabled', true]]) {
+        view[set](value);
+        assert.strictEqual(view[get](), value, `View.${get} did not return what ${set} was given`);
+    }
+
+    view.setShadowType(Filament.View$ShadowType.VSM);
+    assert.strictEqual(view.getShadowType(), Filament.View$ShadowType.VSM);
+    view.setBlendMode(Filament.View$BlendMode.TRANSLUCENT);
+    assert.strictEqual(view.getBlendMode(), Filament.View$BlendMode.TRANSLUCENT);
+    view.setDithering(Filament.View$Dithering.NONE);
+    assert.strictEqual(view.getDithering(), Filament.View$Dithering.NONE);
+    view.setAntiAliasing(Filament.View$AntiAliasing.NONE);
+    assert.strictEqual(view.getAntiAliasing(), Filament.View$AntiAliasing.NONE);
+    view.setAmbientOcclusion(Filament.View$AmbientOcclusion.SSAO);
+    assert.strictEqual(view.getAmbientOcclusion(), Filament.View$AmbientOcclusion.SSAO);
+
+    view.setVisibleLayers(0xff, 0x04);
+    assert.strictEqual(view.getVisibleLayers(), 0x04);
+    view.setLayerEnabled(0, true);
+    assert.strictEqual(view.getVisibleLayers(), 0x05);
+
+    view.setChannelDepthClearEnabled(0, true);
+    assert.strictEqual(view.isChannelDepthClearEnabled(0), true);
+
+    view.setMaterialGlobal(0, [1, 2, 3, 4]);
+    assert.deepStrictEqual(Array.from(view.getMaterialGlobal(0)), [1, 2, 3, 4]);
+
+    view.setGridSize(4);
+    assert.strictEqual(view.getGridSize(), 4);
+    assert.ok(view.getEffectiveGridSize() >= 0);
+    view.setDynamicLightingOptions(5, 100);
+    view.setSampleCount(1);
+    assert.strictEqual(view.getSampleCount(), 1);
+    assert.strictEqual(typeof view.getVisibleRenderableCount(), 'number');
+    assert.strictEqual(view.getLastDynamicResolutionScale().length, 2);
+    assert.ok(view.getFogEntity().getId() > 0);
+    view.clearFrameHistory(engine);
+}));
+
+test('View option structs round-trip field for field', () => withEngine((engine) => {
+    const view = engine.createView();
+
+    view.setBloomOptions({ enabled: true, strength: 0.25, resolution: 256 });
+    const bloom = view.getBloomOptions();
+    assert.strictEqual(bloom.enabled, true);
+    assert.ok(Math.abs(bloom.strength - 0.25) < 1e-6);
+    assert.strictEqual(bloom.resolution, 256);
+
+    view.setFogOptions({ enabled: true, distance: 10, density: 0.5 });
+    const fog = view.getFogOptions();
+    assert.strictEqual(fog.enabled, true);
+    assert.strictEqual(fog.distance, 10);
+
+    view.setVignetteOptions({ enabled: true, midPoint: 0.4, roundness: 0.6 });
+    assert.strictEqual(view.getVignetteOptions().enabled, true);
+
+    view.setDepthOfFieldOptions({ enabled: true, cocScale: 2 });
+    assert.strictEqual(view.getDepthOfFieldOptions().cocScale, 2);
+
+    view.setAmbientOcclusionOptions({ enabled: true, radius: 0.5, power: 2 });
+    const ao = view.getAmbientOcclusionOptions();
+    assert.strictEqual(ao.enabled, true);
+    assert.ok(Math.abs(ao.radius - 0.5) < 1e-6);
+
+    view.setGuardBandOptions({ enabled: true });
+    assert.strictEqual(view.getGuardBandOptions().enabled, true);
+
+    view.setStereoscopicOptions({ enabled: false });
+    assert.strictEqual(view.getStereoscopicOptions().enabled, false);
+
+    view.setTemporalAntiAliasingOptions({ enabled: true, feedback: 0.5, filterWidth: 1.5 });
+    const taa = view.getTemporalAntiAliasingOptions();
+    assert.strictEqual(taa.enabled, true);
+    assert.ok(Math.abs(taa.feedback - 0.5) < 1e-6);
+
+    view.setScreenSpaceReflectionsOptions({ enabled: true, thickness: 0.25 });
+    assert.strictEqual(view.getScreenSpaceReflectionsOptions().enabled, true);
+
+    view.setMultiSampleAntiAliasingOptions({ enabled: true, sampleCount: 4 });
+    assert.strictEqual(view.getMultiSampleAntiAliasingOptions().enabled, true);
+
+    view.setDynamicResolutionOptions({ enabled: true, minScale: [1, 1], maxScale: [1, 1] });
+    assert.strictEqual(view.getDynamicResolutionOptions().enabled, true);
+
+    view.setRenderQuality({ hdrColorBuffer: Filament.View$QualityLevel.HIGH });
+    assert.strictEqual(view.getRenderQuality().hdrColorBuffer, Filament.View$QualityLevel.HIGH);
+
+    view.setVsmShadowOptions({ anisotropy: 1, mipmapping: true, msaaSamples: 2 });
+    const vsm = view.getVsmShadowOptions();
+    assert.strictEqual(vsm.anisotropy, 1);
+    assert.strictEqual(vsm.mipmapping, true);
+
+    view.setSoftShadowOptions({ penumbraScale: 2, penumbraRatioScale: 3 });
+    const soft = view.getSoftShadowOptions();
+    assert.strictEqual(soft.penumbraScale, 2);
+    assert.strictEqual(soft.penumbraRatioScale, 3);
+}));
+
+test('View holds on to the objects it is bound to', () => withEngine((engine) => {
+    const view = engine.createView();
+    assert.strictEqual(view.hasCamera(), false);
+
+    const scene = engine.createScene();
+    const camera = engine.createCamera(newEntity());
+    const colorGrading = Filament.ColorGrading.Builder().build(engine);
+    const renderTarget = Filament.RenderTarget.Builder()
+        .texture(Filament.RenderTarget$AttachmentPoint.COLOR, Filament.Texture.Builder()
+            .width(8).height(8)
+            .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+            .format(Filament.Texture$InternalFormat.RGBA8)
+            .usage(textureUsage('COLOR_ATTACHMENT', 'SAMPLEABLE'))
+            .build(engine))
+        .build(engine);
+    view.setScene(scene);
+    view.setCamera(camera);
+    view.setColorGrading(colorGrading);
+    view.setRenderTarget(renderTarget);
+
+    assert.strictEqual(view.hasCamera(), true);
+    assert.ok(view.getScene(), 'getScene returned null');
+    assert.ok(view.getCamera(), 'getCamera returned null');
+    assert.ok(view.getColorGrading(), 'getColorGrading returned null');
+    assert.ok(view.getRenderTarget(), 'getRenderTarget returned null');
+}));
+
+test('Scene counts what it holds', () => withEngine((engine) => {
+    const scene = engine.createScene();
+    assert.strictEqual(scene.getEntityCount(), 0);
+
+    const entity = newEntity();
+    scene.addEntity(entity);
+    assert.strictEqual(scene.getEntityCount(), 1);
+    assert.strictEqual(scene.hasEntity(entity), true);
+
+    const more = [newEntity(), newEntity()];
+    scene.addEntities(more);
+    assert.strictEqual(scene.getEntityCount(), 3);
+    scene.removeEntities(more);
+    assert.strictEqual(scene.getEntityCount(), 1);
+    scene.remove(entity);
+    assert.strictEqual(scene.getEntityCount(), 0);
+
+    // A light is an entity with a light component, and is counted twice over.
+    const lightEntity = newEntity();
+    Filament.LightManager.Builder(Filament.LightManager$Type.POINT).build(engine, lightEntity);
+    scene.addEntity(lightEntity);
+    assert.strictEqual(scene.getLightCount(), 1);
+    assert.strictEqual(scene.getRenderableCount(), 0);
+
+    const skybox = Filament.Skybox.Builder().color([0, 0, 0, 1]).build(engine);
+    const indirectLight = Filament.IndirectLight.Builder().build(engine);
+    scene.setSkybox(skybox);
+    scene.setIndirectLight(indirectLight);
+    assert.ok(scene.getSkybox(), 'getSkybox returned null');
+    assert.ok(scene.getIndirectLight(), 'getIndirectLight returned null');
+    scene.setSkybox(null);
+    scene.setIndirectLight(null);
+}));
+
+test('Renderer runs a frame and keeps its clocks', () => withEngine((engine) => {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = engine.createView();
+    view.setScene(engine.createScene());
+    view.setCamera(engine.createCamera(newEntity()));
+    view.setViewport([0, 0, 16, 16]);
+
+    renderer.render(swapChain, view);
+    assert.strictEqual(renderer.beginFrame(swapChain), true);
+    renderer.renderView(view);
+    renderer.endFrame();
+
+    // Standalone rendering draws into the view's own render target rather than a swap chain.
+    view.setRenderTarget(Filament.RenderTarget.Builder()
+        .texture(Filament.RenderTarget$AttachmentPoint.COLOR,
+            Filament.Texture.Builder().width(8).height(8)
+                .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+                .format(Filament.Texture$InternalFormat.RGBA8)
+                .usage(textureUsage('COLOR_ATTACHMENT', 'SAMPLEABLE'))
+                .build(engine))
+        .build(engine));
+    renderer.renderStandaloneView(view);
+
+    assert.ok(renderer.getUserTime() >= 0);
+    assert.ok(renderer.getMaterialTime() >= 0);
+    renderer.resetUserTime();
+    renderer.setMaterialTimeEpoch(0);
+
+    renderer.skipNextFrames(2);
+    assert.strictEqual(renderer.getFrameToSkipCount(), 2);
+    // Both of these read the same frame skipper, so they have to disagree.
+    assert.strictEqual(renderer.hasGpuFallenBehind(), !renderer.shouldRenderFrame());
+
+    const now = Filament.Engine.getSteadyClockTimeNano();
+    renderer.setPresentationTime(now);
+    renderer.setDesiredPresentationTime(now);
+    renderer.setRenderingDeadline(now);
+    renderer.setVsyncTime(now);
+    renderer.skipFrame(now);
+    renderer.pauseRenderThread(0);
+    renderer.copyFrame(swapChain, [0, 0, 8, 8], [0, 0, 8, 8], 0);
+}));
+
+test('Renderer clear options round-trip', () => withEngine((engine) => {
+    const renderer = engine.createRenderer();
+    renderer.setClearOptions({ clearColor: [0.25, 0.5, 0.75, 1], clear: true, discard: false });
+    const options = renderer.getClearOptions();
+    assert.deepStrictEqual(Array.from(options.clearColor), [0.25, 0.5, 0.75, 1]);
+    assert.strictEqual(options.clear, true);
+    assert.strictEqual(options.discard, false);
+}));
+
+// ---------------------------------------------------------------------------
+// Component managers
+// ---------------------------------------------------------------------------
+
+test('TransformManager composes a parent-child hierarchy', () => withEngine((engine) => {
+    const tcm = engine.getTransformManager();
+    const parent = newEntity();
+    const child = newEntity();
+    tcm.create(parent);
+    tcm.create(child);
+    assert.strictEqual(tcm.hasComponent(parent), true);
+
+    const parentInstance = tcm.getInstance(parent);
+    const childInstance = tcm.getInstance(child);
+
+    // A translation of (1, 2, 3), column-major.
+    const translate = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1];
+    tcm.setTransform(parentInstance, translate);
+    assert.deepStrictEqual(Array.from(tcm.getTransform(parentInstance)), translate);
+
+    tcm.setParent(childInstance, parentInstance);
+    assert.strictEqual(tcm.getParent(childInstance).getId(), parent.getId());
+    assert.strictEqual(tcm.getChildCount(parentInstance), 1);
+    assert.strictEqual(tcm.getChildren(parentInstance).size(), 1);
+    // The child inherits the parent's translation through the world transform.
+    assert.deepStrictEqual(Array.from(tcm.getWorldTransform(childInstance)), translate);
+
+    tcm.openLocalTransformTransaction();
+    tcm.setTransform(childInstance, translate);
+    tcm.commitLocalTransformTransaction();
+
+    tcm.setAccurateTranslationsEnabled(true);
+    assert.strictEqual(tcm.isAccurateTranslationsEnabled(), true);
+
+    childInstance.delete();
+    parentInstance.delete();
+    tcm.destroy(child);
+    tcm.destroy(parent);
+    assert.strictEqual(tcm.hasComponent(child), false);
+}));
+
+test('RenderableManager$Builder options survive into the instance', () => withEngine((engine) => {
+    const entity = newEntity();
+    const box = { center: [0, 0, 0], halfExtent: [2, 2, 2] };
+    Filament.RenderableManager.Builder(1)
+        .boundingBox(box)
+        .layerMask(0xff, 0x01)
+        .priority(4)
+        .channel(1)
+        .culling(true)
+        .castShadows(true)
+        .receiveShadows(true)
+        .screenSpaceContactShadows(false)
+        .fog(true)
+        .lightChannel(0, true)
+        .blendOrder(0, 1)
+        .globalBlendOrderEnabled(0, true)
+        .instances(2)
+        .build(engine, entity);
+
+    const rm = engine.getRenderableManager();
+    assert.strictEqual(rm.hasComponent(entity), true);
+    const instance = rm.getInstance(entity);
+
+    assert.deepStrictEqual(Array.from(rm.getAxisAlignedBoundingBox(instance).halfExtent),
+        [2, 2, 2]);
+    assert.strictEqual(rm.getPriority(instance), 4);
+    assert.strictEqual(rm.getChannel(instance), 1);
+    assert.strictEqual(rm.isCullingEnabled(instance), true);
+    assert.strictEqual(rm.isShadowCaster(instance), true);
+    assert.strictEqual(rm.isShadowReceiver(instance), true);
+    assert.strictEqual(rm.isScreenSpaceContactShadowsEnabled(instance), false);
+    assert.strictEqual(rm.getFogEnabled(instance), true);
+    assert.strictEqual(rm.getLightChannel(instance, 0), true);
+    assert.strictEqual(rm.getBlendOrderAt(instance, 0), 1);
+    assert.strictEqual(rm.isGlobalBlendOrderEnabledAt(instance, 0), true);
+    assert.strictEqual(rm.getInstanceCount(instance), 2);
+    assert.strictEqual(rm.getPrimitiveCount(instance), 1);
+
+    // The same knobs, now through the instance-side setters.
+    rm.setAxisAlignedBoundingBox(instance, { center: [0, 0, 0], halfExtent: [1, 1, 1] });
+    assert.deepStrictEqual(Array.from(rm.getAxisAlignedBoundingBox(instance).halfExtent),
+        [1, 1, 1]);
+    rm.setPriority(instance, 3);
+    assert.strictEqual(rm.getPriority(instance), 3);
+    rm.setChannel(instance, 2);
+    assert.strictEqual(rm.getChannel(instance), 2);
+    rm.setCastShadows(instance, false);
+    assert.strictEqual(rm.isShadowCaster(instance), false);
+    rm.setReceiveShadows(instance, false);
+    assert.strictEqual(rm.isShadowReceiver(instance), false);
+    rm.setCulling(instance, false);
+    assert.strictEqual(rm.isCullingEnabled(instance), false);
+    rm.setFogEnabled(instance, false);
+    assert.strictEqual(rm.getFogEnabled(instance), false);
+    rm.setLightChannel(instance, 0, false);
+    assert.strictEqual(rm.getLightChannel(instance, 0), false);
+    rm.setScreenSpaceContactShadows(instance, true);
+    assert.strictEqual(rm.isScreenSpaceContactShadowsEnabled(instance), true);
+    rm.setBlendOrderAt(instance, 0, 7);
+    assert.strictEqual(rm.getBlendOrderAt(instance, 0), 7);
+    rm.setGlobalBlendOrderEnabledAt(instance, 0, false);
+    assert.strictEqual(rm.isGlobalBlendOrderEnabledAt(instance, 0), false);
+    rm.setLayerMask(instance, 0xff, 0x02);
+
+    instance.delete();
+    rm.destroy(entity);
+    assert.strictEqual(rm.hasComponent(entity), false);
+}));
+
+test('RenderableManager carries geometry and material assignments', () => withEngine((engine) => {
+    const vertexBuffer = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+            Filament.VertexBuffer$AttributeType.FLOAT3, 0, 16)
+        .attribute(Filament.VertexAttribute.TANGENTS, 0,
+            Filament.VertexBuffer$AttributeType.SHORT4, 12, 16)
+        .build(engine);
+    vertexBuffer.setBufferAt(engine, 0, new Float32Array(12));
+    const indexBuffer = Filament.IndexBuffer.Builder()
+        .indexCount(3)
+        .bufferType(Filament.IndexBuffer$IndexType.USHORT)
+        .build(engine);
+    indexBuffer.setBuffer(engine, new Uint16Array([0, 1, 2]));
+
+    const mat = material(engine);
+    const matinst = mat.createInstance();
+    const entity = newEntity();
+    // A renderable with primitives is rejected without a bounding box to cull against.
+    Filament.RenderableManager.Builder(3)
+        .boundingBox({ center: [0, 0, 0], halfExtent: [1, 1, 1] })
+        .material(0, matinst)
+        .material(1, matinst)
+        .material(2, matinst)
+        .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer, indexBuffer)
+        .geometryOffset(1, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer,
+            indexBuffer, 0, 3)
+        .geometryMinMax(2, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer,
+            indexBuffer, 0, 0, 2, 3)
+        .build(engine, entity);
+
+    const rm = engine.getRenderableManager();
+    const instance = rm.getInstance(entity);
+    assert.strictEqual(rm.getPrimitiveCount(instance), 3);
+    // POSITION is attribute 0, so the enabled-attribute bitmask is exactly bit 0.
+    assert.strictEqual(rm.getEnabledAttributesAt(instance, 0), 3);
+    assert.ok(rm.getMaterialInstanceAt(instance, 0), 'primitive 0 has no material');
+
+    rm.setMaterialInstanceAt(instance, 1, matinst);
+    assert.ok(rm.getMaterialInstanceAt(instance, 1), 'setMaterialInstanceAt did not take');
+    rm.setGeometryAt(instance, 0, Filament.RenderableManager$PrimitiveType.TRIANGLES,
+        vertexBuffer, indexBuffer, 0, 3);
+    rm.clearMaterialInstanceAt(instance, 1);
+    rm.setMaterialInstanceAt(instance, 1, matinst);
+    instance.delete();
+
+    // The index-free forms, which take a vertex count instead of an index buffer.
+    const noIndices = newEntity();
+    Filament.RenderableManager.Builder(2)
+        .boundingBox({ center: [0, 0, 0], halfExtent: [1, 1, 1] })
+        .material(0, matinst)
+        .material(1, matinst)
+        .geometryType(Filament.RenderableManager$Builder$GeometryType.DYNAMIC)
+        .geometryNoIndices(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer)
+        .geometryNoIndicesOffset(1, Filament.RenderableManager$PrimitiveType.TRIANGLES,
+            vertexBuffer, 0, 3)
+        .build(engine, noIndices);
+    const noIndicesInstance = rm.getInstance(noIndices);
+    rm.setGeometryNoIndicesAt(noIndicesInstance, 0,
+        Filament.RenderableManager$PrimitiveType.TRIANGLES, vertexBuffer, 0, 3);
+    assert.strictEqual(rm.getPrimitiveCount(noIndicesInstance), 2);
+    rm.destroy(entity);
+    rm.destroy(noIndices);
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyMaterial(mat);
+    engine.destroyVertexBuffer(vertexBuffer);
+    engine.destroyIndexBuffer(indexBuffer);
+}));
+
+test('Skinning and morphing buffers report what they were built with', () => withEngine((engine) => {
+    const bone = { unitQuaternion: [0, 0, 0, 1], translation: [0, 0, 0] };
+    const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+    // RenderableManager::setSkinningBuffer always binds CONFIG_MAX_BONE_COUNT bones, whatever
+    // count it is given, so a buffer it is pointed at has to be that large.
+    const skinningBuffer = Filament.SkinningBuffer.Builder()
+        .boneCount(256)
+        .initialize(true)
+        .build(engine);
+    assert.strictEqual(skinningBuffer.getBoneCount(), 256);
+    skinningBuffer.setBones(engine, [bone], 0);
+    skinningBuffer.setBonesFromMatrices(engine, [identity], 0);
+    assert.ok(engine.isValidSkinningBuffer(skinningBuffer));
+
+    const morphTargetBuffer = Filament.MorphTargetBuffer.Builder()
+        .vertexCount(3)
+        .count(2)
+        .withPositions(true)
+        .withTangents(true)
+        .enableCustomMorphing(true)
+        .build(engine);
+    assert.strictEqual(morphTargetBuffer.getVertexCount(), 3);
+    assert.strictEqual(morphTargetBuffer.getCount(), 2);
+    assert.strictEqual(morphTargetBuffer.hasPositions(), true);
+    assert.strictEqual(morphTargetBuffer.hasTangents(), true);
+    assert.strictEqual(morphTargetBuffer.isCustomMorphingEnabled(), true);
+    morphTargetBuffer.setPositionsAt(engine, 0, new Float32Array(9), 3, 0);
+    morphTargetBuffer.setTangentsAt(engine, 0, new Int16Array(12), 3, 0);
+    assert.ok(engine.isValidMorphTargetBuffer(morphTargetBuffer));
+
+    const entity = newEntity();
+    Filament.RenderableManager.Builder(1)
+        .enableSkinningBuffers(true)
+        .skinningBuffer(skinningBuffer, 256, 0)
+        .morphingTargetCount(2)
+        .morphingBuffer(morphTargetBuffer)
+        .morphingBufferOffset(0, 0, 0)
+        .build(engine, entity);
+
+    const rm = engine.getRenderableManager();
+    const instance = rm.getInstance(entity);
+    assert.strictEqual(rm.getMorphTargetCount(instance), 2);
+    rm.setSkinningBuffer(instance, skinningBuffer, 256, 0);
+    rm.setMorphWeights(instance, [0.0, 1.0]);
+    rm.setMorphWeightsOffset(instance, [1.0], 1);
+    rm.setMorphTargetBufferOffsetAt(instance, 0, 0, 0);
+    instance.delete();
+
+    // The bone-transform forms, which write into the renderable's own skinning storage.
+    const boned = newEntity();
+    Filament.RenderableManager.Builder(1)
+        .skinning(1)
+        .skinningBones([bone])
+        .build(engine, boned);
+    const bonedInstance = rm.getInstance(boned);
+    rm.setBones(bonedInstance, [bone], 0);
+    rm.setBonesFromMatrices(bonedInstance, [identity], 0);
+    bonedInstance.delete();
+
+    Filament.RenderableManager.Builder(1).skinningMatrices([identity]).build(engine, newEntity());
+
+    engine.destroySkinningBuffer(skinningBuffer);
+    engine.destroyMorphTargetBuffer(morphTargetBuffer);
+}));
+
+test('LightManager placement and sun controls round-trip', () => withEngine((engine) => {
+    const lm = engine.getLightManager();
+    const entity = newEntity();
+    Filament.LightManager.Builder(Filament.LightManager$Type.SUN)
+        .castLight(true)
+        .castShadows(true)
+        .color([1, 1, 1])
+        .direction([0, -1, 0])
+        .position([1, 2, 3])
+        .intensity(110000)
+        .sunAngularRadius(1)
+        .sunHaloSize(10)
+        .sunHaloFalloff(80)
+        .lightChannel(0, true)
+        .shadowOptions({
+            mapSize: 1024, shadowCascades: 4,
+            cascadeSplitPositions: [0.25, 0.5, 0.75],
+            vsm: { elvsm: true, blurWidth: 2.0 }
+        })
+        .build(engine, entity);
+
+    assert.strictEqual(lm.hasComponent(entity), true);
+    assert.strictEqual(lm.getComponentCount(), 1);
+    const instance = lm.getInstance(entity);
+
+    assert.strictEqual(lm.getType(instance), Filament.LightManager$Type.SUN);
+    assert.strictEqual(lm.isDirectional(instance), true);
+    assert.strictEqual(lm.isPointLight(instance), false);
+    assert.strictEqual(lm.isSpotLight(instance), false);
+    assert.strictEqual(lm.isShadowCaster(instance), true);
+    assert.deepStrictEqual(Array.from(lm.getColor(instance)), [1, 1, 1]);
+    assert.deepStrictEqual(Array.from(lm.getDirection(instance)), [0, -1, 0]);
+    assert.deepStrictEqual(Array.from(lm.getPosition(instance)), [1, 2, 3]);
+    assert.strictEqual(lm.getSunAngularRadius(instance), 1);
+    assert.strictEqual(lm.getSunHaloSize(instance), 10);
+    assert.strictEqual(lm.getSunHaloFalloff(instance), 80);
+    assert.strictEqual(lm.getLightChannel(instance, 0), true);
+
+    lm.setPosition(instance, [4, 5, 6]);
+    assert.deepStrictEqual(Array.from(lm.getPosition(instance)), [4, 5, 6]);
+    lm.setDirection(instance, [0, 0, -1]);
+    assert.deepStrictEqual(Array.from(lm.getDirection(instance)), [0, 0, -1]);
+    lm.setColor(instance, [1, 0, 0]);
+    assert.deepStrictEqual(Array.from(lm.getColor(instance)), [1, 0, 0]);
+    lm.setIntensity(instance, 100);
+    assert.ok(Math.abs(lm.getIntensity(instance) - 100) < 1e-2);
+    lm.setSunAngularRadius(instance, 0.5);
+    assert.ok(Math.abs(lm.getSunAngularRadius(instance) - 0.5) < 1e-5);
+    lm.setSunHaloSize(instance, 11);
+    assert.strictEqual(lm.getSunHaloSize(instance), 11);
+    lm.setSunHaloFalloff(instance, 60);
+    assert.strictEqual(lm.getSunHaloFalloff(instance), 60);
+    lm.setLightChannel(instance, 0, false);
+    assert.strictEqual(lm.getLightChannel(instance, 0), false);
+    lm.setShadowCaster(instance, false);
+    assert.strictEqual(lm.isShadowCaster(instance), false);
+    lm.setShadowOptions(instance, { mapSize: 512 });
+
+    // The three photometric intensity setters all land on the same stored value.
+    lm.setIntensityCandela(instance, 1000);
+    lm.setIntensityEnergy(instance, 100, 0.5);
+    assert.ok(lm.getIntensity(instance) > 0);
+
+    instance.delete();
+    lm.destroy(entity);
+    assert.strictEqual(lm.hasComponent(entity), false);
+}));
+
+test('LightManager spot cone getters mirror setSpotLightCone', () => withEngine((engine) => {
+    const lm = engine.getLightManager();
+    const entity = newEntity();
+
+    Filament.LightManager.Builder(Filament.LightManager$Type.SPOT)
+        .castShadows(false)
+        .position([0, 0, 0])
+        .direction([0, -1, 0])
+        .intensityCandela(1000)
+        .spotLightCone(0.25, 0.5)
+        .build(engine, entity);
+
+    // The outer angle is stored as given; the inner one is recomputed from the packed cone
+    // scale, which LightManager.h documents as not round-tripping exactly.
+    const instance = lm.getInstance(entity);
+    assert.strictEqual(lm.isSpotLight(instance), true);
+    assert.ok(Math.abs(lm.getSpotLightOuterCone(instance) - 0.5) < 1e-5,
+        `outer cone was ${lm.getSpotLightOuterCone(instance)}`);
+    assert.ok(Math.abs(lm.getSpotLightInnerCone(instance) - 0.25) < 1e-2,
+        `inner cone was ${lm.getSpotLightInnerCone(instance)}`);
+
+    lm.setSpotLightCone(instance, 0.1, 0.2);
+    assert.ok(Math.abs(lm.getSpotLightOuterCone(instance) - 0.2) < 1e-5,
+        `outer cone was ${lm.getSpotLightOuterCone(instance)}`);
+    assert.ok(Math.abs(lm.getSpotLightInnerCone(instance) - 0.1) < 1e-2,
+        `inner cone was ${lm.getSpotLightInnerCone(instance)}`);
+}));
+
+test('LightManager$ShadowCascades computes split positions', () => {
+    const uniform = Filament.LightManager$ShadowCascades.computeUniformSplits(4);
+    const log = Filament.LightManager$ShadowCascades.computeLogSplits(4, 0.1, 100);
+    const practical = Filament.LightManager$ShadowCascades.computePracticalSplits(4, 0.1, 100, 0.5);
+    for (const splits of [uniform, log, practical]) {
+        assert.strictEqual(splits.length, 3, 'four cascades have three splits between them');
+        assert.ok(splits[0] < splits[1] && splits[1] < splits[2], `unsorted splits ${splits}`);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// GPU resources: buffers, textures, materials, render targets
+// ---------------------------------------------------------------------------
+
+test('Vertex, index and buffer objects report their sizes', () => withEngine((engine) => {
+    const vertexBuffer = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+            Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .normalized(Filament.VertexAttribute.COLOR)
+        .normalizedIf(Filament.VertexAttribute.COLOR, false)
+        .build(engine);
+    vertexBuffer.setBufferAt(engine, 0, new Float32Array(9));
+    assert.strictEqual(vertexBuffer.getVertexCount(), 3);
+
+    const indexBuffer = Filament.IndexBuffer.Builder()
+        .indexCount(3)
+        .bufferType(Filament.IndexBuffer$IndexType.USHORT)
+        .build(engine);
+    indexBuffer.setBuffer(engine, new Uint16Array([0, 1, 2]));
+    assert.strictEqual(indexBuffer.getIndexCount(), 3);
+
+    const bufferObject = Filament.BufferObject.Builder()
+        .size(36)
+        .bindingType(Filament.BufferObject$BindingType.VERTEX)
+        .build(engine);
+    bufferObject.setBuffer(engine, new Float32Array(9));
+    assert.strictEqual(bufferObject.getByteCount(), 36);
+
+    // A vertex buffer built with buffer objects sources its data from one instead of its own
+    // storage, so it takes setBufferObjectAt rather than setBufferAt.
+    const boBacked = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .enableBufferObjects(true)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+            Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .build(engine);
+    boBacked.setBufferObjectAt(engine, 0, bufferObject);
+}));
+
+test('Texture reports the shape it was built with', () => withEngine((engine) => {
+    const texture = Filament.Texture.Builder()
+        .width(16)
+        .height(8)
+        .depth(1)
+        .levels(2)
+        .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('UPLOADABLE', 'SAMPLEABLE'))
+        .build(engine);
+
+    assert.strictEqual(texture.getWidth(engine), 16);
+    assert.strictEqual(texture.getHeight(engine, 0), 8);
+    assert.strictEqual(texture.getWidth(engine, 1), 8, 'level 1 is half as wide');
+    assert.strictEqual(texture.getDepth(engine, 0), 1);
+    assert.strictEqual(texture.getLevels(engine), 2);
+    assert.strictEqual(texture.getTarget(), Filament.Texture$Sampler.SAMPLER_2D);
+    assert.strictEqual(texture.getFormat(), Filament.Texture$InternalFormat.RGBA8);
+
+    texture.setImage(engine, 0, Filament.PixelBuffer(new Uint8Array(16 * 8 * 4),
+        Filament.PixelDataFormat.RGBA, Filament.PixelDataType.UBYTE));
+    texture.setImage(engine, 1, 0, 0, 8, 4, Filament.PixelBuffer(new Uint8Array(8 * 4 * 4),
+        Filament.PixelDataFormat.RGBA, Filament.PixelDataType.UBYTE));
+
+    assert.strictEqual(Filament.Texture.validatePixelFormatAndType(
+        Filament.Texture$InternalFormat.RGBA8, Filament.PixelDataFormat.RGBA,
+        Filament.PixelDataType.UBYTE), true);
+    assert.strictEqual(Filament.Texture.isTextureFormatSupported(engine,
+        Filament.Texture$InternalFormat.RGBA8), true);
+    assert.strictEqual(typeof Filament.Texture.isTextureFormatMipmappable(engine,
+        Filament.Texture$InternalFormat.RGBA8), 'boolean');
+    assert.strictEqual(typeof Filament.Texture.isTextureSwizzleSupported(engine), 'boolean');
+    assert.ok(Filament.Texture.getMaxTextureSize(engine,
+        Filament.Texture$Sampler.SAMPLER_2D) > 0);
+    assert.ok(Filament.Texture.getMaxArrayTextureLayers(engine) > 0);
+}));
+
+test('TextureSampler state round-trips', () => {
+    const sampler = new Filament.TextureSampler(Filament.MinFilter.LINEAR,
+        Filament.MagFilter.LINEAR, Filament.WrapMode.CLAMP_TO_EDGE);
+    assert.strictEqual(sampler.getMinFilter(), Filament.MinFilter.LINEAR);
+    assert.strictEqual(sampler.getMagFilter(), Filament.MagFilter.LINEAR);
+    assert.strictEqual(sampler.getWrapModeS(), Filament.WrapMode.CLAMP_TO_EDGE);
+
+    sampler.setAnisotropy(4);
+    assert.strictEqual(sampler.getAnisotropy(), 4);
+    sampler.setCompareMode(Filament.CompareMode.COMPARE_TO_TEXTURE,
+        Filament.CompareFunc.LESS_EQUAL);
+    assert.strictEqual(sampler.getCompareMode(), Filament.CompareMode.COMPARE_TO_TEXTURE);
+    assert.strictEqual(sampler.getCompareFunc(), Filament.CompareFunc.LESS_EQUAL);
+    sampler.setMinFilter(Filament.MinFilter.NEAREST);
+    assert.strictEqual(sampler.getMinFilter(), Filament.MinFilter.NEAREST);
+    sampler.setMagFilter(Filament.MagFilter.NEAREST);
+    assert.strictEqual(sampler.getMagFilter(), Filament.MagFilter.NEAREST);
+    sampler.setWrapModeS(Filament.WrapMode.REPEAT);
+    assert.strictEqual(sampler.getWrapModeS(), Filament.WrapMode.REPEAT);
+    sampler.setWrapModeT(Filament.WrapMode.MIRRORED_REPEAT);
+    assert.strictEqual(sampler.getWrapModeT(), Filament.WrapMode.MIRRORED_REPEAT);
+    sampler.setWrapModeR(Filament.WrapMode.REPEAT);
+    assert.strictEqual(sampler.getWrapModeR(), Filament.WrapMode.REPEAT);
+});
+
+test('Material reflects what it was compiled with', () => withEngine((engine) => {
+    const mat = material(engine);
+    assert.strictEqual(mat.getName(), 'LitOpaque');
+    assert.strictEqual(mat.getShading(), Filament.Shading.LIT);
+    assert.strictEqual(mat.getBlendingMode(), Filament.BlendingMode.OPAQUE);
+    assert.strictEqual(mat.getInterpolation(), Filament.Interpolation.SMOOTH);
+    assert.strictEqual(mat.getVertexDomain(), Filament.VertexDomain.OBJECT);
+    assert.strictEqual(mat.getFeatureLevel(), Filament.FeatureLevel.FEATURE_LEVEL_1);
+    assert.strictEqual(mat.getRefractionMode(), Filament.RefractionMode.NONE);
+    assert.strictEqual(mat.getRefractionType(), Filament.RefractionType.SOLID);
+    assert.strictEqual(mat.getReflectionMode(), Filament.ReflectionMode.DEFAULT);
+    assert.strictEqual(mat.getCullingMode(), Filament.CullingMode.BACK);
+    assert.strictEqual(mat.getTransparencyMode(), Filament.TransparencyMode.DEFAULT);
+    assert.strictEqual(mat.isDoubleSided(), false);
+    assert.strictEqual(mat.isColorWriteEnabled(), true);
+    assert.strictEqual(mat.isDepthWriteEnabled(), true);
+    assert.strictEqual(mat.isDepthCullingEnabled(), true);
+    assert.strictEqual(typeof mat.isAlphaToCoverageEnabled(), 'boolean');
+    assert.ok(mat.getRequiredAttributes() > 0);
+    assert.ok(mat.getMaskThreshold() >= 0);
+    assert.ok(mat.getSpecularAntiAliasingVariance() >= 0);
+    assert.ok(mat.getSpecularAntiAliasingThreshold() >= 0);
+
+    // The parameter list must agree with itself and name the parameters the material declares.
+    const parameters = mat.getParameters();
+    assert.strictEqual(parameters.length, mat.getParameterCount());
+    const names = parameters.map((p) => p.name);
+    assert.ok(names.includes('baseColor'), `no baseColor in ${names}`);
+    assert.strictEqual(mat.hasParameter('baseColor'), true);
+    assert.strictEqual(mat.hasParameter('nonexistent'), false);
+    assert.strictEqual(typeof parameters[0].isSampler, 'boolean');
+    assert.strictEqual(typeof parameters[0].count, 'number');
+
+    assert.ok(mat.getDefaultInstance(), 'no default instance');
+    const createdInst = mat.createInstance();
+    assert.ok(createdInst, 'createInstance returned null');
+    engine.destroyMaterialInstance(createdInst);
+    const named = mat.createNamedInstance('named');
+    assert.strictEqual(named.getName(), 'named');
+    engine.destroyMaterialInstance(named);
+    engine.destroyMaterial(mat);
+}));
+
+test('MaterialInstance parameter setters accept every bound type', () => withEngine((engine) => {
+    const mat = material(engine);
+    const matinst = mat.createInstance();
+
+    matinst.setFloatParameter('roughness', 0.5);
+    matinst.setFloat3Parameter('baseColor', [1, 0, 0]);
+    matinst.setFloat4Parameter('emissive', [1, 0, 0, 1]);
+    matinst.setColor3Parameter('baseColor', Filament.RgbType.sRGB, [1, 0, 0]);
+    matinst.setColor4Parameter('emissive', Filament.RgbaType.sRGB, [1, 0, 0, 1]);
+
+    // The remaining typed setters have no matching parameter in this material, so they are
+    // checked for registration rather than called; a wrong name aborts the engine.
+    for (const setter of ['setBoolParameter', 'setBool2Parameter', 'setBool3Parameter',
+        'setBool4Parameter', 'setIntParameter', 'setInt2Parameter', 'setInt3Parameter',
+        'setInt4Parameter', 'setFloat2Parameter', 'setMat3Parameter', 'setMat4Parameter',
+        'setConstantBool', 'setConstantFloat', 'setConstantInt']) {
+        assert.strictEqual(typeof matinst[setter], 'function', `${setter} is not registered`);
+    }
+
+    const duplicate = matinst.duplicate();
+    assert.ok(duplicate, 'duplicate returned null');
+    const copy = matinst.duplicateNamed('copy');
+    assert.strictEqual(copy.getName(), 'copy');
+    assert.strictEqual(matinst.getMaterial().getName(), mat.getName());
+
+    matinst.setScissor(0, 0, 16, 16);
+    matinst.unsetScissor();
+
+    engine.destroyMaterialInstance(duplicate);
+    engine.destroyMaterialInstance(copy);
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyMaterial(mat);
+}));
+
+test('MaterialInstance render state round-trips', () => withEngine((engine) => {
+    const matinst = material(engine).createInstance();
+
+    matinst.setCullingMode(Filament.CullingMode.FRONT);
+    assert.strictEqual(matinst.getCullingMode(), Filament.CullingMode.FRONT);
+    matinst.setCullingModeSeparate(Filament.CullingMode.BACK, Filament.CullingMode.FRONT);
+    assert.strictEqual(matinst.getCullingMode(), Filament.CullingMode.BACK);
+    assert.strictEqual(matinst.getShadowCullingMode(), Filament.CullingMode.FRONT);
+
+    matinst.setColorWrite(false);
+    assert.strictEqual(matinst.isColorWriteEnabled(), false);
+    matinst.setDepthWrite(false);
+    assert.strictEqual(matinst.isDepthWriteEnabled(), false);
+    matinst.setDepthCulling(false);
+    assert.strictEqual(matinst.isDepthCullingEnabled(), false);
+    matinst.setDepthFunc(Filament.CompareFunc.GREATER);
+    assert.strictEqual(matinst.getDepthFunc(), Filament.CompareFunc.GREATER);
+
+    matinst.setTransparencyMode(Filament.TransparencyMode.TWO_PASSES_ONE_SIDE);
+    assert.strictEqual(matinst.getTransparencyMode(),
+        Filament.TransparencyMode.TWO_PASSES_ONE_SIDE);
+
+    matinst.setStencilWrite(true);
+    assert.strictEqual(matinst.isStencilWriteEnabled(), true);
+    matinst.setStencilCompareFunction(Filament.CompareFunc.EQUAL);
+    matinst.setStencilCompareFunction(Filament.CompareFunc.EQUAL, Filament.StencilFace.FRONT);
+    matinst.setStencilOpStencilFail(Filament.StencilOperation.KEEP);
+    matinst.setStencilOpDepthFail(Filament.StencilOperation.KEEP, Filament.StencilFace.BACK);
+    matinst.setStencilOpDepthStencilPass(Filament.StencilOperation.REPLACE);
+    matinst.setStencilReferenceValue(1);
+    matinst.setStencilReadMask(0xff);
+    matinst.setStencilWriteMask(0xff, Filament.StencilFace.FRONT_AND_BACK);
+
+    matinst.setPolygonOffset(1.0, 1.0);
+
+    // setMaskThreshold and the specular anti-aliasing setters abort unless the material was
+    // compiled for them, so only their getters are safe to call on an ordinary opaque material.
+    assert.ok(matinst.getMaskThreshold() >= 0);
+    assert.ok(matinst.getSpecularAntiAliasingVariance() >= 0);
+    assert.ok(matinst.getSpecularAntiAliasingThreshold() >= 0);
+    assert.strictEqual(typeof matinst.isDoubleSided(), 'boolean');
+    assert.strictEqual(typeof matinst.setDoubleSided, 'function');
+
+    const mat = matinst.getMaterial();
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyMaterial(mat);
+}));
+
+test('MaterialInstance binds a texture parameter', () => withEngine((engine) => {
+    const mat = engine.createMaterial(asset(TEXTURED_MATERIAL));
+    const samplers = mat.getParameters().filter((p) => p.isSampler).map((p) => p.name);
+    assert.ok(samplers.includes('albedo'), `no albedo sampler in ${samplers}`);
+    assert.strictEqual(typeof mat.getParameterTransformName('albedo'), 'string');
+
+    const texture = Filament.Texture.Builder()
+        .width(4).height(4)
+        .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('UPLOADABLE', 'SAMPLEABLE'))
+        .build(engine);
+    const matinst = mat.createInstance();
+    matinst.setTextureParameter('albedo', texture,
+        new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR,
+            Filament.WrapMode.CLAMP_TO_EDGE));
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyTexture(texture);
+    engine.destroyMaterial(mat);
+}));
+
+test('Every tone mapper builds a ColorGrading', () => withEngine((engine) => {
+    const mappers = [
+        new Filament.LinearToneMapper(),
+        new Filament.ACESToneMapper(),
+        new Filament.ACESLegacyToneMapper(),
+        new Filament.FilmicToneMapper(),
+        new Filament.PBRNeutralToneMapper(),
+        new Filament.GT7ToneMapper(),
+        new Filament.DisplayRangeToneMapper(),
+        new Filament.AgxToneMapper(Filament.AgxToneMapper$AgxLook.PUNCHY),
+    ];
+    for (const mapper of mappers) {
+        assert.ok(Filament.ColorGrading.Builder().toneMapper(mapper).build(engine),
+            'toneMapper build returned null');
+        mapper.delete();
+    }
+
+    const generic = new Filament.GenericToneMapper(1.55, 0.18, 0.215, 10.0);
+    assert.ok(Math.abs(generic.getContrast() - 1.55) < 1e-5);
+    assert.ok(Math.abs(generic.getMidGrayIn() - 0.18) < 1e-5);
+    assert.ok(Math.abs(generic.getMidGrayOut() - 0.215) < 1e-5);
+    assert.ok(Math.abs(generic.getHdrMax() - 10.0) < 1e-5);
+    generic.setContrast(1.6);
+    generic.setMidGrayIn(0.2);
+    generic.setMidGrayOut(0.22);
+    generic.setHdrMax(12.0);
+    assert.ok(Math.abs(generic.getContrast() - 1.6) < 1e-5);
+    assert.ok(Math.abs(generic.getMidGrayIn() - 0.2) < 1e-5);
+    assert.ok(Math.abs(generic.getMidGrayOut() - 0.22) < 1e-5);
+    assert.ok(Math.abs(generic.getHdrMax() - 12.0) < 1e-5);
+    assert.ok(Filament.ColorGrading.Builder().toneMapper(generic).build(engine));
+    generic.delete();
+}));
+
+test('ColorGrading$Builder accepts its whole grading chain', () => withEngine((engine) => {
+    const colorGrading = Filament.ColorGrading.Builder()
+        .quality(Filament.ColorGrading$QualityLevel.HIGH)
+        .format(Filament.ColorGrading$LutFormat.INTEGER)
+        .dimensions(16)
+        .toneMapping(Filament.ColorGrading$ToneMapping.ACES)
+        .luminanceScaling(true)
+        .gamutMapping(true)
+        .exposure(0.0)
+        .nightAdaptation(0.5)
+        .whiteBalance(0.1, -0.1)
+        .channelMixer([1, 0, 0], [0, 1, 0], [0, 0, 1])
+        .shadowsMidtonesHighlights([1, 1, 1, 0], [1, 1, 1, 0], [1, 1, 1, 0], [0, 0.33, 0.66, 1])
+        .slopeOffsetPower([1, 1, 1], [0, 0, 0], [1, 1, 1])
+        .contrast(1.1)
+        .vibrance(1.1)
+        .saturation(1.1)
+        .curves([1, 1, 1], [1, 1, 1], [1, 1, 1])
+        .fastMath(true)
+        .build(engine);
+    assert.ok(engine.isValidColorGrading(colorGrading));
+
+    // A custom LUT replaces the whole chain above; 2x2x2 is the smallest legal one.
+    const lut = Filament.ColorGrading.Builder()
+        .customLut(new Float32Array([
+            1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1,
+        ]), 2)
+        .build(engine);
+    assert.ok(engine.isValidColorGrading(lut));
+}));
+
+test('IndirectLight round-trips intensity, rotation and its textures', () => withEngine((engine) => {
+    const sh = new Float32Array(9 * 3);
+    for (let i = 0; i < sh.length; i++) {
+        sh[i] = 0.1 * (i + 1);
+    }
+    const ibl = Filament.IndirectLight.Builder()
+        .irradiance(3, sh)
+        .radiance(3, sh)
+        .intensity(30000)
+        .build(engine);
+    assert.strictEqual(ibl.getIntensity(), 30000);
+    ibl.setIntensity(25000);
+    assert.strictEqual(ibl.getIntensity(), 25000);
+
+    const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    ibl.setRotation(identity);
+    assert.deepStrictEqual(Array.from(ibl.getRotation()), identity);
+
+    // The estimators read the SH coefficients directly, without an engine or a texture.
+    const direction = Filament.IndirectLight.getDirectionEstimate(sh);
+    assert.strictEqual(direction.length, 3);
+    assert.ok(Number.isFinite(direction[0]), `direction estimate was ${direction}`);
+    const color = Filament.IndirectLight.getColorEstimate(sh, direction);
+    assert.strictEqual(color.length, 4);
+    assert.ok(Number.isFinite(color[0]), `color estimate was ${color}`);
+
+    const cubemap = Filament.Texture.Builder()
+        .width(16).height(16)
+        .sampler(Filament.Texture$Sampler.SAMPLER_CUBEMAP)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('UPLOADABLE', 'SAMPLEABLE'))
+        .build(engine);
+    // Both forms of irradiance are one name, which embind tells apart by argument count.
+    const textured = Filament.IndirectLight.Builder()
+        .reflections(cubemap)
+        .irradiance(cubemap)
+        .rotation(identity)
+        .build(engine);
+    assert.ok(textured.getReflectionsTexture(), 'reflections texture was not kept');
+    assert.ok(textured.getIrradianceTexture(), 'irradiance texture was not kept');
+}));
+
+test('Skybox round-trips its layer mask and texture', () => withEngine((engine) => {
+    const skybox = Filament.Skybox.Builder()
+        .color([0, 0, 0, 1])
+        .intensity(30000)
+        .showSun(true)
+        .priority(1)
+        .build(engine);
+    skybox.setColor([1, 1, 1, 1]);
+    assert.strictEqual(skybox.getLayerMask(), 1);
+    skybox.setLayerMask(0xff, 0x04);
+    assert.strictEqual(skybox.getLayerMask(), 0x04);
+
+    const envmap = Filament.Texture.Builder()
+        .width(16).height(16).levels(1)
+        .sampler(Filament.Texture$Sampler.SAMPLER_CUBEMAP)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('UPLOADABLE', 'SAMPLEABLE'))
+        .build(engine);
+    const textured = Filament.Skybox.Builder().environment(envmap).build(engine);
+    assert.ok(textured.getTexture(), 'environment texture was not kept');
+}));
+
+test('RenderTarget round-trips its attachment', () => withEngine((engine) => {
+    const color = Filament.Texture.Builder()
+        .width(16).height(16).levels(2)
+        .sampler(Filament.Texture$Sampler.SAMPLER_2D)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .usage(textureUsage('COLOR_ATTACHMENT', 'SAMPLEABLE'))
+        .build(engine);
+    const renderTarget = Filament.RenderTarget.Builder()
+        .texture(Filament.RenderTarget$AttachmentPoint.COLOR, color)
+        .mipLevel(Filament.RenderTarget$AttachmentPoint.COLOR, 1)
+        .face(Filament.RenderTarget$AttachmentPoint.COLOR,
+            Filament.Texture$CubemapFace.POSITIVE_X)
+        .layer(Filament.RenderTarget$AttachmentPoint.COLOR, 0)
+        .build(engine);
+
+    assert.ok(renderTarget.getTexture(Filament.RenderTarget$AttachmentPoint.COLOR),
+        'attachment texture was not kept');
+    assert.strictEqual(renderTarget.getMipLevel(Filament.RenderTarget$AttachmentPoint.COLOR), 1);
+    assert.strictEqual(renderTarget.getFace(Filament.RenderTarget$AttachmentPoint.COLOR),
+        Filament.Texture$CubemapFace.POSITIVE_X);
+    assert.strictEqual(renderTarget.getLayer(Filament.RenderTarget$AttachmentPoint.COLOR), 0);
+    assert.ok(renderTarget.getSupportedColorAttachmentsCount() > 0);
+}));
+
+test('SwapChain reports what the backend supports', () => withEngine((engine) => {
+    const swapChain = engine.createSwapChain();
+    assert.ok(engine.isValidSwapChain(swapChain));
+    assert.strictEqual(typeof Filament.SwapChain.isSRGBSwapChainSupported(engine), 'boolean');
+    assert.strictEqual(typeof Filament.SwapChain.isProtectedContentSupported(engine), 'boolean');
+    assert.strictEqual(typeof Filament.SwapChain.isMSAASwapChainSupported(engine, 4), 'boolean');
+}));
+
+// FSwapChain tracks the flag above the driver, so it is correct under NOOP even though nothing
+// fires there. Actual invocation is covered by test-browser.html.
+test('SwapChain frame-scheduled callback is set, replaced and cleared', () => withEngine((engine) => {
+    const swapChain = engine.createSwapChain();
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), false);
+
+    swapChain.setFrameScheduledCallback(() => {});
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), true);
+
+    // Replacing keeps it set; the previous val handle is released with the old std::function.
+    swapChain.setFrameScheduledCallback(() => {});
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), true);
+
+    // No argument clears it, matching the C++ default-argument overload.
+    swapChain.setFrameScheduledCallback();
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), false);
+
+    // Explicit null/undefined clear it too, so callers can pass a nullable straight through.
+    swapChain.setFrameScheduledCallback(() => {});
+    swapChain.setFrameScheduledCallback(null);
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), false);
+
+    // Re-arming after a clear has to work.
+    swapChain.setFrameScheduledCallback(() => {});
+    assert.strictEqual(swapChain.isFrameScheduledCallbackSet(), true);
+    engine.destroySwapChain(swapChain);
+}));
+
+// ---------------------------------------------------------------------------
+// Geometry / image helpers
+// ---------------------------------------------------------------------------
+
+test('SurfaceOrientation returns a quaternion per vertex, in each layout', () => {
+    // Three vertices whose normals all point down +Z, with matching tangents and positions.
+    const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    const tangents = new Float32Array([1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1]);
+    const builder = new Filament.SurfaceOrientation$Builder()
+        .vertexCount(3)
+        .normals(normals, 0)
+        .tangents(tangents, 0);
+    // Every setter must return the builder, which is what filament.d.ts promises and what the
+    // chain above depends on.
+    assert.ok(builder instanceof Filament.SurfaceOrientation$Builder,
+        'SurfaceOrientation$Builder setters do not chain');
+
+    const orientation = builder.build();
+    assert.strictEqual(orientation.getQuats(3).length, 12, 'short4 quats are 4 shorts each');
+    assert.strictEqual(orientation.getQuatsHalf4(3).length, 12);
+    assert.strictEqual(orientation.getQuatsFloat4(3).length, 12);
+    orientation.delete();
+
+    // The other inputs: uvs, positions and an index buffer, in both index widths.
+    const fromTriangles16 = new Filament.SurfaceOrientation$Builder()
+        .vertexCount(3)
+        .normals(normals, 0)
+        .uvs(new Float32Array([0, 0, 1, 0, 0, 1]), 0)
+        .positions(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 0)
+        .triangleCount(1)
+        .triangles16(new Uint16Array([0, 1, 2]))
+        .build();
+    assert.strictEqual(fromTriangles16.getQuats(3).length, 12);
+    fromTriangles16.delete();
+
+    const fromTriangles32 = new Filament.SurfaceOrientation$Builder()
+        .vertexCount(3)
+        .normals(normals, 0)
+        .positions(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 0)
+        .triangleCount(1)
+        .triangles32(new Uint32Array([0, 1, 2]))
+        .build();
+    assert.strictEqual(fromTriangles32.getQuats(3).length, 12);
+    fromTriangles32.delete();
+});
+
+test('Ktx1Bundle parses a cubemap and its metadata', () => {
+    const bundle = new Filament.Ktx1Bundle(Filament.Buffer(asset(IBL_KTX)));
+    assert.ok(bundle.getNumMipLevels() > 0);
+    assert.strictEqual(bundle.getArrayLength(), 1);
+    assert.strictEqual(bundle.isCubemap(), true);
+    assert.strictEqual(bundle.isCompressed(), false);
+    assert.ok(bundle.getInternalFormat(true) !== undefined);
+    assert.ok(bundle.getPixelDataFormat() !== undefined);
+    assert.ok(bundle.getPixelDataType() !== undefined);
+
+    const info = bundle.info();
+    assert.ok(info.pixelWidth > 0);
+    assert.strictEqual(info.pixelHeight, info.pixelWidth, 'a cubemap face is square');
+    assert.strictEqual(info.pixelDepth, 0);
+    assert.ok(info.glInternalFormat > 0);
+    assert.ok(info.glFormat >= 0);
+    assert.ok(info.glType >= 0);
+    assert.ok(info.glTypeSize > 0);
+    assert.ok(info.endianness >= 0);
+    assert.ok(info.glBaseInternalFormat > 0);
+
+    // One face of the top mip, then all six of them.
+    const face = bundle.getBlob([0, 0, 0]);
+    assert.ok(face.byteLength > 0);
+    assert.strictEqual(bundle.getCubeBlob(0).byteLength, face.byteLength * 6);
+    // This environment carries its spherical harmonics as a metadata string.
+    assert.ok(bundle.getMetadata('sh').length > 0, 'no sh metadata');
+});
+
+test('MeshReader$MaterialRegistry maps names to material instances', () => withEngine((engine) => {
+    const registry = new Filament.MeshReader$MaterialRegistry();
+    assert.strictEqual(registry.size(), 0);
+    const mat = material(engine);
+    registry.set('DefaultMaterial', mat.getDefaultInstance());
+    assert.strictEqual(registry.size(), 1);
+    assert.ok(registry.get('DefaultMaterial'), 'registry lost the instance it was given');
+    assert.strictEqual(registry.keys().size(), 1);
+    registry.delete();
+    engine.destroyMaterial(mat);
+}));
+
+test('driver buffer descriptors expose their bytes', () => {
+    const buffer = new Filament.driver$BufferDescriptor(16);
+    assert.strictEqual(buffer.getBytes().byteLength, 16);
+    const pixels = new Filament.driver$PixelBufferDescriptor(16, Filament.PixelDataFormat.RGBA,
+        Filament.PixelDataType.UBYTE);
+    assert.strictEqual(pixels.getBytes().byteLength, 16);
+    buffer.delete();
+    pixels.delete();
+});
+
+// ---------------------------------------------------------------------------
+// Camera manipulator (camutils)
+// ---------------------------------------------------------------------------
+
+test('Camutils orbit manipulator tracks its home position', () => withEngine((engine) => {
+    const builder = new Filament.Camutils$Manipulator$Builder()
+        .viewport(1024, 768)
+        .orbitHomePosition(0, 0, 4)
+        .orbitSpeed(0.01, 0.01)
+        .targetPosition(0, 0, 0)
+        .upVector(0, 1, 0)
+        .zoomSpeed(0.01)
+        .fovDirection(Filament.Camutils$Fov.VERTICAL)
+        .fovDegrees(45)
+        .farPlane(1000)
+        .mapExtent(512, 512)
+        .mapMinDistance(1)
+        .groundPlane(0, 1, 0, 0)
+        .panning(true);
+    const manipulator = builder.build(Filament.Camutils$Mode.ORBIT);
+    builder.delete();
+
+    const eye = [0, 0, 0];
+    const target = [0, 0, 0];
+    const up = [0, 0, 0];
+    manipulator.getLookAt(eye, target, up);
+    assert.deepStrictEqual(eye, [0, 0, 4], 'getLookAt did not write back the home position');
+    assert.deepStrictEqual(target, [0, 0, 0]);
+
+    manipulator.setViewport(800, 600);
+    manipulator.grabBegin(10, 10, false);
+    manipulator.grabUpdate(20, 20);
+    manipulator.grabEnd();
+    manipulator.scroll(10, 10, 1);
+    manipulator.update(0.016);
+
+    const origin = [0, 0, 0];
+    const direction = [0, 0, 0];
+    manipulator.getRay(512, 384, origin, direction);
+    assert.ok(direction.some((c) => c !== 0), 'getRay did not write a direction');
+    const hit = [0, 0, 0];
+    assert.strictEqual(typeof manipulator.raycast(512, 384, hit), 'boolean');
+
+    const camEntity = newEntity();
+    const camera = engine.createCamera(camEntity);
+    camera.setLookAt(manipulator);
+
+    const current = manipulator.getCurrentBookmark();
+    const home = manipulator.getHomeBookmark();
+    const midpoint = Filament.Camutils$Bookmark.interpolate(current, home, 0.5);
+    assert.ok(Filament.Camutils$Bookmark.duration(current, home) >= 0);
+    engine.destroyCameraComponent(camEntity);
+    manipulator.delete();
+}));
+
+test('Camutils free-flight manipulator accepts key events', () => {
+    const builder = new Filament.Camutils$Manipulator$Builder()
+        .viewport(1024, 768)
+        .flightStartPosition(0, 0, 5)
+        .flightStartOrientation(0, 0)
+        .flightMaxMoveSpeed(10)
+        .flightSpeedSteps(80)
+        .flightPanSpeed(0.01, 0.01)
+        .flightMoveDamping(15);
+    const manipulator = builder.build(Filament.Camutils$Mode.FREE_FLIGHT);
+    builder.delete();
+
+    const eye = [0, 0, 0];
+    const target = [0, 0, 0];
+    const up = [0, 0, 0];
+    manipulator.getLookAt(eye, target, up);
+    assert.deepStrictEqual(eye, [0, 0, 5]);
+
+    // Holding forward for a second has to move the camera along its view direction.
+    manipulator.keyDown(Filament.Camutils$Key.FORWARD);
+    for (let i = 0; i < 60; i++) {
+        manipulator.update(1 / 60);
+    }
+    manipulator.keyUp(Filament.Camutils$Key.FORWARD);
+    manipulator.getLookAt(eye, target, up);
+    assert.ok(eye[2] < 5, `free flight did not move forward, eye is at ${eye}`);
+    manipulator.delete();
+});
+
+// ---------------------------------------------------------------------------
+// glTF (gltfio)
+// ---------------------------------------------------------------------------
+
+test('gltfio loads an asset and reports its contents', () => withEngine((engine) => {
+    const loader = engine.createAssetLoader();
+    const asset_ = loader.createAsset(triangleGltf());
+    assert.ok(asset_, 'createAsset returned null');
+
+    const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
+    assert.strictEqual(resourceLoader.loadResources(asset_), true);
+
+    assert.strictEqual(asset_.getEntityCount(), 1);
+    assert.strictEqual(asset_.getRenderableEntityCount(), 1);
+    assert.strictEqual(asset_.getLightEntityCount(), 0);
+    assert.strictEqual(asset_.getCameraEntityCount(), 0);
+    assert.strictEqual(asset_.getSceneCount(), 1);
+    assert.strictEqual(asset_.getResourceUriCount(), 1);
+    assert.strictEqual(asset_.getEntities().length, 1);
+    assert.strictEqual(asset_.getRenderableEntities().length, 1);
+    assert.strictEqual(asset_.getLightEntities().length, 0);
+    assert.strictEqual(asset_.getCameraEntities().length, 0);
+    assert.strictEqual(asset_.getResourceUris().length, 1);
+    assert.ok(asset_.getRoot().getId() > 0);
+    assert.ok(asset_.getWireframe().getId() > 0);
+    assert.ok(asset_.getEngine(), 'getEngine returned null');
+
+    // The node is named "triangle", so every by-name query has to find it and no other.
+    assert.strictEqual(asset_.getEntitiesByName('triangle').length, 1);
+    assert.strictEqual(asset_.getEntitiesByPrefix('tri').length, 1);
+    assert.strictEqual(asset_.getEntitiesByName('nonexistent').length, 0);
+    assert.ok(asset_.getFirstEntityByName('triangle').getId() > 0);
+    assert.strictEqual(asset_.getName(asset_.getFirstEntityByName('triangle')), 'triangle');
+    assert.strictEqual(typeof asset_.getExtras(asset_.getRoot()), 'string');
+    assert.strictEqual(asset_.getMorphTargetCountAt(asset_.getRoot()), 0);
+    assert.strictEqual(asset_.getMorphTargetNames(asset_.getRoot()).length, 0);
+
+    const box = asset_.getBoundingBox();
+    assert.strictEqual(box.min.length, 3);
+    assert.strictEqual(box.max.length, 3);
+
+    // popRenderable(s) drains the queue of renderables that are ready to be added to a scene.
+    assert.ok(asset_.popRenderables(4).size() >= 0);
+    assert.ok(asset_.popRenderable());
+
+    asset_.releaseSourceData();
+    loader.enableDiagnostics(true);
+    resourceLoader.evictResourceData();
+    resourceLoader.delete();
+    loader.destroyAsset(asset_);
+    loader.gc();
+    Filament.gltfio$AssetLoader.destroy(loader);
+}));
+
+test('gltfio instances share one asset', () => withEngine((engine) => {
+    const loader = engine.createAssetLoader();
+    const asset_ = loader.createInstancedAsset(triangleGltf(), [null, null]);
+    const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
+    resourceLoader.loadResources(asset_);
+
+    assert.strictEqual(asset_.getAssetInstanceCount(), 2);
+    assert.strictEqual(asset_.getAssetInstances().length, 2);
+
+    const instance = asset_.getInstance();
+    assert.ok(instance, 'instanced asset has no instance');
+    assert.ok(instance.getAsset(), 'instance does not point back at its asset');
+    assert.strictEqual(instance.getEntityCount(), 1);
+    assert.strictEqual(instance.getEntities().size(), 1);
+    assert.ok(instance.getRoot().getId() > 0);
+    assert.strictEqual(instance.getSkinCount(), 0);
+    assert.strictEqual(instance.getSkinNames().size(), 0);
+    assert.strictEqual(instance.getMaterialVariantCount(), 0);
+    assert.strictEqual(instance.getMaterialVariantNames().length, 0);
+    assert.strictEqual(instance.getMaterialInstanceCount(), 1);
+    assert.strictEqual(instance.getMaterialInstances().size(), 1);
+    assert.strictEqual(typeof instance.detachMaterialInstances, 'function');
+    const animator = instance.getAnimator();
+    assert.strictEqual(animator.getAnimationCount(), 0);
+    animator.updateBoneMatrices();
+    animator.resetBoneMatrices();
+
+    resourceLoader.evictResourceData();
+    resourceLoader.delete();
+    loader.destroyAsset(asset_);
+    Filament.gltfio$AssetLoader.destroy(loader);
+}));
+
+test('gltfio resource loader holds and evicts resource data', () => withEngine((engine) => {
+    const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
+    // One provider type for all three decoders, so one entry point takes any of them.
+    const TextureProvider = Filament.gltfio$TextureProvider;
+    resourceLoader.addTextureProvider('image/png', TextureProvider.createStbProvider(engine));
+    resourceLoader.addTextureProvider('image/ktx2', TextureProvider.createKtx2Provider(engine));
+    resourceLoader.addTextureProvider('image/webp', TextureProvider.createWebpProvider(engine));
+
+    resourceLoader.addResourceData('tex.png', Filament.Buffer(new Uint8Array(4)));
+    assert.strictEqual(resourceLoader.hasResourceData('tex.png'), true);
+    assert.strictEqual(resourceLoader.hasResourceData('other.png'), false);
+    assert.strictEqual(resourceLoader.asyncGetLoadProgress(), 0);
+    resourceLoader.asyncCancelLoad();
+    resourceLoader.evictResourceData();
+    assert.strictEqual(resourceLoader.hasResourceData('tex.png'), false);
+
+    assert.strictEqual(typeof TextureProvider.isWebpSupported(), 'boolean');
+    const ubershader = new Filament.gltfio$UbershaderProvider(engine);
+    ubershader.destroyMaterials();
+    ubershader.delete();
+    resourceLoader.delete();
+}));
+
+test('gltfio loads asynchronously', () => withEngine((engine) => {
+    try {
+    const loader = engine.createAssetLoader();
+    const asset_ = loader.createAsset(triangleGltf());
+    const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
+    const stb = Filament.gltfio$TextureProvider.createStbProvider(engine);
+    resourceLoader.addTextureProvider('image/png', stb);
+    assert.strictEqual(resourceLoader.asyncBeginLoad(asset_), true);
+    resourceLoader.asyncUpdateLoad();
+    assert.strictEqual(resourceLoader.asyncGetLoadProgress(), 1);
+    resourceLoader.asyncCancelLoad();
+    resourceLoader.evictResourceData();
+    stb.delete();
+    resourceLoader.delete();
+    loader.destroyAsset(asset_);
+    Filament.gltfio$AssetLoader.destroy(loader);
+    } catch(err) {
+        console.error('TEST 52 ERROR:', err && err.stack ? err.stack : err);
+        throw err;
+    }
+}));
+
+// ---------------------------------------------------------------------------
+// Viewer / automation harness (gltf_viewer tooling)
+// ---------------------------------------------------------------------------
+
+test('AutomationSpec generates and reads test cases', () => {
+    const spec = Filament.AutomationSpec.generateDefaultTestCases();
+    assert.ok(spec.size() > 0);
+    assert.ok(spec.getName(0).length > 0);
+
+    const settings = Filament.AutomationEngine.createDefault().getSettings();
+    assert.strictEqual(spec.get(0, settings), true);
+    assert.strictEqual(spec.get(spec.size(), settings), false, 'out of range get must fail');
+
+    assert.ok(Filament.AutomationSpec.generate('[{"name":"t","base":{}}]'),
+        'generate rejected a valid spec');
+    spec.delete();
+});
+
+test('JsonSerializer round-trips a settings blob', () => {
+    const auto = Filament.AutomationEngine.createDefault();
+    const settings = auto.getSettings();
+    const serializer = new Filament.JsonSerializer();
+    const json = serializer.writeJson(settings);
+    assert.ok(json.length > 0);
+    assert.strictEqual(serializer.readJson(json, settings), true);
+    assert.strictEqual(serializer.readJson('not json', settings), false);
+    auto.delete();
+});
+
+test('AutomationEngine steps through a batch', () => withEngine((engine) => {
+    const view = engine.createView();
+    view.setScene(engine.createScene());
+    view.setCamera(engine.createCamera(newEntity()));
+    view.setViewport([0, 0, 16, 16]);
+    const content = {
+        view,
+        renderer: engine.createRenderer(),
+        materials: [],
+        lightManager: engine.getLightManager(),
+        scene: engine.createScene(),
+        indirectLight: null,
+        sunlight: newEntity(),
+        assetLights: [],
+    };
+
+    const auto = Filament.AutomationEngine.createDefault();
+    assert.ok(Filament.AutomationEngine.createFromJSON('[{"name":"t","base":{}}]'),
+        'createFromJSON rejected a valid spec');
+    assert.ok(auto.testCount() > 0);
+    assert.strictEqual(auto.isRunning(), false);
+
+    const options = auto.getOptions();
+    options.sleepDuration = 0;
+    options.minFrameCount = 1;
+    options.verbose = false;
+    options.exportScreenshots = false;
+    options.exportSettings = false;
+    options.exportFormat = Filament.AutomationEngine$ExportFormat.PPM;
+    auto.setOptions(options);
+    assert.strictEqual(auto.getOptions().minFrameCount, 1);
+
+    auto.startRunning();
+    auto.tick(engine, content, 0.016);
+    assert.strictEqual(auto.currentTest(), 0);
+    auto.applySettings(engine, '{"view":{"bloom":{"enabled":true}}}', content);
+    assert.strictEqual(view.getBloomOptions().enabled, true, 'applySettings did not reach the view');
+    assert.strictEqual(typeof auto.getStatusMessage(), 'string');
+    assert.strictEqual(auto.shouldClose(), false);
+    assert.ok(auto.getViewerOptions(), 'getViewerOptions returned null');
+    // The color grading is only built once a test case has been applied.
+    auto.getColorGrading(engine);
+
+    auto.startBatchMode();
+    auto.signalBatchMode();
+    auto.stopRunning();
+    assert.strictEqual(auto.isRunning(), false);
+
+    auto.terminate();
+    auto.delete();
+}));
+
+test('ViewerGui builds its user interface', () => withEngine((engine) => {
+    // The viewer pushes its settings into the view's camera, so the view needs one; a view
+    // without a camera cannot be rendered anyway.
+    const viewWithCamera = () => {
+        const view = engine.createView();
+        view.setScene(engine.createScene());
+        view.setCamera(engine.createCamera(newEntity()));
+        view.setViewport([0, 0, 300, 600]);
+        return view;
+    };
+
+    const gui = new Filament.ViewerGui(engine, engine.createScene(), viewWithCamera(), 300);
+    gui.mouseEvent(10, 10, true, 0, false);
+    gui.keyDownEvent(65);
+    gui.keyUpEvent(65);
+    gui.keyPressEvent(65);
+    assert.ok(gui.getSettings(), 'ViewerGui has no settings');
+
+    // Twice, because the first call is the one that builds the ImGui context and its atlas.
+    const guiView = viewWithCamera();
+    gui.renderUserInterface(0.016, guiView, 1.0);
+    gui.renderUserInterface(0.016, guiView, 1.0);
+    gui.delete();
+}));
+
+// ---------------------------------------------------------------------------
+
+globalThis.Filament.init([], () => {
+    Filament = globalThis.Filament;
+    let failed = 0;
+    for (const [name, fn] of TESTS) {
+        try {
+            fn();
+            console.log(`  ok   ${name}`);
+        } catch (e) {
+            failed++;
+            console.log(`  FAIL ${name}\n       ${e && e.stack ? e.stack : e}`);
+        }
+    }
+    console.log(`\n${TESTS.length - failed}/${TESTS.length} passed`);
+    process.exit(failed === 0 ? 0 : 1);
+});

--- a/web/filament-js/test.ts
+++ b/web/filament-js/test.ts
@@ -58,8 +58,14 @@ function smoke_entity_manager() {
     const em = Filament.EntityManager.get();
     const entity: Filament.Entity = em.create();
     const id: number = entity.getId();
+    // getActiveEntityCount is only compiled in when FILAMENT_UTILS_TRACK_ENTITIES is set, which
+    // the release wasm build does not do, so callers must feature-detect it.
     const activeEntities: number = em.getActiveEntityCount();
-    console.log(id, activeEntities);
+    const entityCount: number = em.getEntityCount();
+    const maxEntities: number = Filament.EntityManager.getMaxEntityCount();
+    em.advanceEpoch();
+    em.destroy(entity);
+    console.log(id, activeEntities, entityCount, maxEntities);
 }
 
 function smoke_engine() {
@@ -77,10 +83,100 @@ function smoke_engine() {
     const status: Filament.FenceStatus = fence.wait(Filament.Fence$Mode.FLUSH, 0);
     engine.destroyFence(fence);
     console.log(validFence, status);
+    engine.flush();
+    engine.flushAndWait();
     const failed: boolean = engine.hasUnrecoverableFailure();
     const maxEyes: number = Filament.Engine.getMaxStereoscopicEyes();
     const now: number = Filament.Engine.getSteadyClockTimeNano();
-    console.log(backend, em, fl, supported, instancing, failed, maxEyes, now);
+    const config: Filament.Engine$Config = engine.getConfig();
+    // The same feature flags Engine$Builder.feature sets before construction, after it.
+    const flagSet: boolean = engine.setFeatureFlag("backend.disable_parallel_shader_compile", true);
+    const hasFlag: boolean = engine.hasFeatureFlag("backend.disable_parallel_shader_compile");
+    const flag: boolean|undefined =
+            engine.getFeatureFlag("backend.disable_parallel_shader_compile");
+    console.log(flagSet, hasFlag, flag);
+    engine.execute();
+    console.log(backend, em, fl, supported, instancing, failed, maxEyes, now, config);
+}
+
+// Every object the Engine owns, created and then handed back to the matching destroy overload.
+function smoke_engine_lifecycle() {
+    const cameraEntity = newEntity();
+    engine.createCamera(cameraEntity);
+    const camera: Filament.Camera = engine.getCameraComponent(cameraEntity);
+    const material = engine.createMaterial("nonexistent.filamat");
+    const matinst = material.createInstance();
+    const expensiveCheck: boolean = engine.isValidExpensiveMaterialInstance(matinst);
+    const texture = Filament.Texture.Builder().width(1).height(1).build(engine);
+    const rt = Filament.RenderTarget.Builder().build(engine);
+    const colorGrading = Filament.ColorGrading.Builder().build(engine);
+    const ibl = Filament.IndirectLight.Builder().build(engine);
+    const skybox = Filament.Skybox.Builder().color([0, 0, 0, 1]).build(engine);
+    const vb = Filament.VertexBuffer.Builder().vertexCount(1).bufferCount(1).build(engine);
+    const ib = Filament.IndexBuffer.Builder().indexCount(1).build(engine);
+
+    engine.destroyMaterialInstance(matinst);
+    engine.destroyMaterial(material);
+    engine.destroyTexture(texture);
+    engine.destroyRenderTarget(rt);
+    engine.destroyColorGrading(colorGrading);
+    engine.destroyIndirectLight(ibl);
+    engine.destroySkybox(skybox);
+    engine.destroyVertexBuffer(vb);
+    engine.destroyIndexBuffer(ib);
+    engine.destroySwapChain(engine.createSwapChain());
+    engine.destroyRenderer(engine.createRenderer());
+    engine.destroyView(engine.createView());
+    engine.destroyScene(engine.createScene());
+    engine.destroyCameraComponent(cameraEntity);
+    engine.destroyEntity(cameraEntity);
+    console.log(camera, expensiveCheck);
+}
+
+// The asset-decoding entry points. Each takes a URL registered with Filament.init, or a buffer.
+function smoke_engine_asset_helpers() {
+    const png: Filament.Texture = engine.createTextureFromPng("albedo.png");
+    const jpeg: Filament.Texture = engine.createTextureFromJpeg("albedo.jpg", { srgb: true });
+    const ktx1: Filament.Texture = engine.createTextureFromKtx1("albedo.ktx");
+    const ktx2: Filament.Texture = engine.createTextureFromKtx2("albedo.ktx2");
+    const ibl: Filament.IndirectLight = engine.createIblFromKtx1("env_ibl.ktx");
+    const sky: Filament.Skybox = engine.createSkyFromKtx1("env_skybox.ktx");
+    const mesh = engine.loadFilamesh("model.filamesh");
+    const renderable: Filament.Entity = mesh.renderable;
+    engine.getSupportedFormatSuffix("etc s3tc");
+    console.log(png, jpeg, ktx1, ktx2, ibl, sky, renderable);
+}
+
+function smoke_engine_builder() {
+    const config: Filament.Engine$Config = Filament.Engine.createDefaultConfig();
+    config.commandBufferSizeMB = 3;
+    config.jobSystemThreadCount = 0;
+    config.disableParallelShaderCompile = true;
+    config.disableHandleUseAfterFreeCheck = true;
+    config.assertNativeWindowIsValid = false;
+    config.forceGLES2Context = false;
+    config.stereoscopicType = Filament.StereoscopicType.NONE;
+    config.stereoscopicEyeCount = 2;
+    config.preferredShaderLanguage = Filament.ShaderLanguage.DEFAULT;
+    config.gpuContextPriority = Filament.GpuContextPriority.DEFAULT;
+    config.sharedUboInitialSizeInBytes = 16384;
+
+    const colorGrading = Filament.ColorGrading.Builder();
+    const builder: Filament.Engine$Builder = new Filament.Engine$Builder();
+    builder.backend(Filament.Backend.OPENGL)
+        .config(config)
+        .featureLevel(Filament.FeatureLevel.FEATURE_LEVEL_1)
+        .feature("backend.disable_parallel_shader_compile", true)
+        .colorGrading(colorGrading);
+
+    // The same settings are reachable through Engine.create, which owns the canvas' context.
+    const other: Filament.Engine = Filament.Engine.create(canvas, {
+        backend: Filament.Backend.OPENGL,
+        featureLevel: Filament.FeatureLevel.FEATURE_LEVEL_1,
+        features: { "backend.disable_parallel_shader_compile": true },
+        colorGrading: Filament.ColorGrading.Builder(),
+    }, config);
+    console.log(builder, other);
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +198,29 @@ function smoke_camera_frustum() {
     const v5 = frustum.getNormalizedPlane(Filament.Frustum$Plane.BOTTOM) as glm.vec4;
     const b: boolean = frustum.intersectsSphere([0, 1, 2, 3]);
     const c: boolean = frustum.intersectsSphere(glm.vec4.fromValues(0, 1, 2, 3));
-    console.log(m5, m6, v5, b, c);
+    const d: boolean = frustum.intersectsBox({ center: v3, halfExtent: v3 });
+    const standalone = new Filament.Frustum(m4);
+    console.log(m5, m6, v5, b, c, d, standalone);
+}
+
+// The view matrix and the basis vectors derived from it, plus the two projection statics.
+function smoke_camera_transform() {
+    const camera = engine.createCamera(newEntity());
+    camera.setModelMatrix(m4);
+    const model = camera.getModelMatrix() as glm.mat4;
+    const view = camera.getViewMatrix() as glm.mat4;
+    const position: Filament.float3 = camera.getPosition();
+    const left: Filament.float3 = camera.getLeftVector();
+    const up: Filament.float3 = camera.getUpVector();
+    const forward: Filament.float3 = camera.getForwardVector();
+    camera.setScaling([2, 2]);
+    const scaling: Filament.double4 = camera.getScaling();
+    const near: number = camera.getNear();
+    const cullingFar: number = camera.getCullingFar();
+    const inverse = Filament.Camera.inverseProjection(m4) as glm.mat4;
+    const effFocal: number = Filament.Camera.computeEffectiveFocalLength(0.05, 5);
+    console.log(model, view, position, left, up, forward, scaling, near, cullingFar, inverse,
+            effFocal);
 }
 
 function smoke_camera_exposure_shift() {
@@ -115,9 +233,15 @@ function smoke_camera_exposure_shift() {
     const focus: number = camera.getFocusDistance();
     camera.setShift([0.1, 0.2]);
     const shift: Filament.double2 = camera.getShift();
+    const shutter: number = camera.getShutterSpeed();
+    const sensitivity: number = camera.getSensitivity();
+    console.log(shutter, sensitivity);
     const effFov: number = Filament.Camera.computeEffectiveFov(45, 5);
     const fov: number = camera.getFieldOfViewInDegrees(Filament.Camera$Fov.VERTICAL);
-    console.log(aperture, focal, focus, shift, effFov, fov);
+    const cameraEntity: Filament.Entity = camera.getEntity();
+    camera.setEyeModelMatrix(0, m4);
+    camera.setCustomEyeProjection([m4, m4], m4, 0.1, 100);
+    console.log(aperture, focal, focus, shift, effFov, fov, cameraEntity);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +282,85 @@ function smoke_view() {
     view.clearFrameHistory(engine);
     console.log(validView, viewport, hasCamera, sampleCount, blendMode, dro, gridSize, inverted,
             materialGlobal, fogEntity);
+
+    // Post-processing option getters (each setter already had a binding; the getters are new).
+    const bloom: Filament.View$BloomOptions = view.getBloomOptions();
+    view.setBloomOptions(bloom);
+    const fog: Filament.View$FogOptions = view.getFogOptions();
+    view.setFogOptions(fog);
+    const vignette: Filament.View$VignetteOptions = view.getVignetteOptions();
+    view.setVignetteOptions(vignette);
+    const dof: Filament.View$DepthOfFieldOptions = view.getDepthOfFieldOptions();
+    view.setDepthOfFieldOptions(dof);
+    const ao: Filament.View$AmbientOcclusionOptions = view.getAmbientOcclusionOptions();
+    view.setAmbientOcclusionOptions(ao);
+    const guardBand: Filament.View$GuardBandOptions = view.getGuardBandOptions();
+    view.setGuardBandOptions(guardBand);
+    const stereo: Filament.View$StereoscopicOptions = view.getStereoscopicOptions();
+    view.setStereoscopicOptions(stereo);
+    const taa: Filament.View$TemporalAntiAliasingOptions = view.getTemporalAntiAliasingOptions();
+    view.setTemporalAntiAliasingOptions(taa);
+    const ssr: Filament.View$ScreenSpaceReflectionsOptions =
+            view.getScreenSpaceReflectionsOptions();
+    view.setScreenSpaceReflectionsOptions(ssr);
+    const msaa: Filament.View$MultiSampleAntiAliasingOptions =
+            view.getMultiSampleAntiAliasingOptions();
+    view.setMultiSampleAntiAliasingOptions(msaa);
+    const renderQuality: Filament.View$RenderQuality = view.getRenderQuality();
+    view.setRenderQuality(renderQuality);
+    const dithering: Filament.View$Dithering = view.getDithering();
+
+    // Scalar/handle getters and the layer + refraction toggles.
+    const visibleLayers: number = view.getVisibleLayers();
+    view.setVisibleLayers(0xff, 0x01);
+    view.setLayerEnabled(1, true);
+    view.setPostProcessingEnabled(true);
+    const postProcessing: boolean = view.isPostProcessingEnabled();
+    view.setScreenSpaceRefractionEnabled(true);
+    const ssRefraction: boolean = view.isScreenSpaceRefractionEnabled();
+    view.setName("smoke view");
+    const viewName: string = view.getName();
+    const viewScene: Filament.Scene = view.getScene();
+    const viewCamera: Filament.Camera = view.getCamera();
+    const viewRenderTarget: Filament.RenderTarget = view.getRenderTarget();
+    console.log(bloom, fog, vignette, dof, ao, guardBand, stereo, taa, ssr, msaa, renderQuality,
+            dithering, visibleLayers, postProcessing, ssRefraction, viewName, viewScene,
+            viewCamera, viewRenderTarget);
+}
+
+// The setters that wire a view to the objects it draws, and the pipeline toggles that pair with
+// the option structs exercised above.
+function smoke_view_bindings() {
+    const view = engine.createView();
+    view.setScene(engine.createScene());
+    view.setCamera(engine.createCamera(newEntity()));
+    view.setViewport([0, 0, 64, 64]);
+    view.setColorGrading(Filament.ColorGrading.Builder().build(engine));
+    view.setRenderTarget(Filament.RenderTarget.Builder().build(engine));
+    view.setSampleCount(4);
+    view.setDynamicLightingOptions(5, 100);
+
+    view.setAntiAliasing(Filament.View$AntiAliasing.FXAA);
+    const antiAliasing: Filament.View$AntiAliasing = view.getAntiAliasing();
+    view.setAmbientOcclusion(Filament.View$AmbientOcclusion.SSAO);
+    const ambientOcclusion: Filament.View$AmbientOcclusion = view.getAmbientOcclusion();
+    view.setStencilBufferEnabled(true);
+    const stencilBuffer: boolean = view.isStencilBufferEnabled();
+    view.setTransparentPickingEnabled(true);
+    const transparentPicking: boolean = view.isTransparentPickingEnabled();
+    view.setChannelDepthClearEnabled(0, true);
+    const depthClear: boolean = view.isChannelDepthClearEnabled(0);
+
+    const effectiveGridSize: number = view.getEffectiveGridSize();
+    const visibleRenderables: number = view.getVisibleRenderableCount();
+    const resolutionScale: Filament.float2 = view.getLastDynamicResolutionScale();
+
+    view.pick(16, 16, (result: Filament.PickingQueryResult) => {
+        const renderable: Filament.Entity = result.renderable;
+        console.log(renderable, result.depth, result.fragCoords);
+    });
+    console.log(antiAliasing, ambientOcclusion, stencilBuffer, transparentPicking, depthClear,
+            effectiveGridSize, visibleRenderables, resolutionScale);
 }
 
 function smoke_scene() {
@@ -169,10 +372,16 @@ function smoke_scene() {
     const renderableCount: number = scene.getRenderableCount();
     const lightCount: number = scene.getLightCount();
     const hasEntity: boolean = scene.hasEntity(entity);
+    scene.setSkybox(Filament.Skybox.Builder().color([0, 0, 0, 1]).build(engine));
+    scene.setIndirectLight(Filament.IndirectLight.Builder().build(engine));
     const skybox: Filament.Skybox = scene.getSkybox();
     const ibl: Filament.IndirectLight = scene.getIndirectLight();
     const validScene: boolean = engine.isValidScene(scene);
     scene.remove(entity);
+    scene.removeEntities([entity]);
+    // Both accept null, which detaches whatever the scene was holding.
+    scene.setSkybox(null);
+    scene.setIndirectLight(null);
     console.log(entityCount, renderableCount, lightCount, hasEntity, skybox, ibl, validScene);
 }
 
@@ -183,6 +392,8 @@ function smoke_renderer() {
     renderer.skipNextFrames(1);
     const skipCount: number = renderer.getFrameToSkipCount();
     const shouldRender: boolean = renderer.shouldRenderFrame();
+    const gpuBehind: boolean = renderer.hasGpuFallenBehind();
+    console.log(gpuBehind);
     renderer.setClearOptions({ clearColor: [0, 0, 0, 1], clear: true });
     const clearOptions: Filament.Renderer$ClearOptions = renderer.getClearOptions();
     const validRenderer: boolean = engine.isValidRenderer(renderer);
@@ -200,6 +411,37 @@ function smoke_renderer() {
     console.log(userTime, skipCount, shouldRender, clearOptions, validRenderer);
 }
 
+// The frame loop itself: the begin/end pair, the three ways to submit a view, and the clocks that
+// drive pacing.
+function smoke_renderer_frame() {
+    const renderer = engine.createRenderer();
+    const swapChain = engine.createSwapChain();
+    const view = engine.createView();
+    view.setScene(engine.createScene());
+    view.setCamera(engine.createCamera(newEntity()));
+    view.setViewport([0, 0, 16, 16]);
+
+    renderer.render(swapChain, view);
+    if (renderer.beginFrame(swapChain)) {
+        renderer.renderView(view);
+        renderer.endFrame();
+    }
+    // Standalone rendering targets the view's own RenderTarget rather than a swap chain.
+    view.setRenderTarget(Filament.RenderTarget.Builder().build(engine));
+    renderer.renderStandaloneView(view);
+
+    const materialTime: number = renderer.getMaterialTime();
+    renderer.setMaterialTimeEpoch(0);
+    const now: number = Filament.Engine.getSteadyClockTimeNano();
+    renderer.setPresentationTime(now);
+    renderer.setDesiredPresentationTime(now);
+    renderer.setRenderingDeadline(now);
+    renderer.setVsyncTime(now);
+    renderer.skipFrame(now);
+    renderer.pauseRenderThread(0);
+    console.log(materialTime);
+}
+
 // ---------------------------------------------------------------------------
 // Component managers
 // ---------------------------------------------------------------------------
@@ -207,6 +449,17 @@ function smoke_renderer() {
 function smoke_transforms() {
     const tcm = engine.getTransformManager();
     const entity = newEntity();
+    tcm.create(entity);
+    const hasComponent: boolean = tcm.hasComponent(entity);
+    console.log(hasComponent);
+
+    const child = newEntity();
+    tcm.create(child);
+    const childInst = tcm.getInstance(child);
+    tcm.setParent(childInst, tcm.getInstance(entity));
+    childInst.delete();
+    tcm.destroy(child);
+
     const inst: Filament.TransformManager$Instance = tcm.getInstance(entity);
     tcm.setTransform(inst, m4);
     const m5 = tcm.getTransform(inst) as glm.mat4;
@@ -215,7 +468,10 @@ function smoke_transforms() {
     tcm.commitLocalTransformTransaction();
     const parent: Filament.Entity = tcm.getParent(inst);
     const children: Filament.Vector<Filament.Entity> = tcm.getChildren(inst);
-    console.log(m5, m6, parent, children);
+    const childCount: number = tcm.getChildCount(inst);
+    tcm.setAccurateTranslationsEnabled(true);
+    const accurate: boolean = tcm.isAccurateTranslationsEnabled();
+    console.log(m5, m6, parent, children, childCount, accurate);
     inst.delete();
 }
 
@@ -229,8 +485,84 @@ function smoke_renderables() {
     };
     rm.setCastShadows(inst, true);
     rm.setBones(inst, [bone], 0);
-    Filament.RenderableManager.Builder(1).skinningBones([bone]).build(engine, entity);
+    rm.setBonesFromMatrices(inst, [m4], 0);
+    Filament.RenderableManager.Builder(1)
+        .skinning(1)
+        .skinningBones([bone])
+        .skinningMatrices([m4])
+        .build(engine, entity);
+    const hasComponent: boolean = rm.hasComponent(entity);
+    console.log(hasComponent);
     inst.delete();
+    rm.destroy(entity);
+}
+
+// The Builder options that describe how a renderable is drawn, and their instance-side setters.
+function smoke_renderable_appearance() {
+    const rm = engine.getRenderableManager();
+    const entity = newEntity();
+    const box: Filament.Box = { center: v3, halfExtent: [1, 1, 1] };
+    Filament.RenderableManager.Builder(1)
+        .boundingBox(box)
+        .layerMask(0xff, 0x01)
+        .priority(4)
+        .channel(1)
+        .culling(true)
+        .castShadows(true)
+        .receiveShadows(true)
+        .screenSpaceContactShadows(false)
+        .fog(true)
+        .lightChannel(0, true)
+        .blendOrder(0, 1)
+        .globalBlendOrderEnabled(0, true)
+        .morphing(false)
+        .instances(2)
+        .build(engine, entity);
+
+    const inst = rm.getInstance(entity);
+    rm.setAxisAlignedBoundingBox(inst, box);
+    rm.setLayerMask(inst, 0xff, 0x01);
+    rm.setPriority(inst, 3);
+    rm.setCulling(inst, true);
+    rm.setReceiveShadows(inst, true);
+    rm.setScreenSpaceContactShadows(inst, false);
+    rm.setBlendOrderAt(inst, 0, 2);
+    rm.setGlobalBlendOrderEnabledAt(inst, 0, true);
+
+    const aabb: Filament.Box = rm.getAxisAlignedBoundingBox(inst);
+    const culling: boolean = rm.isCullingEnabled(inst);
+    const receiver: boolean = rm.isShadowReceiver(inst);
+    const contactShadows: boolean = rm.isScreenSpaceContactShadowsEnabled(inst);
+    const blendOrder: number = rm.getBlendOrderAt(inst, 0);
+    const globalBlendOrder: boolean = rm.isGlobalBlendOrderEnabledAt(inst, 0);
+    const attributes: number = rm.getEnabledAttributesAt(inst, 0);
+    const instanceCount: number = rm.getInstanceCount(inst);
+    inst.delete();
+    console.log(aabb, culling, receiver, contactShadows, blendOrder, globalBlendOrder, attributes,
+            instanceCount);
+}
+
+// Material assignment, which is the one part of a renderable that outlives the Builder.
+function smoke_renderable_materials() {
+    const rm = engine.getRenderableManager();
+    const entity = newEntity();
+    const material = engine.createMaterial("nonexistent.filamat");
+    const matinst = material.createInstance();
+    const vb = Filament.VertexBuffer.Builder().vertexCount(3).bufferCount(1).build(engine);
+    const ib = Filament.IndexBuffer.Builder().indexCount(3).build(engine);
+
+    Filament.RenderableManager.Builder(1)
+        .material(0, matinst)
+        .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
+        .build(engine, entity);
+
+    const inst = rm.getInstance(entity);
+    rm.setMaterialInstanceAt(inst, 0, matinst);
+    const assigned: Filament.MaterialInstance = rm.getMaterialInstanceAt(inst, 0);
+    rm.setGeometryAt(inst, 0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib, 0, 3);
+    rm.clearMaterialInstanceAt(inst, 0);
+    inst.delete();
+    console.log(assigned);
 }
 
 function smoke_renderable_geometry() {
@@ -247,6 +579,13 @@ function smoke_renderable_geometry() {
         .geometryNoIndices(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb)
         .geometryNoIndicesOffset(1, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, 0, 3)
         .build(engine, entity);
+
+    // The indexed forms, which differ in how much of the index buffer each primitive covers.
+    const ib = Filament.IndexBuffer.Builder().indexCount(3).build(engine);
+    Filament.RenderableManager.Builder(2)
+        .geometryOffset(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib, 0, 3)
+        .geometryMinMax(1, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib, 0, 0, 2, 3)
+        .build(engine, newEntity());
     const inst = rm.getInstance(entity);
     rm.setGeometryNoIndicesAt(inst, 0, Filament.RenderableManager$PrimitiveType.TRIANGLES,
             vb, 0, 3);
@@ -292,6 +631,12 @@ function smoke_skinning_morphing_buffers() {
         .morphingBufferOffset(0, 0, 0)
         .build(engine, entity);
 
+    // Instance-side counterpart of Builder::skinningBuffer.
+    const rm = engine.getRenderableManager();
+    const skinInst = rm.getInstance(entity);
+    rm.setSkinningBuffer(skinInst, sb, 4, 0);
+    skinInst.delete();
+
     engine.destroySkinningBuffer(sb);
     engine.destroyMorphTargetBuffer(mtb);
     console.log(boneCount, validSb, vertexCount, targetCount, hasPositions, hasTangents,
@@ -310,7 +655,12 @@ function smoke_renderable_instance() {
     const lightChannel: boolean = rm.getLightChannel(rinst, 0);
     const shadowCaster: boolean = rm.isShadowCaster(rinst);
     const primitiveCount: number = rm.getPrimitiveCount(rinst);
-    console.log(priority, channel, fogEnabled, lightChannel, shadowCaster, primitiveCount);
+    const morphTargetCount: number = rm.getMorphTargetCount(rinst);
+    rm.setMorphWeights(rinst, [0.0, 1.0]);
+    rm.setMorphWeightsOffset(rinst, [0.0, 1.0], 2);
+    rm.setMorphTargetBufferOffsetAt(rinst, 0, 0, 0);
+    console.log(priority, channel, fogEnabled, lightChannel, shadowCaster, primitiveCount,
+            morphTargetCount);
 }
 
 function smoke_lights() {
@@ -338,8 +688,64 @@ function smoke_lights() {
     const color: Filament.float3 = lm.getColor(inst);
     lm.setLightChannel(inst, 0, true);
     const lightChannel: boolean = lm.getLightChannel(inst, 0);
+    lm.setIntensityCandela(inst, 1000);
     inst.delete();
+    lm.destroy(entity);
     console.log(has, type, intensity, color, lightChannel);
+
+    const spotEntity = newEntity();
+    Filament.LightManager.Builder(Filament.LightManager$Type.SPOT)
+        .intensityCandela(1000)
+        .spotLightCone(0.25, 0.5)
+        .build(engine, spotEntity);
+    const spot: Filament.LightManager$Instance = lm.getInstance(spotEntity);
+    lm.setSpotLightCone(spot, 0.1, 0.2);
+    const innerCone: number = lm.getSpotLightInnerCone(spot);
+    const outerCone: number = lm.getSpotLightOuterCone(spot);
+    console.log(innerCone, outerCone);
+
+    // The point/spot placement and sun-disc controls, on the Builder and on the instance.
+    const sunEntity = newEntity();
+    Filament.LightManager.Builder(Filament.LightManager$Type.SUN)
+        .castLight(true)
+        .position([1, 2, 3])
+        .direction([0, -1, 0])
+        .falloff(10)
+        .intensityEnergy(100, 0.8)
+        .sunAngularRadius(1)
+        .sunHaloSize(10)
+        .sunHaloFalloff(80)
+        .lightChannel(0, true)
+        .build(engine, sunEntity);
+    const sun: Filament.LightManager$Instance = lm.getInstance(sunEntity);
+    lm.setPosition(sun, [4, 5, 6]);
+    lm.setDirection(sun, [0, 0, -1]);
+    lm.setFalloff(sun, 20);
+    lm.setIntensityEnergy(sun, 100, 0.5);
+    lm.setSunAngularRadius(sun, 0.5);
+    lm.setSunHaloSize(sun, 11);
+    lm.setSunHaloFalloff(sun, 60);
+    lm.setShadowCaster(sun, true);
+    lm.setShadowOptions(sun, { mapSize: 512, shadowCascades: 1 });
+    const position: Filament.float3 = lm.getPosition(sun);
+    const direction: Filament.float3 = lm.getDirection(sun);
+    const falloff: number = lm.getFalloff(sun);
+    const angularRadius: number = lm.getSunAngularRadius(sun);
+    const haloSize: number = lm.getSunHaloSize(sun);
+    const haloFalloff: number = lm.getSunHaloFalloff(sun);
+    const caster: boolean = lm.isShadowCaster(sun);
+    const directional: boolean = lm.isDirectional(sun);
+    const point: boolean = lm.isPointLight(sun);
+    const isSpot: boolean = lm.isSpotLight(sun);
+    sun.delete();
+    console.log(position, direction, falloff, angularRadius, haloSize, haloFalloff, caster,
+            directional, point, isSpot);
+
+    const uniform: number[] = Filament.LightManager$ShadowCascades.computeUniformSplits(4);
+    const logSplits: number[] = Filament.LightManager$ShadowCascades.computeLogSplits(4, 0.1, 100);
+    const practical: number[] =
+            Filament.LightManager$ShadowCascades.computePracticalSplits(4, 0.1, 100, 0.5);
+    console.log(uniform, logSplits, practical);
 }
 
 // ---------------------------------------------------------------------------
@@ -352,9 +758,26 @@ function smoke_buffers() {
         .bufferCount(1)
         .attribute(Filament.VertexAttribute.POSITION, 0,
                 Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .normalized(Filament.VertexAttribute.COLOR)
+        .normalizedIf(Filament.VertexAttribute.COLOR, false)
         .build(engine);
     vb.setBufferAt(engine, 0, new Float32Array(9));
     const validVb: boolean = engine.isValidVertexBuffer(vb);
+
+    // A vertex buffer can source its data from a BufferObject instead of its own storage.
+    const boVb = Filament.VertexBuffer.Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .enableBufferObjects(true)
+        .attribute(Filament.VertexAttribute.POSITION, 0,
+                Filament.VertexBuffer$AttributeType.FLOAT3, 0, 12)
+        .build(engine);
+    const vbo = Filament.BufferObject.Builder()
+        .size(36)
+        .bindingType(Filament.BufferObject$BindingType.VERTEX)
+        .build(engine);
+    vbo.setBuffer(engine, new Float32Array(9));
+    boVb.setBufferObjectAt(engine, 0, vbo);
 
     const ib = Filament.IndexBuffer.Builder()
         .indexCount(3)
@@ -369,7 +792,9 @@ function smoke_buffers() {
         .build(engine);
     bo.setBuffer(engine, new Float32Array(9));
     const byteCount: number = bo.getByteCount();
-    console.log(validVb, validIb, byteCount);
+    const vertexCount: number = vb.getVertexCount();
+    const indexCount: number = ib.getIndexCount();
+    console.log(validVb, validIb, byteCount, vertexCount, indexCount);
 }
 
 function smoke_texture() {
@@ -383,7 +808,12 @@ function smoke_texture() {
         .build(engine);
     const w: number = texture.getWidth(engine);
     const h: number = texture.getHeight(engine, 0);
+    const d: number = texture.getDepth(engine, 0);
     const levels: number = texture.getLevels(engine);
+    const validFormat: boolean = Filament.Texture.validatePixelFormatAndType(
+            Filament.Texture$InternalFormat.RGBA8, Filament.PixelDataFormat.RGBA,
+            Filament.PixelDataType.UBYTE);
+    console.log(d, validFormat);
     texture.generateMipmaps(engine);
     const mipmappable: boolean = Filament.Texture.isTextureFormatMipmappable(engine,
             Filament.Texture$InternalFormat.RGBA8);
@@ -391,10 +821,52 @@ function smoke_texture() {
     console.log(swizzleSupported);
     const validTexture: boolean = engine.isValidTexture(texture);
 
+    const target: Filament.Texture$Sampler = texture.getTarget();
+    const format: Filament.Texture$InternalFormat = texture.getFormat();
+    const formatSupported: boolean = Filament.Texture.isTextureFormatSupported(engine,
+            Filament.Texture$InternalFormat.RGBA8);
+    const maxSize: number = Filament.Texture.getMaxTextureSize(engine,
+            Filament.Texture$Sampler.SAMPLER_2D);
+    const maxLayers: number = Filament.Texture.getMaxArrayTextureLayers(engine);
+    console.log(target, format, formatSupported, maxSize, maxLayers);
+
+    // swizzle() is reachable, but build() throws on WebGL, which has no texture swizzle. This
+    // file is only ever type-checked, never executed, so the call is safe to express here.
+    Filament.Texture.Builder()
+        .width(16)
+        .height(16)
+        .depth(1)
+        .samples(1)
+        .swizzle(Filament.Texture$Swizzle.CHANNEL_0, Filament.Texture$Swizzle.CHANNEL_1,
+                Filament.Texture$Swizzle.CHANNEL_2, Filament.Texture$Swizzle.SUBSTITUTE_ONE)
+        .build(engine);
+
+    // Likewise external(): the web has no stream or image to attach, so the texture stays empty.
+    Filament.Texture.Builder()
+        .width(16)
+        .height(16)
+        .sampler(Filament.Texture$Sampler.SAMPLER_EXTERNAL)
+        .external()
+        .build(engine);
+
     const sampler = new Filament.TextureSampler(Filament.MinFilter.LINEAR,
             Filament.MagFilter.LINEAR, Filament.WrapMode.CLAMP_TO_EDGE);
     sampler.setAnisotropy(4);
     sampler.setCompareMode(Filament.CompareMode.NONE, Filament.CompareFunc.LESS_EQUAL);
+    sampler.setMinFilter(Filament.MinFilter.NEAREST);
+    sampler.setMagFilter(Filament.MagFilter.NEAREST);
+    sampler.setWrapModeS(Filament.WrapMode.REPEAT);
+    sampler.setWrapModeT(Filament.WrapMode.REPEAT);
+    sampler.setWrapModeR(Filament.WrapMode.REPEAT);
+    const anisotropy: number = sampler.getAnisotropy();
+    const compareMode: Filament.CompareMode = sampler.getCompareMode();
+    const compareFunc: Filament.CompareFunc = sampler.getCompareFunc();
+    const minFilter: Filament.MinFilter = sampler.getMinFilter();
+    const magFilter: Filament.MagFilter = sampler.getMagFilter();
+    const wrapS: Filament.WrapMode = sampler.getWrapModeS();
+    const wrapT: Filament.WrapMode = sampler.getWrapModeT();
+    const wrapR: Filament.WrapMode = sampler.getWrapModeR();
+    console.log(anisotropy, compareMode, compareFunc, minFilter, magFilter, wrapS, wrapT, wrapR);
 
     const pbd = new Filament.driver$PixelBufferDescriptor(16 * 16 * 4,
             Filament.PixelDataFormat.RGBA, Filament.PixelDataType.UBYTE);
@@ -419,12 +891,65 @@ function smoke_material() {
     console.log(source, dup, dupNamed);
 
     matinst.setFloatParameter("alpha", 1.0);
+    matinst.setBoolParameter("flag", true);
+    matinst.setBool2Parameter("flag2", [true, false]);
+    matinst.setBool3Parameter("flag3", [true, false, true]);
+    matinst.setBool4Parameter("flag4", [true, false, true, false]);
+    matinst.setIntParameter("count", 1);
+    matinst.setInt2Parameter("count2", [1, 2]);
+    matinst.setInt3Parameter("count3", [1, 2, 3]);
+    matinst.setInt4Parameter("count4", [1, 2, 3, 4]);
+    matinst.setFloat2Parameter("uvScale", [1, 1]);
+    matinst.setFloat3Parameter("tint", v3);
+    matinst.setFloat4Parameter("rect", v4);
+    matinst.setMat3Parameter("uvTransform", m4);
+    matinst.setMat4Parameter("transform", m3);
     matinst.setColor3Parameter("baseColor", Filament.RgbType.sRGB, v3);
+    matinst.setColor4Parameter("emissive", Filament.RgbaType.sRGB, v4);
+    matinst.setTextureParameter("albedo",
+            Filament.Texture.Builder().width(1).height(1).build(engine),
+            new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR,
+                    Filament.WrapMode.REPEAT));
     matinst.setCullingMode(Filament.CullingMode.BACK);
     matinst.setTransparencyMode(Filament.TransparencyMode.DEFAULT);
     const transparency: Filament.TransparencyMode = matinst.getTransparencyMode();
     const threshold: number = matinst.getMaskThreshold();
     console.log(named, def, name, validMaterial, validInstance, transparency, threshold);
+
+    matinst.setConstantBool("test_bool", true);
+    matinst.setConstantFloat("test_float", 1.0);
+    matinst.setConstantInt("test_int", 1);
+    const stencilWrite: boolean = matinst.isStencilWriteEnabled();
+    console.log(stencilWrite);
+
+    // Reflection surface: parameter enumeration plus the compiled-in material properties.
+    const paramCount: number = material.getParameterCount();
+    const params: Filament.Material$ParameterInfo[] = material.getParameters();
+    const hasParam: boolean = material.hasParameter("baseColor");
+    const shading: Filament.Shading = material.getShading();
+    const interpolation: Filament.Interpolation = material.getInterpolation();
+    const blending: Filament.BlendingMode = material.getBlendingMode();
+    const refractionMode: Filament.RefractionMode = material.getRefractionMode();
+    const refractionType: Filament.RefractionType = material.getRefractionType();
+    const reflectionMode: Filament.ReflectionMode = material.getReflectionMode();
+    const vertexDomain: Filament.VertexDomain = material.getVertexDomain();
+    const culling: Filament.CullingMode = material.getCullingMode();
+    const matTransparency: Filament.TransparencyMode = material.getTransparencyMode();
+    console.log(matTransparency);
+    const featureLevel: Filament.FeatureLevel = material.getFeatureLevel();
+    const maskThreshold: number = material.getMaskThreshold();
+    const saaVariance: number = material.getSpecularAntiAliasingVariance();
+    const saaThreshold: number = material.getSpecularAntiAliasingThreshold();
+    const requiredAttributes: number = material.getRequiredAttributes();
+    const doubleSided: boolean = material.isDoubleSided();
+    const alphaToCoverage: boolean = material.isAlphaToCoverageEnabled();
+    const colorWrite: boolean = material.isColorWriteEnabled();
+    const depthWrite: boolean = material.isDepthWriteEnabled();
+    const depthCulling: boolean = material.isDepthCullingEnabled();
+    console.log(paramCount, params, hasParam, shading, interpolation, blending, refractionMode,
+            refractionType, reflectionMode, vertexDomain, culling, featureLevel, maskThreshold,
+            saaVariance, saaThreshold, requiredAttributes, doubleSided, alphaToCoverage,
+            colorWrite, depthWrite, depthCulling);
 
     try {
         matinst.getConstantBool("test_bool");
@@ -435,10 +960,100 @@ function smoke_material() {
     }
 }
 
+// The per-instance render state: rasterizer, depth and stencil. Each setter overrides what the
+// material was compiled with, so every one of them has a matching getter to read back.
+function smoke_material_instance_state() {
+    const material = engine.createMaterial("nonexistent.filamat");
+    const matinst = material.createInstance();
+
+    matinst.setDoubleSided(true);
+    matinst.setCullingModeSeparate(Filament.CullingMode.BACK, Filament.CullingMode.FRONT);
+    matinst.setPolygonOffset(1.0, 1.0);
+    matinst.setColorWrite(true);
+    matinst.setDepthWrite(true);
+    matinst.setDepthCulling(true);
+    matinst.setDepthFunc(Filament.CompareFunc.LESS);
+    // Only legal on a MASKED material; the mask threshold is ignored otherwise.
+    matinst.setMaskThreshold(0.4);
+    matinst.setSpecularAntiAliasingVariance(0.2);
+    matinst.setSpecularAntiAliasingThreshold(0.1);
+
+    const doubleSided: boolean = matinst.isDoubleSided();
+    const cullingMode: Filament.CullingMode = matinst.getCullingMode();
+    const shadowCulling: Filament.CullingMode = matinst.getShadowCullingMode();
+    const colorWrite: boolean = matinst.isColorWriteEnabled();
+    const depthWrite: boolean = matinst.isDepthWriteEnabled();
+    const depthCulling: boolean = matinst.isDepthCullingEnabled();
+    const depthFunc: Filament.CompareFunc = matinst.getDepthFunc();
+    const saaVariance: number = matinst.getSpecularAntiAliasingVariance();
+    const saaThreshold: number = matinst.getSpecularAntiAliasingThreshold();
+
+    matinst.setStencilWrite(true);
+    matinst.setStencilCompareFunction(Filament.CompareFunc.EQUAL);
+    matinst.setStencilCompareFunction(Filament.CompareFunc.EQUAL, Filament.StencilFace.FRONT);
+    matinst.setStencilOpStencilFail(Filament.StencilOperation.KEEP);
+    matinst.setStencilOpDepthFail(Filament.StencilOperation.KEEP, Filament.StencilFace.BACK);
+    matinst.setStencilOpDepthStencilPass(Filament.StencilOperation.REPLACE);
+    matinst.setStencilReferenceValue(1);
+    matinst.setStencilReadMask(0xff);
+    matinst.setStencilWriteMask(0xff, Filament.StencilFace.FRONT_AND_BACK);
+
+    const transformName: string = material.getParameterTransformName("albedo");
+    console.log(doubleSided, cullingMode, shadowCulling, colorWrite, depthWrite, depthCulling,
+            depthFunc, saaVariance, saaThreshold, transformName);
+}
+
+function smoke_tone_mappers() {
+    // Each operator reachable through ColorGrading$Builder.toneMapper. The four below the
+    // deprecated ToneMapping enum cannot express are PBRNeutral, GT7, AgX and Generic.
+    const mappers: Filament.ToneMapper[] = [
+        new Filament.LinearToneMapper(),
+        new Filament.ACESToneMapper(),
+        new Filament.ACESLegacyToneMapper(),
+        new Filament.FilmicToneMapper(),
+        new Filament.PBRNeutralToneMapper(),
+        new Filament.GT7ToneMapper(),
+        new Filament.DisplayRangeToneMapper(),
+        new Filament.AgxToneMapper(Filament.AgxToneMapper$AgxLook.PUNCHY),
+    ];
+
+    const generic = new Filament.GenericToneMapper(1.55, 0.18, 0.215, 10.0);
+    generic.setContrast(1.6);
+    generic.setMidGrayIn(0.2);
+    generic.setMidGrayOut(0.22);
+    generic.setHdrMax(12.0);
+    const contrast: number = generic.getContrast();
+    const midGrayIn: number = generic.getMidGrayIn();
+    const midGrayOut: number = generic.getMidGrayOut();
+    const hdrMax: number = generic.getHdrMax();
+    console.log(contrast, midGrayIn, midGrayOut, hdrMax);
+
+    for (const mapper of mappers) {
+        Filament.ColorGrading.Builder().toneMapper(mapper).build(engine);
+        mapper.delete();
+    }
+    Filament.ColorGrading.Builder().toneMapper(generic).build(engine);
+    generic.delete();
+}
+
 function smoke_color_grading() {
     const cg = Filament.ColorGrading.Builder()
         .quality(Filament.ColorGrading$QualityLevel.HIGH)
+        .format(Filament.ColorGrading$LutFormat.INTEGER)
+        .dimensions(16)
         .toneMapping(Filament.ColorGrading$ToneMapping.ACES)
+        .luminanceScaling(true)
+        .gamutMapping(true)
+        .nightAdaptation(0.5)
+        .whiteBalance(0.1, -0.1)
+        .channelMixer([1, 0, 0], [0, 1, 0], [0, 0, 1])
+        .shadowsMidtonesHighlights([1, 1, 1, 0], [1, 1, 1, 0], [1, 1, 1, 0], [0, 0.33, 0.66, 1])
+        .slopeOffsetPower([1, 1, 1], [0, 0, 0], [1, 1, 1])
+        .contrast(1.1)
+        .vibrance(1.1)
+        .saturation(1.1)
+        .curves([1, 1, 1], [1, 1, 1], [1, 1, 1])
+        .fastMath(true)
         .exposure(0.0)
         .customLut(new Float32Array([
             1.0, 0.0, 0.0,
@@ -456,8 +1071,12 @@ function smoke_color_grading() {
 }
 
 function smoke_indirect_light() {
+    const sh = new Float32Array(9 * 3);
     const ibl = Filament.IndirectLight.Builder()
+        .irradiance(3, sh)
+        .radiance(3, sh)
         .intensity(30000)
+        .rotation(m3)
         .build(engine);
     ibl.setIntensity(25000);
     const intensity: number = ibl.getIntensity();
@@ -465,18 +1084,48 @@ function smoke_indirect_light() {
     const rotation: Filament.mat3 = ibl.getRotation();
     const valid: boolean = engine.isValidIndirectLight(ibl);
     console.log(intensity, rotation, valid);
+
+    // The cubemap-backed form, plus the two estimators that read the SH coefficients directly.
+    const cubemap = Filament.Texture.Builder()
+        .width(16)
+        .height(16)
+        .sampler(Filament.Texture$Sampler.SAMPLER_CUBEMAP)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .build(engine);
+    // The cubemap form of irradiance, which embind tells apart from the SH form by arity.
+    const textured = Filament.IndirectLight.Builder()
+        .reflections(cubemap)
+        .irradiance(cubemap)
+        .build(engine);
+    const reflections: Filament.Texture = textured.getReflectionsTexture();
+    const irradiance: Filament.Texture = textured.getIrradianceTexture();
+    const direction: Filament.float3 = Filament.IndirectLight.getDirectionEstimate(sh);
+    const color: Filament.float4 = Filament.IndirectLight.getColorEstimate(sh, direction);
+    console.log(reflections, irradiance, direction, color);
 }
 
 function smoke_skybox() {
     const sky = Filament.Skybox.Builder()
         .color([0, 0, 0, 1])
+        .intensity(30000)
         .showSun(true)
+        .priority(1)
         .build(engine);
     sky.setColor([1, 1, 1, 1]);
     const mask: number = sky.getLayerMask();
     sky.setLayerMask(0xff, 0x01);
     const valid: boolean = engine.isValidSkybox(sky);
-    console.log(mask, valid);
+
+    // The textured form, whose cubemap is readable back off the skybox.
+    const envmap = Filament.Texture.Builder()
+        .width(16)
+        .height(16)
+        .sampler(Filament.Texture$Sampler.SAMPLER_CUBEMAP)
+        .format(Filament.Texture$InternalFormat.RGBA8)
+        .build(engine);
+    const textured = Filament.Skybox.Builder().environment(envmap).build(engine);
+    const texture: Filament.Texture = textured.getTexture();
+    console.log(mask, valid, texture);
 }
 
 function smoke_render_target() {
@@ -489,19 +1138,30 @@ function smoke_render_target() {
         .build(engine);
     const rt = Filament.RenderTarget.Builder()
         .texture(Filament.RenderTarget$AttachmentPoint.COLOR, color)
+        .mipLevel(Filament.RenderTarget$AttachmentPoint.COLOR, 0)
+        .face(Filament.RenderTarget$AttachmentPoint.COLOR, Filament.Texture$CubemapFace.POSITIVE_X)
+        .layer(Filament.RenderTarget$AttachmentPoint.COLOR, 0)
         .build(engine);
     const tex: Filament.Texture = rt.getTexture(Filament.RenderTarget$AttachmentPoint.COLOR);
     const mip: number = rt.getMipLevel(Filament.RenderTarget$AttachmentPoint.COLOR);
+    const face: Filament.Texture$CubemapFace =
+            rt.getFace(Filament.RenderTarget$AttachmentPoint.COLOR);
+    const layer: number = rt.getLayer(Filament.RenderTarget$AttachmentPoint.COLOR);
     const supported: number = rt.getSupportedColorAttachmentsCount();
     const valid: boolean = engine.isValidRenderTarget(rt);
-    console.log(tex, mip, supported, valid);
+    console.log(tex, mip, face, layer, supported, valid);
 }
 
 function smoke_swap_chain() {
     const sc = engine.createSwapChain();
     const valid: boolean = engine.isValidSwapChain(sc);
     const srgb: boolean = Filament.SwapChain.isSRGBSwapChainSupported(engine);
-    console.log(valid, srgb);
+    const protectedContent: boolean = Filament.SwapChain.isProtectedContentSupported(engine);
+    const msaa: boolean = Filament.SwapChain.isMSAASwapChainSupported(engine, 4);
+    sc.setFrameScheduledCallback(() => console.log("frame scheduled"));
+    const callbackSet: boolean = sc.isFrameScheduledCallbackSet();
+    sc.setFrameScheduledCallback();
+    console.log(valid, srgb, protectedContent, msaa, callbackSet);
 }
 
 // ---------------------------------------------------------------------------
@@ -509,40 +1169,77 @@ function smoke_swap_chain() {
 // ---------------------------------------------------------------------------
 
 function smoke_surface_orientation() {
+    // Every input the builder accepts. Normals alone are enough, but tangents, uvs, positions and
+    // an index buffer each feed a different code path in the tangent-frame solver.
     const so = new Filament.SurfaceOrientation$Builder()
         .vertexCount(3)
         .normals(new Float32Array(9), 0)
         .tangents(new Float32Array(12), 0)
+        .uvs(new Float32Array(6), 0)
+        .positions(new Float32Array(9), 0)
+        .triangleCount(1)
+        .triangles16(new Uint16Array([0, 1, 2]))
         .build();
     const quats: Int16Array = so.getQuats(3);
+    const half4: Uint16Array = so.getQuatsHalf4(3);
+    const float4: Float32Array = so.getQuatsFloat4(3);
     so.delete();
-    console.log(quats);
+
+    const indexed32 = new Filament.SurfaceOrientation$Builder()
+        .vertexCount(3)
+        .normals(new Float32Array(9), 0)
+        .triangleCount(1)
+        .triangles32(new Uint32Array([0, 1, 2]))
+        .build();
+    indexed32.delete();
+    console.log(quats, half4, float4);
 }
 
 function smoke_ktx2_reader() {
     const reader = new Filament.Ktx2Reader(engine, true);
     reader.requestFormat(Filament.Texture$InternalFormat.RGBA8);
     reader.unrequestFormat(Filament.Texture$InternalFormat.RGBA8);
-    console.log(reader);
+    const texture: Filament.Texture|null = reader.load("image.ktx2",
+            Filament.Ktx2Reader$TransferFunction.LINEAR);
+    console.log(reader, texture);
 }
 
 function smoke_ktx1_bundle() {
     const bd = new Filament.driver$BufferDescriptor(4);
+    const bytes: ArrayBuffer = bd.getBytes();
     const bundle = new Filament.Ktx1Bundle(bd);
     const mips: number = bundle.getNumMipLevels();
     const arrayLength: number = bundle.getArrayLength();
     const format: Filament.Texture$InternalFormat = bundle.getInternalFormat(true);
+    const pixelFormat: Filament.PixelDataFormat = bundle.getPixelDataFormat();
+    const pixelType: Filament.PixelDataType = bundle.getPixelDataType();
+    const compressedType: Filament.CompressedPixelDataType = bundle.getCompressedPixelDataType();
     const compressed: boolean = bundle.isCompressed();
     const cubemap: boolean = bundle.isCubemap();
     const info: Filament.KtxInfo = bundle.info();
     const width: number = info.pixelWidth;
+    const height: number = info.pixelHeight;
+    const depth: number = info.pixelDepth;
+    const endianness: number = info.endianness;
+    const glType: number = info.glType;
+    const glTypeSize: number = info.glTypeSize;
+    const glFormat: number = info.glFormat;
+    const glInternalFormat: number = info.glInternalFormat;
+    const glBaseInternalFormat: number = info.glBaseInternalFormat;
+    console.log(height, depth, endianness, glType, glTypeSize, glFormat, glInternalFormat,
+            glBaseInternalFormat);
     const blob: ArrayBuffer = bundle.getBlob([0, 0, 0]);
+    const cubeBlob: ArrayBuffer = bundle.getCubeBlob(0);
     const metadata: string = bundle.getMetadata("key");
-    console.log(mips, arrayLength, format, compressed, cubemap, width, blob, metadata);
+    console.log(mips, arrayLength, format, pixelFormat, pixelType, compressedType, compressed,
+            cubemap, width, blob, cubeBlob, metadata, bytes);
 }
 
 function smoke_mesh_reader() {
     const registry = new Filament.MeshReader$MaterialRegistry();
+    const material = engine.createMaterial("nonexistent.filamat");
+    registry.set("DefaultMaterial", material.getDefaultInstance());
+    const stored: Filament.MaterialInstance = registry.get("DefaultMaterial");
     const size: number = registry.size();
     const keys: Filament.Vector<string> = registry.keys();
     const bd = new Filament.driver$BufferDescriptor(4);
@@ -550,7 +1247,7 @@ function smoke_mesh_reader() {
     const renderable: Filament.Entity = mesh.renderable();
     const vb: Filament.VertexBuffer = mesh.vertexBuffer();
     const ib: Filament.IndexBuffer = mesh.indexBuffer();
-    console.log(size, keys, renderable, vb, ib);
+    console.log(size, keys, stored, renderable, vb, ib);
 }
 
 // ---------------------------------------------------------------------------
@@ -561,14 +1258,56 @@ function smoke_camutils() {
     const manip = new Filament.Camutils$Manipulator$Builder()
         .viewport(1024, 768)
         .orbitHomePosition(0, 0, 1)
+        .orbitSpeed(0.01, 0.01)
         .targetPosition(0, 0, 0)
         .upVector(0, 1, 0)
+        .zoomSpeed(0.01)
+        .fovDirection(Filament.Camutils$Fov.VERTICAL)
+        .fovDegrees(45)
+        .farPlane(1000)
+        .mapExtent(512, 512)
+        .mapMinDistance(1)
+        .groundPlane(0, 1, 0, 0)
+        .panning(true)
         .build(Filament.Camutils$Mode.ORBIT);
     manip.attach(canvas);
     manip.update(0.016);
     const camera: Filament.Camera = engine.createCamera(newEntity());
     camera.setLookAt(manip);
     manip.detach(canvas);
+
+    // Free-flight adds a keyboard-driven mode, so it exercises the flight* options and keyDown/Up.
+    const flight = new Filament.Camutils$Manipulator$Builder()
+        .viewport(1024, 768)
+        .flightStartPosition(0, 0, 5)
+        .flightStartOrientation(0, 0)
+        .flightMaxMoveSpeed(10)
+        .flightSpeedSteps(80)
+        .flightPanSpeed(0.01, 0.01)
+        .flightMoveDamping(15)
+        .build(Filament.Camutils$Mode.FREE_FLIGHT);
+    flight.setViewport(800, 600);
+    flight.keyDown(Filament.Camutils$Key.FORWARD);
+    flight.keyUp(Filament.Camutils$Key.FORWARD);
+    flight.grabBegin(10, 10, false);
+    flight.grabUpdate(20, 20);
+    flight.grabEnd();
+    flight.scroll(10, 10, 1);
+    flight.update(0.016);
+
+    // getLookAt, getRay and raycast write into the vectors they are handed.
+    const eye = v3, target = v3, up = v3;
+    flight.getLookAt(eye, target, up);
+    flight.getRay(10, 10, v3, v3);
+    const hit: boolean = flight.raycast(10, 10, v3);
+
+    const current: Filament.Camutils$Bookmark = flight.getCurrentBookmark();
+    const home: Filament.Camutils$Bookmark = flight.getHomeBookmark();
+    const midpoint: Filament.Camutils$Bookmark =
+            Filament.Camutils$Bookmark.interpolate(current, home, 0.5);
+    const duration: number = Filament.Camutils$Bookmark.duration(current, home);
+    flight.jumpToBookmark(midpoint);
+    console.log(hit, duration);
 }
 
 // ---------------------------------------------------------------------------
@@ -592,26 +1331,104 @@ function smoke_gltfio() {
     const animator = instance.getAnimator();
     const animCount: number = animator.getAnimationCount();
     animator.applyAnimation(0, 0.0);
+    animator.applyCrossFade(0, 0.0, 0.5);
     animator.updateBoneMatrices();
+    animator.resetBoneMatrices();
+    const animDuration: number = animator.getAnimationDuration(0);
+    const animName: string = animator.getAnimationName(0);
+    console.log(animDuration, animName);
+    // Count accessors, so callers can size a buffer without materializing the entity vector.
+    const entityCount: number = asset.getEntityCount();
+    const lightCount: number = asset.getLightEntityCount();
+    const renderableCount: number = asset.getRenderableEntityCount();
+    const cameraCount: number = asset.getCameraEntityCount();
+    const resourceUriCount: number = asset.getResourceUriCount();
+    const assetMorphCount: number = asset.getMorphTargetCountAt(root);
+    const sceneCount: number = asset.getSceneCount();
+    const assetInstanceCount: number = asset.getAssetInstanceCount();
+    const popped: Filament.Vector<Filament.Entity> = asset.popRenderables(4);
+    const instEntityCount: number = instance.getEntityCount();
+    const variantCount: number = instance.getMaterialVariantCount();
+    const matInstCount: number = instance.getMaterialInstanceCount();
+    loader.enableDiagnostics(true);
+    console.log(entityCount, lightCount, renderableCount, cameraCount, resourceUriCount,
+            assetMorphCount, sceneCount, assetInstanceCount, popped, instEntityCount,
+            variantCount, matInstCount);
+
     loader.destroyAsset(asset);
-    loader.delete();
+    loader.gc();
+    Filament.gltfio$AssetLoader.destroy(loader);
     console.log(entities, root, box, skinNames, variants, animCount);
+}
+
+// The entity queries an asset answers, and the instance-side skin and variant switching.
+function smoke_gltfio_queries() {
+    const loader = engine.createAssetLoader();
+    const asset = loader.createAsset("model.glb");
+    const root = asset.getRoot();
+
+    const named: Filament.Entity[] = asset.getEntitiesByName("Cube");
+    const first: Filament.Entity = asset.getFirstEntityByName("Cube");
+    const prefixed: Filament.Entity[] = asset.getEntitiesByPrefix("Cu");
+    const lights: Filament.Entity[] = asset.getLightEntities();
+    const renderables: Filament.Entity[] = asset.getRenderableEntities();
+    const cameras: Filament.Entity[] = asset.getCameraEntities();
+    const wireframe: Filament.Entity = asset.getWireframe();
+    const popped: Filament.Entity = asset.popRenderable();
+    const uris: string[] = asset.getResourceUris();
+    const name: string = asset.getName(root);
+    const extras: string = asset.getExtras(root);
+    const owner: Filament.Engine = asset.getEngine();
+    const instances: Filament.gltfio$FilamentInstance[] = asset.getAssetInstances();
+
+    // Resources can be pulled in by the asset itself or by an explicit ResourceLoader.
+    asset.loadResources(() => console.log("done"), (uri: string) => console.log(uri), null, null);
+    const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
+    const loaded: boolean = resourceLoader.loadResources(asset);
+    const begun: boolean = resourceLoader.asyncBeginLoad(asset);
+    resourceLoader.asyncUpdateLoad();
+    asset.releaseSourceData();
+
+    const instanced = loader.createInstancedAsset("model.glb", [null, null]);
+    const instance = instanced.getInstance();
+    instance.applyMaterialVariant(0);
+    instance.attachSkin(0, root);
+    instance.detachSkin(0, root);
+    const owningAsset: Filament.gltfio$FilamentAsset = instance.getAsset();
+    const materialInstances: Filament.Vector<Filament.MaterialInstance> =
+            instance.getMaterialInstances();
+    instance.detachMaterialInstances();
+    const instanceEntities: Filament.Vector<Filament.Entity> = instance.getEntities();
+    const instanceRoot: Filament.Entity = instance.getRoot();
+
+    console.log(named, first, prefixed, lights, renderables, cameras, wireframe, popped,
+            uris, name, extras, owner, instances, loaded, begun, owningAsset, materialInstances,
+            instanceEntities, instanceRoot);
 }
 
 function smoke_gltfio_resource_loader() {
     const resourceLoader = new Filament.gltfio$ResourceLoader(engine, true);
-    const stb = new Filament.gltfio$StbProvider(engine);
-    const ktx2 = new Filament.gltfio$Ktx2Provider(engine);
-    const webp = new Filament.gltfio$WebpProvider(engine);
+    const stb: Filament.gltfio$TextureProvider =
+            Filament.gltfio$TextureProvider.createStbProvider(engine);
+    const ktx2: Filament.gltfio$TextureProvider =
+            Filament.gltfio$TextureProvider.createKtx2Provider(engine);
+    const webp: Filament.gltfio$TextureProvider =
+            Filament.gltfio$TextureProvider.createWebpProvider(engine);
     const ubershader = new Filament.gltfio$UbershaderProvider(engine);
-    resourceLoader.addStbProvider("image/png", stb);
-    resourceLoader.addKtx2Provider("image/ktx2", ktx2);
-    resourceLoader.addWebpProvider("image/webp", webp);
+    resourceLoader.addTextureProvider("image/png", stb);
+    resourceLoader.addTextureProvider("image/ktx2", ktx2);
+    resourceLoader.addTextureProvider("image/webp", webp);
     const bd = new Filament.driver$BufferDescriptor(4);
     resourceLoader.addResourceData("tex.png", bd);
     const has: boolean = resourceLoader.hasResourceData("tex.png");
     const progress: number = resourceLoader.asyncGetLoadProgress();
-    const webpSupported: boolean = Filament.gltfio$WebpProvider.isWebpSupported();
+    const webpSupported: boolean = Filament.gltfio$TextureProvider.isWebpSupported();
+    resourceLoader.asyncCancelLoad();
+    resourceLoader.evictResourceData();
+    const materialsCount: number = ubershader.getMaterialsCount();
+    const materials: Filament.Vector<Filament.Material> = ubershader.getMaterials();
+    const needsDummyUvs: boolean = ubershader.needsDummyData(Filament.VertexAttribute.UV0);
+    console.log(materialsCount, materials, needsDummyUvs);
     ubershader.destroyMaterials();
     console.log(has, progress, webpSupported);
 }
@@ -623,9 +1440,14 @@ function smoke_gltfio_resource_loader() {
 function smoke_viewer() {
     const spec = Filament.AutomationSpec.generateDefaultTestCases();
     const specSize: number = spec.size();
+    const specName: string = spec.getName(0);
+    const generated: Filament.AutomationSpec|null = Filament.AutomationSpec.generate("[]");
     const auto = Filament.AutomationEngine.createDefault();
     const settings = auto.getSettings();
-    const json: string = new Filament.JsonSerializer().writeJson(settings);
+    const fetched: boolean = spec.get(0, settings);
+    const serializer = new Filament.JsonSerializer();
+    const json: string = serializer.writeJson(settings);
+    const parsed: boolean = serializer.readJson(json, settings);
     const running: boolean = auto.isRunning();
     const testCount: number = auto.testCount();
     const gui = new Filament.ViewerGui(engine, engine.createScene(), engine.createView(), 300);
@@ -633,7 +1455,58 @@ function smoke_viewer() {
     gui.delete();
     spec.delete();
     auto.delete();
-    console.log(specSize, json, running, testCount);
+    console.log(specSize, specName, generated, fetched, json, parsed, running, testCount);
+}
+
+// The batch-mode driver: an AutomationEngine steps through its spec one frame at a time, applying
+// each test case to the content it is handed.
+function smoke_automation_engine() {
+    const view = engine.createView();
+    const content: Filament.ViewerContent = {
+        view,
+        renderer: engine.createRenderer(),
+        materials: [],
+        lightManager: engine.getLightManager(),
+        scene: engine.createScene(),
+        indirectLight: null,
+        sunlight: newEntity(),
+        assetLights: [],
+    };
+
+    const auto = Filament.AutomationEngine.createDefault();
+    const fromJson: Filament.AutomationEngine|null =
+            Filament.AutomationEngine.createFromJSON("[]");
+    const options: Filament.AutomationEngine$Options = auto.getOptions();
+    options.sleepDuration = 0.1;
+    options.minFrameCount = 2;
+    options.verbose = false;
+    options.exportScreenshots = false;
+    options.exportSettings = false;
+    options.exportFormat = Filament.AutomationEngine$ExportFormat.PPM;
+    auto.setOptions(options);
+
+    auto.startRunning();
+    auto.startBatchMode();
+    auto.tick(engine, content, 0.016);
+    auto.applySettings(engine, '{"view":{"bloom":{"enabled":true}}}', content);
+    const colorGrading: Filament.ColorGrading = auto.getColorGrading(engine);
+    const viewerOptions: Filament.ViewerOptions = auto.getViewerOptions();
+    const current: number = auto.currentTest();
+    const status: string = auto.getStatusMessage();
+    const shouldClose: boolean = auto.shouldClose();
+    auto.signalBatchMode();
+    auto.stopRunning();
+    auto.terminate();
+    auto.delete();
+
+    const gui = new Filament.ViewerGui(engine, engine.createScene(), engine.createView(), 300);
+    gui.mouseEvent(10, 10, true, 0, false);
+    gui.keyDownEvent(65);
+    gui.keyUpEvent(65);
+    gui.renderUserInterface(0.016, engine.createView(), 1.0);
+    const guiSettings: Filament.viewer$Settings = gui.getSettings();
+    gui.delete();
+    console.log(fromJson, colorGrading, viewerOptions, current, status, shouldClose, guiSettings);
 }
 
 // Registry of every smoke test. tsc validates each function body's signatures against the
@@ -641,13 +1514,21 @@ function smoke_viewer() {
 const SMOKE_TESTS: Array<() => void> = [
     smoke_entity_manager,
     smoke_engine,
+    smoke_engine_builder,
+    smoke_engine_lifecycle,
+    smoke_engine_asset_helpers,
     smoke_camera_frustum,
+    smoke_camera_transform,
     smoke_camera_exposure_shift,
     smoke_view,
+    smoke_view_bindings,
     smoke_scene,
     smoke_renderer,
+    smoke_renderer_frame,
     smoke_transforms,
     smoke_renderables,
+    smoke_renderable_appearance,
+    smoke_renderable_materials,
     smoke_renderable_geometry,
     smoke_skinning_morphing_buffers,
     smoke_renderable_instance,
@@ -655,6 +1536,8 @@ const SMOKE_TESTS: Array<() => void> = [
     smoke_buffers,
     smoke_texture,
     smoke_material,
+    smoke_material_instance_state,
+    smoke_tone_mappers,
     smoke_color_grading,
     smoke_indirect_light,
     smoke_skybox,
@@ -666,8 +1549,10 @@ const SMOKE_TESTS: Array<() => void> = [
     smoke_mesh_reader,
     smoke_camutils,
     smoke_gltfio,
+    smoke_gltfio_queries,
     smoke_gltfio_resource_loader,
     smoke_viewer,
+    smoke_automation_engine,
 ];
 
 for (const test of SMOKE_TESTS) {

--- a/web/filament-js/test.ts
+++ b/web/filament-js/test.ts
@@ -77,6 +77,8 @@ function smoke_engine() {
     const status: Filament.FenceStatus = fence.wait(Filament.Fence$Mode.FLUSH, 0);
     engine.destroyFence(fence);
     console.log(validFence, status);
+    engine.flush();
+    engine.flushAndWait();
     const failed: boolean = engine.hasUnrecoverableFailure();
     const maxEyes: number = Filament.Engine.getMaxStereoscopicEyes();
     const now: number = Filament.Engine.getSteadyClockTimeNano();
@@ -117,7 +119,10 @@ function smoke_camera_exposure_shift() {
     const shift: Filament.double2 = camera.getShift();
     const effFov: number = Filament.Camera.computeEffectiveFov(45, 5);
     const fov: number = camera.getFieldOfViewInDegrees(Filament.Camera$Fov.VERTICAL);
-    console.log(aperture, focal, focus, shift, effFov, fov);
+    const cameraEntity: Filament.Entity = camera.getEntity();
+    camera.setEyeModelMatrix(0, m4);
+    camera.setCustomEyeProjection([m4, m4], m4, 0.1, 100);
+    console.log(aperture, focal, focus, shift, effFov, fov, cameraEntity);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +163,49 @@ function smoke_view() {
     view.clearFrameHistory(engine);
     console.log(validView, viewport, hasCamera, sampleCount, blendMode, dro, gridSize, inverted,
             materialGlobal, fogEntity);
+
+    // Post-processing option getters (each setter already had a binding; the getters are new).
+    const bloom: Filament.View$BloomOptions = view.getBloomOptions();
+    view.setBloomOptions(bloom);
+    const fog: Filament.View$FogOptions = view.getFogOptions();
+    view.setFogOptions(fog);
+    const vignette: Filament.View$VignetteOptions = view.getVignetteOptions();
+    view.setVignetteOptions(vignette);
+    const dof: Filament.View$DepthOfFieldOptions = view.getDepthOfFieldOptions();
+    view.setDepthOfFieldOptions(dof);
+    const ao: Filament.View$AmbientOcclusionOptions = view.getAmbientOcclusionOptions();
+    view.setAmbientOcclusionOptions(ao);
+    const guardBand: Filament.View$GuardBandOptions = view.getGuardBandOptions();
+    view.setGuardBandOptions(guardBand);
+    const stereo: Filament.View$StereoscopicOptions = view.getStereoscopicOptions();
+    view.setStereoscopicOptions(stereo);
+    const taa: Filament.View$TemporalAntiAliasingOptions = view.getTemporalAntiAliasingOptions();
+    view.setTemporalAntiAliasingOptions(taa);
+    const ssr: Filament.View$ScreenSpaceReflectionsOptions =
+            view.getScreenSpaceReflectionsOptions();
+    view.setScreenSpaceReflectionsOptions(ssr);
+    const msaa: Filament.View$MultiSampleAntiAliasingOptions =
+            view.getMultiSampleAntiAliasingOptions();
+    view.setMultiSampleAntiAliasingOptions(msaa);
+    const renderQuality: Filament.View$RenderQuality = view.getRenderQuality();
+    view.setRenderQuality(renderQuality);
+    const dithering: Filament.View$Dithering = view.getDithering();
+
+    // Scalar/handle getters and the layer + refraction toggles.
+    const visibleLayers: number = view.getVisibleLayers();
+    view.setLayerEnabled(1, true);
+    view.setPostProcessingEnabled(true);
+    const postProcessing: boolean = view.isPostProcessingEnabled();
+    view.setScreenSpaceRefractionEnabled(true);
+    const ssRefraction: boolean = view.isScreenSpaceRefractionEnabled();
+    view.setName("smoke view");
+    const viewName: string = view.getName();
+    const viewScene: Filament.Scene = view.getScene();
+    const viewCamera: Filament.Camera = view.getCamera();
+    const viewRenderTarget: Filament.RenderTarget = view.getRenderTarget();
+    console.log(bloom, fog, vignette, dof, ao, guardBand, stereo, taa, ssr, msaa, renderQuality,
+            dithering, visibleLayers, postProcessing, ssRefraction, viewName, viewScene,
+            viewCamera, viewRenderTarget);
 }
 
 function smoke_scene() {
@@ -215,7 +263,10 @@ function smoke_transforms() {
     tcm.commitLocalTransformTransaction();
     const parent: Filament.Entity = tcm.getParent(inst);
     const children: Filament.Vector<Filament.Entity> = tcm.getChildren(inst);
-    console.log(m5, m6, parent, children);
+    const childCount: number = tcm.getChildCount(inst);
+    tcm.setAccurateTranslationsEnabled(true);
+    const accurate: boolean = tcm.isAccurateTranslationsEnabled();
+    console.log(m5, m6, parent, children, childCount, accurate);
     inst.delete();
 }
 
@@ -292,6 +343,12 @@ function smoke_skinning_morphing_buffers() {
         .morphingBufferOffset(0, 0, 0)
         .build(engine, entity);
 
+    // Instance-side counterpart of Builder::skinningBuffer.
+    const rm = engine.getRenderableManager();
+    const skinInst = rm.getInstance(entity);
+    rm.setSkinningBuffer(skinInst, sb, 4, 0);
+    skinInst.delete();
+
     engine.destroySkinningBuffer(sb);
     engine.destroyMorphTargetBuffer(mtb);
     console.log(boneCount, validSb, vertexCount, targetCount, hasPositions, hasTangents,
@@ -310,7 +367,12 @@ function smoke_renderable_instance() {
     const lightChannel: boolean = rm.getLightChannel(rinst, 0);
     const shadowCaster: boolean = rm.isShadowCaster(rinst);
     const primitiveCount: number = rm.getPrimitiveCount(rinst);
-    console.log(priority, channel, fogEnabled, lightChannel, shadowCaster, primitiveCount);
+    const morphTargetCount: number = rm.getMorphTargetCount(rinst);
+    rm.setMorphWeights(rinst, [0.0, 1.0]);
+    rm.setMorphWeightsOffset(rinst, [0.0, 1.0], 2);
+    rm.setMorphTargetBufferOffsetAt(rinst, 0, 0, 0);
+    console.log(priority, channel, fogEnabled, lightChannel, shadowCaster, primitiveCount,
+            morphTargetCount);
 }
 
 function smoke_lights() {
@@ -338,8 +400,20 @@ function smoke_lights() {
     const color: Filament.float3 = lm.getColor(inst);
     lm.setLightChannel(inst, 0, true);
     const lightChannel: boolean = lm.getLightChannel(inst, 0);
+    lm.setIntensityCandela(inst, 1000);
     inst.delete();
+    lm.destroy(entity);
     console.log(has, type, intensity, color, lightChannel);
+
+    Filament.LightManager.Builder(Filament.LightManager$Type.SPOT)
+        .intensityCandela(1000)
+        .build(engine, newEntity());
+
+    const uniform: number[] = Filament.LightManager$ShadowCascades.computeUniformSplits(4);
+    const logSplits: number[] = Filament.LightManager$ShadowCascades.computeLogSplits(4, 0.1, 100);
+    const practical: number[] =
+            Filament.LightManager$ShadowCascades.computePracticalSplits(4, 0.1, 100, 0.5);
+    console.log(uniform, logSplits, practical);
 }
 
 // ---------------------------------------------------------------------------
@@ -369,7 +443,9 @@ function smoke_buffers() {
         .build(engine);
     bo.setBuffer(engine, new Float32Array(9));
     const byteCount: number = bo.getByteCount();
-    console.log(validVb, validIb, byteCount);
+    const vertexCount: number = vb.getVertexCount();
+    const indexCount: number = ib.getIndexCount();
+    console.log(validVb, validIb, byteCount, vertexCount, indexCount);
 }
 
 function smoke_texture() {
@@ -391,10 +467,43 @@ function smoke_texture() {
     console.log(swizzleSupported);
     const validTexture: boolean = engine.isValidTexture(texture);
 
+    const target: Filament.Texture$Sampler = texture.getTarget();
+    const format: Filament.Texture$InternalFormat = texture.getFormat();
+    const formatSupported: boolean = Filament.Texture.isTextureFormatSupported(engine,
+            Filament.Texture$InternalFormat.RGBA8);
+    const maxSize: number = Filament.Texture.getMaxTextureSize(engine,
+            Filament.Texture$Sampler.SAMPLER_2D);
+    const maxLayers: number = Filament.Texture.getMaxArrayTextureLayers(engine);
+    console.log(target, format, formatSupported, maxSize, maxLayers);
+
+    // swizzle() is reachable, but build() throws on WebGL, which has no texture swizzle. This
+    // file is only ever type-checked, never executed, so the call is safe to express here.
+    Filament.Texture.Builder()
+        .width(16)
+        .height(16)
+        .samples(1)
+        .swizzle(Filament.Texture$Swizzle.CHANNEL_0, Filament.Texture$Swizzle.CHANNEL_1,
+                Filament.Texture$Swizzle.CHANNEL_2, Filament.Texture$Swizzle.SUBSTITUTE_ONE)
+        .build(engine);
+
     const sampler = new Filament.TextureSampler(Filament.MinFilter.LINEAR,
             Filament.MagFilter.LINEAR, Filament.WrapMode.CLAMP_TO_EDGE);
     sampler.setAnisotropy(4);
     sampler.setCompareMode(Filament.CompareMode.NONE, Filament.CompareFunc.LESS_EQUAL);
+    sampler.setMinFilter(Filament.MinFilter.NEAREST);
+    sampler.setMagFilter(Filament.MagFilter.NEAREST);
+    sampler.setWrapModeS(Filament.WrapMode.REPEAT);
+    sampler.setWrapModeT(Filament.WrapMode.REPEAT);
+    sampler.setWrapModeR(Filament.WrapMode.REPEAT);
+    const anisotropy: number = sampler.getAnisotropy();
+    const compareMode: Filament.CompareMode = sampler.getCompareMode();
+    const compareFunc: Filament.CompareFunc = sampler.getCompareFunc();
+    const minFilter: Filament.MinFilter = sampler.getMinFilter();
+    const magFilter: Filament.MagFilter = sampler.getMagFilter();
+    const wrapS: Filament.WrapMode = sampler.getWrapModeS();
+    const wrapT: Filament.WrapMode = sampler.getWrapModeT();
+    const wrapR: Filament.WrapMode = sampler.getWrapModeR();
+    console.log(anisotropy, compareMode, compareFunc, minFilter, magFilter, wrapS, wrapT, wrapR);
 
     const pbd = new Filament.driver$PixelBufferDescriptor(16 * 16 * 4,
             Filament.PixelDataFormat.RGBA, Filament.PixelDataType.UBYTE);
@@ -419,12 +528,55 @@ function smoke_material() {
     console.log(source, dup, dupNamed);
 
     matinst.setFloatParameter("alpha", 1.0);
+    matinst.setBoolParameter("flag", true);
+    matinst.setBool2Parameter("flag2", [true, false]);
+    matinst.setBool3Parameter("flag3", [true, false, true]);
+    matinst.setBool4Parameter("flag4", [true, false, true, false]);
+    matinst.setIntParameter("count", 1);
+    matinst.setInt2Parameter("count2", [1, 2]);
+    matinst.setInt3Parameter("count3", [1, 2, 3]);
+    matinst.setInt4Parameter("count4", [1, 2, 3, 4]);
     matinst.setColor3Parameter("baseColor", Filament.RgbType.sRGB, v3);
     matinst.setCullingMode(Filament.CullingMode.BACK);
     matinst.setTransparencyMode(Filament.TransparencyMode.DEFAULT);
     const transparency: Filament.TransparencyMode = matinst.getTransparencyMode();
     const threshold: number = matinst.getMaskThreshold();
     console.log(named, def, name, validMaterial, validInstance, transparency, threshold);
+
+    matinst.setConstantBool("test_bool", true);
+    matinst.setConstantFloat("test_float", 1.0);
+    matinst.setConstantInt("test_int", 1);
+    const stencilWrite: boolean = matinst.isStencilWriteEnabled();
+    console.log(stencilWrite);
+
+    // Reflection surface: parameter enumeration plus the compiled-in material properties.
+    const paramCount: number = material.getParameterCount();
+    const params: Filament.Material$ParameterInfo[] = material.getParameters();
+    const hasParam: boolean = material.hasParameter("baseColor");
+    const shading: Filament.Shading = material.getShading();
+    const interpolation: Filament.Interpolation = material.getInterpolation();
+    const blending: Filament.BlendingMode = material.getBlendingMode();
+    const refractionMode: Filament.RefractionMode = material.getRefractionMode();
+    const refractionType: Filament.RefractionType = material.getRefractionType();
+    const reflectionMode: Filament.ReflectionMode = material.getReflectionMode();
+    const vertexDomain: Filament.VertexDomain = material.getVertexDomain();
+    const culling: Filament.CullingMode = material.getCullingMode();
+    const matTransparency: Filament.TransparencyMode = material.getTransparencyMode();
+    console.log(matTransparency);
+    const featureLevel: Filament.FeatureLevel = material.getFeatureLevel();
+    const maskThreshold: number = material.getMaskThreshold();
+    const saaVariance: number = material.getSpecularAntiAliasingVariance();
+    const saaThreshold: number = material.getSpecularAntiAliasingThreshold();
+    const requiredAttributes: number = material.getRequiredAttributes();
+    const doubleSided: boolean = material.isDoubleSided();
+    const alphaToCoverage: boolean = material.isAlphaToCoverageEnabled();
+    const colorWrite: boolean = material.isColorWriteEnabled();
+    const depthWrite: boolean = material.isDepthWriteEnabled();
+    const depthCulling: boolean = material.isDepthCullingEnabled();
+    console.log(paramCount, params, hasParam, shading, interpolation, blending, refractionMode,
+            refractionType, reflectionMode, vertexDomain, culling, featureLevel, maskThreshold,
+            saaVariance, saaThreshold, requiredAttributes, doubleSided, alphaToCoverage,
+            colorWrite, depthWrite, depthCulling);
 
     try {
         matinst.getConstantBool("test_bool");
@@ -433,6 +585,39 @@ function smoke_material() {
     } catch (e) {
         // constants might not exist in nonexistent.filamat, which is fine for smoke test
     }
+}
+
+function smoke_tone_mappers() {
+    // Each operator reachable through ColorGrading$Builder.toneMapper. The four below the
+    // deprecated ToneMapping enum cannot express are PBRNeutral, GT7, AgX and Generic.
+    const mappers: Filament.ToneMapper[] = [
+        new Filament.LinearToneMapper(),
+        new Filament.ACESToneMapper(),
+        new Filament.ACESLegacyToneMapper(),
+        new Filament.FilmicToneMapper(),
+        new Filament.PBRNeutralToneMapper(),
+        new Filament.GT7ToneMapper(),
+        new Filament.DisplayRangeToneMapper(),
+        new Filament.AgxToneMapper(Filament.AgxToneMapper$AgxLook.PUNCHY),
+    ];
+
+    const generic = new Filament.GenericToneMapper(1.55, 0.18, 0.215, 10.0);
+    generic.setContrast(1.6);
+    generic.setMidGrayIn(0.2);
+    generic.setMidGrayOut(0.22);
+    generic.setHdrMax(12.0);
+    const contrast: number = generic.getContrast();
+    const midGrayIn: number = generic.getMidGrayIn();
+    const midGrayOut: number = generic.getMidGrayOut();
+    const hdrMax: number = generic.getHdrMax();
+    console.log(contrast, midGrayIn, midGrayOut, hdrMax);
+
+    for (const mapper of mappers) {
+        Filament.ColorGrading.Builder().toneMapper(mapper).build(engine);
+        mapper.delete();
+    }
+    Filament.ColorGrading.Builder().toneMapper(generic).build(engine);
+    generic.delete();
 }
 
 function smoke_color_grading() {
@@ -456,7 +641,10 @@ function smoke_color_grading() {
 }
 
 function smoke_indirect_light() {
+    const sh = new Float32Array(9 * 3);
     const ibl = Filament.IndirectLight.Builder()
+        .irradianceSh(3, sh)
+        .radianceSh(3, sh)
         .intensity(30000)
         .build(engine);
     ibl.setIntensity(25000);
@@ -470,6 +658,7 @@ function smoke_indirect_light() {
 function smoke_skybox() {
     const sky = Filament.Skybox.Builder()
         .color([0, 0, 0, 1])
+        .intensity(30000)
         .showSun(true)
         .build(engine);
     sky.setColor([1, 1, 1, 1]);
@@ -593,8 +782,26 @@ function smoke_gltfio() {
     const animCount: number = animator.getAnimationCount();
     animator.applyAnimation(0, 0.0);
     animator.updateBoneMatrices();
+    // Count accessors, so callers can size a buffer without materializing the entity vector.
+    const entityCount: number = asset.getEntityCount();
+    const lightCount: number = asset.getLightEntityCount();
+    const renderableCount: number = asset.getRenderableEntityCount();
+    const cameraCount: number = asset.getCameraEntityCount();
+    const resourceUriCount: number = asset.getResourceUriCount();
+    const assetMorphCount: number = asset.getMorphTargetCountAt(root);
+    const sceneCount: number = asset.getSceneCount();
+    const assetInstanceCount: number = asset.getAssetInstanceCount();
+    const popped: Filament.Vector<Filament.Entity> = asset.popRenderables(4);
+    const instEntityCount: number = instance.getEntityCount();
+    const variantCount: number = instance.getMaterialVariantCount();
+    const matInstCount: number = instance.getMaterialInstanceCount();
+    loader.enableDiagnostics(true);
+    console.log(entityCount, lightCount, renderableCount, cameraCount, resourceUriCount,
+            assetMorphCount, sceneCount, assetInstanceCount, popped, instEntityCount,
+            variantCount, matInstCount);
+
     loader.destroyAsset(asset);
-    loader.delete();
+    Filament.gltfio$AssetLoader.destroy(loader);
     console.log(entities, root, box, skinNames, variants, animCount);
 }
 
@@ -612,6 +819,8 @@ function smoke_gltfio_resource_loader() {
     const has: boolean = resourceLoader.hasResourceData("tex.png");
     const progress: number = resourceLoader.asyncGetLoadProgress();
     const webpSupported: boolean = Filament.gltfio$WebpProvider.isWebpSupported();
+    resourceLoader.asyncCancelLoad();
+    resourceLoader.evictResourceData();
     ubershader.destroyMaterials();
     console.log(has, progress, webpSupported);
 }
@@ -655,6 +864,7 @@ const SMOKE_TESTS: Array<() => void> = [
     smoke_buffers,
     smoke_texture,
     smoke_material,
+    smoke_tone_mappers,
     smoke_color_grading,
     smoke_indirect_light,
     smoke_skybox,

--- a/web/filament-js/utilities.js
+++ b/web/filament-js/utilities.js
@@ -358,9 +358,16 @@ Filament._createTextureFromImageFile = function(fileContents, engine, options) {
         .sampler(Sampler.SAMPLER_2D)
         .format(texformat);
 
-    if (options['usage'] !== undefined) {
-        tex.usage(options['usage']);
+    // generateMipmaps rejects a texture whose usage lacks GEN_MIPMAPPABLE, so ask for it whenever
+    // a mip chain is wanted. Engine.debug.assert_texture_can_generate_mipmap used to be off, which
+    // let the engine infer the flag; it now defaults to on.
+    const Usage = Filament.Texture$Usage;
+    let usage = options['usage'] !== undefined ? options['usage'] :
+            (Usage.UPLOADABLE.value | Usage.SAMPLEABLE.value);
+    if (!nomips) {
+        usage |= Usage.GEN_MIPMAPPABLE.value;
     }
+    tex.usage(usage);
 
     tex = tex.build(engine);
 


### PR DESCRIPTION
Follow-up to #10216.

That PR closed gaps found by auditing one downstream binding layer. This one starts from the public C++ headers, which surfaces a larger set — including one case where JavaScript could not set integer material parameters at all — and adds tests that actually run the bindings, which turned up seven bugs that all type-checked cleanly.

## Bugs fixed

Each of these was found by running the bindings rather than declaring them.

| Binding | Symptom |
|---|---|
| `BufferObject$Builder.build` | Never wrapped: `BufferObject.Builder()…build(engine)` threw `build is not a function` |
| `SurfaceOrientation$Builder` `normals`/`tangents`/`uvs`/`positions`/`triangles16`/`triangles32` | Returned `undefined` instead of the builder, so the chained form `filament.d.ts` documents broke at the second call |
| `LightManager$Builder.intensityEnergy` | Wrapper called a `_intensityEnergy` that does not exist, shadowing the working binding underneath |
| `createTextureFromPng` / `createTextureFromJpeg` | Threw for anything mipmapped: they call `generateMipmaps` without asking for `GEN_MIPMAPPABLE`, now required by default. User-facing on every web client |
| `gltfio$FilamentAsset.getEntitiesByPrefix` | Always returned empty: asked for a count first, which that API answers with `0` |
| `MeshReader$MaterialRegistry.keys` | Returned twice as many entries as it had, half of them empty |
| `View.setDynamicResolutionOptions`, `setRenderQuality` | Rejected partial options objects, unlike every other option setter |
| `filament.d.ts` `getEntityByName` | Declared a method that is bound nowhere and does not exist in C++ |
| `ViewerGui` constructor | Wrote `true` through a null pointer into address 0 — see below |

## Bindings added

| Class | Added |
|---|---|
| `RenderableManager` | `getMorphTargetCount`, `setMorphTargetBufferOffsetAt`, `setSkinningBuffer`, `setMorphWeightsOffset` |
| `View` | The eleven option getters, plus `getRenderQuality`, `getDithering`, `getVisibleLayers`, `setLayerEnabled`, `isPostProcessingEnabled`, `set`/`isScreenSpaceRefractionEnabled`, `getScene`, `getCamera`, `getRenderTarget`, `set`/`getName`, `setSampleCount`, `getAntiAliasing` |
| `Material` | The whole reflective API: `hasParameter`, `getParameterCount`, `getParameters`, the shading/blending/refraction/reflection/vertex-domain getters, the raster-state queries |
| `MaterialInstance` | `setIntParameter` and the `int2-4`/`bool2-4` forms — **integer parameters could not be set from JS at all** — plus `setConstantBool/Float/Int` and `isStencilWriteEnabled` |
| `ToneMapper` | The hierarchy (Linear, ACES, ACESLegacy, Filmic, PBRNeutral, GT7, DisplayRange, AgX, Generic) and `ColorGrading::Builder::toneMapper`. The deprecated `toneMapping` enum could not reach the last four |
| `TextureSampler` | All twelve get/set accessors; the class was write-only at construction |
| `Texture` | `getTarget`, `getFormat`, `isTextureFormatSupported`, `getMaxTextureSize`, `getMaxArrayTextureLayers`, `Builder::samples`/`swizzle`/`external` |
| `Engine` | `setFeatureFlag`, `hasFeatureFlag`, `getFeatureFlag` (pairs with `Engine$Builder::feature`; returns `undefined` where C++ returns an empty optional), `flush`, `flushAndWait` |
| `SwapChain` | `isProtectedContentSupported`, `isMSAASwapChainSupported` |
| `Renderer` | `hasGpuFallenBehind` |
| `Camera` | `getEntity`, `setEyeModelMatrix`, `setCustomEyeProjection` |
| `LightManager` | `destroy`, `setIntensityCandela`, `Builder::intensityCandela`, the `ShadowCascades` split helpers |
| gltfio | The count accessors, `popRenderables`, `detachMaterialInstances`, `AssetLoader::enableDiagnostics`/`gc`/`destroy`, `ResourceLoader::asyncCancelLoad`/`evictResourceData`, the `MaterialProvider` members that take no `MaterialKey` |
| Also | `EntityManager` lifetime methods, `TransformManager::getChildCount` and the accurate-translations toggle, `IndexBuffer::getIndexCount`, `VertexBuffer::getVertexCount`, `Skybox::Builder::intensity` |

`AssetLoader::destroy` is worth flagging: `BIND(AssetLoader)` registers a no-op `raw_destructor`, so `loader.delete()` frees nothing and the loader leaks. There was previously no way to release it.

## Renames ⚠️

Two names diverged from C++ for no reason the binding layer forces:

| Was | Now | Why |
|---|---|---|
| `irradianceSh` / `irradianceTex`, `radianceSh` | `irradiance` (both), `radiance` | embind picks an overload by argument count, and the two `irradiance` forms differ in arity, so neither needs a name of its own |
| `gltfio$StbProvider`/`Ktx2Provider`/`WebpProvider`, `addStbProvider`/`addKtx2Provider`/`addWebpProvider` | `gltfio$TextureProvider` with `createStbProvider`/`createKtx2Provider`/`createWebpProvider`, and one `addTextureProvider` | They were split three ways because `TextureProvider` is polymorphic and embind reaches a base class through RTTI, which this build compiles without. An opaque handle sidesteps that, and matches how C++ and Java spell it |

## Tooling and tests

`tools/web-binding-audit` now holds two scripts, one per half of the question:

- **`unbound_apis.py`** (was `run.py`) — diffs the public C++ headers against the embind registrations and reports what the Java bindings already expose, so acting on a finding never makes the web surface wider than Android's. `filament.d.ts` is deliberately not treated as evidence a method is bound; a stale declaration is exactly how `getEntityByName` survived. Deliberate omissions carry their reason; anything else exits 1.
- **`untested_bindings.py`** — reports bindings no test calls. Currently 836 of 838 bound class members are exercised; the two exceptions are an internal entry point and a validity check for `Stream`, which JS cannot construct.

Three test files, each covering what the one before it cannot:

| File | How it runs | What it proves |
|---|---|---|
| `test.ts` | `tsc`, never executed | `filament.d.ts` matches the bindings, including calls that would abort at runtime |
| `test-runtime.js` | Node, NOOP backend | the bindings exist and marshal — **53 tests** |
| `test-browser.html` | browser, WebGL | rendering, pixel readback, picking, image decoding — **13 tests** |

They assert on round-trips, not on registration: option structs come back field for field, a child transform inherits its parent's translation, the free-flight manipulator moves when a key is held. Neither runnable file needs assets beyond three committed files and a glTF built inline; the browser page draws its own test images.

## Deliberately not bound

Recorded in `unbound_apis.py` with a reason each, checked against the implementation rather than the header. The short version: `Fence::waitAndDestroy` needs threads; `Engine::isValid` is overloaded per resource type at one argument each, so it stays the `isValidX` family; `Material::Builder` is not registered; `Material::setDefaultParameter` is sugar for `getDefaultInstance()->setParameter()`, both of which are bound; the three `compile()` methods and `Scene::forEach` need a `CallbackHandler` layer; `MaterialProvider::createMaterialInstance`/`getMaterial` are blocked on the bitfield-packed `MaterialKey`.

## Testing

`./build.sh -p wasm release` clean · runtime 53/53 · browser 13/13 in Chrome on both ANGLE/Metal and SwiftShader · `tsc` clean · both audit scripts exit 0. The audit was itself verified by deleting 15 registrations across all three binding styles and confirming it reported exactly those 15.

### The ViewerGui crash

Worth its own note, since it took `-sSAFE_HEAP` to find and it is not web-specific.

`ViewerGui`'s constructor did:

```cpp
*debug.getPropertyAddress<bool>("d.stereo.combine_multiview_images") = true;
```

That property is registered by the **first `Renderer` the engine creates**. A viewer built before any renderer exists — which the web bindings let you do, and which is the natural order for a page that sets up its UI first — gets `nullptr` back and writes `true` to address 0. Nothing traps: it corrupts the bottom of the heap, and the damage surfaces later somewhere unrelated, or not at all, depending on the heap layout. It moved around as unrelated bindings were added, which is what made it worth chasing.

The UI it draws had a second, milder version of the same assumption: `updateUserInterface` read `mAsset` and `mInstance` unconditionally, and a viewer that has not loaded anything has neither. Those reads are guarded now, so the sidebar can be drawn before a model is loaded.
