### PR TITLE
Speed up the AABB culler

### DIFF
--- a/filament/benchmark/benchmark_filament.cpp
+++ b/filament/benchmark/benchmark_filament.cpp
@@ -36,12 +36,40 @@
 
 #include <benchmark/benchmark.h>
 
+#include <math/fast.h>
+
+#include <cmath>
 #include <random>
 #include <vector>
 
 using namespace filament;
 using namespace filament::math;
 using namespace utils;
+
+namespace {
+
+static void baselineAabbIntersects(Culler::result_type* UTILS_RESTRICT results,
+        Frustum const& UTILS_RESTRICT frustum,
+        float3 const* UTILS_RESTRICT center,
+        float3 const* UTILS_RESTRICT extent,
+        size_t count) noexcept {
+    float4 const* UTILS_RESTRICT const planes = frustum.getNormalizedPlanes();
+    count = Culler::round(count);
+    for (size_t i = 0; i < count; i++) {
+        int visible = ~0;
+        for (size_t j = 0; j < 6; j++) {
+            const float dot =
+                    planes[j].x * center[i].x - std::abs(planes[j].x) * extent[i].x +
+                    planes[j].y * center[i].y - std::abs(planes[j].y) * extent[i].y +
+                    planes[j].z * center[i].z - std::abs(planes[j].z) * extent[i].z +
+                    planes[j].w;
+            visible &= fast::signbit(dot);
+        }
+        results[i] = Culler::result_type(visible);
+    }
+}
+
+} // namespace
 
 
 class FilamentCullingFixture : public benchmark::Fixture {
@@ -51,6 +79,12 @@ protected:
     Frustum frustum{};
     std::vector<float3> boxesCenter;
     std::vector<float3> boxesExtent;
+    std::vector<float> boxesCenterX;
+    std::vector<float> boxesCenterY;
+    std::vector<float> boxesCenterZ;
+    std::vector<float> boxesExtentX;
+    std::vector<float> boxesExtentY;
+    std::vector<float> boxesExtentZ;
     std::vector<float4> spheres;
     Culler::result_type* UTILS_RESTRICT visibles = nullptr;
 
@@ -66,6 +100,12 @@ public:
 
         boxesCenter.resize(batch);
         boxesExtent.resize(batch);
+        boxesCenterX.resize(batch);
+        boxesCenterY.resize(batch);
+        boxesCenterZ.resize(batch);
+        boxesExtentX.resize(batch);
+        boxesExtentY.resize(batch);
+        boxesExtentZ.resize(batch);
         spheres.resize(batch);
         for (size_t i = 0; i < batch; i++) {
             float4& sphere = spheres[i];
@@ -81,6 +121,16 @@ public:
                     rand(gen, std::uniform_real_distribution<float>::param_type{ 0.11f, 25.0f }),
                     rand(gen, std::uniform_real_distribution<float>::param_type{ 0.11f, 25.0f })
             };
+
+        }
+
+        for (size_t i = 0; i < batch; i++) {
+            boxesCenterX[i] = boxesCenter[i].x;
+            boxesCenterY[i] = boxesCenter[i].y;
+            boxesCenterZ[i] = boxesCenter[i].z;
+            boxesExtentX[i] = boxesExtent[i].x;
+            boxesExtentY[i] = boxesExtent[i].y;
+            boxesExtentZ[i] = boxesExtent[i].z;
         }
 
         visibles = (Culler::result_type*)utils::aligned_alloc(batch * sizeof(*visibles), 32);
@@ -95,7 +145,22 @@ BENCHMARK_F(FilamentCullingFixture, boxCulling)(benchmark::State& state) {
     {
         PerformanceCounters pc(state);
         for (UTILS_UNUSED auto _ : state) {
-            Culler::Test::intersects(visibles, frustum, boxesCenter.data(), boxesExtent.data(), BATCH_SIZE);
+            Culler::Test::intersects(visibles, frustum,
+                    boxesCenterX.data(), boxesCenterY.data(), boxesCenterZ.data(),
+                    boxesExtentX.data(), boxesExtentY.data(), boxesExtentZ.data(),
+                    BATCH_SIZE);
+        }
+        benchmark::ClobberMemory();
+        pc.stop();
+        state.SetItemsProcessed(state.iterations() * BATCH_SIZE);
+    }
+}
+
+BENCHMARK_F(FilamentCullingFixture, boxCullingScalarBaseline)(benchmark::State& state) {
+    {
+        PerformanceCounters pc(state);
+        for (UTILS_UNUSED auto _ : state) {
+            baselineAabbIntersects(visibles, frustum, boxesCenter.data(), boxesExtent.data(), BATCH_SIZE);
         }
         benchmark::ClobberMemory();
         pc.stop();

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -20,16 +20,11 @@
 
 #include <math/fast.h>
 
+#include <cmath>
+
 using namespace filament::math;
 
-// use 8 if Culler::result_type is 8-bits, on ARMv8 it allows the compiler to write eight
-// results in one go.
-#define FILAMENT_CULLER_VECTORIZE_HINT 4
-
 namespace filament {
-
-static_assert(Culler::MODULO % FILAMENT_CULLER_VECTORIZE_HINT == 0,
-        "MODULO m=must be a multiple of FILAMENT_CULLER_VECTORIZE_HINT");
 
 void Culler::intersects(
         result_type* UTILS_RESTRICT results,
@@ -40,16 +35,10 @@ void Culler::intersects(
     float4 const * const UTILS_RESTRICT planes = frustum.mPlanes;
 
     count = round(count);
-#if defined(__clang__)
-    #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
-#endif
     for (size_t i = 0; i < count; i++) {
         int visible = ~0;
         float4 const sphere(b[i]);
 
-#if defined(__clang__)
-        #pragma clang loop unroll(full)
-#endif
         for (size_t j = 0; j < 6; j++) {
             // clang doesn't seem to generate vector * scalar instructions, which leads
             // to increased register pressure and stack spills
@@ -66,38 +55,68 @@ void Culler::intersects(
 void Culler::intersects(
         result_type* UTILS_RESTRICT results,
         Frustum const& UTILS_RESTRICT frustum,
-        float3 const* UTILS_RESTRICT center,
-        float3 const* UTILS_RESTRICT extent,
+    float const* UTILS_RESTRICT centerX,
+    float const* UTILS_RESTRICT centerY,
+    float const* UTILS_RESTRICT centerZ,
+    float const* UTILS_RESTRICT extentX,
+    float const* UTILS_RESTRICT extentY,
+    float const* UTILS_RESTRICT extentZ,
         size_t count, size_t const bit) noexcept {
 
     float4 const * UTILS_RESTRICT const planes = frustum.mPlanes;
+    float3 absPlanes[6];
+    for (size_t j = 0; j < 6; j++) {
+        absPlanes[j].x = std::abs(planes[j].x);
+        absPlanes[j].y = std::abs(planes[j].y);
+        absPlanes[j].z = std::abs(planes[j].z);
+    }
 
     count = round(count);
-#if defined(__clang__)
-    #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
-#endif
-    for (size_t i = 0; i < count; i++) {
-        int visible = ~0;
-
-#if defined(__clang__)
-        #pragma clang loop unroll(full)
-#endif
-        for (size_t j = 0; j < 6; j++) {
-            // clang doesn't seem to generate vector * scalar instructions, which leads
-            // to increased register pressure and stack spills
-            const float dot =
-                    planes[j].x * center[i].x - std::abs(planes[j].x) * extent[i].x +
-                    planes[j].y * center[i].y - std::abs(planes[j].y) * extent[i].y +
-                    planes[j].z * center[i].z - std::abs(planes[j].z) * extent[i].z +
-                    planes[j].w;
-
-            visible &= fast::signbit(dot) << bit;
+    constexpr size_t BLOCK_SIZE = 4;
+    static_assert(MODULO % BLOCK_SIZE == 0,
+            "MODULO must be a multiple of 4");
+    size_t const blockCount = count / BLOCK_SIZE;
+    for (size_t i = 0; i < blockCount; i++) {
+        int visible[BLOCK_SIZE];
+        for (size_t n = 0; n < BLOCK_SIZE; n++) {
+            visible[n] = ~0;
         }
 
-        auto r = results[i];
-        r &= ~result_type(1u << bit);
-        r |= result_type(visible);
-        results[i] = r;
+        size_t const base = i * BLOCK_SIZE;
+        const float4 cx{ centerX[base + 0], centerX[base + 1], centerX[base + 2], centerX[base + 3] };
+        const float4 cy{ centerY[base + 0], centerY[base + 1], centerY[base + 2], centerY[base + 3] };
+        const float4 cz{ centerZ[base + 0], centerZ[base + 1], centerZ[base + 2], centerZ[base + 3] };
+        const float4 ex{ extentX[base + 0], extentX[base + 1], extentX[base + 2], extentX[base + 3] };
+        const float4 ey{ extentY[base + 0], extentY[base + 1], extentY[base + 2], extentY[base + 3] };
+        const float4 ez{ extentZ[base + 0], extentZ[base + 1], extentZ[base + 2], extentZ[base + 3] };
+
+        for (size_t j = 0; j < 6; j++) {
+            const float pX = planes[j].x;
+            const float absPX = absPlanes[j].x;
+            const float pY = planes[j].y;
+            const float absPY = absPlanes[j].y;
+            const float pZ = planes[j].z;
+            const float absPZ = absPlanes[j].z;
+            const float pW = planes[j].w;
+
+            const float4 dots =
+                pX * cx - absPX * ex +
+                pY * cy - absPY * ey +
+                pZ * cz - absPZ * ez +
+                pW;
+
+            visible[0] &= fast::signbit(dots.x) << bit;
+            visible[1] &= fast::signbit(dots.y) << bit;
+            visible[2] &= fast::signbit(dots.z) << bit;
+            visible[3] &= fast::signbit(dots.w) << bit;
+        }
+
+        for (size_t n = 0; n < BLOCK_SIZE; n++) {
+            auto r = results[base + n];
+            r &= ~result_type(1u << bit);
+            r |= result_type(visible[n]);
+            results[base + n] = r;
+        }
     }
 }
 
@@ -107,12 +126,23 @@ void Culler::intersects(
 
 bool Culler::intersects(Frustum const& frustum, Box const& box) noexcept {
     // The main intersection routine assumes multiples of 8 items
-    float3 centers[MODULO];
-    float3 extents[MODULO];
+    float centerX[MODULO] = {};
+    float centerY[MODULO] = {};
+    float centerZ[MODULO] = {};
+    float extentX[MODULO] = {};
+    float extentY[MODULO] = {};
+    float extentZ[MODULO] = {};
     result_type results[MODULO];
-    centers[0] = box.center;
-    extents[0] = box.halfExtent;
-    intersects(results, frustum, centers, extents, MODULO, 0);
+    centerX[0] = box.center.x;
+    centerY[0] = box.center.y;
+    centerZ[0] = box.center.z;
+    extentX[0] = box.halfExtent.x;
+    extentY[0] = box.halfExtent.y;
+    extentZ[0] = box.halfExtent.z;
+    intersects(results, frustum,
+            centerX, centerY, centerZ,
+            extentX, extentY, extentZ,
+            MODULO, 0);
     return bool(results[0] & 1);
 }
 
@@ -133,10 +163,17 @@ bool Culler::intersects(Frustum const& frustum, float4 const& sphere) noexcept {
 void Culler::Test::intersects(
         result_type* UTILS_RESTRICT results,
         Frustum const& UTILS_RESTRICT frustum,
-        float3 const* UTILS_RESTRICT c,
-        float3 const* UTILS_RESTRICT e,
+    float const* UTILS_RESTRICT centerX,
+    float const* UTILS_RESTRICT centerY,
+    float const* UTILS_RESTRICT centerZ,
+    float const* UTILS_RESTRICT extentX,
+    float const* UTILS_RESTRICT extentY,
+    float const* UTILS_RESTRICT extentZ,
         size_t const count) noexcept {
-    Culler::intersects(results, frustum, c, e, count, 0);
+    Culler::intersects(results, frustum,
+            centerX, centerY, centerZ,
+            extentX, extentY, extentZ,
+            count, 0);
 }
 
 void Culler::Test::intersects(

--- a/filament/src/Culler.h
+++ b/filament/src/Culler.h
@@ -49,8 +49,12 @@ public:
      */
     static void intersects(result_type* results,
             Frustum const& frustum,
-            math::float3 const* center,
-            math::float3 const* extent,
+            float const* centerX,
+            float const* centerY,
+            float const* centerZ,
+            float const* extentX,
+            float const* extentY,
+            float const* extentZ,
             size_t count, size_t bit) noexcept;
 
     /*
@@ -80,8 +84,12 @@ public:
     struct UTILS_PUBLIC Test {
         static void intersects(result_type* results,
                 Frustum const& frustum,
-                math::float3 const* c,
-                math::float3 const* e,
+                float const* centerX,
+                float const* centerY,
+                float const* centerZ,
+                float const* extentX,
+                float const* extentY,
+                float const* extentZ,
                 size_t count) noexcept;
 
         static void intersects(result_type* results,

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -555,7 +555,9 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
 
     float const cameraPositionDotCameraForward = dot(cameraPosition, cameraForward);
 
-    auto const* const UTILS_RESTRICT soaWorldAABBCenter = soa.data<FScene::WORLD_AABB_CENTER>();
+    auto const* const UTILS_RESTRICT soaWorldAABBCenterX = soa.data<FScene::WORLD_AABB_CENTER_X>();
+    auto const* const UTILS_RESTRICT soaWorldAABBCenterY = soa.data<FScene::WORLD_AABB_CENTER_Y>();
+    auto const* const UTILS_RESTRICT soaWorldAABBCenterZ = soa.data<FScene::WORLD_AABB_CENTER_Z>();
     auto const* const UTILS_RESTRICT soaVisibility      = soa.data<FScene::VISIBILITY_STATE>();
     auto const* const UTILS_RESTRICT soaSkinningData    = soa.data<FScene::SKINNING_STATE>();
     auto const* const UTILS_RESTRICT soaPrimitives      = soa.data<FScene::PRIMITIVES>();
@@ -610,7 +612,11 @@ RenderPass::Command* RenderPass::generateCommandsImpl(CommandTypeFlags extraFlag
         //   Here, objects close to the camera (but behind) will be drawn first.
         // An alternative that keeps the mathematical ordering is given here:
         //   distanceBits ^= ((int32_t(distanceBits) >> 31) | 0x80000000u);
-        float const distance = -(dot(soaWorldAABBCenter[i], cameraForward) - cameraPositionDotCameraForward);
+        float const distance = -(
+                soaWorldAABBCenterX[i] * cameraForward.x +
+                soaWorldAABBCenterY[i] * cameraForward.y +
+                soaWorldAABBCenterZ[i] * cameraForward.z -
+                cameraPositionDotCameraForward);
         uint32_t const distanceBits = reinterpret_cast<uint32_t const&>(distance);
 
         // calculate the per-primitive face winding order inversion

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1157,8 +1157,12 @@ void ShadowMap::visitScene(FScene::RenderableSoa const& soa, uint32_t const visi
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
     using State = FRenderableManager::Visibility;
-    float3 const* const worldAABBCenter = soa.data<FScene::WORLD_AABB_CENTER>();
-    float3 const* const worldAABBExtent = soa.data<FScene::WORLD_AABB_EXTENT>();
+    float const* const worldAABBCenterX = soa.data<FScene::WORLD_AABB_CENTER_X>();
+    float const* const worldAABBCenterY = soa.data<FScene::WORLD_AABB_CENTER_Y>();
+    float const* const worldAABBCenterZ = soa.data<FScene::WORLD_AABB_CENTER_Z>();
+    float const* const worldAABBExtentX = soa.data<FScene::WORLD_AABB_EXTENT_X>();
+    float const* const worldAABBExtentY = soa.data<FScene::WORLD_AABB_EXTENT_Y>();
+    float const* const worldAABBExtentZ = soa.data<FScene::WORLD_AABB_EXTENT_Z>();
     uint8_t const* const layers = soa.data<FScene::LAYERS>();
     State const* const visibility = soa.data<FScene::VISIBILITY_STATE>();
     auto const* const visibleMasks = soa.data<FScene::VISIBLE_MASK>();
@@ -1166,8 +1170,12 @@ void ShadowMap::visitScene(FScene::RenderableSoa const& soa, uint32_t const visi
     for (size_t i = 0; i < c; i++) {
         if (layers[i] & visibleLayers) {
             Aabb const aabb{
-                worldAABBCenter[i] - worldAABBExtent[i],
-                worldAABBCenter[i] + worldAABBExtent[i]
+                                { worldAABBCenterX[i] - worldAABBExtentX[i],
+                                    worldAABBCenterY[i] - worldAABBExtentY[i],
+                                    worldAABBCenterZ[i] - worldAABBExtentZ[i] },
+                                { worldAABBCenterX[i] + worldAABBExtentX[i],
+                                    worldAABBCenterY[i] + worldAABBExtentY[i],
+                                    worldAABBCenterZ[i] + worldAABBExtentZ[i] }
             };
             visitor(aabb, visibleMasks[i], visibility[i]);
         }

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -1162,14 +1162,22 @@ void ShadowMapManager::cullSpotShadowMap(ShadowMap const& shadowMap,
     const Frustum frustum(MpMv);
 
     // Cull shadow casters
-    float3 const* worldAABBCenter = renderableData.data<FScene::WORLD_AABB_CENTER>();
-    float3 const* worldAABBExtent = renderableData.data<FScene::WORLD_AABB_EXTENT>();
+    float const* worldAABBCenterX = renderableData.data<FScene::WORLD_AABB_CENTER_X>();
+    float const* worldAABBCenterY = renderableData.data<FScene::WORLD_AABB_CENTER_Y>();
+    float const* worldAABBCenterZ = renderableData.data<FScene::WORLD_AABB_CENTER_Z>();
+    float const* worldAABBExtentX = renderableData.data<FScene::WORLD_AABB_EXTENT_X>();
+    float const* worldAABBExtentY = renderableData.data<FScene::WORLD_AABB_EXTENT_Y>();
+    float const* worldAABBExtentZ = renderableData.data<FScene::WORLD_AABB_EXTENT_Z>();
     FScene::VisibleMaskType* visibleArray = renderableData.data<FScene::VISIBLE_MASK>();
     Culler::intersects(
             visibleArray + range.first,
             frustum,
-            worldAABBCenter + range.first,
-            worldAABBExtent + range.first,
+            worldAABBCenterX + range.first,
+            worldAABBCenterY + range.first,
+            worldAABBCenterZ + range.first,
+            worldAABBExtentX + range.first,
+            worldAABBExtentY + range.first,
+            worldAABBExtentZ + range.first,
             range.size(),
             VISIBLE_DYN_SHADOW_RENDERABLE_BIT);
 
@@ -1231,14 +1239,22 @@ void ShadowMapManager::cullPointShadowMap(ShadowMap const& shadowMap, FView cons
     Frustum const frustum{ highPrecisionMultiply(Mp, Mv) };
 
     // Cull shadow casters
-    float3 const* worldAABBCenter = renderableData.data<FScene::WORLD_AABB_CENTER>();
-    float3 const* worldAABBExtent = renderableData.data<FScene::WORLD_AABB_EXTENT>();
+    float const* worldAABBCenterX = renderableData.data<FScene::WORLD_AABB_CENTER_X>();
+    float const* worldAABBCenterY = renderableData.data<FScene::WORLD_AABB_CENTER_Y>();
+    float const* worldAABBCenterZ = renderableData.data<FScene::WORLD_AABB_CENTER_Z>();
+    float const* worldAABBExtentX = renderableData.data<FScene::WORLD_AABB_EXTENT_X>();
+    float const* worldAABBExtentY = renderableData.data<FScene::WORLD_AABB_EXTENT_Y>();
+    float const* worldAABBExtentZ = renderableData.data<FScene::WORLD_AABB_EXTENT_Z>();
     FScene::VisibleMaskType* visibleArray = renderableData.data<FScene::VISIBLE_MASK>();
     Culler::intersects(
             visibleArray + range.first,
             frustum,
-            worldAABBCenter + range.first,
-            worldAABBExtent + range.first,
+            worldAABBCenterX + range.first,
+            worldAABBCenterY + range.first,
+            worldAABBCenterZ + range.first,
+            worldAABBExtentX + range.first,
+            worldAABBExtentY + range.first,
+            worldAABBExtentZ + range.first,
             range.size(),
             VISIBLE_DYN_SHADOW_RENDERABLE_BIT);
 

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -232,11 +232,15 @@ void FScene::prepare(JobSystem& js,
             sceneData.elementAt<SKINNING_BUFFER>(index)     = rcm.getSkinningBufferInfo(ri);
             sceneData.elementAt<MORPHING_BUFFER>(index)     = rcm.getMorphingBufferInfo(ri);
             sceneData.elementAt<INSTANCES>(index)           = rcm.getInstancesInfo(ri);
-            sceneData.elementAt<WORLD_AABB_CENTER>(index)   = worldAABB.center;
+            sceneData.elementAt<WORLD_AABB_CENTER_X>(index) = worldAABB.center.x;
+            sceneData.elementAt<WORLD_AABB_CENTER_Y>(index) = worldAABB.center.y;
+            sceneData.elementAt<WORLD_AABB_CENTER_Z>(index) = worldAABB.center.z;
             sceneData.elementAt<VISIBLE_MASK>(index)        = 0;
             sceneData.elementAt<CHANNELS>(index)            = rcm.getLightChannels(ri);
             sceneData.elementAt<LAYERS>(index)              = rcm.getLayerMask(ri);
-            sceneData.elementAt<WORLD_AABB_EXTENT>(index)   = worldAABB.halfExtent;
+            sceneData.elementAt<WORLD_AABB_EXTENT_X>(index) = worldAABB.halfExtent.x;
+            sceneData.elementAt<WORLD_AABB_EXTENT_Y>(index) = worldAABB.halfExtent.y;
+            sceneData.elementAt<WORLD_AABB_EXTENT_Z>(index) = worldAABB.halfExtent.z;
             //sceneData.elementAt<PRIMITIVES>(index)          = {}; // already initialized, Slice<>
             sceneData.elementAt<SUMMED_PRIMITIVE_COUNT>(index) = 0;
             //sceneData.elementAt<UBO>(index)                 = {}; // not needed here
@@ -359,7 +363,7 @@ void FScene::prepare(JobSystem& js,
 void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables, FScene::SceneCacheData& cache) const noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
     RenderableSoa& sceneData = cache.renderableData;
-    
+
     cache.hasContactShadows = false;
     for (uint32_t const i : visibleRenderables) {
         PerRenderableData& uboData = sceneData.elementAt<UBO>(i);

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -90,13 +90,17 @@ public:
         SKINNING_BUFFER,        //   8 | bones uniform buffer handle, offset, indices and weights
         MORPHING_BUFFER,        //  16 | weights uniform buffer handle, count, morph targets
         INSTANCES,              //  16 | instancing info for this Renderable
-        WORLD_AABB_CENTER,      //  12 | world-space bounding box center of the renderable
+        WORLD_AABB_CENTER_X,    //   4 | world-space bounding box center.x of the renderable
+        WORLD_AABB_CENTER_Y,    //   4 | world-space bounding box center.y of the renderable
+        WORLD_AABB_CENTER_Z,    //   4 | world-space bounding box center.z of the renderable
         VISIBLE_MASK,           //   2 | each bit represents a visibility in a pass
         CHANNELS,               //   1 | currently light channels only
 
         // These are not needed anymore after culling
         LAYERS,                 //   1 | layers
-        WORLD_AABB_EXTENT,      //  12 | world-space bounding box half-extent of the renderable
+        WORLD_AABB_EXTENT_X,    //   4 | world-space bounding box half-extent.x of the renderable
+        WORLD_AABB_EXTENT_Y,    //   4 | world-space bounding box half-extent.y of the renderable
+        WORLD_AABB_EXTENT_Z,    //   4 | world-space bounding box half-extent.z of the renderable
 
         // These are temporaries and should be stored out of line
         PRIMITIVES,             //   8 | level-of-detail'ed primitives
@@ -116,11 +120,15 @@ public:
             FRenderableManager::SkinningBindingInfo,    // SKINNING_BUFFER
             FRenderableManager::MorphingBindingInfo,    // MORPHING_BUFFER
             FRenderableManager::InstancesInfo,          // INSTANCES
-            math::float3,                               // WORLD_AABB_CENTER
+            float,                                      // WORLD_AABB_CENTER_X
+            float,                                      // WORLD_AABB_CENTER_Y
+            float,                                      // WORLD_AABB_CENTER_Z
             VisibleMaskType,                            // VISIBLE_MASK
             uint8_t,                                    // CHANNELS
             uint8_t,                                    // LAYERS
-            math::float3,                               // WORLD_AABB_EXTENT
+            float,                                      // WORLD_AABB_EXTENT_X
+            float,                                      // WORLD_AABB_EXTENT_Y
+            float,                                      // WORLD_AABB_EXTENT_Z
             utils::Slice<const FRenderPrimitive>,       // PRIMITIVES
             uint32_t,                                   // SUMMED_PRIMITIVE_COUNT
             PerRenderableData,                          // UBO
@@ -129,7 +137,7 @@ public:
             float                                       // USER_DATA
     >;
 
-    
+
 
     bool hasContactShadows(SceneCacheData const& cache) const noexcept;
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -564,26 +564,26 @@ void FView::prepareLighting(FEngine& engine, CameraInfo const& cameraInfo) noexc
 /*
  * Calculates an automatic grid size based on the camera frustum dimensions.
  * Handles both perspective and orthographic projections.
- * 
+ *
  * For perspective projections, it uses the width of the frustum at the far plane.
  * This ensures that the grid size scales with the visible volume and accounts for
  * field-of-view (zooming in reduces grid size to preserve precision).
  * For orthographic projections, it uses the absolute width of the frustum.
- * 
+ *
  * camera: The camera to use for the calculation.
  * Returns the calculated grid size (10% of the computed width, chosen as a
  * reasonable balance between precision and snapping frequency).
  */
 double FView::calculateAutomaticGridSize(const FCamera* camera) const noexcept {
     auto const& p = camera->getCullingProjectionMatrix();
-    
+
     // Base scale is the width of the frustum at Z=1 for perspective,
     // or the absolute width for orthographic.
     double baseScale = 2.0 / std::abs(p[0][0]);
-    
+
     // Detect perspective by checking if P[3][2] is non-zero
     bool const isPerspective = std::abs(p[3][2]) > 1e-5;
-    
+
     if (isPerspective) {
         double const zf = camera->getCullingFar();
         // Scale at far plane
@@ -598,11 +598,11 @@ double FView::calculateAutomaticGridSize(const FCamera* camera) const noexcept {
 /*
  * Computes a stable grid origin for the camera to improve floating-point precision.
  * Snapping only occurs when the camera moves beyond the grid boundary plus hysteresis.
- * 
+ *
  * This implementation follows Strategy A: only update the grid size when a position snap occurs.
  * This prevents instability when the frustum (and thus auto grid size) changes smoothly.
  * Alternative Strategy B (scale hysteresis) could be used if we want to respond to large scale changes without moving.
- * 
+ *
  * cameraPosition: The current world position of the camera.
  * currentGridSize: The grid size used in the previous frame (stable).
  * newGridSize: The new calculated grid size (target).
@@ -674,10 +674,10 @@ CameraInfo FView::computeCameraInfo(FEngine const& engine) const noexcept {
                 currentGridSize = newGridSize;
                 mEffectiveGridSize = currentGridSize;
             }
-            
+
             // Force snap if user manually changed grid size to a positive value
             bool const forceSnap = (mGridSize > 0.0 && mGridSize != currentGridSize);
-            
+
             constexpr double hysteresisRatio = 0.5; // Automatic 50% hysteresis
             translation = -computeGridOrigin(cameraPosition, currentGridSize, newGridSize, hysteresisRatio, forceSnap);
         } else {
@@ -1340,18 +1340,30 @@ void FView::cullRenderables(JobSystem&,
         FScene::RenderableSoa& renderableData, Frustum const& frustum, size_t bit) noexcept {
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_FILAMENT);
 
-    float3 const* worldAABBCenter = renderableData.data<FScene::WORLD_AABB_CENTER>();
-    float3 const* worldAABBExtent = renderableData.data<FScene::WORLD_AABB_EXTENT>();
+    float const* worldAABBCenterX = renderableData.data<FScene::WORLD_AABB_CENTER_X>();
+    float const* worldAABBCenterY = renderableData.data<FScene::WORLD_AABB_CENTER_Y>();
+    float const* worldAABBCenterZ = renderableData.data<FScene::WORLD_AABB_CENTER_Z>();
+    float const* worldAABBExtentX = renderableData.data<FScene::WORLD_AABB_EXTENT_X>();
+    float const* worldAABBExtentY = renderableData.data<FScene::WORLD_AABB_EXTENT_Y>();
+    float const* worldAABBExtentZ = renderableData.data<FScene::WORLD_AABB_EXTENT_Z>();
     FScene::VisibleMaskType* visibleArray = renderableData.data<FScene::VISIBLE_MASK>();
 
     // culling job (this runs on multiple threads)
-    auto functor = [&frustum, worldAABBCenter, worldAABBExtent, visibleArray, bit]
+    auto functor = [&frustum,
+            worldAABBCenterX, worldAABBCenterY, worldAABBCenterZ,
+            worldAABBExtentX, worldAABBExtentY, worldAABBExtentZ,
+            visibleArray, bit]
             (uint32_t const index, uint32_t const c) {
         Culler::intersects(
                 visibleArray + index,
                 frustum,
-                worldAABBCenter + index,
-                worldAABBExtent + index, c, bit);
+                worldAABBCenterX + index,
+                worldAABBCenterY + index,
+                worldAABBCenterZ + index,
+                worldAABBExtentX + index,
+                worldAABBExtentY + index,
+                worldAABBExtentZ + index,
+                c, bit);
     };
 
     // Note: we can't use jobs::parallel_for() here because Culler::intersects() must process


### PR DESCRIPTION
Clang (and I assume other compilers) were ~~completely unable to vectorize~~ not fully vectorizing the AABB culler as it stands now.

This is what I would consider the theoretical peak optimal performance: https://godbolt.org/z/Ex9Tv364T

However I haven't been able to fully implement it that way in Filament primarily for the following reason:
In order to supply vec8's (or vec4's, since Filament doesn't have a vec8 type) to the culler, the SoA structure would have to store that type, where each component maps to one element in the scene. 
i.e. worldExtent.x = element 0, worldExtent.y = element 1, and so on, however the SoA assumes the same array size for all entries, and so that would lead to quite a lot of wasted memory.

Also this change unfortunately slightly affects the distance calculation in the renderpass class, but I don't think this is too big of a deal.

Overall, the benchmarks show a 1.519x speedup on my machine in Release mode (msvc), which I think is a solid start.

I think switching the center/extent arrays to vec4 or vec8 would be good (or even necessary) future work, but I am happy to leave this as it is for now until I see a more elegant solution to the SoA problem than wasting all that memory.

Disclaimer:
I used Copilot for generating the benchmarking code.