### PR TITLE
utils: fix multi-cluster PMU tracking in Profiler

### DIFF
--- a/filament/benchmark/PerformanceCounters.h
+++ b/filament/benchmark/PerformanceCounters.h
@@ -44,12 +44,18 @@ public:
         counters = profiler.readCounters();
         if (profiler.isValid()) {
             auto avgItem = double(state.iterations()) / state.items_processed();
-            state.counters.insert({
-                    { "C",   { avgItem * (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
-                    { "I",   { avgItem * (double)counters.getInstructions(), benchmark::Counter::kAvgIterations }},
-                    { "BPU", { avgItem * (double)counters.getBranchMisses(), benchmark::Counter::kAvgIterations }},
-                    { "CPI", {           (double)counters.getCPI(),          benchmark::Counter::kAvgThreads }},
-            });
+            if (counters.getInstructions() > 0) {
+                state.counters.insert({
+                        { "C",   { avgItem * (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
+                        { "I",   { avgItem * (double)counters.getInstructions(), benchmark::Counter::kAvgIterations }},
+                        { "BPU", { avgItem * (double)counters.getBranchMisses(), benchmark::Counter::kAvgIterations }},
+                        { "CPI", {           (double)counters.getCPI(),          benchmark::Counter::kAvgThreads }},
+                });
+            } else if (counters.getCpuCycles() > 0) {
+                state.counters.insert({
+                        { "C",   { avgItem * (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
+                });
+            }
         }
     }
 };

--- a/libs/utils/benchmark/PerformanceCounters.h
+++ b/libs/utils/benchmark/PerformanceCounters.h
@@ -36,12 +36,18 @@ public:
         profiler.stop();
         counters = profiler.readCounters();
         if (profiler.isValid()) {
-            state.counters.insert({
-                    { "C",   { (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
-                    { "I",   { (double)counters.getInstructions(), benchmark::Counter::kAvgIterations }},
-                    { "BPU", { (double)counters.getBranchMisses(), benchmark::Counter::kAvgIterations }},
-                    { "CPI", { (double)counters.getCPI(),          benchmark::Counter::kAvgThreads }},
-            });
+            if (counters.getInstructions() > 0) {
+                state.counters.insert({
+                        { "C",   { (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
+                        { "I",   { (double)counters.getInstructions(), benchmark::Counter::kAvgIterations }},
+                        { "BPU", { (double)counters.getBranchMisses(), benchmark::Counter::kAvgIterations }},
+                        { "CPI", { (double)counters.getCPI(),          benchmark::Counter::kAvgThreads }},
+                });
+            } else if (counters.getCpuCycles() > 0) {
+                state.counters.insert({
+                        { "C",   { (double)counters.getCpuCycles(),    benchmark::Counter::kAvgIterations }},
+                });
+            }
         }
     }
 };

--- a/libs/utils/include/utils/Profiler.h
+++ b/libs/utils/include/utils/Profiler.h
@@ -80,7 +80,7 @@ public:
     uint32_t getEnabledEvents() const noexcept { return mEnabledEvents; }
 
     // could return false if performance counters are not supported/enabled
-    bool isValid() const { return mCountersFd[0] >= 0; }
+    bool isValid() const { return mCountersFd[0][0] >= 0; }
 
     class Counters {
         friend class Profiler;
@@ -124,13 +124,13 @@ public:
         double getIPC() const noexcept {
             uint64_t cpuCycles = getCpuCycles();
             uint64_t instructions = getInstructions();
-            return double(instructions) / double(cpuCycles);
+            return (cpuCycles > 0) ? double(instructions) / double(cpuCycles) : 0.0;
         }
 
         double getCPI() const noexcept {
             uint64_t cpuCycles = getCpuCycles();
             uint64_t instructions = getInstructions();
-            return double(cpuCycles) / double(instructions);
+            return (instructions > 0) ? double(cpuCycles) / double(instructions) : 0.0;
         }
 
         double getL1DMissRate() const noexcept {
@@ -171,30 +171,45 @@ public:
 #if defined(__linux__)
 
     void reset() noexcept {
-        #pragma nounroll
-        for (int fd : mCountersFd) {
-            if (fd >= 0) {
-                ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+        for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+            for (size_t c = 0; c < mCpuCount; ++c) {
+                if (mCountersFd[i][c] >= 0) {
+                    ioctl(mCountersFd[i][c], PERF_EVENT_IOC_RESET, 0);
+                }
             }
         }
     }
 
     void start() noexcept {
-        #pragma nounroll
-        for (int fd : mCountersFd) {
-            if (fd >= 0) {
-                ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+        #if defined(__GNUC__) || defined(__clang__)
+        asm volatile("" ::: "memory");
+        #endif
+        for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+            for (size_t c = 0; c < mCpuCount; ++c) {
+                if (mCountersFd[i][c] >= 0) {
+                    ioctl(mCountersFd[i][c], PERF_EVENT_IOC_ENABLE, 0);
+                }
             }
         }
+        #if defined(__GNUC__) || defined(__clang__)
+        asm volatile("" ::: "memory");
+        #endif
     }
 
     void stop() noexcept {
-        #pragma nounroll
-        for (int fd : mCountersFd) {
-            if (fd >= 0) {
-                ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+        #if defined(__GNUC__) || defined(__clang__)
+        asm volatile("" ::: "memory");
+        #endif
+        for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+            for (size_t c = 0; c < mCpuCount; ++c) {
+                if (mCountersFd[i][c] >= 0) {
+                    ioctl(mCountersFd[i][c], PERF_EVENT_IOC_DISABLE, 0);
+                }
             }
         }
+        #if defined(__GNUC__) || defined(__clang__)
+        asm volatile("" ::: "memory");
+        #endif
     }
 
     Counters readCounters() noexcept;
@@ -209,16 +224,17 @@ public:
 #endif // __linux__
 
     bool hasBranchRates() const noexcept {
-        return (mCountersFd[BRANCHES] >= 0) && (mCountersFd[BRANCH_MISSES] >= 0);
+        return (mCountersFd[BRANCHES][0] >= 0) && (mCountersFd[BRANCH_MISSES][0] >= 0);
     }
 
     bool hasICacheRates() const noexcept {
-        return (mCountersFd[ICACHE_REFS] >= 0) && (mCountersFd[ICACHE_MISSES] >= 0);
+        return (mCountersFd[ICACHE_REFS][0] >= 0) && (mCountersFd[ICACHE_MISSES][0] >= 0);
     }
 
 private:
-    UTILS_UNUSED uint8_t mIds[EVENT_COUNT] = {};
-    int mCountersFd[EVENT_COUNT];
+    static constexpr size_t MAX_CPUS = 32;
+    int mCountersFd[EVENT_COUNT][MAX_CPUS];
+    size_t mCpuCount = 0;
     uint32_t mEnabledEvents = 0;
 };
 

--- a/libs/utils/src/Profiler.cpp
+++ b/libs/utils/src/Profiler.cpp
@@ -32,6 +32,7 @@
 
 #if defined(__linux__)
 
+#include <sched.h>
 #include <sys/syscall.h>
 
 #ifdef __ARM_ARCH
@@ -61,7 +62,11 @@ static int perf_event_open(perf_event_attr* hw_event, pid_t pid,
 namespace utils {
 
 Profiler::Profiler() noexcept {
-    std::uninitialized_fill(std::begin(mCountersFd), std::end(mCountersFd), -1);
+    for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+        for (size_t c = 0; c < MAX_CPUS; ++c) {
+            mCountersFd[i][c] = -1;
+        }
+    }
 }
 
 Profiler::Profiler(uint32_t eventMask) noexcept : Profiler() {
@@ -69,26 +74,33 @@ Profiler::Profiler(uint32_t eventMask) noexcept : Profiler() {
 }
 
 Profiler::~Profiler() noexcept {
-    #pragma nounroll
-    for (int fd : mCountersFd) {
-        if (fd >= 0) {
-            close(fd);
+    for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+        for (size_t c = 0; c < MAX_CPUS; ++c) {
+            if (mCountersFd[i][c] >= 0) {
+                close(mCountersFd[i][c]);
+            }
         }
     }
 }
 
 uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
     // close all counters
-    #pragma nounroll
-    for (int& fd : mCountersFd) {
-        if (fd >= 0) {
-            close(fd);
-            fd = -1;
+    for (size_t i = 0; i < size_t(EVENT_COUNT); ++i) {
+        for (size_t c = 0; c < MAX_CPUS; ++c) {
+            if (mCountersFd[i][c] >= 0) {
+                close(mCountersFd[i][c]);
+                mCountersFd[i][c] = -1;
+            }
         }
     }
     mEnabledEvents = 0;
 
 #if defined(__linux__)
+    long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+    if (num_cpus <= 0) {
+        num_cpus = 1;
+    }
+    mCpuCount = std::min(size_t(num_cpus), MAX_CPUS);
 
     perf_event_attr pe{};
     pe.size = sizeof(perf_event_attr);
@@ -99,6 +111,17 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
                      PERF_FORMAT_TOTAL_TIME_RUNNING |
                      PERF_FORMAT_ID;
 
+    auto openCounter = [this, &pe](size_t eventIndex) {
+        bool anySuccess = false;
+        for (size_t c = 0; c < mCpuCount; ++c) {
+            mCountersFd[eventIndex][c] = perf_event_open(&pe, 0, (int)c, -1, 0);
+            if (mCountersFd[eventIndex][c] >= 0) {
+                anySuccess = true;
+            }
+        }
+        return anySuccess;
+    };
+
     // INSTRUCTIONS is always enabled
 #ifdef __ARM_ARCH
     pe.type = PERF_TYPE_RAW;
@@ -107,9 +130,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
     pe.type = PERF_TYPE_HARDWARE;
     pe.config = PERF_COUNT_HW_INSTRUCTIONS;
 #endif
-    mCountersFd[INSTRUCTIONS] = perf_event_open(&pe, 0, -1, -1, 0);
-
-    if (mCountersFd[INSTRUCTIONS] >= 0) {
+    if (openCounter(INSTRUCTIONS)) {
         if (eventMask & EV_CPU_CYCLES) {
 #ifdef __ARM_ARCH
             pe.type = PERF_TYPE_RAW;
@@ -118,8 +139,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HARDWARE;
             pe.config = PERF_COUNT_HW_CPU_CYCLES;
 #endif
-            mCountersFd[CPU_CYCLES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[CPU_CYCLES] >= 0) {
+            if (openCounter(CPU_CYCLES)) {
                 mEnabledEvents |= EV_CPU_CYCLES;
             }
         }
@@ -132,8 +152,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HARDWARE;
             pe.config = PERF_COUNT_HW_CACHE_REFERENCES;
 #endif
-            mCountersFd[DCACHE_REFS] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[DCACHE_REFS] >= 0) {
+            if (openCounter(DCACHE_REFS)) {
                 mEnabledEvents |= EV_L1D_REFS;
             }
         }
@@ -146,8 +165,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HARDWARE;
             pe.config = PERF_COUNT_HW_CACHE_MISSES;
 #endif
-            mCountersFd[DCACHE_MISSES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[DCACHE_MISSES] >= 0) {
+            if (openCounter(DCACHE_MISSES)) {
                 mEnabledEvents |= EV_L1D_MISSES;
             }
         }
@@ -160,8 +178,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HARDWARE;
             pe.config = PERF_COUNT_HW_BRANCH_INSTRUCTIONS;
 #endif
-            mCountersFd[BRANCHES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[BRANCHES] >= 0) {
+            if (openCounter(BRANCHES)) {
                 mEnabledEvents |= EV_BPU_REFS;
             }
         }
@@ -174,8 +191,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HARDWARE;
             pe.config = PERF_COUNT_HW_BRANCH_MISSES;
 #endif
-            mCountersFd[BRANCH_MISSES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[BRANCH_MISSES] >= 0) {
+            if (openCounter(BRANCH_MISSES)) {
                 mEnabledEvents |= EV_BPU_MISSES;
             }
         }
@@ -184,8 +200,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
         if (eventMask & EV_L1I_REFS) {
             pe.type = PERF_TYPE_RAW;
             pe.config = ARMV8_PMUV3_PERFCTR_L1_ICACHE_ACCESS;
-            mCountersFd[ICACHE_REFS] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[ICACHE_REFS] >= 0) {
+            if (openCounter(ICACHE_REFS)) {
                 mEnabledEvents |= EV_L1I_REFS;
             }
         }
@@ -193,8 +208,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
         if (eventMask & EV_L1I_MISSES) {
             pe.type = PERF_TYPE_RAW;
             pe.config = ARMV8_PMUV3_PERFCTR_L1_ICACHE_REFILL;
-            mCountersFd[ICACHE_MISSES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[ICACHE_MISSES] >= 0) {
+            if (openCounter(ICACHE_MISSES)) {
                 mEnabledEvents |= EV_L1I_MISSES;
             }
         }
@@ -203,8 +217,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HW_CACHE;
             pe.config = PERF_COUNT_HW_CACHE_L1I | 
                 (PERF_COUNT_HW_CACHE_OP_READ<<8) | (PERF_COUNT_HW_CACHE_RESULT_ACCESS<<16);
-            mCountersFd[ICACHE_REFS] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[ICACHE_REFS] >= 0) {
+            if (openCounter(ICACHE_REFS)) {
                 mEnabledEvents |= EV_L1I_REFS;
             }
         }
@@ -213,8 +226,7 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
             pe.type = PERF_TYPE_HW_CACHE;
             pe.config = PERF_COUNT_HW_CACHE_L1I | 
                 (PERF_COUNT_HW_CACHE_OP_READ<<8) | (PERF_COUNT_HW_CACHE_RESULT_MISS<<16);
-            mCountersFd[ICACHE_MISSES] = perf_event_open(&pe, 0, -1, -1, 0);
-            if (mCountersFd[ICACHE_MISSES] >= 0) {
+            if (openCounter(ICACHE_MISSES)) {
                 mEnabledEvents |= EV_L1I_MISSES;
             }
         }
@@ -234,21 +246,50 @@ Profiler::Counters Profiler::readCounters() noexcept {
         uint64_t time_running;
         uint64_t id;
     };
+
+    ReadFormat rf[EVENT_COUNT][MAX_CPUS]{};
+    uint64_t core_active_time[MAX_CPUS]{};
+    uint64_t max_time_enabled = 0;
+
     for (size_t i = 0; i < size_t(EVENT_COUNT); i++) {
-        if (mCountersFd[i] >= 0) {
-            ReadFormat rf{};
-            ssize_t n = read(mCountersFd[i], &rf, sizeof(rf));
-            if (n >= (ssize_t)sizeof(rf)) {
-                if (rf.time_running > 0 && rf.time_running < rf.time_enabled) {
-                    outCounters.counters[i].value = (uint64_t)((double)rf.value * ((double)rf.time_enabled / (double)rf.time_running));
-                } else {
-                    outCounters.counters[i].value = rf.value;
+        for (size_t c = 0; c < mCpuCount; ++c) {
+            int fd = mCountersFd[i][c];
+            if (fd >= 0) {
+                ssize_t n = read(fd, &rf[i][c], sizeof(ReadFormat));
+                if (n >= (ssize_t)sizeof(ReadFormat)) {
+                    core_active_time[c] = std::max(core_active_time[c], rf[i][c].time_running);
+                    max_time_enabled = std::max(max_time_enabled, rf[i][c].time_enabled);
                 }
-                outCounters.counters[i].id = rf.id;
-                outCounters.time_enabled = std::max(outCounters.time_enabled, rf.time_enabled);
-                outCounters.time_running = std::max(outCounters.time_running, rf.time_running);
-                outCounters.nr++;
             }
+        }
+    }
+
+    for (size_t i = 0; i < size_t(EVENT_COUNT); i++) {
+        uint64_t total_val = 0;
+        uint64_t total_time_running = 0;
+        uint64_t last_id = 0;
+        size_t valid_count = 0;
+
+        for (size_t c = 0; c < mCpuCount; ++c) {
+            if (mCountersFd[i][c] >= 0 && rf[i][c].time_running > 0) {
+                uint64_t val = rf[i][c].value;
+                if (rf[i][c].time_running < core_active_time[c]) {
+                    // Physical counter multiplexing occurred on core c: scale by the core's active time
+                    val = (uint64_t)((double)val * ((double)core_active_time[c] / (double)rf[i][c].time_running));
+                }
+                total_val += val;
+                total_time_running += rf[i][c].time_running;
+                last_id = rf[i][c].id;
+                valid_count++;
+            }
+        }
+
+        if (valid_count > 0) {
+            outCounters.counters[i].value = total_val;
+            outCounters.counters[i].id = last_id;
+            outCounters.time_enabled = std::max(outCounters.time_enabled, max_time_enabled);
+            outCounters.time_running = std::max(outCounters.time_running, total_time_running);
+            outCounters.nr++;
         }
     }
     return outCounters;


### PR DESCRIPTION
Add multi-CPU descriptor support to utils::Profiler so hardware performance counters work reliably across heterogeneous CPU clusters (Little/Mid/Big) without requiring thread pinning via taskset.

Key changes:
- Open per-CPU event descriptors for all available cores to track thread execution across cluster migrations without missing counts.
- Compute per-core active execution time to correctly scale counts under hardware PMU multiplexing without cross-core inflation.
- Add compiler and memory barriers in start() and stop() to prevent instruction reordering around microbenchmarks.
- Guard getCPI() and getIPC() against division by zero on kernels that restrict user-space instruction counter access.
- Update PerformanceCounters to dynamically omit unavailable counter columns on devices with partial PMU support.