### PR TITLE
add vertex_objectId varying to fix picking failures on certain Android/GLES drivers

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -11,6 +11,8 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
   a completion callback must check it [⚠️ **API Change**]
 - backend: canceling an async call now always invokes its completion callback, with
   `AsyncCallStatus::CANCELED`. Previously the callback was silently dropped
+- engine: fix picking on PowerVR OpenGL ES drivers that mishandle dynamic uniform-buffer indexing
+  in fragment shaders [⚠️ **Recompile Materials**]
 - engine: support multiple directional lights, opt-in via
   `Engine::Config::enableMultipleDirectionalLights`; the dominant one still provides shadows and
   the sun disc, up to 4 additional directional lights are evaluated without shadows [⚠️ **New

--- a/shaders/src/surface_depth_main.fs
+++ b/shaders/src/surface_depth_main.fs
@@ -20,7 +20,9 @@ highp vec4 computeDepthMomentsVSM(const highp float depth);
 
 void main() {
     filament_lodBias = frameUniforms.lodBias;
-
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING)
+    logical_instance_index = instance_index;
+#endif
     initObjectUniforms();
 
 #if defined(MATERIAL_HAS_CUSTOM_DEPTH) || defined(BLEND_MODE_MASKED) || ((defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)) && defined(MATERIAL_HAS_TRANSPARENT_SHADOW))


### PR DESCRIPTION
Various users have reported picking failures on Android devices (see #8762, #9341, #7965, #7638). 

One failure mode was addressed in #8917, however on my PowerVR device with Filament v1.75.0 and the GLES backend, every call to `pick` still returns 0 when the feature level is greater than 0. When the engine feature level is set to 0, then `pick` correctly returns the renderable entity.

(Everything here uses basic geometry with no material, so the default Filament material is applied). 
 
I've narrowed the problem to the index used to access the object-uniform array in the picking fragment shader. A logical index of 0 used as a dynamic array index produced a different result from using the equivalent constant index. This suggests a driver bug. Moving the lookup to the vertex shader and forwarding through a flat integer `varying` seems to reliably return the correct result on my device.

This draft PR contains a proposed fix for `TARGET_GLES_ENVIRONMENT`: 
- in the depth vertex shader (where object-uniform indexing already works), read the instance object ID  
- forward the ID through a flat varying for picking when feature level is greater than 0
- initialize `logical_instance_index` in the depth fragment shader (matches `surface_main.fs`)

The varying is declared for every GLES depth vertex shader when feature level > 0, but `vertex_objectId` is only read in the fragment shader when `CONFIG_POWER_VR_SHADER_WORKAROUNDS` is true (when false, falls back to the original UBO lookup. This leaves the feature-level-0 RGBA8 picking path unchanged. This reuses location 11 (also used by `vertex_lightSpacePosition` for shadow-receiving surface variants), but the two variants are mutually exclusive so this should not conflict.

Leaving this as draft because I haven't tested it thoroughly, and I'm not sure this is even the best approach.