### PR TITLE
github: Fix two breakages

### DIFF
--- a/.github/actions/android-continuous/action.yml
+++ b/.github/actions/android-continuous/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
     - name: Run build script
       run: |
         cd build/android && printf "y" | ./build.sh continuous ${{ inputs.build-abi }}

--- a/android/filament-android/build.gradle
+++ b/android/filament-android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.dokka" version "2.2.0"
+    id "org.jetbrains.dokka" version "1.9.20"
 }
 
 android {


### PR DESCRIPTION
 - Make sure jdk 21 is used for android continuous build
 - dokka has to remain at 1.9.20 because 2.2.0 does not produce markdown docs.