### PR TITLE
Add --api-level to specify matc api level & --api-level-info to print matc's api levels

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -837,6 +837,8 @@ public:
     filament::UserVariantFilterMask getVariantFilter() const { return mVariantFilter; }
 
     FeatureLevel getFeatureLevel() const noexcept { return mFeatureLevel; }
+
+    uint32_t getApiLevel() const noexcept { return mApiLevel; }
     /// @endcond
 
     struct Attribute {

--- a/libs/filament-matp/include/filament-matp/Config.h
+++ b/libs/filament-matp/include/filament-matp/Config.h
@@ -17,9 +17,9 @@
 #ifndef TNT_CONFIG_H
 #define TNT_CONFIG_H
 
-#include <filamat/MaterialBuilder.h>
-
 #include <filament/MaterialEnums.h>
+
+#include <filamat/MaterialBuilder.h>
 
 #include <backend/DriverEnums.h>
 
@@ -158,6 +158,7 @@ public:
     bool getInsertLineDirectives() const noexcept { return mInsertLineDirectives; }
     bool getInsertLineDirectiveChecks() const noexcept { return mInsertLineDirectiveChecks; }
     bool getIncludeSourceMaterial() const noexcept { return mIncludeSourceMaterial; }
+    uint32_t getApiLevelOverride() const noexcept { return mApiLevelOverride; }
 
 protected:
     bool mDebug = false;
@@ -181,6 +182,9 @@ protected:
     bool mInsertLineDirectives = true;
     bool mInsertLineDirectiveChecks = true;
     bool mIncludeSourceMaterial = false;
+    // Overrides the apiLevel to compile the material. If 0 (the default), compiles with the apiLevel defined in the
+    // .mat file. If the .mat file does not specify an apiLevel, defaults to 1.
+    uint32_t mApiLevelOverride = 0;
 };
 
 } // namespace matp

--- a/libs/filament-matp/src/MaterialParser.cpp
+++ b/libs/filament-matp/src/MaterialParser.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 */
 
-#include <filament-matp/MaterialParser.h>
-
 #include "DirIncluder.h"
 #include "Includes.h"
 #include "JsonishLexer.h"
@@ -24,13 +22,15 @@
 #include "MaterialLexer.h"
 #include "ParametersProcessor.h"
 
+#include <filament-matp/Config.h>
+#include <filament-matp/MaterialParser.h>
+
 #include <filamat/Enums.h>
 #include <filamat/MaterialBuilder.h>
-#include <filament-matp/Config.h>
 
+#include <utils/JobSystem.h>
 #include <utils/sstream.h>
 #include <utils/Status.h>
-#include <utils/JobSystem.h>
 
 #include <memory>
 #include <utility>
@@ -535,6 +535,11 @@ utils::Status MaterialParser::parse(filamat::MaterialBuilder& builder,
     if (utils::Status processedStatus = processMaterialParameters(builder, config);
             !processedStatus.isOk()) {
         return processedStatus;
+    }
+
+    // If the apiLevel is supplied from the commandline, override any apiLevel defined in the .mat file.
+    if (uint32_t apiLevelOverride = config.getApiLevelOverride(); apiLevelOverride > 0) {
+        builder.setApiLevel(apiLevelOverride);
     }
 
     return utils::Status::ok();

--- a/libs/filament-matp/src/ParametersProcessor.cpp
+++ b/libs/filament-matp/src/ParametersProcessor.cpp
@@ -16,20 +16,22 @@
 
 #include "ParametersProcessor.h"
 
-#include <filamat/Enums.h>
-#include <utils/Status.h>
-#include <utils/sstream.h>
-
 #include <private/filament/BufferInterfaceBlock.h>
 #include <private/filament/Variant.h>
 
+#include <filamat/Enums.h>
+
 #include <backend/DriverEnums.h>
+
+#include <utils/sstream.h>
+#include <utils/Status.h>
 
 #include <math/vec3.h>
 
 #include <algorithm>
 #include <iostream>
 #include <string_view>
+
 #include <ctype.h>
 
 using namespace filamat;
@@ -76,7 +78,13 @@ static Status processName(MaterialBuilder& builder, const JsonishValue& value) {
 }
 
 static Status processApiLevel(MaterialBuilder& builder, const JsonishValue& value) {
-    builder.setApiLevel(value.toJsonNumber()->getFloat());
+    const int apiLevel = value.toJsonNumber()->getFloat();
+    if (apiLevel < 1 || apiLevel > filament::UNSTABLE_MATERIAL_API_LEVEL) {
+        io::sstream errorMessage;
+        errorMessage << "parameters: api level must be between 1 and " << filament::UNSTABLE_MATERIAL_API_LEVEL;
+        return Status::invalidArgument(errorMessage.c_str());
+    }
+    builder.setApiLevel(apiLevel);
     return Status::ok();
 }
 
@@ -1438,7 +1446,8 @@ Status ParametersProcessor::process(MaterialBuilder& builder, const JsonishObjec
 
         auto fPointer = mParameters[key].callback;
         if (Status status = fPointer(builder, *field); !status.isOk()) {
-            std::cerr << "Error while processing material json, key:\"" << key << "\"" << std::endl;
+            std::cerr << "Error while processing material json, key:\"" << key << "\"\n" << "Error message: "
+                    << status.getMessage() << std::endl;
             return status;
         }
     }

--- a/libs/filament-matp/tests/MockIncluder.h
+++ b/libs/filament-matp/tests/MockIncluder.h
@@ -18,8 +18,10 @@
 
 #include <utils/CString.h>
 
-#include <unordered_map>
+#include <gtest/gtest.h>
+
 #include <string>
+#include <unordered_map>
 
 // Functor used for test cases.
 class MockIncluder {

--- a/libs/filament-matp/tests/test_matp.cpp
+++ b/libs/filament-matp/tests/test_matp.cpp
@@ -14,16 +14,17 @@
 * limitations under the License.
 */
 
-#include <gtest/gtest.h>
-
-#include "TestMaterialParser.h"
 #include "JsonishLexer.h"
 #include "JsonishParser.h"
 #include "MaterialLexer.h"
 #include "MockIncluder.h"
+#include "TestMaterialParser.h"
+
+#include <filament-matp/MaterialParser.h>
 
 #include <filamat/MaterialBuilder.h>
-#include <filament-matp/MaterialParser.h>
+
+#include <gtest/gtest.h>
 
 class MaterialLexer: public ::testing::Test {
 protected:
@@ -359,6 +360,128 @@ TEST_F(MaterialLexer, JsonMaterialParserSingleDoubleQuoteDoesntCrash) {
             singleDoubleQuote.c_str(), singleDoubleQuote.size(), unused);
 
     EXPECT_EQ(result.getCode(), utils::StatusCode::INVALID_ARGUMENT);
+}
+
+namespace {
+    class MockConfig : public matp::Config {
+    public:
+        MockConfig() = default;
+        ~MockConfig() override = default;
+
+        matp::Config::Output* getOutput() const noexcept override { return nullptr; }
+        matp::Config::Input* getInput() const noexcept override { return nullptr; }
+        std::string toString() const noexcept override { return ""; }
+        std::string toPIISafeString() const noexcept override { return ""; }
+
+        void setApiLevelOverride(uint32_t level) { mApiLevelOverride = level; }
+    };
+}
+
+TEST_F(MaterialLexer, MaterialParserOverrideApiLevel) {
+    matp::MaterialParser parser;
+    filamat::MaterialBuilder::init();
+    filamat::MaterialBuilder builder;
+
+    static std::string source(R"(
+        material {
+            name: "test",
+            shadingModel: unlit,
+            apiLevel: 1
+        }
+    )");
+
+    ssize_t size = source.size();
+    auto buffer = std::make_unique<char[]>(size);
+    std::memcpy(buffer.get(), source.data(), size);
+    std::unique_ptr<const char[]> constBuffer(buffer.release());
+
+    MockConfig config;
+    config.setApiLevelOverride(2);
+
+    utils::Status result = parser.parse(builder, config, size, constBuffer);
+    EXPECT_EQ(result.getCode(), utils::StatusCode::OK);
+    EXPECT_EQ(builder.getApiLevel(), 2);
+
+    filamat::MaterialBuilder::shutdown();
+}
+
+TEST_F(MaterialLexer, MaterialParserUseApiLevelInMatFile) {
+    matp::MaterialParser parser;
+    filamat::MaterialBuilder::init();
+    filamat::MaterialBuilder builder;
+
+    static std::string source(R"(
+        material {
+            name: "test",
+            shadingModel: unlit,
+            apiLevel: 2
+        }
+    )");
+
+    ssize_t size = source.size();
+    auto buffer = std::make_unique<char[]>(size);
+    std::memcpy(buffer.get(), source.data(), size);
+    std::unique_ptr<const char[]> constBuffer(buffer.release());
+
+    MockConfig config;
+
+    utils::Status result = parser.parse(builder, config, size, constBuffer);
+    EXPECT_EQ(result.getCode(), utils::StatusCode::OK);
+    EXPECT_EQ(builder.getApiLevel(), 2);
+
+    filamat::MaterialBuilder::shutdown();
+}
+
+TEST_F(MaterialLexer, MaterialParserNoApiLevelDefaultsToOne) {
+    matp::MaterialParser parser;
+    filamat::MaterialBuilder::init();
+    filamat::MaterialBuilder builder;
+
+    static std::string source(R"(
+        material {
+            name: "test",
+            shadingModel: unlit
+        }
+    )");
+
+    ssize_t size = source.size();
+    auto buffer = std::make_unique<char[]>(size);
+    std::memcpy(buffer.get(), source.data(), size);
+    std::unique_ptr<const char[]> constBuffer(buffer.release());
+
+    MockConfig config;
+
+    utils::Status result = parser.parse(builder, config, size, constBuffer);
+    EXPECT_EQ(result.getCode(), utils::StatusCode::OK);
+    EXPECT_EQ(builder.getApiLevel(), 1);
+
+    filamat::MaterialBuilder::shutdown();
+}
+
+TEST_F(MaterialLexer, MaterialParserInvalidApiLevelFailsToCompile) {
+    matp::MaterialParser parser;
+    filamat::MaterialBuilder::init();
+    filamat::MaterialBuilder builder;
+
+    static std::string source(R"(
+        material {
+            name: "test",
+            shadingModel: unlit,
+            apiLevel: -1
+        }
+    )");
+
+    ssize_t size = source.size();
+    auto buffer = std::make_unique<char[]>(size);
+    std::memcpy(buffer.get(), source.data(), size);
+    std::unique_ptr<const char[]> constBuffer(buffer.release());
+
+    MockConfig config;
+
+    utils::Status result = parser.parse(builder, config, size, constBuffer);
+    EXPECT_EQ(result.getCode(), utils::StatusCode::INVALID_ARGUMENT);
+
+    filamat::MaterialBuilder::shutdown();
 }
 
 int main(int argc, char** argv) {

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -28,6 +28,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <charconv>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -41,36 +42,38 @@ using namespace filament;
 
 namespace matc {
 
-static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:P:OSEr:vV:gtwF1RW:";
+static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:P:OSEr:vV:gtwF1RW:A:i";
 static const utils::getopt::option OPTIONS[] = {
-        { "help",                    utils::getopt::no_argument, nullptr, 'h' },
-        { "license",                 utils::getopt::no_argument, nullptr, 'L' },
-        { "output",            utils::getopt::required_argument, nullptr, 'o' },
-        { "output-format",     utils::getopt::required_argument, nullptr, 'f' },
-        { "debug",                   utils::getopt::no_argument, nullptr, 'd' },
-        { "variant-filter",    utils::getopt::required_argument, nullptr, 'V' },
-        { "platform",          utils::getopt::required_argument, nullptr, 'p' },
-        { "optimize",                utils::getopt::no_argument, nullptr, 'x' }, // for backward compatibility
-        { "optimize",                utils::getopt::no_argument, nullptr, 'O' }, // for backward compatibility
-        { "optimize-size",           utils::getopt::no_argument, nullptr, 'S' },
-        { "optimize-none",           utils::getopt::no_argument, nullptr, 'g' },
-        { "preprocessor-only",       utils::getopt::no_argument, nullptr, 'E' },
-        { "api",               utils::getopt::required_argument, nullptr, 'a' },
-        { "feature-level",     utils::getopt::required_argument, nullptr, 'l' },
-        { "no-essl1",                utils::getopt::no_argument, nullptr, '1' },
-        { "define",            utils::getopt::required_argument, nullptr, 'D' },
-        { "template",          utils::getopt::required_argument, nullptr, 'T' },
-        { "material-parameter",utils::getopt::required_argument, nullptr, 'P' },
-        { "reflect",           utils::getopt::required_argument, nullptr, 'r' },
-        { "print",                   utils::getopt::no_argument, nullptr, 't' },
-        { "version",                 utils::getopt::no_argument, nullptr, 'v' },
-        { "raw",                     utils::getopt::no_argument, nullptr, 'w' },
-        { "no-sampler-validation",   utils::getopt::no_argument, nullptr, 'F' },
-        { "save-raw-variants",       utils::getopt::no_argument, nullptr, 'R' },
-        { "workarounds",       utils::getopt::required_argument, nullptr, 'W' },
-        { "no-insert-line-directives",       utils::getopt::no_argument, nullptr, 'n' },
-        { "no-insert-line-directive-check",       utils::getopt::no_argument, nullptr, 'N' },
-        { "include-source-mat",       utils::getopt::no_argument, nullptr, 'm' },
+        { "help",                           utils::getopt::no_argument, nullptr, 'h' },
+        { "license",                        utils::getopt::no_argument, nullptr, 'L' },
+        { "output",                   utils::getopt::required_argument, nullptr, 'o' },
+        { "output-format",            utils::getopt::required_argument, nullptr, 'f' },
+        { "debug",                          utils::getopt::no_argument, nullptr, 'd' },
+        { "variant-filter",           utils::getopt::required_argument, nullptr, 'V' },
+        { "platform",                 utils::getopt::required_argument, nullptr, 'p' },
+        { "optimize",                       utils::getopt::no_argument, nullptr, 'x' }, // for backward compatibility
+        { "optimize",                       utils::getopt::no_argument, nullptr, 'O' }, // for backward compatibility
+        { "optimize-size",                  utils::getopt::no_argument, nullptr, 'S' },
+        { "optimize-none",                  utils::getopt::no_argument, nullptr, 'g' },
+        { "preprocessor-only",              utils::getopt::no_argument, nullptr, 'E' },
+        { "api",                      utils::getopt::required_argument, nullptr, 'a' },
+        { "feature-level",            utils::getopt::required_argument, nullptr, 'l' },
+        { "no-essl1",                       utils::getopt::no_argument, nullptr, '1' },
+        { "define",                   utils::getopt::required_argument, nullptr, 'D' },
+        { "template",                 utils::getopt::required_argument, nullptr, 'T' },
+        { "material-parameter",       utils::getopt::required_argument, nullptr, 'P' },
+        { "reflect",                  utils::getopt::required_argument, nullptr, 'r' },
+        { "print",                          utils::getopt::no_argument, nullptr, 't' },
+        { "version",                        utils::getopt::no_argument, nullptr, 'v' },
+        { "raw",                            utils::getopt::no_argument, nullptr, 'w' },
+        { "no-sampler-validation",          utils::getopt::no_argument, nullptr, 'F' },
+        { "save-raw-variants",              utils::getopt::no_argument, nullptr, 'R' },
+        { "workarounds",              utils::getopt::required_argument, nullptr, 'W' },
+        { "no-insert-line-directives",      utils::getopt::no_argument, nullptr, 'n' },
+        { "no-insert-line-directive-check", utils::getopt::no_argument, nullptr, 'N' },
+        { "include-source-mat",             utils::getopt::no_argument, nullptr, 'm' },
+        { "api-level",                utils::getopt::required_argument, nullptr, 'A' },
+        { "api-level-info",                 utils::getopt::no_argument, nullptr, 'i' },
         { nullptr, 0, nullptr, 0 }  // termination of the utils::getopt::option list
 };
 
@@ -165,7 +168,14 @@ static void usage(char* name) {
             "       Some drivers may complain about the use of cpp style #line directives\n"
             "       if they don't support it.\n\n"
             "   --include-source-mat\n"
-            "       Embeds the source ASCII material definition if set.\n"
+            "       Embeds the source ASCII material definition if set.\n\n"
+            "   --api-level, -A\n"
+            "       Specify the API level to compile the material against.\n"
+            "       If the source ASCII material already has an `apiLevel` tag, this overrides it.\n"
+            "       The value cannot exceed the unstable API level:\n"
+            "           MATC --api-level 2\n\n"
+            "   --api-level-info, -i\n"
+            "       Print the MATC API levels (both current and unstable).\n\n"
 
             "Internal use and debugging only:\n"
             "   --optimize-none, -g, -O0\n"
@@ -412,6 +422,23 @@ bool CommandlineConfig::parse() {
             case 'm':
                 mIncludeSourceMaterial = true;
                 break;
+            case 'A': {
+                int apiLevel = 0;
+                auto const [ptr, ec] = std::from_chars(optarg, optarg + strlen(optarg), apiLevel);
+                if (ec != std::errc{} || ptr != optarg + strlen(optarg) || apiLevel < 1 || apiLevel >
+                    UNSTABLE_MATERIAL_API_LEVEL) {
+                    std::cerr << "Invalid matc api level. Must be [1, " << UNSTABLE_MATERIAL_API_LEVEL << "]" <<
+                            std::endl;
+                    return false;
+                }
+                mApiLevelOverride = apiLevel;
+                break;
+            }
+            case 'i':
+                std::cout << "current MATC API level: " << RELEASED_MATERIAL_API_LEVEL << "\n"
+                        << "unstable MATC API level: " << UNSTABLE_MATERIAL_API_LEVEL << std::endl;
+                // exit to avoid subsequent error spew such as "Missing input filename" etc.
+                exit(0);
         }
     }
 


### PR DESCRIPTION
* --api-level: specifies apiLevel to compile the material against (this overrides apiLevel in mat)
* --api-level-info: prints out the current and unstable api levels

* added apiLevel validation before calling `MaterialBuilder::setApiLevel`. even though we have the validation in `MaterialBuilder`, we need to do it before calling `setApiLevel` since it's implicitly casted to `uint32_t`.
* also fix a bug where a specific error message getting omitted when json parsing fails.

FIXES=544716846, 544715218