### PR TITLE
backend: destroy canceled jobs outside the JobQueue lock

### DIFF
--- a/filament/backend/src/JobQueue.cpp
+++ b/filament/backend/src/JobQueue.cpp
@@ -143,14 +143,22 @@ JobQueue::JobId JobQueue::issueJobId() noexcept {
 }
 
 bool JobQueue::cancel(JobId const jobId) noexcept {
-    LockGuard const lock(mQueueMutex);
+    // The canceled job is moved out of the map here and destroyed once the lock is released below.
+    // Destroying a job runs arbitrary user code (e.g. the release callback of a captured
+    // BufferDescriptor), which must not run while `mQueueMutex` is held: `mQueueMutex` is not
+    // recursive, so a callback calling back into this queue would deadlock.
+    Job job;
+    {
+        LockGuard const lock(mQueueMutex);
 
-    auto it = mJobsMap.find(jobId);
-    if (it == mJobsMap.end()) {
-        return false; // Job not found, must have been completed or canceled.
+        auto it = mJobsMap.find(jobId);
+        if (it == mJobsMap.end()) {
+            return false; // Job not found, must have been completed or canceled.
+        }
+
+        job = std::move(it->second);
+        mJobsMap.erase(it);
     }
-
-    mJobsMap.erase(it);
 
     return true;
 }

--- a/filament/backend/src/JobQueue.h
+++ b/filament/backend/src/JobQueue.h
@@ -137,6 +137,10 @@ public:
     /**
      * Cancels a job by its ID.
      *
+     * The canceled job is destroyed on the calling thread, without the queue's lock held, so it is
+     * safe for the job (or anything it captured) to call back into this queue while being
+     * destroyed.
+     *
      * @param jobId The job ID to cancel.
      * @return true if the job was found and cancelled, false otherwise.
      */

--- a/filament/backend/test/test_JobQueue.cpp
+++ b/filament/backend/test/test_JobQueue.cpp
@@ -19,6 +19,9 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
 #include <thread>
 
 using namespace filament::backend;
@@ -97,6 +100,42 @@ TEST(JobQueue, Cancel) {
 TEST(JobQueue, CancelInvalid) {
     JobQueue::Ptr queue = JobQueue::create();
     EXPECT_FALSE(queue->cancel(123));
+}
+
+TEST(JobQueue, CancelDestroysJobWithoutHoldingLock) {
+    JobQueue::Ptr queue = JobQueue::create();
+
+    // Mimics what a canceled job captures in practice: something whose destructor runs user code
+    // that calls back into the queue (e.g. a BufferDescriptor whose release callback chains the
+    // next asynchronous call). Destroying the job while the queue's lock is held deadlocks.
+    struct ReentrantOnDestroy {
+        JobQueue::Ptr queue;
+        std::atomic<JobQueue::JobId>* reentrantJobId;
+        ~ReentrantOnDestroy() { reentrantJobId->store(queue->issueJobId()); }
+    };
+
+    std::atomic<JobQueue::JobId> reentrantJobId = { JobQueue::InvalidJobId };
+    JobQueue::JobId const idToCancel = queue->push(
+            [guard = std::make_unique<ReentrantOnDestroy>(
+                     ReentrantOnDestroy{ queue, &reentrantJobId })]() {});
+
+    // Cancel from another thread so that a regression fails the test instead of hanging it.
+    auto canceled = std::make_shared<std::promise<bool>>();
+    std::future<bool> future = canceled->get_future();
+    std::thread canceller([queue, idToCancel, canceled]() {
+        canceled->set_value(queue->cancel(idToCancel));
+    });
+
+    if (future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        canceller.detach(); // the thread is stuck holding the queue's lock, it can't be joined
+        FAIL() << "cancel() deadlocked: the job was destroyed while holding the queue's lock";
+    }
+
+    EXPECT_TRUE(future.get());
+    canceller.join();
+
+    // The job's destructor must have been able to use the queue.
+    EXPECT_NE(JobQueue::InvalidJobId, reentrantJobId.load());
 }
 
 TEST(JobQueue, Stop) {


### PR DESCRIPTION
`JobQueue::cancel()` erased the map entry while holding `mQueueMutex`, so the job was destroyed with the lock held. Destroying a job could run arbitrary user code. E.g., async jobs could capture a BufferDescriptor whose destructor invokes the user's release callback. Since `mQueueMutex` is not recursive, a callback that calls back into the queue self-deadlocks, and even a well-behaved callback blocks the backend thread's `push()` and the worker's `pop()` for its whole duration.

Move the job out of the map under the lock and let it die after the lock is released, matching what `pop()`,`popBatch()` already do.