### PR TITLE
filamentapp: fix metal resize bug

### DIFF
--- a/libs/filamentapp/include/filamentapp/NativeWindowHelper.h
+++ b/libs/filamentapp/include/filamentapp/NativeWindowHelper.h
@@ -26,8 +26,12 @@ extern "C" void* getNativeWindowFromSDL(SDL_Window* sdlWindow);
 extern "C" void* setUpMetalLayer(void* nativeWindow);
 // Setup the window the way Filament expects (color space, etc.).
 extern "C" void prepareNativeWindow(SDL_Window* sdlWindow);
-// Resize the backing CAMetalLayer's drawable to match the new view's size. Returns the layer.
-extern "C" void* resizeMetalLayer(void* nativeView);
+// Resize the CAMetalLayer's bounds and drawable to match the layer delegate view's size. Returns
+// the layer.
+extern "C" void* resizeMetalLayer(void* metalLayer);
+// Resize the backing CAMetalLayer's bounds and drawable to match the NSView's size. Returns the
+// layer.
+extern "C" void* resizeMetalLayerFromView(void* nativeView);
 #endif
 
 #endif // TNT_FILAMENT_NATIVE_WINDOW_HELPER_H

--- a/libs/filamentapp/src/display_managers/NativeWindowHelperCocoa.mm
+++ b/libs/filamentapp/src/display_managers/NativeWindowHelperCocoa.mm
@@ -49,6 +49,8 @@ void* setUpMetalLayer(void* nativeView) {
     [view setWantsLayer:YES];
     CAMetalLayer* metalLayer = [CAMetalLayer layer];
     metalLayer.bounds = view.bounds;
+    metalLayer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+    metalLayer.delegate = (id<CALayerDelegate>) view;
 
     // It's important to set the drawableSize to the actual backing pixels. When rendering
     // full-screen, we can skip the macOS compositor if the size matches the display size.
@@ -70,14 +72,35 @@ void* setUpMetalLayer(void* nativeView) {
     return metalLayer;
 }
 
-void* resizeMetalLayer(void* nativeView) {
-    NSView* view = (NSView*) nativeView;
+void* resizeMetalLayerFromView(void* nativeView) {
+    if (!nativeView) {
+        return nullptr;
+    }
+    id obj = (__bridge id) nativeView;
+    if (![obj isKindOfClass:[NSView class]]) {
+        return nullptr;
+    }
+    NSView* view = (NSView*) obj;
     CAMetalLayer* metalLayer = (CAMetalLayer*) view.layer;
-    CGSize viewSize = view.bounds.size;
-    NSSize newDrawableSize = [view convertSizeToBacking:view.bounds.size];
-    metalLayer.drawableSize = newDrawableSize;
-    metalLayer.contentsScale = view.window.backingScaleFactor;
+    if (metalLayer && [metalLayer isKindOfClass:[CAMetalLayer class]]) {
+        metalLayer.bounds = view.bounds;
+        metalLayer.drawableSize = [view convertSizeToBacking:view.bounds.size];
+        metalLayer.contentsScale = view.window.backingScaleFactor;
+    }
     return metalLayer;
+}
+
+void* resizeMetalLayer(void* layer) {
+    if (!layer) {
+        return nullptr;
+    }
+    id obj = (__bridge id) layer;
+    if (![obj isKindOfClass:[CAMetalLayer class]]) {
+        return nullptr;
+    }
+    CAMetalLayer* metalLayer = (CAMetalLayer*) obj;
+    NSView* view = (NSView*) metalLayer.delegate;
+    return resizeMetalLayerFromView(view);
 }
 
 // When running in headless/web-server mode, the standard SDL main event pump is bypassed.

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -234,13 +234,9 @@ void setup_window(Window& w, Engine* engine) {
     void* nativeSwapChain = nativeWindow;
 #if defined(__APPLE__)
     void* metalLayer = nullptr;
-
-#if defined(FILAMENT_SUPPORTS_WEBGPU)
-    if (kBackend == filament::Engine::Backend::METAL || kBackend == filament::Engine::Backend::VULKAN
-        || kBackend == filament::Engine::Backend::WEBGPU) {
-#else
-    if (kBackend == filament::Engine::Backend::METAL || kBackend == filament::Engine::Backend::VULKAN) {
-#endif
+    if (kBackend == filament::Engine::Backend::METAL ||
+            kBackend == filament::Engine::Backend::VULKAN ||
+            kBackend == filament::Engine::Backend::WEBGPU) {
         metalLayer = setUpMetalLayer(nativeWindow);
         // The swap chain on both native Metal and MoltenVK is a CAMetalLayer.
         nativeSwapChain = metalLayer;
@@ -281,14 +277,11 @@ void destroy_window(Window& w, Engine* engine) {
 void resize_window(Window& w, Engine* engine) {
 #if defined(__APPLE__)
     void* nativeWindow = ::getNativeWindowFromSDL(w.sdl_window);
-    if (kBackend == filament::Engine::Backend::METAL) {
-        resizeMetalLayer(nativeWindow);
+    if (kBackend == filament::Engine::Backend::METAL ||
+            kBackend == filament::Engine::Backend::VULKAN ||
+            kBackend == filament::Engine::Backend::WEBGPU) {
+        resizeMetalLayerFromView(nativeWindow);
     }
-#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
-    if (kBackend == filament::Engine::Backend::VULKAN) {
-        resizeMetalLayer(nativeWindow);
-    }
-#endif
 #endif
 
     int width, height;


### PR DESCRIPTION
In SDLDisplayManager, the native window stored for the Metal backend is a CAMetalLayer, not an NSView. When the window was resized, this layer was incorrectly passed to resizeMetalLayer() and cast to an NSView, breaking window resizing on macOS.

This commit updates resizeMetalLayer() to correctly expect and handle a CAMetalLayer. It also introduces resizeMetalLayerFromView() for callers that still pass an NSView (e.g., the multiple_windows sample). Additionally, we set the CAMetalLayer's delegate to the NSView to easily retrieve it, and add type checks to prevent future crashes.