### PR TITLE
Make error associated with material api level more readable

### DIFF
--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -60,36 +60,49 @@ static void formatApiLevelErrorLog(utils::io::ostream& out, const char* log) {
         }
         
         std::string_view line = fullLog.substr(start, end - start);
-        // Error message follows the format: ERROR_{custom_error_message}_END
+
+        // The error message follows the format: #define {myFunctionName} ERROR_{myFunctionName}_api_level_{N}_END
         constexpr std::string_view prefix = "ERROR_";
+        constexpr std::string_view postfix = "_END";
+
         size_t startPos = line.find(prefix);
-        if (startPos != std::string_view::npos) {
-            size_t endPos = line.find("_END", startPos);
-            if (endPos != std::string_view::npos) {
-                // Extract the message after "ERROR_" and before "_END"
-                size_t msgStart = startPos + prefix.length();
-                std::string_view rawMsg = line.substr(msgStart, endPos - msgStart);
-                
-                utils::CString message(rawMsg);
-                for (char& c : message) {
-                    if (c == '_') c = ' ';
-                }
-                
-                size_t quoteStart = line.rfind('\'', startPos);
-                if (quoteStart != std::string_view::npos) {
-                    // Print prefix (e.g. "ERROR: 0:9: ") and message, discarding everything after
-                    out << line.substr(0, quoteStart) << message;
-                } else {
-                    out << line.substr(0, startPos) << message;
-                }
-                out << utils::io::endl;
-            } else {
-                out << line << utils::io::endl;
-            }
-        } else {
+        size_t endPos = line.find(postfix, startPos);
+        if (startPos == std::string_view::npos || endPos == std::string_view::npos) {
+            // Doesn't fit to the template, simply print the log as is.
             out << line << utils::io::endl;
+            start = end + 1;
+            continue;
         }
-        
+
+        // Extract the message between "ERROR_" and "_END".
+        size_t msgStart = startPos + prefix.length();
+        std::string_view rawMsg = line.substr(msgStart, endPos - msgStart);
+
+        // First append prefix.
+        size_t quoteStart = line.rfind('\'', startPos);
+        if (quoteStart != std::string_view::npos) {
+            // Print prefix (e.g. "ERROR: 0:9: ") and message, discarding everything after.
+            out << line.substr(0, quoteStart);
+        } else {
+            out << line.substr(0, startPos);
+        }
+
+        // Check if this is a templated api level error.
+        constexpr std::string_view apiLevelMarker = "_api_level_";
+        size_t apiLevelPos = rawMsg.find(apiLevelMarker);
+
+        if (apiLevelPos != std::string_view::npos) {
+            std::string_view symbol = rawMsg.substr(0, apiLevelPos);
+            std::string_view level = rawMsg.substr(apiLevelPos + apiLevelMarker.length());
+            // Format using the template (single quotes around the symbol name).
+            out << "'" << symbol << "'" << " requires api level " << level;
+        } else {
+            // Fallback: Replace '_' with space when it doesn't follow the api level error template.
+            for (const char& c : rawMsg) {
+                out << ((c == '_') ? ' ' : c);
+            }
+        }
+        out << utils::io::endl;
         start = end + 1;
     }
 }

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -29,6 +29,8 @@
 #include <InfoSink.h>
 #include <localintermediate.h>
 
+#include <string_view>
+
 using namespace utils;
 using namespace glslang;
 using namespace filament::backend;
@@ -45,6 +47,52 @@ GLSLangCleaner::~GLSLangCleaner() {
 }
 
 // ------------------------------------------------------------------------------------------------
+// If the error message is associated with API level, this formats it to be more human-readable.
+static void formatApiLevelErrorLog(utils::io::ostream& out, const char* log) {
+    if (!log) return;
+    
+    std::string_view fullLog(log);
+    size_t start = 0;
+    while (start < fullLog.length()) {
+        size_t end = fullLog.find('\n', start);
+        if (end == std::string_view::npos) {
+            end = fullLog.length();
+        }
+        
+        std::string_view line = fullLog.substr(start, end - start);
+        // Error message follows the format: ERROR_{custom_error_message}_END
+        constexpr std::string_view prefix = "ERROR_";
+        size_t startPos = line.find(prefix);
+        if (startPos != std::string_view::npos) {
+            size_t endPos = line.find("_END", startPos);
+            if (endPos != std::string_view::npos) {
+                // Extract the message after "ERROR_" and before "_END"
+                size_t msgStart = startPos + prefix.length();
+                std::string_view rawMsg = line.substr(msgStart, endPos - msgStart);
+                
+                utils::CString message(rawMsg);
+                for (char& c : message) {
+                    if (c == '_') c = ' ';
+                }
+                
+                size_t quoteStart = line.rfind('\'', startPos);
+                if (quoteStart != std::string_view::npos) {
+                    // Print prefix (e.g. "ERROR: 0:9: ") and message, discarding everything after
+                    out << line.substr(0, quoteStart) << message;
+                } else {
+                    out << line.substr(0, startPos) << message;
+                }
+                out << utils::io::endl;
+            } else {
+                out << line << utils::io::endl;
+            }
+        } else {
+            out << line << utils::io::endl;
+        }
+        
+        start = end + 1;
+    }
+}
 
 static std::string_view getMaterialFunctionName(MaterialBuilder::MaterialDomain domain) noexcept {
     switch (domain) {
@@ -346,7 +394,7 @@ bool GLSLTools::findProperties(
     if (!ok) {
         // Even with all properties set the shader doesn't build. This is likely a syntax error
         // with user provided code.
-        utils::slog.e << tShader.getInfoLog() << utils::io::endl;
+        formatApiLevelErrorLog(utils::slog.e, tShader.getInfoLog());
         return false;
     }
 

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -85,6 +85,8 @@ highp mat4 getWorldFromClipMatrix() {
 highp vec3 getWorldRayFromClip(highp vec2 clipXY) {
     return frameUniforms.worldRayFromClipMatrix * vec3(clipXY, 1.0);
 }
+#else
+#define getWorldRayFromClip ERROR_getWorldRayFromClip_requires_api_level_2_END
 #endif
 
 /** @public-api */

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -86,7 +86,7 @@ highp vec3 getWorldRayFromClip(highp vec2 clipXY) {
     return frameUniforms.worldRayFromClipMatrix * vec3(clipXY, 1.0);
 }
 #else
-#define getWorldRayFromClip ERROR_getWorldRayFromClip_requires_api_level_2_END
+#define getWorldRayFromClip ERROR_getWorldRayFromClip_api_level_2_END
 #endif
 
 /** @public-api */

--- a/shaders/src/surface_getters.vs
+++ b/shaders/src/surface_getters.vs
@@ -2,7 +2,17 @@
 // Uniforms access
 //------------------------------------------------------------------------------
 
-#if CLIENT_MATERIAL_API_LEVEL < UNSTABLE_MATERIAL_API_LEVEL
+#if CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
+/** @public-api */
+highp mat4 getWorldFromModelMatrix() {
+    return object_uniforms_worldFromModelMatrix;
+}
+
+/** @public-api */
+highp mat3 getWorldFromModelNormalMatrix() {
+    return object_uniforms_worldFromModelNormalMatrix;
+}
+#else
 /** @public-api */
 mat4 getWorldFromModelMatrix() {
     return object_uniforms_worldFromModelMatrix;
@@ -207,6 +217,10 @@ void morphPosition(inout vec4 p) {
     morphData4(p, sampler1_positions);
 }
 #else
+#define morphData2 ERROR_morphData2_requires_api_level_2_END
+#define morphData3 ERROR_morphData3_requires_api_level_2_END
+#define morphData4 ERROR_morphData4_requires_api_level_2_END
+
 void morphPosition(inout vec4 p) {
     int index = getVertexIndex() + pushConstants.morphingBufferOffset;
     ivec3 texcoord = ivec3(index % MAX_MORPH_TARGET_BUFFER_WIDTH, index / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);

--- a/shaders/src/surface_getters.vs
+++ b/shaders/src/surface_getters.vs
@@ -217,9 +217,9 @@ void morphPosition(inout vec4 p) {
     morphData4(p, sampler1_positions);
 }
 #else
-#define morphData2 ERROR_morphData2_requires_api_level_2_END
-#define morphData3 ERROR_morphData3_requires_api_level_2_END
-#define morphData4 ERROR_morphData4_requires_api_level_2_END
+#define morphData2 ERROR_morphData2_api_level_2_END
+#define morphData3 ERROR_morphData3_api_level_2_END
+#define morphData4 ERROR_morphData4_api_level_2_END
 
 void morphPosition(inout vec4 p) {
     int index = getVertexIndex() + pushConstants.morphingBufferOffset;

--- a/shaders/src/surface_instancing.glsl
+++ b/shaders/src/surface_instancing.glsl
@@ -53,15 +53,3 @@ highp int getInstanceIndex() {
     return logical_instance_index;
 }
 #endif
-
-#if CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
-/** @public-api */
-highp mat4 getWorldFromModelMatrix() {
-    return object_uniforms_worldFromModelMatrix;
-}
-
-/** @public-api */
-highp mat3 getWorldFromModelNormalMatrix() {
-    return object_uniforms_worldFromModelNormalMatrix;
-}
-#endif

--- a/shaders/src/surface_material_inputs.vs
+++ b/shaders/src/surface_material_inputs.vs
@@ -33,6 +33,8 @@ struct MaterialVertexInputs {
 #endif // MATERIAL_HAS_CLIP_SPACE_TRANSFORM
 #if defined(MATERIAL_HAS_CLIP_SPACE_POSITION) && CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
     vec4 clipSpacePosition;
+#elif defined(MATERIAL_HAS_CLIP_SPACE_POSITION)
+#define clipSpacePosition ERROR_clipSpacePosition_requires_api_level_2_END
 #endif // MATERIAL_HAS_CLIP_SPACE_POSITION
 #endif // VERTEX_DOMAIN_DEVICE
 };

--- a/shaders/src/surface_material_inputs.vs
+++ b/shaders/src/surface_material_inputs.vs
@@ -34,7 +34,7 @@ struct MaterialVertexInputs {
 #if defined(MATERIAL_HAS_CLIP_SPACE_POSITION) && CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
     vec4 clipSpacePosition;
 #elif defined(MATERIAL_HAS_CLIP_SPACE_POSITION)
-#define clipSpacePosition ERROR_clipSpacePosition_requires_api_level_2_END
+#define clipSpacePosition ERROR_clipSpacePosition_api_level_2_END
 #endif // MATERIAL_HAS_CLIP_SPACE_POSITION
 #endif // VERTEX_DOMAIN_DEVICE
 };


### PR DESCRIPTION
If a material is using an api that requires 2 but uses api level of 1, it fails to compile with `ERROR 'apiName' : no matching overloaded function found.` The error message is not very straighforward, so this PR makes the error message more readable.

For example,
```
ERROR: 0:9: 'getWorldRayFromClip' : no matching overloaded function found
```
is now
```
ERROR: 0:9: getWorldRayFromClip requires api level 2
```

To make this work, any new api that is introduced in `UNSTABLE_MATERIAL_API_LEVEL` should add this template in the else branch: `#define {myNewFeature} ERROR_{myNewFeature}_api_level_{N}_END`.

For example:
```
#if CLIENT_MATERIAL_API_LEVEL >= UNSTABLE_MATERIAL_API_LEVEL
/**
 * @api-level 2
 */
void myNewFeature() {...}
#else
#define myNewFeature ERROR_myNewFeature_api_level_2_END
#endif
```
Note:
- If the new api only changes the behavior between the api levels, you don't need to add this error template. This is because the function always presents.  An example for this case is `getWorldFromModelMatrix`.
- If it doesn't follow the template `ERROR_api_level_{N}_END`, for example `ERROR_some_custom_error_message_END`, it'd just replace `_` with  ` `.
- `getWorldFromModelMatrix` is moved from `shaders/src/surface_instancing.glsl` to `shaders/src/surface_getters.vs`, so that we have them in the same place.

FIXES=544716600