### PR TITLE
github: pass head_commit author fields through env in get-commit-msg

### DIFF
--- a/.github/actions/get-commit-msg/action.yml
+++ b/.github/actions/get-commit-msg/action.yml
@@ -16,18 +16,18 @@ runs:
       shell: bash
       env:
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+        AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+        TSTAMP: ${{ github.event.head_commit.timestamp }}
+        HASH: ${{ github.event.head_commit.id }}
       run: |
-        AUTHOR_NAME="${{ github.event.head_commit.author.name }}"
-        AUTHOR_EMAIL="${{ github.event.head_commit.author.email }}"
-        TSTAMP="${{ github.event.head_commit.timestamp }}"
-        HASH="${{ github.event.head_commit.id }}"
-        echo "commit $HASH" >> /tmp/commit_msg.txt
+        echo "commit ${HASH}" >> /tmp/commit_msg.txt
         echo "Author: ${AUTHOR_NAME}<${AUTHOR_EMAIL}>" >> /tmp/commit_msg.txt
         echo "Date: ${TSTAMP}" >> /tmp/commit_msg.txt
         echo "" >> /tmp/commit_msg.txt
         echo "$COMMIT_MESSAGE" >> /tmp/commit_msg.txt
-        echo "$HASH" > /tmp/commit_hash.txt
-        echo "$HASH" > /tmp/commit_hashes.txt
+        echo "${HASH}" > /tmp/commit_hash.txt
+        echo "${HASH}" > /tmp/commit_hashes.txt
     - name: Find commit message (PR)
       shell: bash
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
`get-commit-msg` already passes `github.event.head_commit.message` through `env:` rather than
interpolating it into the `run:` block. #9330 added that, and its description gives the reason:

> "If we assign the message (which might contain quotes) to an environment variable and then echo it, this should prevent the problem of having a double quote (\")."

The four fields on the lines immediately below — `author.name`, `author.email`, `timestamp` and `id` —
are still interpolated directly. `author.name` and `author.email` are git metadata the committer
writes themselves with `git commit --author=`, and inside a double-quoted bash assignment `$( )` and
backticks are evaluated rather than stored.

Checked locally, control and arm, on a scratch repository:

```
[CONTROL] git stored : [Jane Developer]
        AUTHOR_NAME="Jane Developer"
[CONTROL] AUTHOR_NAME ended up as: [Jane Developer]
[ARM] git stored : [$(id|tee /tmp/marker) Jane Developer]
        AUTHOR_NAME="$(id|tee /tmp/marker) Jane Developer"
[ARM] AUTHOR_NAME ended up as: [uid=1000(...) groups=... Jane Developer]
```

git strips `<` and `>` from an author name — they delimit the email in the commit header — so the
shell's `>` operator is not available, but every other metacharacter survives (`$ ( ) \` ; | & " ' \`
and space, checked one at a time), which is why `tee` is used above.

This matters on the `push` branch specifically, because `postsubmit-main.yml` calls this action in
three jobs that hold `secrets.FILAMENTBOT_TOKEN`. The `pull_request` branch of the same action is
unaffected — it reads these fields with `git log --format=%an` into shell variables, which is
assignment, not evaluation.

This change extends the existing `env:` block to cover the remaining four fields and references them
as `${HASH}` etc. in the script body. No behaviour changes for ordinary commits.

Reported to the Google OSS VRP as issue 544180155; closed as a duplicate of an existing internal bug,
so this is offered as the patch rather than as a new report.
