### PR TITLE
backend: report cancellation status to async completion callbacks

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,6 +6,9 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+- backend: async completion callbacks now take a `backend::AsyncCallStatus` argument reporting
+  whether the operation ran (`COMPLETED`) or was canceled (`CANCELED`). Callers chaining work from
+  a completion callback must check it [⚠️ **API Change**]
 - engine: support multiple directional lights, opt-in via
   `Engine::Config::enableMultipleDirectionalLights`; the dominant one still provides shadows and
   the sun disc, up to 4 additional directional lights are evaluated without shadows [⚠️ **New

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1776,6 +1776,33 @@ using AsyncCallId = uint32_t;
 
 static constexpr AsyncCallId InvalidAsyncCallId = std::numeric_limits<AsyncCallId>::max();
 
+/**
+ * Outcome of an asynchronous operation, reported to its completion callback.
+ *
+ * A completion callback that cannot say why it fired is ambiguous: chaining another operation from
+ * a callback that fired because the operation was canceled would proceed on a resource that was
+ * never populated. The caller cannot reconstruct the answer out of band either, because an
+ * operation can be canceled without anyone asking for it (the driver dropping queued work while
+ * shutting down).
+ *
+ * @see AsyncCallback, cancelAsyncJob
+ */
+enum class AsyncCallStatus : uint8_t {
+    COMPLETED,  //!< The operation ran to completion.
+    CANCELED,   //!< The operation never ran: it was canceled, or dropped because the driver is
+                //!< shutting down.
+};
+
+/**
+ * Completion callback of an asynchronous operation.
+ *
+ * This is deliberately not a CallbackHandler::Callback: that one is shared with readPixels(),
+ * fences, buffer release and others, none of which has a cancellation concept.
+ *
+ * @see AsyncCallStatus
+ */
+using AsyncCallback = void(*)(void* user, AsyncCallStatus status);
+
 using AsynchronousMode = Platform::AsynchronousMode;
 
 } // namespace filament::backend

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -193,7 +193,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::VertexBufferHandle, createVertexBufferAsync,
         uint32_t, vertexCount,
         backend::VertexBufferInfoHandle, vbih,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::IndexBufferHandle, createIndexBuffer,
@@ -206,7 +206,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::IndexBufferHandle, createIndexBufferAsync,
         uint32_t, indexCount,
         backend::BufferUsage, usage,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::BufferObjectHandle, createBufferObject,
@@ -219,7 +219,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::BufferObjectHandle, createBufferObjectAsync,
         backend::BufferObjectBinding, bindingType,
         backend::BufferUsage, usage,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, createTexture,
@@ -242,7 +242,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, createTextureAsync,
         uint32_t, depth,
         backend::TextureUsage, usage,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, createTextureView,
@@ -264,7 +264,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, createTextureViewSwizzleAsync
         backend::TextureSwizzle, b,
         backend::TextureSwizzle, a,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, createTextureExternalImage2,
@@ -313,7 +313,7 @@ DECL_DRIVER_API_TAGGED_R_N(backend::TextureHandle, importTextureAsync,
         uint32_t, depth,
         backend::TextureUsage, usage,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_TAGGED_R_N(backend::RenderPrimitiveHandle, createRenderPrimitive,
@@ -451,7 +451,7 @@ DECL_DRIVER_API_R_N(backend::AsyncCallId, setVertexBufferObjectAsync,
         uint32_t, index,
         backend::BufferObjectHandle, bufferObject,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(updateIndexBuffer,
@@ -464,7 +464,7 @@ DECL_DRIVER_API_R_N(backend::AsyncCallId, updateIndexBufferAsync,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(updateBufferObject,
@@ -477,7 +477,7 @@ DECL_DRIVER_API_R_N(backend::AsyncCallId, updateBufferObjectAsync,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(updateBufferObjectUnsynchronized,
@@ -510,7 +510,7 @@ DECL_DRIVER_API_R_N(backend::AsyncCallId, update3DImageAsync,
         uint32_t, depth,
         backend::PixelBufferDescriptor&&, data,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(generateMipmaps,
@@ -711,7 +711,7 @@ DECL_DRIVER_API_N(scissor,
 DECL_DRIVER_API_R_N(backend::AsyncCallId, queueCommandAsync,
         utils::Invocable<void(void)>&&, command,
         backend::CallbackHandler*, handler,
-        backend::CallbackHandler::Callback, callback,
+        backend::AsyncCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, cancelAsyncJob, backend::AsyncCallId, jobId)

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -223,6 +223,22 @@ public:
     void scheduleCallback(CallbackHandler* handler, void* user, CallbackHandler::Callback callback) final;
 
     /**
+     * Schedules the completion callback of an asynchronous operation, telling it whether the
+     * operation ran or was canceled. Can be called from any thread.
+     *
+     * The status has to be bound to the call site, so this goes through the functor overload above
+     * rather than dispatching the callback directly.
+     */
+    void scheduleAsyncCallback(CallbackHandler* handler, AsyncCallback callback, void* user,
+            AsyncCallStatus const status) {
+        if (callback) {
+            scheduleCallback(handler, [callback, user, status]() {
+                callback(user, status);
+            });
+        }
+    }
+
+    /**
      * Waits for a predicate to become true or until a timeout is reached.
      * Returns ERROR if the driver encountered an unrecoverable error.
      */

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -491,12 +491,12 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh,
 
 void MetalDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh,
         uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih,
-        CallbackHandler* handler, CallbackHandler::Callback callback,
+        CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     MetalVertexBufferInfo const* const vbi = handle_cast<const MetalVertexBufferInfo>(vbih);
     construct_handle<MetalVertexBuffer>(vbh, *mContext, vertexCount, vbi->bufferCount, vbih, true);
     mHandleAllocator.associateTagToHandle(vbh.getId(), std::move(tag));
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
@@ -514,7 +514,7 @@ void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elem
 
 void MetalDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> ibh, ElementType elementType,
         uint32_t indexCount, BufferUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto* indexBuffer = construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize,
             indexCount, true);
@@ -524,7 +524,7 @@ void MetalDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> ibh, ElementType
             << ", tag=" << tag.c_str_safe();
     buffer.setLabel(tag);
     mHandleAllocator.associateTagToHandle(ibh.getId(), std::move(tag));
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
@@ -540,7 +540,7 @@ void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteC
 
 void MetalDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t byteCount,
         BufferObjectBinding bindingType, BufferUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     auto* bufferObject = construct_handle<MetalBufferObject>(boh, *mContext, bindingType, usage,
             byteCount, true);
     FILAMENT_CHECK_POSTCONDITION(bufferObject->getBuffer()->wasAllocationSuccessful())
@@ -548,7 +548,7 @@ void MetalDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t 
             << ", tag=" << tag.c_str_safe();
     bufferObject->getBuffer()->setLabel(tag);
     mHandleAllocator.associateTagToHandle(boh.getId(), std::move(tag));
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 // fixme: TextureUsage is a bitfield
@@ -604,7 +604,7 @@ void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8
 
 void MetalDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
-        TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback callback,
+        TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     // Clamp sample count to what the device supports.
     auto& sc = mContext->sampleCountLookup;
@@ -622,7 +622,7 @@ void MetalDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target, 
             th.getId(), stringify(target), levels, samples, width, height, depth, stringify(usage));
 
     mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void MetalDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> srch,
@@ -652,7 +652,7 @@ void MetalDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwTextu
 void MetalDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<HwTexture> srch,
         backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
         backend::TextureSwizzle a, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback const callback, void* user, utils::ImmutableCString&& tag) {
     MetalTexture const* src = handle_cast<MetalTexture>(srch);
     MetalTexture* texture = construct_handle<MetalTexture>(th, *mContext, src, r, g, b, a, true);
     mContext->textures.insert(texture);
@@ -660,7 +660,7 @@ void MetalDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<Hw
     DEBUG_LOG(
             "createTextureViewSwizzleAsyncR(th = %d, srch = %d, r = %d, g = %d, b = %d, a = %d)\n",
             th.getId(), srch.getId(), r, g, b, a);
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     mHandleAllocator.associateTagToHandle(th.getId(), std::move(tag));
 }
 
@@ -726,10 +726,10 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
 void MetalDriver::importTextureAsyncR(Handle<HwTexture> th, intptr_t i, SamplerType target,
         uint8_t levels, TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
         uint32_t depth, TextureUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     importTextureR(th, i, target, levels, format, samples, width, height, depth, usage,
             std::move(tag));
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void MetalDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
@@ -1560,7 +1560,7 @@ void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&
 
 void MetalDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuffer> ibh,
         BufferDescriptor&& data, uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     FILAMENT_CHECK_PRECONDITION(data.buffer)
             << "updateIndexBufferAsyncR called with a null buffer.";
 
@@ -1575,7 +1575,7 @@ void MetalDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuffe
                         [&tag]() { return tag.c_str_safe(); });
 
                 [cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
-                  scheduleCallback(handler, user, callback);
+                  scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
                 }];
 
                 [cmdBuffer commit];
@@ -1601,7 +1601,7 @@ void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescripto
 
 void MetalDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObject> boh,
         BufferDescriptor&& data, uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     FILAMENT_CHECK_PRECONDITION(!isInRenderPass(mContext))
             << "updateBufferObjectAsyncR must be called outside of a render pass. tag="
             << mHandleAllocator.getHandleTag(boh.getId()).c_str_safe();
@@ -1620,7 +1620,7 @@ void MetalDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObj
                         [&tag]() { return tag.c_str_safe(); });
 
                 [cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
-                  scheduleCallback(handler, user, callback);
+                  scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
                 }];
 
                 [cmdBuffer commit];
@@ -1656,9 +1656,9 @@ void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t ind
 
 void MetalDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId, Handle<HwVertexBuffer> vbh,
         uint32_t index, Handle<HwBufferObject> boh, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     setVertexBufferObject(vbh, index, boh);
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void MetalDriver::update3DImage(Handle<HwTexture> th, uint32_t level,
@@ -1682,7 +1682,7 @@ void MetalDriver::update3DImage(Handle<HwTexture> th, uint32_t level,
 void MetalDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th, uint32_t level,
         uint32_t xoffset, uint32_t yoffset, uint32_t zoffset, uint32_t width, uint32_t height,
         uint32_t depth, PixelBufferDescriptor&& data, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     FILAMENT_CHECK_PRECONDITION(!isInRenderPass(mContext))
             << "update3DImageAsyncR must be called outside of a render pass.";
     FILAMENT_CHECK_PRECONDITION(data.buffer) << "update3DImageAsyncR called with a null buffer.";
@@ -1707,7 +1707,7 @@ void MetalDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th, u
                         MTLRegionMake3D(xoffset, yoffset, zoffset, width, height, depth), data);
 
                 [cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
-                  scheduleCallback(handler, user, callback);
+                  scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
                 }];
 
                 [cmdBuffer commit];
@@ -2749,14 +2749,14 @@ void MetalDriver::copyToMemoryMappedBuffer(MemoryMappedBufferHandle mmbh, size_t
 }
 
 void MetalDriver::queueCommandAsyncR(AsyncCallId jobId, utils::Invocable<void()>&& command,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user) {
+        CallbackHandler* handler, AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
     getJobQueue()->push(
             [this, command = std::move(command), handler, callback, user]() {
                 if (command) {
                     command();
                 }
-                scheduleCallback(handler, user, callback);
+                scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
             },
             jobId);
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -805,7 +805,7 @@ void OpenGLDriver::createVertexBufferR(
 
 void OpenGLDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh,
         uint32_t vertexCount, Handle<HwVertexBufferInfo> vbih,
-        CallbackHandler* handler, CallbackHandler::Callback const callback,
+        CallbackHandler* handler, AsyncCallback const callback,
         void* user, ImmutableCString&& tag) {
     // For object creation, the object should be constructed first to determine the initial settings
     // early. For example, the `asynchronous` field needs to be decided at this stage so that
@@ -820,7 +820,7 @@ void OpenGLDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh,
     // to fire the callback after any previously-queued worker jobs.
     getJobQueue()->push([this, handler, callback, user]() mutable {
         DEBUG_MARKER_NAME("createVertexBufferAsyncR")
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -859,7 +859,7 @@ void OpenGLDriver::createIndexBufferAsyncR(
         ElementType const elementType,
         uint32_t indexCount,
         BufferUsage const usage,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user,
+        CallbackHandler* handler, AsyncCallback const callback, void* user,
         ImmutableCString&& tag) {
     uint8_t const elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     // For object creation, the object should be constructed first to determine the initial settings
@@ -877,7 +877,7 @@ void OpenGLDriver::createIndexBufferAsyncR(
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -918,7 +918,7 @@ void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byte
 
 void OpenGLDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t byteCount,
         BufferObjectBinding bindingType, BufferUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user, ImmutableCString&& tag) {
+        AsyncCallback const callback, void* user, ImmutableCString&& tag) {
     // For object creation, the object should be constructed first to determine the initial settings
     // early. For example, the `asynchronous` field needs to be decided at this stage so that
     // subsequent backend APIs can handle operations based on this setting.
@@ -934,7 +934,7 @@ void OpenGLDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -1198,7 +1198,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 
 void OpenGLDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
-        TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback const callback,
+        TextureUsage usage, CallbackHandler* handler, AsyncCallback const callback,
         void* user, ImmutableCString&& tag) {
     // For object creation, the object should be constructed first to determine the initial settings
     // early. For example, the `asynchronous` field needs to be decided at this stage so that
@@ -1216,7 +1216,7 @@ void OpenGLDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target,
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -1340,7 +1340,7 @@ void OpenGLDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 
 void OpenGLDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<HwTexture> srch,
         TextureSwizzle const r, TextureSwizzle const g, TextureSwizzle const b, TextureSwizzle const a,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user,
+        CallbackHandler* handler, AsyncCallback const callback, void* user,
         ImmutableCString&& tag) {
     // For object creation, the object should be constructed first to determine the initial settings
     // early. For example, the `asynchronous` field needs to be decided at this stage so that
@@ -1359,7 +1359,7 @@ void OpenGLDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<H
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -1557,7 +1557,7 @@ void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t const id,
 void OpenGLDriver::importTextureAsyncR(Handle<HwTexture> th, intptr_t const id,
         SamplerType target, uint8_t levels, TextureFormat format, uint8_t samples,
         uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user,
+        CallbackHandler* handler, AsyncCallback const callback, void* user,
         ImmutableCString&& tag) {
 
     // For object creation, the object should be constructed first to determine the initial settings
@@ -1576,7 +1576,7 @@ void OpenGLDriver::importTextureAsyncR(Handle<HwTexture> th, intptr_t const id,
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -3303,7 +3303,7 @@ void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
 
 void OpenGLDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId, Handle<HwVertexBuffer> vbh,
         uint32_t const index, Handle<HwBufferObject> boh, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     getJobQueue()->push([this, vbh, index, boh, handler, callback, user]() mutable {
         DEBUG_MARKER_NAME("setVertexBufferObjectAsyncR")
         setVertexBufferObjectCommon(vbh, index, boh);
@@ -3311,7 +3311,7 @@ void OpenGLDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId, Handle<HwVerte
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -3337,7 +3337,7 @@ void OpenGLDriver::updateIndexBuffer(
 
 void OpenGLDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuffer> ibh,
         BufferDescriptor&& p, uint32_t const byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     getJobQueue()->push([this, ibh, p=std::move(p), byteOffset, handler, callback,
             user]() mutable {
         DEBUG_MARKER_NAME("updateIndexBufferAsyncR")
@@ -3346,7 +3346,7 @@ void OpenGLDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuff
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -3390,7 +3390,7 @@ void OpenGLDriver::updateBufferObject(
 
 void OpenGLDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObject> boh,
         BufferDescriptor&& bd, uint32_t const byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     getJobQueue()->push([this, boh, bd=std::move(bd), byteOffset, handler, callback,
             user]() mutable {
         DEBUG_MARKER_NAME("updateBufferObjectAsyncR")
@@ -3399,7 +3399,7 @@ void OpenGLDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferOb
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -3493,7 +3493,7 @@ void OpenGLDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th,
         uint32_t const level, uint32_t const xoffset, uint32_t const yoffset, uint32_t const zoffset,
         uint32_t const width, uint32_t const height, uint32_t const depth,
         PixelBufferDescriptor&& data, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     getJobQueue()->push([this, th, level, xoffset, yoffset, zoffset, width, height, depth,
             data=std::move(data), handler, callback, user]() mutable {
         DEBUG_MARKER_NAME("update3DImageAsync")
@@ -3503,7 +3503,7 @@ void OpenGLDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th,
         // the driver may delay submitting commands to the GPU, preventing other contexts from
         // seeing the changes immediately. This ensures submitting the current commands right away.
         glFlush();
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -5177,14 +5177,14 @@ void OpenGLDriver::dispatchCompute(Handle<HwProgram> program, uint3 const workGr
 }
 
 void OpenGLDriver::queueCommandAsyncR(AsyncCallId jobId, Invocable<void()>&& command, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, command=std::move(command), handler, callback, user]() {
         DEBUG_MARKER_NAME("queueCommandAsync")
         if (command) {
             command();
         }
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -746,7 +746,7 @@ void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint32_t vert
 
 void VulkanDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh, uint32_t vertexCount,
         Handle<HwVertexBufferInfo> vbih, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     FVK_SYSTRACE_SCOPE();
 
     // This doesn't allocate GPU memory yet, so call it synchronously on the backend thread.
@@ -754,7 +754,7 @@ void VulkanDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh, uint32_t
 
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, handler, callback, user]() {
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -794,7 +794,7 @@ void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType ele
 
 void VulkanDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> ibh, ElementType elementType,
         uint32_t indexCount, BufferUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     FVK_SYSTRACE_SCOPE();
 
     // Create the resource synchronously on the backend thread because:
@@ -806,7 +806,7 @@ void VulkanDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> ibh, ElementTyp
 
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, handler, callback, user]() {
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -846,7 +846,7 @@ void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byte
 
 void VulkanDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t byteCount,
         BufferObjectBinding bindingType, BufferUsage usage, CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback callback, void* user, utils::ImmutableCString&& tag) {
     FVK_SYSTRACE_SCOPE();
 
     // Create the resource synchronously on the backend thread because:
@@ -858,7 +858,7 @@ void VulkanDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t
 
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, handler, callback, user]() {
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -907,7 +907,7 @@ void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 
 void VulkanDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
-        TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback callback,
+        TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     FVK_SYSTRACE_SCOPE();
 
@@ -918,7 +918,7 @@ void VulkanDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target,
 
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, handler, callback, user]() {
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -954,7 +954,7 @@ void VulkanDriver::createTextureViewSwizzleR(Handle<HwTexture> th, Handle<HwText
 void VulkanDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<HwTexture> srch,
         backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
         backend::TextureSwizzle a, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback const callback, void* user, utils::ImmutableCString&& tag) {
     FVK_SYSTRACE_SCOPE();
 
     // This doesn't allocate GPU memory yet, so call it synchronously on the backend thread.
@@ -962,7 +962,7 @@ void VulkanDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<H
 
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, handler, callback, user]() {
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     });
 }
 
@@ -1052,14 +1052,14 @@ void VulkanDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
 void VulkanDriver::importTextureAsyncR(Handle<HwTexture> th, intptr_t id,
         SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
-        TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback callback,
+        TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     importTextureCommon(th, id, target, levels, format, samples, w, h, depth, usage,
             std::move(tag));
     // Still fire the callback to avoid deadlocking the frontend's `CountdownCallbackHandler`. In
     // release builds where the assert is compiled out, an unfired callback would leave
     // mCreationComplete stuck at false, causing deferred destruction to spin forever.
-    scheduleCallback(handler, user, callback);
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
@@ -2048,7 +2048,7 @@ void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t in
 
 void VulkanDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId, Handle<HwVertexBuffer> vbh,
         uint32_t index, Handle<HwBufferObject> boh, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
 
     // We cannot pass a resource handle into the lambda because the `cast` method has a strict
@@ -2061,7 +2061,7 @@ void VulkanDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId, Handle<HwVerte
 
     getJobQueue()->push([this, vb, bo, index, handler, callback, user]() mutable {
         setVertexBufferObjectCommon(vb, index, bo);
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -2081,7 +2081,7 @@ void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor
 
 void VulkanDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuffer> ibh,
         BufferDescriptor&& p, uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
 
     // We cannot pass a resource handle into the lambda because the `cast` method has a strict
@@ -2094,7 +2094,7 @@ void VulkanDriver::updateIndexBufferAsyncR(AsyncCallId jobId, Handle<HwIndexBuff
     getJobQueue()->push([this, ib, p = std::move(p), byteOffset, handler, callback,
             user]() mutable {
         updateIndexBufferCommon(ib, std::move(p), byteOffset);
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -2114,7 +2114,7 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
 
 void VulkanDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObject> boh,
         BufferDescriptor&& bd, uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
 
     // We cannot pass a resource handle into the lambda because the `cast` method has a strict
@@ -2127,7 +2127,7 @@ void VulkanDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferOb
     getJobQueue()->push([this, bo, bd = std::move(bd), byteOffset, handler, callback,
             user]() mutable {
         updateBufferObjectCommon(bo, std::move(bd), byteOffset);
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -2168,7 +2168,7 @@ void VulkanDriver::update3DImage(Handle<HwTexture> th, uint32_t level, uint32_t 
 void VulkanDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th,
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset, uint32_t width,
         uint32_t height, uint32_t depth, PixelBufferDescriptor&& data, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
 
     // We cannot pass a resource handle into the lambda because the `cast` method has a strict
@@ -2182,7 +2182,7 @@ void VulkanDriver::update3DImageAsyncR(AsyncCallId jobId, Handle<HwTexture> th,
             data = std::move(data), handler, callback, user]() mutable {
         update3DImageCommon(t, level, xoffset, yoffset, zoffset, width, height, depth,
                 std::move(data));
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 
@@ -3131,13 +3131,13 @@ void VulkanDriver::endTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 
 void VulkanDriver::queueCommandAsyncR(AsyncCallId jobId, utils::Invocable<void()>&& command,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user) {
+        CallbackHandler* handler, AsyncCallback const callback, void* user) {
     assert_invariant(getJobQueue());
     getJobQueue()->push([this, command = std::move(command), handler, callback, user]() mutable {
         if (command) {
             command();
         }
-        scheduleCallback(handler, user, callback);
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
     }, jobId);
 }
 

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -555,7 +555,7 @@ void WebGPUDriver::createVertexBufferR(Handle<HwVertexBuffer> vertexBufferHandle
 
 void WebGPUDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vertexBufferHandle,
         const uint32_t vertexCount, Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
-        CallbackHandler* handler, CallbackHandler::Callback callback, void* user,
+        CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
     // TODO: implement this.
 }
@@ -571,7 +571,7 @@ void WebGPUDriver::createIndexBufferR(Handle<HwIndexBuffer> indexBufferHandle,
 
 void WebGPUDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> indexBufferHandle,
         const ElementType elementType, const uint32_t indexCount, const BufferUsage usage,
-        CallbackHandler* handler, CallbackHandler::Callback callback, void* user,
+        CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
     // TODO: implement this.
 }
@@ -586,7 +586,7 @@ void WebGPUDriver::createBufferObjectR(Handle<HwBufferObject> bufferObjectHandle
 
 void WebGPUDriver::createBufferObjectAsyncR(Handle<HwBufferObject> bufferObjectHandle,
         const uint32_t byteCount, const BufferObjectBinding bindingType, const BufferUsage usage,
-        CallbackHandler* handler, CallbackHandler::Callback callback, void* user,
+        CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
     // TODO: implement this.
 }
@@ -604,7 +604,7 @@ void WebGPUDriver::createTextureR(Handle<HwTexture> textureHandle, const Sampler
 void WebGPUDriver::createTextureAsyncR(Handle<HwTexture> textureHandle, const SamplerType target,
         const uint8_t levels, const TextureFormat format, const uint8_t samples,
         const uint32_t width, const uint32_t height, const uint32_t depth,
-        const TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback callback,
+        const TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     // TODO: implement this.
     FWGPU_SYSTRACE_SCOPE();
@@ -651,7 +651,7 @@ void WebGPUDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> textureHandl
         Handle<HwTexture> sourceTextureHandle, const backend::TextureSwizzle r,
         const backend::TextureSwizzle g, const backend::TextureSwizzle b,
         const backend::TextureSwizzle a, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user, utils::ImmutableCString&& tag) {
+        AsyncCallback const callback, void* user, utils::ImmutableCString&& tag) {
     // TODO: implement this.
 }
 
@@ -687,7 +687,7 @@ void WebGPUDriver::importTextureR(Handle<HwTexture> textureHandle, const intptr_
 void WebGPUDriver::importTextureAsyncR(Handle<HwTexture> textureHandle, const intptr_t id,
         const SamplerType target, const uint8_t levels, const TextureFormat format,
         const uint8_t samples, const uint32_t width, const uint32_t height, const uint32_t depth,
-        const TextureUsage usage, CallbackHandler* handler, CallbackHandler::Callback callback,
+        const TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
     PANIC_POSTCONDITION("Import WebGPU Texture is not supported");
     // TODO: implement this.
@@ -1050,7 +1050,7 @@ void WebGPUDriver::updateIndexBuffer(Handle<HwIndexBuffer> indexBufferHandle,
 void WebGPUDriver::updateIndexBufferAsyncR(AsyncCallId jobId,
         Handle<HwIndexBuffer> indexBufferHandle, BufferDescriptor&& bufferDescriptor,
         const uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     // TODO: implement this.
 }
 
@@ -1063,7 +1063,7 @@ void WebGPUDriver::updateBufferObject(Handle<HwBufferObject> bufferObjectHandle,
 
 void WebGPUDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObject> bufferObjectHandle,
         BufferDescriptor&& bufferDescriptor, const uint32_t byteOffset, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     // TODO: implement this.
 }
 
@@ -1090,7 +1090,7 @@ void WebGPUDriver::setVertexBufferObject(Handle<HwVertexBuffer> vertexBufferHand
 void WebGPUDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId,
         Handle<HwVertexBuffer> vertexBufferHandle, const uint32_t index,
         Handle<HwBufferObject> bufferObjectHandle, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     // TODO: implement this.
 }
 
@@ -1243,7 +1243,7 @@ void WebGPUDriver::update3DImageAsyncR(AsyncCallId jobId,
         const uint32_t xoffset, const uint32_t yoffset, const uint32_t zoffset,
         const uint32_t width, const uint32_t height, const uint32_t depth,
         PixelBufferDescriptor&& pixelBufferDescriptor, CallbackHandler* handler,
-        CallbackHandler::Callback const callback, void* user) {
+        AsyncCallback const callback, void* user) {
     // TODO: implement this.
 }
 
@@ -2380,7 +2380,7 @@ void WebGPUDriver::copyToMemoryMappedBuffer(MemoryMappedBufferHandle mmbh, size_
 }
 
 void WebGPUDriver::queueCommandAsyncR(AsyncCallId jobId, utils::Invocable<void()>&& command,
-        CallbackHandler* handler, CallbackHandler::Callback const callback, void* user) {
+        CallbackHandler* handler, AsyncCallback const callback, void* user) {
     // TODO: implement this.
 }
 

--- a/filament/backend/test/test_AsyncUploads.cpp
+++ b/filament/backend/test/test_AsyncUploads.cpp
@@ -45,7 +45,8 @@ struct AsyncState {
     bool commandQueued = false;
 };
 
-static void signalCallback(void* user) {
+static void signalCallback(void* user, AsyncCallStatus const status) {
+    EXPECT_EQ(status, AsyncCallStatus::COMPLETED);
     bool* flag = static_cast<bool*>(user);
     *flag = true;
 }

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -197,7 +197,8 @@ public:
     using Driver = backend::Driver;
     using GpuContextPriority = backend::Platform::GpuContextPriority;
     using AsynchronousMode = backend::AsynchronousMode;
-    using AsyncCompletionCallback = std::function<void(void* UTILS_NULLABLE)>;
+    using AsyncCallStatus = backend::AsyncCallStatus;
+    using AsyncCompletionCallback = std::function<void(void* UTILS_NULLABLE, AsyncCallStatus)>;
     using AsyncCallId = backend::AsyncCallId;
 
     /**
@@ -1098,10 +1099,10 @@ public:
      *
      * Beware of overusing this method. It shares the execution queue with other asynchronous tasks
      * like texture updates, so flooding it can delay those critical engine tasks. The recommended
-     * practice is to use this method for resource preparation, such as asset loading(images/meshes).
-     * This facilitates an efficient chaining pattern, where subsequent asynchronous operations
-     * (e.g., creating textures/vertex buffers) can be initiated directly within the completion
-     * callback.
+     * practice is to use this method for resource preparation, such as asset
+     * loading(images/meshes). This facilitates an efficient chaining pattern, where subsequent
+     * asynchronous operations (e.g., creating textures/vertex buffers) can be initiated directly
+     * within the completion callback.
      *
      * Users can call the `Engine::cancelAsyncCall()` method with the returned ID to cancel the
      * asynchronous call.
@@ -1112,7 +1113,9 @@ public:
      * @param command The custom command to be executed.
      * @param handler The handler from which `onComplete` is invoked. If null, it's called from the
      * main thread.
-     * @param onComplete The callback function that runs once the command has finished.
+     * @param onComplete The callback function that runs once the command has finished. Its
+     *                   `AsyncCallStatus` argument reports the outcome: `COMPLETED` if the command
+     *                   ran, `CANCELED` if it never ran.
      * @param user    The custom data that will be passed as an argument to the `onComplete`.
      * @return A unique identifier for the asynchronous call.
      */

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -52,8 +52,9 @@ class UTILS_PUBLIC IndexBuffer : public FilamentAPI {
 
 public:
     using BufferDescriptor = backend::BufferDescriptor;
-    using AsyncCompletionCallback =
-            std::function<void(IndexBuffer* UTILS_NONNULL, void* UTILS_NULLABLE)>;
+    using AsyncCallStatus = backend::AsyncCallStatus;
+    using AsyncCompletionCallback = std::function<void(IndexBuffer* UTILS_NONNULL,
+            void* UTILS_NULLABLE, AsyncCallStatus)>;
     using AsyncCallId = backend::AsyncCallId;
 
     /**
@@ -131,6 +132,8 @@ public:
          *
          * @param handler Handler to dispatch the callback or nullptr for the default handler
          * @param callback A function to be called upon the completion of an asynchronous creation.
+         *                 Its `AsyncCallStatus` argument reports whether the operation ran
+         *                 (`COMPLETED`) or never ran (`CANCELED`).
          * @param user The custom data that will be passed as the second argument to the `callback`.
          * @return This Builder, for chaining calls.
          */
@@ -185,6 +188,8 @@ public:
      * @param byteOffset Offset in *bytes* into the IndexBuffer. Must be multiple of 4.
      * @param handler   Handler to dispatch the callback or nullptr for the default handler
      * @param callback  A function to be called upon the completion of an asynchronous creation.
+     *                  Its `AsyncCallStatus` argument reports whether the operation ran
+     *                  (`COMPLETED`) or never ran (`CANCELED`).
      * @param user      The custom data that will be passed as the second argument to the `callback`.
      *
      * @return       An ID that the caller can use to cancel the operation.

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -87,8 +87,9 @@ public:
     using Swizzle = backend::TextureSwizzle;                         //!< Texture swizzle
     using ExternalImageHandle = backend::Platform::ExternalImageHandle;
     using ExternalImageHandleRef = backend::Platform::ExternalImageHandleRef;
-    using AsyncCompletionCallback =
-            std::function<void(Texture* UTILS_NONNULL, void* UTILS_NULLABLE)>;
+    using AsyncCallStatus = backend::AsyncCallStatus;
+    using AsyncCompletionCallback = std::function<void(Texture* UTILS_NONNULL,
+            void* UTILS_NULLABLE, AsyncCallStatus)>;
     using AsyncCallId = backend::AsyncCallId;
 
     /** @return Whether a backend supports a particular format. */
@@ -282,6 +283,8 @@ public:
          *
          * @param handler Handler to dispatch the callback or nullptr for the default handler
          * @param callback A function to be called upon the completion of an asynchronous creation.
+         *                 Its `AsyncCallStatus` argument reports whether the operation ran
+         *                 (`COMPLETED`) or never ran (`CANCELED`).
          * @param user The custom data that will be passed as the second argument to the `callback`.
          * @return This Builder, for chaining calls.
          */
@@ -461,6 +464,8 @@ public:
      * @param buffer    Client-side buffer containing the image to set.
      * @param handler   Handler to dispatch the callback or nullptr for the default handler
      * @param callback  A function to be called upon the completion of an asynchronous creation.
+     *                  Its `AsyncCallStatus` argument reports whether the operation ran
+     *                  (`COMPLETED`) or never ran (`CANCELED`).
      * @param user      The custom data that will be passed as the second argument to the `callback`.
      *
      * @return          An ID that the caller can use to cancel the operation.

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -63,8 +63,9 @@ class UTILS_PUBLIC VertexBuffer : public FilamentAPI {
 public:
     using AttributeType = backend::ElementType;
     using BufferDescriptor = backend::BufferDescriptor;
-    using AsyncCompletionCallback =
-            std::function<void(VertexBuffer* UTILS_NONNULL, void* UTILS_NULLABLE)>;
+    using AsyncCallStatus = backend::AsyncCallStatus;
+    using AsyncCompletionCallback = std::function<void(VertexBuffer* UTILS_NONNULL,
+            void* UTILS_NULLABLE, AsyncCallStatus)>;
     using AsyncCallId = backend::AsyncCallId;
 
 
@@ -208,6 +209,8 @@ public:
          *
          * @param handler Handler to dispatch the callback or nullptr for the default handler
          * @param callback A function to be called upon the completion of an asynchronous creation.
+         *                 Its `AsyncCallStatus` argument reports whether the operation ran
+         *                 (`COMPLETED`) or never ran (`CANCELED`).
          * @param user The custom data that will be passed as the second argument to the `callback`.
          * @return This Builder, for chaining calls.
          */
@@ -277,6 +280,8 @@ public:
      *                   buffer set.  Must be multiple of 4.
      * @param handler Handler to dispatch the callback or nullptr for the default handler
      * @param callback A function to be called upon the completion of an asynchronous creation.
+     *                 Its `AsyncCallStatus` argument reports whether the operation ran
+     *                 (`COMPLETED`) or never ran (`CANCELED`).
      * @param user The custom data that will be passed as the second argument to the `callback`.
      *
      * @return An ID that the caller can use to cancel the operation.
@@ -316,6 +321,8 @@ public:
      * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
      * @param handler   Handler to dispatch the callback or nullptr for the default handler
      * @param callback  A function to be called upon the completion of an asynchronous creation.
+     *                  Its `AsyncCallStatus` argument reports whether the operation ran
+     *                  (`COMPLETED`) or never ran (`CANCELED`).
      * @param user      The custom data that will be passed as the second argument to the `callback`.
      *
      * @return An ID that the caller can use to cancel the operation.

--- a/filament/src/details/AsyncHelpers.h
+++ b/filament/src/details/AsyncHelpers.h
@@ -20,7 +20,9 @@
 #include <private/backend/Driver.h>
 
 #include <backend/CallbackHandler.h>
+#include <backend/DriverEnums.h>
 
+#include <atomic>
 #include <functional>
 
 namespace filament {
@@ -30,12 +32,12 @@ using namespace utils;
 // This acts as an adapter that bridges a user-provided callback with the specific requirements of
 // the Filament callback system.
 // E.g.
-//   The callback that users expect => std::function<void(Texture*, void*)>
-//   Filament callback system requirement => CallbackHandler::Callback* callback, void* user
+//   The callback that users expect => std::function<void(Texture*, void*, AsyncCallStatus)>
+//   Filament callback system requirement => AsyncCallback callback, void* user
 template<typename T>
 class CallbackAdapter {
 public:
-    using UserCallback = std::function<void(T*, void*)>;
+    using UserCallback = std::function<void(T*, void*, backend::AsyncCallStatus)>;
 
     template<typename... Args>
     static CallbackAdapter<T>* make(Args&&... args) {
@@ -45,9 +47,10 @@ public:
     CallbackAdapter(UserCallback&& callback, const T* param, void* custom)
         : mUserCallback(std::move(callback)), mUserParam1(param), mUserParam2(custom) {}
 
-    static void func(void* user) {
+    static void func(void* user, backend::AsyncCallStatus const status) {
         auto* const thisObject = static_cast<CallbackAdapter*>(user);
-        thisObject->mUserCallback(const_cast<T*>(thisObject->mUserParam1), thisObject->mUserParam2);
+        thisObject->mUserCallback(const_cast<T*>(thisObject->mUserParam1), thisObject->mUserParam2,
+                status);
         delete thisObject;
     }
 
@@ -63,7 +66,7 @@ private:
 template<typename T>
 class CountdownCallbackHandler : public backend::CallbackHandler {
 public:
-    using UserCallback = std::function<void(T*, void*)>;
+    using UserCallback = std::function<void(T*, void*, backend::AsyncCallStatus)>;
     using CountdownCompleteCallback = std::function<void()>;
 
     template<typename... Args>
@@ -93,8 +96,15 @@ public:
     // 3. Decreases the count of pending asynchronous operations. When the counter hits zero,
     // the final callback is scheduled with the *REAL* user's handler to execute the *REAL*
     // user's callback.
-    static void countdownCallback(void* user) {
+    static void countdownCallback(void* user, backend::AsyncCallStatus const status) {
         auto* thisObject = static_cast<CountdownCallbackHandler*>(user);
+        if (status == backend::AsyncCallStatus::CANCELED) {
+            // One canceled operation makes the whole aggregate canceled: the object being built is
+            // incomplete either way. `std::memory_order_relaxed` is sufficient because this write
+            // is sequenced before decreaseCountdown()'s fetch_sub(acq_rel), which publishes it to
+            // whichever thread observes the count reaching zero.
+            thisObject->mCanceled.store(true, std::memory_order_relaxed);
+        }
         if (thisObject->decreaseCountdown()) {
             if (thisObject->mCountdownCompleteCallback) {
                 thisObject->mCountdownCompleteCallback();
@@ -111,7 +121,12 @@ public:
         auto* thisObject = static_cast<CountdownCallbackHandler*>(user);
         // 6. Executes the *REAL* user's callback.
         if (thisObject->mUserCallback) {
-            thisObject->mUserCallback(thisObject->mUserParam1, thisObject->mUserParam2);
+            // `std::memory_order_relaxed` is sufficient because scheduleCallback() takes a mutex
+            // between the thread that stored this and the handler thread running us.
+            auto const status = thisObject->mCanceled.load(std::memory_order_relaxed)
+                    ? backend::AsyncCallStatus::CANCELED
+                    : backend::AsyncCallStatus::COMPLETED;
+            thisObject->mUserCallback(thisObject->mUserParam1, thisObject->mUserParam2, status);
         }
         delete thisObject;
     }
@@ -135,6 +150,8 @@ private:
     }
 
     std::atomic_uint32_t mCount = 0;
+    // set if any of the tracked operations was canceled
+    std::atomic_bool mCanceled = false;
     CallbackHandler* mUserHandler = nullptr;
     UserCallback mUserCallback;
     T* mUserParam1 = nullptr;

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1565,9 +1565,9 @@ AsyncCallId FEngine::runCommandAsync(Invocable<void()>&& command,
     struct RunCommandAsyncCallback {
         AsyncCompletionCallback userCallback;
         void* userParam;
-        static void func(void* wrappedData) {
+        static void func(void* wrappedData, AsyncCallStatus const status) {
             auto const* const data = static_cast<RunCommandAsyncCallback*>(wrappedData);
-            data->userCallback(data->userParam);
+            data->userCallback(data->userParam, status);
             delete data;
         }
     };

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -86,7 +86,7 @@ struct Texture::BuilderDetails {
            Swizzle::CHANNEL_0, Swizzle::CHANNEL_1,
            Swizzle::CHANNEL_2, Swizzle::CHANNEL_3 };
     CallbackHandler* mAsyncCreationHandler = nullptr;
-    std::function<void(Texture* UTILS_NONNULL, void* UTILS_NULLABLE)> mAsyncCreationCallback;
+    Texture::AsyncCompletionCallback mAsyncCreationCallback;
     void* mAsyncCreationUserData = nullptr;
 };
 

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -73,7 +73,7 @@ struct VertexBuffer::BuilderDetails {
     bool mAdvancedSkinningEnabled = false; // TODO: use bits to save memory
     bool mAsynchronous = false;
     CallbackHandler* mAsyncCreationHandler = nullptr;
-    std::function<void(VertexBuffer* UTILS_NONNULL, void* UTILS_NULLABLE)> mAsyncCreationCallback;
+    VertexBuffer::AsyncCompletionCallback mAsyncCreationCallback;
     void* mAsyncCreationUserData = nullptr;
 };
 

--- a/samples/helloasync.cpp
+++ b/samples/helloasync.cpp
@@ -52,6 +52,7 @@ using utils::EntityManager;
 using utils::Path;
 using MinFilter = TextureSampler::MinFilter;
 using MagFilter = TextureSampler::MagFilter;
+using AsyncCallStatus = backend::AsyncCallStatus;
 
 struct Vertex {
     filament::math::float2 position;
@@ -430,7 +431,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
 
         if (engine->isAsynchronousModeEnabled()) {
             // Build a pipeline for asynchronous operations.
-            app->onLoadImageComplete = [app](void* user) {
+            // Every completion callback receives an AsyncCallStatus. CANCELED means the operation
+            // never ran, so the resource it was meant to populate is not usable: the chain has to
+            // stop there instead of moving on to a stage that would read an empty resource.
+            app->onLoadImageComplete = [app](void* user, AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 // Load this once as it's universal across all objects
                 app->createMaterial();
                 // Initiate loading multiple renderables at the same time.
@@ -440,23 +447,45 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                 app->startLoadingOneRenderable();
                 app->startLoadingOneRenderable();
             };
-            app->onCreateTextureComplete = [app](Texture* tex, void* user) {
+            app->onCreateTextureComplete = [app](Texture* tex, void* user, AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->updateTexture(user, app->onTextureUpdateComplete);
             };
-            app->onTextureUpdateComplete = [app](Texture* tex, void* user) {
+            app->onTextureUpdateComplete = [app](Texture* tex, void* user, AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->createMaterialInstance(user);
                 app->textureReady(user);
             };
-            app->onCreateVertexBufferComplete = [app](VertexBuffer* vb, void* user) {
+            app->onCreateVertexBufferComplete = [app](VertexBuffer* vb, void* user,
+                                                        AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->updateVertexBuffer(user, app->onVertexBufferUpdateComplete);
             };
-            app->onVertexBufferUpdateComplete = [app](VertexBuffer* vb, void* user) {
+            app->onVertexBufferUpdateComplete = [app](VertexBuffer* vb, void* user,
+                                                        AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->vertexBufferReady(user);
             };
-            app->onCreateIndexBufferComplete = [app](IndexBuffer* ib, void* user) {
+            app->onCreateIndexBufferComplete = [app](IndexBuffer* ib, void* user,
+                                                       AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->updateIndexBuffer(user, app->onIndexBufferUpdateComplete);
             };
-            app->onIndexBufferUpdateComplete = [app](IndexBuffer* ib, void* user) {
+            app->onIndexBufferUpdateComplete = [app](IndexBuffer* ib, void* user,
+                                                       AsyncCallStatus status) {
+                if (status == AsyncCallStatus::CANCELED) {
+                    return;
+                }
                 app->indexBufferReady(user);
             };
 


### PR DESCRIPTION
An async completion callback carried no argument saying why it fired, so a canceled operation was indistinguishable from a successful one. The caller cannot reconstruct that out of band either. `push()` drops jobs when the queue is stopping and `stop()` discards whatever is left, so an operation can be canceled without anyone having called `cancelAsyncCall()`

Add `backend::AsyncCallStatus` and `backend::AsyncCallback`, which is a thin wrapper of `CallbackHandler::Callback`(which doesn't have a cancellation concept). A new method
`DriverBase::scheduleAsyncCallback()` binds the status through the existing functor overload.

`CountdownCallbackHandler` fans several creations into a single user callback, so it aggregates: if any of the operations it tracks was canceled, the user callback reports CANCELED.

Nothing produces CANCELED yet, because a canceled job still drops its callback entirely instead of invoking it. That is fixed separately as a followup commit. This change is the API prerequisite for it.