### PR TITLE
Fix vector return type to match what is returned

### DIFF
--- a/filament/src/details/ColorGradingNeon.h
+++ b/filament/src/details/ColorGradingNeon.h
@@ -179,9 +179,9 @@ inline float32x4_t v_atan2q_f32(float32x4_t const y, float32x4_t const x) {
  */
 UTILS_ALWAYS_INLINE
 inline void v_oetf_sRGB(float32x4_t& cg_r, float32x4_t& cg_g, float32x4_t& cg_b) {
-    float32x4_t const r_cond = vcleq_f32(cg_r, vdupq_n_f32(0.0031308f));
-    float32x4_t const g_cond = vcleq_f32(cg_g, vdupq_n_f32(0.0031308f));
-    float32x4_t const b_cond = vcleq_f32(cg_b, vdupq_n_f32(0.0031308f));
+    uint32x4_t const r_cond = vcleq_f32(cg_r, vdupq_n_f32(0.0031308f));
+    uint32x4_t const g_cond = vcleq_f32(cg_g, vdupq_n_f32(0.0031308f));
+    uint32x4_t const b_cond = vcleq_f32(cg_b, vdupq_n_f32(0.0031308f));
 
     float32x4_t const r_lin = vmulq_n_f32(cg_r, 12.92f);
     float32x4_t const g_lin = vmulq_n_f32(cg_g, 12.92f);


### PR DESCRIPTION
`vcleq_f32` signature is
`uint32x4_t vcleq_f32(float32x4_t a, float32x4_t b)`

Previously the result of this call was stored in variable of type `float32x4_t` and clang would do an implicit conversion, this uses the correct type.

For completeness, the result of this would get passed later on to `vbslq_f32` as the first argument implicitly converting in the opposite direction as the first argument is `uint32x4_t`:

`float32x4_t	vbslq_f32 (uint32x4_t a, float32x4_t b, float32x4_t c)`

This also now matches the type.

ARM instruction reference:
https://developer.arm.com/architectures/instruction-sets/intrinsics/vcleq_f32
https://developer.arm.com/architectures/instruction-sets/intrinsics/vbslq_f32