### PR TITLE
Fix directional shadow receiver bounds

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1216,7 +1216,7 @@ void ShadowMap::updateSceneInfoDirectional(mat4f const& Mv, FScene::RenderableSo
                     sceneInfo.lsCastersNearFar.x = max(sceneInfo.lsCastersNearFar.x, r.max.z);
                     sceneInfo.lsCastersNearFar.y = min(sceneInfo.lsCastersNearFar.y, r.min.z);
                 }
-                if (visibility.castShadows) {
+                if (visibility.receiveShadows) {
                     // account only for objects that are visible by the camera
                     constexpr auto mask = 1u << VISIBLE_RENDERABLE_BIT;
                     if ((vis & mask) == mask) {


### PR DESCRIPTION
Receiver bounds may not be correctly calculated when using objects that receives shadows but do not cast them.

This most readily shows up with camera looking directly at a ground plane with `castShadows` off.

This is also visible on the existing `shadowtest` sample:
 - orient the camera so that a long shadow is visible.
 - pan the view until the model is outside of the camera bounds.
 - see the shadow is also removed once the model is out of view.
