### PR TITLE
fix: [smol-v] bound decoded output writes

### DIFF
--- a/libs/filaflat/tests/test_filaflat.cpp
+++ b/libs/filaflat/tests/test_filaflat.cpp
@@ -21,6 +21,7 @@
 #include <filaflat/MaterialChunk.h>
 #include <filaflat/Unflattener.h>
 #include <filament/MaterialChunkType.h>
+#include <smolv.h>
 
 #include <vector>
 #include <cstdint>
@@ -37,6 +38,32 @@ protected:
     }
     void write16(std::vector<uint8_t>& vec, uint16_t val) {
         for (int i = 0; i < 2; i++) vec.push_back((val >> (8 * i)) & 0xFF);
+    }
+    std::vector<uint8_t> makeSmolv(uint32_t decodedSize) {
+        std::vector<uint8_t> result;
+        write32(result, 0x534d4f4c); // "SMOL"
+        write32(result, 0x00010000); // SPIR-V version 1.0
+        write32(result, 0);          // generator
+        write32(result, 1);          // bound
+        write32(result, 0);          // schema
+        write32(result, decodedSize);
+        return result;
+    }
+    std::vector<uint8_t> makeSpirvDictionary(std::vector<uint8_t> const& smolv) {
+        std::vector<uint8_t> payload;
+        write32(payload, 1); // compression scheme
+        write32(payload, 1); // blob count
+        while ((12 + payload.size()) % 8 != 0) {
+            payload.push_back(0);
+        }
+        write64(payload, smolv.size());
+        payload.insert(payload.end(), smolv.begin(), smolv.end());
+
+        std::vector<uint8_t> result;
+        write64(result, uint64_t(filamat::ChunkType::DictionarySpirv));
+        write32(result, payload.size());
+        result.insert(result.end(), payload.begin(), payload.end());
+        return result;
     }
 };
 
@@ -218,6 +245,70 @@ TEST_F(FilaflatSecurityTest, UnflattenerIntegerWrapBypass) {
     // A secure implementation should evaluate the impossible wrapper size and explicitly return false.
     // The vulnerability forces it to return true, defying the integer boundaries and bypassing checks.
     EXPECT_FALSE(bypassed) << "VULNERABILITY: Integer wrap successfully bypassed Unflattener boundaries!";
+}
+
+TEST_F(FilaflatSecurityTest, SmolvRejectsInvalidDecodedSizes) {
+    for (uint32_t const decodedSize : { 0u, 1u, 4u, 19u, 21u }) {
+        auto const smolv = makeSmolv(decodedSize);
+        EXPECT_EQ(smolv::GetDecodedBufferSize(smolv.data(), smolv.size()), 0u);
+        std::vector<uint8_t> output(64);
+        EXPECT_FALSE(smolv::Decode(smolv.data(), smolv.size(), output.data(), output.size()));
+    }
+
+    auto const minimum = makeSmolv(20);
+    EXPECT_EQ(smolv::GetDecodedBufferSize(minimum.data(), minimum.size()), 20u);
+    std::vector<uint8_t> minimumOutput(20);
+    EXPECT_TRUE(smolv::Decode(
+            minimum.data(), minimum.size(), minimumOutput.data(), minimumOutput.size()));
+
+    auto const malformedLarge = makeSmolv(64);
+    EXPECT_EQ(smolv::GetDecodedBufferSize(malformedLarge.data(), malformedLarge.size()), 64u);
+    std::vector<uint8_t> malformedOutput(64);
+    EXPECT_FALSE(smolv::Decode(malformedLarge.data(), malformedLarge.size(),
+            malformedOutput.data(), malformedOutput.size()));
+}
+
+TEST_F(FilaflatSecurityTest, SmolvBoundsEveryDecodedWrite) {
+    std::vector<uint32_t> const spirv = {
+            0x07230203, 0x00010000, 0, 1, 0,
+            0x00010000, // OpNop
+    };
+    smolv::ByteArray encoded;
+    ASSERT_TRUE(smolv::Encode(spirv.data(), spirv.size() * sizeof(uint32_t), encoded, 0));
+
+    size_t const decodedSize = smolv::GetDecodedBufferSize(encoded.data(), encoded.size());
+    ASSERT_EQ(decodedSize, spirv.size() * sizeof(uint32_t));
+    std::vector<uint8_t> output(decodedSize);
+    EXPECT_TRUE(smolv::Decode(encoded.data(), encoded.size(), output.data(), output.size()));
+
+    encoded[20] = 20;
+    encoded[21] = encoded[22] = encoded[23] = 0;
+    std::vector<uint8_t> undersizedOutput(20);
+    EXPECT_FALSE(smolv::Decode(
+            encoded.data(), encoded.size(), undersizedOutput.data(), undersizedOutput.size()));
+}
+
+TEST_F(FilaflatSecurityTest, DictionarySpirvRejectsInvalidDecodedSizes) {
+    for (uint32_t const decodedSize : { 0u, 1u, 4u, 19u, 21u, 64u }) {
+        auto const package = makeSpirvDictionary(makeSmolv(decodedSize));
+        ChunkContainer container(package.data(), package.size());
+        ASSERT_TRUE(container.parse());
+        BlobDictionary dictionary;
+        EXPECT_FALSE(DictionaryReader::unflatten(
+                container, filamat::ChunkType::DictionarySpirv, dictionary));
+    }
+
+    std::vector<uint32_t> const spirv = { 0x07230203, 0x00010000, 0, 1, 0 };
+    smolv::ByteArray encoded;
+    ASSERT_TRUE(smolv::Encode(spirv.data(), spirv.size() * sizeof(uint32_t), encoded, 0));
+    auto const package = makeSpirvDictionary(encoded);
+    ChunkContainer container(package.data(), package.size());
+    ASSERT_TRUE(container.parse());
+    BlobDictionary dictionary;
+    EXPECT_TRUE(DictionaryReader::unflatten(
+            container, filamat::ChunkType::DictionarySpirv, dictionary));
+    ASSERT_EQ(dictionary.size(), 1u);
+    EXPECT_EQ(dictionary[0].size(), spirv.size() * sizeof(uint32_t));
 }
 
 

--- a/third_party/smol-v/source/smolv.cpp
+++ b/third_party/smol-v/source/smolv.cpp
@@ -1110,6 +1110,16 @@ static void smolv_Write4(smolv::ByteArray& arr, uint32_t v)
 	arr.push_back(v >> 24);
 }
 
+static bool smolv_Write4Checked(uint8_t*& buf, size_t& remaining, uint32_t v)
+{
+	if (remaining < 4)
+		return false;
+	memcpy(buf, &v, 4);
+	buf += 4;
+	remaining -= 4;
+	return true;
+}
+
 static void smolv_Write4(uint8_t*& buf, uint32_t v)
 {
 	memcpy(buf, &v, 4);
@@ -1452,7 +1462,10 @@ size_t smolv::GetDecodedBufferSize(const void* smolvData, size_t smolvSize)
 	if (!smolv_CheckSmolHeader((const uint8_t*)smolvData, smolvSize))
 		return 0;
 	const uint32_t* words = (const uint32_t*)smolvData;
-	return words[5];
+	const size_t decodedSize = words[5];
+	if (decodedSize < 5 * sizeof(uint32_t) || decodedSize % sizeof(uint32_t) != 0)
+		return 0;
+	return decodedSize;
 }
 
 
@@ -1471,15 +1484,16 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 	const uint8_t* bytesEnd = bytes + smolvSize;
 
 	uint8_t* outSpirv = (uint8_t*)spirvOutputBuffer;
+	size_t remainingOutputSize = neededBufferSize;
 	
 	uint32_t val;
 
 	// header
-	smolv_Write4(outSpirv, kSpirVHeaderMagic); bytes += 4;
-	smolv_Read4(bytes, bytesEnd, val); smolv_Write4(outSpirv, val); // version
-	smolv_Read4(bytes, bytesEnd, val); smolv_Write4(outSpirv, val); // generator
-	smolv_Read4(bytes, bytesEnd, val); smolv_Write4(outSpirv, val); // bound
-	smolv_Read4(bytes, bytesEnd, val); smolv_Write4(outSpirv, val); // schema
+	if (!smolv_Write4Checked(outSpirv, remainingOutputSize, kSpirVHeaderMagic)) return false; bytes += 4;
+	smolv_Read4(bytes, bytesEnd, val); if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false; // version
+	smolv_Read4(bytes, bytesEnd, val); if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false; // generator
+	smolv_Read4(bytes, bytesEnd, val); if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false; // bound
+	smolv_Read4(bytes, bytesEnd, val); if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false; // schema
 	bytes += 4; // decode buffer size
 
 	uint32_t prevResult = 0;
@@ -1495,7 +1509,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 		const bool wasSwizzle = (op == SpvOpVectorShuffleCompact);
 		if (wasSwizzle)
 			op = SpvOpVectorShuffle;
-		smolv_Write4(outSpirv, (instrLen << 16) | op);
+		if (!smolv_Write4Checked(outSpirv, remainingOutputSize, (instrLen << 16) | op)) return false;
 
 		size_t ioffs = 1;
 
@@ -1503,7 +1517,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 		if (smolv_OpHasType(op))
 		{
 			if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
-			smolv_Write4(outSpirv, val);
+			if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 			ioffs++;
 		}
 		// read result as delta+varint, if we have it
@@ -1511,7 +1525,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 		{
 			if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
 			val = prevResult + smolv_ZigDecode(val);
-			smolv_Write4(outSpirv, val);
+			if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 			prevResult = val;
 			ioffs++;
 		}
@@ -1521,7 +1535,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 		{
 			if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
 			val = prevDecorate + smolv_ZigDecode(val);
-			smolv_Write4(outSpirv, val);
+			if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 			prevDecorate = val;
 			ioffs++;
 		}
@@ -1558,11 +1572,11 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 				// write SPIR-V op+length (unless it's first member decoration, in which case it was written before)
 				if (m != 0)
 				{
-					smolv_Write4(outSpirv, (memberLen << 16) | op);
-					smolv_Write4(outSpirv, prevDecorate);
+					if (!smolv_Write4Checked(outSpirv, remainingOutputSize, (memberLen << 16) | op)) return false;
+					if (!smolv_Write4Checked(outSpirv, remainingOutputSize, prevDecorate)) return false;
 				}
-				smolv_Write4(outSpirv, memberIndex);
-				smolv_Write4(outSpirv, memberDec);
+				if (!smolv_Write4Checked(outSpirv, remainingOutputSize, memberIndex)) return false;
+				if (!smolv_Write4Checked(outSpirv, remainingOutputSize, memberDec)) return false;
 				// Special case for Offset decorations
 				if (memberDec == 35) // Offset
 				{
@@ -1570,7 +1584,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 						return false;
 					if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
 					val += prevOffset;
-					smolv_Write4(outSpirv, val);
+					if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 					prevOffset = val;
 				}
 				else
@@ -1578,7 +1592,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 					for (int i = 4; i < memberLen; ++i)
 					{
 						if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
-						smolv_Write4(outSpirv, val);
+						if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 					}
 				}
 			}
@@ -1591,16 +1605,16 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 		{
 			if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
 			val = smolv_ZigDecode(val);
-			smolv_Write4(outSpirv, prevResult - val);
+			if (!smolv_Write4Checked(outSpirv, remainingOutputSize, prevResult - val)) return false;
 		}
 
 		if (wasSwizzle && instrLen <= 9)
 		{
 			uint32_t swizzle = *bytes++;
-			if (instrLen > 5) smolv_Write4(outSpirv, (swizzle >> 6) & 3);
-			if (instrLen > 6) smolv_Write4(outSpirv, (swizzle >> 4) & 3);
-			if (instrLen > 7) smolv_Write4(outSpirv, (swizzle >> 2) & 3);
-			if (instrLen > 8) smolv_Write4(outSpirv, swizzle & 3);
+			if (instrLen > 5 && !smolv_Write4Checked(outSpirv, remainingOutputSize, (swizzle >> 6) & 3)) return false;
+			if (instrLen > 6 && !smolv_Write4Checked(outSpirv, remainingOutputSize, (swizzle >> 4) & 3)) return false;
+			if (instrLen > 7 && !smolv_Write4Checked(outSpirv, remainingOutputSize, (swizzle >> 2) & 3)) return false;
+			if (instrLen > 8 && !smolv_Write4Checked(outSpirv, remainingOutputSize, swizzle & 3)) return false;
 		}
 		else if (smolv_OpVarRest(op))
 		{
@@ -1608,7 +1622,7 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 			for (; ioffs < instrLen; ++ioffs)
 			{
 				if (!smolv_ReadVarint(bytes, bytesEnd, val)) return false;
-				smolv_Write4(outSpirv, val);
+				if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 			}
 		}
 		else
@@ -1617,12 +1631,12 @@ bool smolv::Decode(const void* smolvData, size_t smolvSize, void* spirvOutputBuf
 			for (; ioffs < instrLen; ++ioffs)
 			{
 				if (!smolv_Read4(bytes, bytesEnd, val)) return false;
-				smolv_Write4(outSpirv, val);
+				if (!smolv_Write4Checked(outSpirv, remainingOutputSize, val)) return false;
 			}
 		}
 	}
 
-	if ((uint8_t*)spirvOutputBuffer + neededBufferSize != outSpirv)
+	if (remainingOutputSize != 0)
 		return false; // something went wrong during decoding? we should have decoded to exact output size
 	
 	return true;
@@ -1892,4 +1906,3 @@ void smolv::StatsPrint(const Stats* stats)
 		);
 	}	
 }
-


### PR DESCRIPTION
## Summary

  This PR fixes a heap-buffer overflow in Filament’s bundled SMOL-V decoder.

  The change is submitted to Filament because the affected decoder is vendored directly into this repository, is consumed by Filament’s material-package parser, and has diverged from the standalone SMOL-V source. The standalone project
  has also been inactive since September 2024.

  ## Analysis

  `DictionaryReader` reads the decoded SPIR-V size from an untrusted material package, allocates a buffer of exactly that size, and passes it to the bundled `smolv::Decode()` implementation.

  The decoder trusted the declared size when writing the fixed five-word SPIR-V header and subsequent instruction words. Decoded sizes smaller than the header, non-word-aligned sizes, or instruction streams exceeding the declared output
  capacity could therefore write beyond Filament’s allocation.

  This is directly reachable through Filament’s material-package APIs, including `Material::Builder::package(...).build(...)`. The regression coverage consequently should belong at Filament’s `DictionaryReader` integration boundary, in
  addition to the direct decoder checks.

  ## Why is  this change is in Filament (and not upstream)?

  Filament maintains and builds its own bundled copy at `third_party/smol-v/source/smolv.cpp`; it does not consume SMOL-V as a live external dependency.

  Filament maintains a non-identical bundled copy of SMOL-V and directly exposes it through its material-package parser, and `DictionaryReader` provides the concrete allocation and parsing path affected by the bug. Fixing only the inactive standalone repository would neither update Filament’s copy nor add coverage for Filament’s vulnerable integration.

  This PR therefore repairs the copy that Filament actually ships and adds regression coverage at the production consumer boundary.

  ## The Fix

  Reject decoded sizes below the SPIR-V header size or not aligned to a complete word.

  Track the output boundary and verify capacity before every decoded write.

  ## Testing

  - Added coverage for decoded sizes `0`, `1`, `4`, `19`, `20`, and `21`
  - Added a stream whose header fits but whose instruction exceeds the declared output capacity
  - Added `DictionaryReader` integration coverage for invalid decoded sizes
  - Confirmed a genuine repository shader still round-trips through SMOL-V
  - Ran the focused ASan+UBSan tests: 3 tests passed
  - Ran the complete owning ASan+UBSan suite: 8 tests passed
 
