### PR TITLE
fix: prevent casting/receiving shadows for materials which filter out VSM

### DIFF
--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -324,6 +324,8 @@ static void createOverdrawVisualizerEntities(Engine* engine, Scene* scene, App* 
                 .material(0, matInstances[i])
                 .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vertexBuffer, indexBuffer, 0, 3)
                 .culling(false)
+                .castShadows(false)
+                .receiveShadows(false)
                 .priority(7u)   // ensure the overdraw primitives are drawn last
                 .layerMask(0xFF, 1u << App::Scene::OVERDRAW_VISIBILITY_LAYER)
                 .build(*engine, overdrawEntity);

--- a/samples/image_viewer.cpp
+++ b/samples/image_viewer.cpp
@@ -125,6 +125,8 @@ static void createImageRenderable(Engine* engine, Scene* scene, App& app) {
             .material(0, material->getDefaultInstance())
             .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vertexBuffer, indexBuffer, 0, 3)
             .culling(false)
+            .castShadows(false)
+            .receiveShadows(false)
             .build(*engine, imageEntity);
 
     scene->addEntity(imageEntity);


### PR DESCRIPTION
`image.mat` and `overdraw.mat` filter out `vsm` variant explicitly, so we have to set their renderable's `castShadow` and `receiveShadow` to false to prevent crash when VSM/PCSS is enabled in the scene.