### PR TITLE
JobSystem optimizations

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -53,6 +53,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/Status.h
         ${PUBLIC_HDR_DIR}/${TARGET}/StructureOfArrays.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Systrace.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/ThreadMap.h
         ${PUBLIC_HDR_DIR}/${TARGET}/sstream.h
         ${PUBLIC_HDR_DIR}/${TARGET}/unwindows.h
 )
@@ -229,6 +230,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_BinaryTreeArray.cpp
             test/test_Status.cpp
             test/test_Mutex.cpp
+            test/test_ThreadMap.cpp
     )
 
     if (WASM_PTHREADS)

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -365,6 +365,13 @@ public:
     AtomicFreeList(const AtomicFreeList& rhs) = delete;
     AtomicFreeList& operator=(const AtomicFreeList& rhs) = delete;
 
+    // We disable TSAN instrumentation on pop() and push() because in a lock-free tagged
+    // freelist, pop() speculatively reads node.next from memory that might concurrently
+    // be written to by another thread (either in push() or by user code writing to the
+    // allocated memory). In the C++ memory model, this constitutes a data race, even though
+    // it is logically benign because any corrupted/stale read is discarded when the subsequent
+    // compare_exchange_weak() on the tagged pointer fails.
+    UTILS_NO_SANITIZE_THREAD
     void* pop() noexcept {
         Node* const pStorage = mStorage;
 
@@ -374,7 +381,6 @@ public:
             // thread raced ahead of us. But in that case, the computed "newHead" will be discarded
             // since compare_exchange_weak() fails. Then this thread will loop with the updated
             // value of currentHead, and try again.
-            // TSAN complains if we don't use a local variable here.
             Node const node = pStorage[currentHead.offset];
             Node const* const pNext = node.next;
             const HeadPtr newHead{ pNext ? int32_t(pNext - pStorage) : -1, currentHead.tag + 1 };
@@ -397,6 +403,7 @@ public:
         return p;
     }
 
+    UTILS_NO_SANITIZE_THREAD
     void push(void* p) noexcept {
         Node* const storage = mStorage;
         assert(p && p >= storage);

--- a/libs/utils/include/utils/Futex.h
+++ b/libs/utils/include/utils/Futex.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_FUTEX_H
+#define TNT_UTILS_FUTEX_H
+
+#if defined(__linux__) || defined(__ANDROID__)
+#include <utils/linux/Futex.h>
+#else
+#include <utils/generic/Futex.h>
+#endif
+
+#endif // TNT_UTILS_FUTEX_H

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -461,7 +461,7 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    Arena<ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
+    Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>
     using aligned_vector = std::vector<T, STLAlignedAllocator<T>>;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -461,6 +461,7 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
+    std::atomic<uint32_t> mSleepingThreads = { 0 };
     Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -21,6 +21,7 @@
 #include <utils/architecture.h>
 #include <utils/compiler.h>
 #include <utils/Condition.h>
+#include <utils/Futex.h>
 #include <utils/memalign.h>
 #include <utils/Mutex.h>
 #include <utils/ostream.h>
@@ -452,16 +453,19 @@ private:
 
     [[nodiscard]]
     uint32_t wait(UniqueLock& lock, Job* job) noexcept;
-    void wait(UniqueLock& lock) noexcept;
-    void wakeAll() noexcept;
+    void waitForWork(UniqueLock& lock) noexcept;
+    void waitForJob(UniqueLock& lock, Job const* job, uint32_t expected) noexcept UTILS_NO_THREAD_SAFETY_ANALYSIS;
+    void wakeWaiters() noexcept;
     void wakeOne() noexcept;
 
     // these have thread contention, keep them together
     Mutex mWaiterLock;
-    Condition mWaiterCondition;
+    Condition mWorkCondition;
+    Condition mJobCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    std::atomic<uint32_t> mSleepingThreads = { 0 };
+    std::atomic<uint32_t> mSleepingWorkers = { 0 };
+    std::atomic<uint32_t> mSleepingWaiters = { 0 };
     Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -25,9 +25,8 @@
 #include <utils/Mutex.h>
 #include <utils/ostream.h>
 #include <utils/Slice.h>
+#include <utils/ThreadMap.h>
 #include <utils/WorkStealingDequeue.h>
-
-#include <tsl/robin_map.h>
 
 #include <atomic>
 #include <functional>
@@ -44,6 +43,7 @@
 namespace utils {
 
 class JobSystem {
+    static constexpr uint32_t MAX_THREADS = 32;
     static constexpr size_t MAX_JOB_COUNT = 1 << 14; // 16384
     static constexpr uint32_t JOB_COUNT_MASK = MAX_JOB_COUNT - 1;
     static constexpr uint32_t WAITER_COUNT_SHIFT = 24;
@@ -475,14 +475,13 @@ private:
     alignas(16) // at least we align to half (or quarter) cache-line
     aligned_vector<ThreadState> mThreadStates;          // actual data is stored offline
     std::atomic<bool> mExitRequested = { false };       // this one is almost never written
-    std::atomic<uint16_t> mAdoptedThreads = { 0 };      // this one is almost never written
+    std::atomic<uint32_t> mAdoptableSlotsMask = { 0 };  // available slots for adoptable threads
     Job* const mJobStorageBase;                         // Base for conversion to indices
     uint16_t mThreadCount = 0;                          // total # of threads in the pool
     uint8_t mParallelSplitCount = 0;                    // # of split allowable in parallel_for
     Job* mRootJob = nullptr;
 
-    Mutex mThreadMapLock; // this should have very little contention
-    tsl::robin_map<std::thread::id, ThreadState *> mThreadMap UTILS_GUARDED_BY(mThreadMapLock);
+    ThreadMap<ThreadState*, MAX_THREADS> mThreadMap;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/libs/utils/include/utils/ThreadMap.h
+++ b/libs/utils/include/utils/ThreadMap.h
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_THREADMAP_H
+#define TNT_UTILS_THREADMAP_H
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Panic.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <limits>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+#include <assert.h>
+#include <stdint.h>
+
+namespace utils {
+
+/**
+ * ThreadMap is a fixed-capacity, lock-free and wait-free associative mapping from
+ * std::thread::id to a value of type T (such as pointers, handles, or small structs).
+ *
+ * Designed for high-performance multithreading subsystems (such as job systems, thread pools,
+ * and memory allocators) where a small, bounded number of threads need fast thread-local
+ * association without relying on compiler-dependent thread_local storage (which is
+ * problematic on some platforms and dynamic libraries).
+ *
+ * Thread IDs are stored in an inline, cache-line-packed array of std::atomic<std::thread::id>.
+ * Lookups perform a linear scan over the active capacity. For small thread counts (e.g. <= 32-64
+ * threads), all thread IDs fit in 1-4 L1 cache lines, allowing lookups to complete in ~1-2
+ * nanoseconds without any mutex locking, hash table overhead, or heap allocations on the critical
+ * path.
+ *
+ * Usage Example:
+ * --------------
+ *
+ * struct WorkerState {
+ *     int workerId;
+ *     WorkQueue queue;
+ * };
+ *
+ * // Create a map with compile-time fixed capacity for 8 threads (no heap allocation)
+ * utils::ThreadMap<WorkerState*, 8> threadMap;
+ *
+ * // In each worker thread:
+ * threadMap.set(slotIndex, &localState);
+ *
+ * // Later, in any worker or caller thread:
+ * WorkerState* state = threadMap.get(); // looks up std::this_thread::get_id()
+ * if (state) {
+ *     state->queue.push(...);
+ * }
+ *
+ * // When shutting down or when a thread exits:
+ * threadMap.erase(); // unregisters std::this_thread::get_id()
+ */
+template <typename VALUE, uint32_t CAPACITY>
+class UTILS_PUBLIC ThreadMap {
+    static_assert(CAPACITY > 0, "CAPACITY must be greater than zero");
+
+public:
+    using value_type = VALUE;
+    using size_type = uint32_t;
+    using key_type = std::thread::id;
+
+    static constexpr size_type INVALID_INDEX = std::numeric_limits<size_type>::max();
+    static constexpr size_type CAPACITY_COUNT = CAPACITY;
+
+    /**
+     * Constructs an empty ThreadMap. No heap allocations are performed.
+     */
+    ThreadMap() noexcept = default;
+
+    ~ThreadMap() = default;
+
+    ThreadMap(const ThreadMap&) = delete;
+    ThreadMap& operator=(const ThreadMap&) = delete;
+    ThreadMap(ThreadMap&&) = delete;
+    ThreadMap& operator=(ThreadMap&&) = delete;
+
+    /**
+     * Returns the maximum thread capacity.
+     */
+    static constexpr size_type getCapacity() noexcept {
+        return CAPACITY;
+    }
+
+    /**
+     * Associates the specified slot index with a thread ID and value.
+     *
+     * @param index Slot index (must be < getCapacity()).
+     * @param value The value to associate with the thread.
+     * @param tid The thread ID (defaults to the current calling thread).
+     */
+    void set(size_type const index, value_type value,
+            key_type const tid = std::this_thread::get_id()) noexcept {
+        assert_invariant(index < CAPACITY);
+        assert_invariant(tid != key_type{});
+        mValues[index] = std::move(value);
+        mThreadIds[index].store(tid, std::memory_order_release);
+    }
+
+    /**
+     * Registers a thread into the first available (empty) slot.
+     *
+     * @param value The value to associate with the thread.
+     * @param tid The thread ID (defaults to the current calling thread).
+     * @return The slot index where the thread was registered, or INVALID_INDEX if full.
+     */
+    size_type emplace(value_type value,
+            key_type const tid = std::this_thread::get_id()) noexcept {
+        assert_invariant(tid != key_type{});
+        const key_type empty{};
+        for (size_type i = 0; i < CAPACITY; ++i) {
+            key_type expected = empty;
+            if (mThreadIds[i].compare_exchange_strong(expected, tid,
+                    std::memory_order_acq_rel, std::memory_order_relaxed)) {
+                mValues[i] = std::move(value);
+                return i;
+            }
+            if (expected == tid) {
+                mValues[i] = std::move(value);
+                return i;
+            }
+        }
+        return INVALID_INDEX;
+    }
+
+    /**
+     * Finds the pointer to the value associated with the specified thread ID.
+     * Wait-free and lock-free.
+     *
+     * @param tid The thread ID to look up (defaults to the current calling thread).
+     * @return Pointer to the stored value if found, or nullptr if not found.
+     */
+    value_type* find(key_type const tid = std::this_thread::get_id()) noexcept {
+        size_type const idx = findIndex(tid);
+        return (idx != INVALID_INDEX) ? &mValues[idx] : nullptr;
+    }
+
+    /**
+     * Finds the const pointer to the value associated with the specified thread ID.
+     * Wait-free and lock-free.
+     *
+     * @param tid The thread ID to look up (defaults to the current calling thread).
+     * @return Const pointer to the stored value if found, or nullptr if not found.
+     */
+    const value_type* find(key_type const tid = std::this_thread::get_id()) const noexcept {
+        size_type const idx = findIndex(tid);
+        return (idx != INVALID_INDEX) ? &mValues[idx] : nullptr;
+    }
+
+    /**
+     * Retrieves the value associated with the specified thread ID.
+     * Convenience method when value_type is a pointer or default-constructible type.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The associated value, or value_type{} if not found.
+     */
+    value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
+        size_type const idx = findIndex(tid);
+        return (idx != INVALID_INDEX) ? mValues[idx] : value_type{};
+    }
+
+    /**
+     * Finds the slot index of the specified thread ID.
+     * Wait-free and lock-free.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The slot index if found, or INVALID_INDEX if not registered.
+     */
+    size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
+        if (UTILS_UNLIKELY(tid == key_type{})) {
+            return INVALID_INDEX;
+        }
+        for (size_type i = 0; i < CAPACITY; ++i) {
+            if (UTILS_LIKELY(mThreadIds[i].load(std::memory_order_acquire) == tid)) {
+                return i;
+            }
+        }
+        return INVALID_INDEX;
+    }
+
+    /**
+     * Returns true if the specified thread is registered in this map.
+     *
+     * @param tid The thread ID to check (defaults to current thread).
+     */
+    bool contains(key_type const tid = std::this_thread::get_id()) const noexcept {
+        return findIndex(tid) != INVALID_INDEX;
+    }
+
+    /**
+     * Unregisters the specified thread ID from the map and resets its slot to empty.
+     *
+     * @param tid The thread ID to unregister (defaults to current thread).
+     * @return true if the thread was found and unregistered, false otherwise.
+     */
+    bool erase(key_type const tid = std::this_thread::get_id()) noexcept {
+        size_type const idx = findIndex(tid);
+        if (idx != INVALID_INDEX) {
+            mThreadIds[idx].store(key_type{}, std::memory_order_release);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Unregisters the thread at a specific slot index.
+     *
+     * @param index The slot index to clear (must be < getCapacity()).
+     */
+    void eraseAt(size_type const index) noexcept {
+        assert_invariant(index < CAPACITY);
+        mThreadIds[index].store(key_type{}, std::memory_order_release);
+    }
+
+    /**
+     * Clears all registered threads from the map.
+     */
+    void clear() noexcept {
+        for (size_type i = 0; i < CAPACITY; ++i) {
+            mThreadIds[i].store(key_type{}, std::memory_order_relaxed);
+        }
+    }
+
+    /**
+     * Returns the number of currently registered threads.
+     */
+    size_type size() const noexcept {
+        size_type count = 0;
+        const key_type empty{};
+        for (size_type i = 0; i < CAPACITY; ++i) {
+            if (mThreadIds[i].load(std::memory_order_relaxed) != empty) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Returns true if no threads are currently registered.
+     */
+    bool empty() const noexcept {
+        return size() == 0;
+    }
+
+private:
+    std::atomic<key_type> mThreadIds[CAPACITY]{};
+    value_type mValues[CAPACITY]{};
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_THREADMAP_H

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -82,7 +82,7 @@
 #endif
 
 #define UTILS_NO_SANITIZE_THREAD
-#if __has_feature(thread_sanitizer)
+#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
 #undef UTILS_NO_SANITIZE_THREAD
 #define UTILS_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
 #endif

--- a/libs/utils/include/utils/generic/Futex.h
+++ b/libs/utils/include/utils/generic/Futex.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_GENERIC_FUTEX_H
+#define TNT_UTILS_GENERIC_FUTEX_H
+
+#include <utils/compiler.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace utils {
+
+class Futex {
+public:
+#if defined(__cpp_lib_atomic_wait) && (__cpp_lib_atomic_wait >= 201907L)
+    static constexpr bool HAS_FUTEX = true;
+
+    static inline void wait(std::atomic<uint32_t> const* addr, uint32_t value) noexcept {
+        const_cast<std::atomic<uint32_t>*>(addr)->wait(value, std::memory_order_relaxed);
+    }
+
+    static inline void wake(std::atomic<uint32_t> const* addr, int count = 1) noexcept {
+        if (count == 1) {
+            const_cast<std::atomic<uint32_t>*>(addr)->notify_one();
+        } else {
+            const_cast<std::atomic<uint32_t>*>(addr)->notify_all();
+        }
+    }
+
+    static inline void wakeAll(std::atomic<uint32_t> const* addr) noexcept {
+        const_cast<std::atomic<uint32_t>*>(addr)->notify_all();
+    }
+#else
+    static constexpr bool HAS_FUTEX = false;
+
+    static inline void wait(std::atomic<uint32_t> const*, uint32_t) noexcept {}
+    static inline void wake(std::atomic<uint32_t> const*, int = 1) noexcept {}
+    static inline void wakeAll(std::atomic<uint32_t> const*) noexcept {}
+#endif
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_GENERIC_FUTEX_H

--- a/libs/utils/include/utils/linux/Futex.h
+++ b/libs/utils/include/utils/linux/Futex.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_LINUX_FUTEX_H
+#define TNT_UTILS_LINUX_FUTEX_H
+
+#include <utils/compiler.h>
+
+#include <linux/futex.h>
+
+#include <atomic>
+#include <cstdint>
+#include <limits>
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace utils {
+
+class Futex {
+public:
+    static constexpr bool HAS_FUTEX = true;
+
+    static inline void wait(std::atomic<uint32_t> const* addr, uint32_t value) noexcept {
+        syscall(__NR_futex, const_cast<std::atomic<uint32_t>*>(addr),
+                FUTEX_WAIT_PRIVATE, value, nullptr, nullptr, 0);
+    }
+
+    static inline void wake(std::atomic<uint32_t> const* addr, int count = 1) noexcept {
+        syscall(__NR_futex, const_cast<std::atomic<uint32_t>*>(addr),
+                FUTEX_WAKE_PRIVATE, count, nullptr, nullptr, 0);
+    }
+
+    static inline void wakeAll(std::atomic<uint32_t> const* addr) noexcept {
+        wake(addr, std::numeric_limits<int>::max());
+    }
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_LINUX_FUTEX_H

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -309,7 +309,9 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
 
 inline void JobSystem::wait(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+    mSleepingThreads.fetch_add(1, std::memory_order_relaxed);
     mWaiterCondition.wait(lock);
+    mSleepingThreads.fetch_sub(1, std::memory_order_relaxed);
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
@@ -324,7 +326,7 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
             job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
 
     if (runningJobCount & JOB_COUNT_MASK) {
-        mWaiterCondition.wait(lock);
+        wait(lock);
     }
 
     runningJobCount =
@@ -382,13 +384,14 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
     // BEFORE workQueue.push(). If a preemption happened right there, other threads 
     // would see mActiveJobs > 0, enter the steal() loop, fail to find the job, and 
     // spin infinitely, recreating the exact same priority inversion lockup on the push side!
-    mActiveJobs.fetch_add(1, std::memory_order_release);
+    int32_t const prevActiveJobs = mActiveJobs.fetch_add(1, std::memory_order_release);
 
-    // Note: it's absolutely possible for mActiveJobs to be 0 here, because the job could have
-    // been handled by a zealous worker already. In that case we could avoid calling wakeOne(),
-    // but that is not the common case.
-
-    wakeOne();
+    // Only wake a sleeping thread if there are more sleeping threads than previously
+    // queued active jobs. This ensures we wake at most as many threads as are sleeping,
+    // avoiding redundant wakeOne() calls during batch job submissions (e.g. parallel_for).
+    if (UTILS_UNLIKELY(prevActiveJobs < int32_t(mSleepingThreads.load(std::memory_order_relaxed)))) {
+        wakeOne();
+    }
 }
 
 JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -395,12 +395,22 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
 }
 
 JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
+    // Fast check: if no jobs are active, avoid touching atomics.
+    if (UTILS_UNLIKELY(!hasActiveJobs())) {
+        return nullptr;
+    }
+
     // We speculatively decrement mActiveJobs before taking the job.
     // If a thread is preempted here, mActiveJobs is temporarily undercounted.
     // This is safe and desirable: it allows other idle threads to see 0 and go to sleep
     // (yielding the CPU) instead of spinning infinitely on hasActiveJobs(),
     // completely preventing priority inversion lockups.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    int32_t const prevActiveJobs = mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    if (UTILS_UNLIKELY(prevActiveJobs <= 0)) {
+        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+        return nullptr;
+    }
+
     size_t const index = workQueue.pop();
     assert(index <= MAX_JOB_COUNT);
     Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
@@ -412,15 +422,9 @@ JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
 }
 
 JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
-    // See JobSystem::pop() for why we pre-decrement mActiveJobs.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
     size_t const index = workQueue.steal();
     assert_invariant(index <= MAX_JOB_COUNT);
-    Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
-    if (UTILS_UNLIKELY(!job)) {
-        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
-    }
-    return job;
+    return !index ? nullptr : &mJobStorageBase[index - 1];
 }
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
@@ -444,14 +448,42 @@ inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state
 
 JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+
+    // Fast check: if no jobs are active, avoid attempting to steal or touch atomics.
+    if (UTILS_UNLIKELY(!hasActiveJobs())) {
+        return nullptr;
+    }
+
+    // Speculatively claim one job count before searching across queues.
+    // If preempted while stealing or executing, mActiveJobs is already decremented,
+    // allowing other threads to sleep rather than spin (preventing priority inversions).
+    int32_t const prevActiveJobs = mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    if (UTILS_UNLIKELY(prevActiveJobs <= 0)) {
+        // Another thread took the last available job; restore count and exit immediately.
+        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+        return nullptr;
+    }
+
     Job* job = nullptr;
+    auto const& threadStates = mThreadStates;
+    uint16_t const threadCount = uint16_t(threadStates.size());
+
+    // Search queues for the job we claimed.
+    // We try at least threadCount queues to find our job, and continue as long as
+    // additional active jobs remain in the system.
+    size_t attempts = 0;
     do {
         if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
             job = steal(stateToStealFrom->workQueue);
         }
-        // nullptr -> nothing to steal in that queue either, if there are active jobs,
-        // continue to try stealing one.
-    } while (!job && hasActiveJobs());
+        attempts++;
+    } while (!job && (attempts < threadCount || hasActiveJobs()));
+
+    if (UTILS_UNLIKELY(!job)) {
+        // If we couldn't find a job (e.g. consumed concurrently), restore the count.
+        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+    }
+
     return job;
 }
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -489,6 +489,9 @@ void JobSystem::loop(ThreadState* state) {
     // run our main loop...
     do {
         if (!execute(*state)) {
+            if (hasActiveJobs()) {
+                continue;
+            }
             UniqueLock lock(mWaiterLock);
             while (!exitRequested() && !hasActiveJobs()) {
                 wait(lock);
@@ -616,9 +619,13 @@ void JobSystem::waitAndRelease(Job*& job) noexcept {
     ThreadState& state(getState());
     do {
         if (UTILS_UNLIKELY(!execute(state))) {
-            // test if job has completed first, to possibly avoid taking the lock
-            if (hasJobCompleted(job)) {
+            // test if job has completed or exit was requested first, to possibly avoid taking the lock
+            if (hasJobCompleted(job) || exitRequested()) {
                 break;
+            }
+
+            if (hasActiveJobs()) {
+                continue;
             }
 
             // the only way we can be here is if the job we're waiting on it being handled

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -30,6 +30,7 @@
 
 #include <private/utils/Tracing.h>
 
+#include <utils/algorithm.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Log.h>
@@ -201,10 +202,13 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
             // one of the thread will be the user thread
             threadPoolCount = hwThreads - 1;
         }
-        // make sure we have at least one thread in the thread pool
-        threadPoolCount = std::max(1u, threadPoolCount);
-        // and also limit the pool to 32 threads
-        threadPoolCount = std::min(UTILS_HAS_THREADING ? 32u : 0u, threadPoolCount);
+        // clamp adoptableThreadsCount so it does not exceed MAX_THREADS
+        adoptableThreadsCount = std::min(adoptableThreadsCount, MAX_THREADS);
+        // limit the pool such that threadPoolCount + adoptableThreadsCount <= MAX_THREADS
+        const uint32_t maxThreadPoolCount = MAX_THREADS - adoptableThreadsCount;
+        // make sure we have at least one thread in the thread pool if capacity permits
+        threadPoolCount = std::max(maxThreadPoolCount > 0 ? 1u : 0u, threadPoolCount);
+        threadPoolCount = std::min(UTILS_HAS_THREADING ? maxThreadPoolCount : 0u, threadPoolCount);
     } else {
         threadPoolCount = 0;
         adoptableThreadsCount = 1;
@@ -214,8 +218,14 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
     mThreadCount = uint16_t(threadPoolCount);
     mParallelSplitCount = uint8_t(std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount))));
 
+    uint32_t adoptableMask = 0;
+    for (uint32_t i = 0; i < adoptableThreadsCount; ++i) {
+        adoptableMask |= (1u << (threadPoolCount + i));
+    }
+    mAdoptableSlotsMask.store(adoptableMask, std::memory_order_relaxed);
+
     static_assert(std::atomic<bool>::is_always_lock_free);
-    static_assert(std::atomic<uint16_t>::is_always_lock_free);
+    static_assert(std::atomic<uint32_t>::is_always_lock_free);
 
     const size_t hardwareThreadCount = mThreadCount;
     auto& states = mThreadStates;
@@ -349,10 +359,9 @@ void JobSystem::wakeOne() noexcept {
 }
 
 inline JobSystem::ThreadState& JobSystem::getState() {
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(std::this_thread::get_id());
-    FILAMENT_CHECK_PRECONDITION(iter != mThreadMap.end()) << "This thread has not been adopted.";
-    return *iter->second;
+    ThreadState* const state = mThreadMap.get();
+    FILAMENT_CHECK_PRECONDITION(state) << "This thread has not been adopted.";
+    return *state;
 }
 
 JobSystem::Job* JobSystem::allocateJob() noexcept {
@@ -413,10 +422,7 @@ JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
     auto& threadStates = mThreadStates;
-    // memory_order_relaxed is okay because we don't take any action that has data dependency
-    // on this value (in particular mThreadStates, is always initialized properly).
-    uint16_t const adopted = mAdoptedThreads.load(std::memory_order_relaxed);
-    uint16_t const threadCount = mThreadCount + adopted;
+    uint16_t const threadCount = uint16_t(threadStates.size());
 
     ThreadState* stateToStealFrom = nullptr;
 
@@ -478,13 +484,8 @@ void JobSystem::loop(ThreadState* state) {
     setThreadPriority(Priority::DISPLAY);
 
     // record our work queue
-    bool inserted;
-    {
-        LockGuard const lock(mThreadMapLock);
-        inserted = mThreadMap.emplace(std::this_thread::get_id(), state).second;
-    }
-
-    FILAMENT_CHECK_PRECONDITION(inserted) << "This thread is already in a loop.";
+    size_t const index = std::distance(mThreadStates.data(), state);
+    mThreadMap.set(uint32_t(index), state);
 
     // run our main loop...
     do {
@@ -670,15 +671,7 @@ void JobSystem::runAndWait(Job*& job) noexcept {
 }
 
 void JobSystem::adopt() {
-    const auto tid = std::this_thread::get_id();
-
-    ThreadState const* state = nullptr;
-    {
-        LockGuard const lock(mThreadMapLock);
-        auto const iter = mThreadMap.find(tid);
-        state = iter ==  mThreadMap.end() ? nullptr : iter->second;
-    }
-
+    ThreadState const* const state = mThreadMap.get();
     if (state) {
         // we're already part of a JobSystem, do nothing.
         FILAMENT_CHECK_PRECONDITION(this == state->js)
@@ -687,10 +680,16 @@ void JobSystem::adopt() {
         return;
     }
 
-    // memory_order_relaxed is safe because we don't take action on this value.
-    uint16_t const adopted = mAdoptedThreads.fetch_add(1, std::memory_order_relaxed);
-    size_t const index = mThreadCount + adopted;
+    uint32_t mask = mAdoptableSlotsMask.load(std::memory_order_relaxed);
+    uint32_t bit = 0;
+    do {
+        FILAMENT_CHECK_POSTCONDITION(mask != 0)
+                << "Too many calls to adopt(). No more adoptable threads!";
+        bit = 1u << utils::ctz(mask);
+    } while (!mAdoptableSlotsMask.compare_exchange_weak(mask, mask & ~bit,
+            std::memory_order_acquire, std::memory_order_relaxed));
 
+    size_t const index = utils::ctz(bit);
     FILAMENT_CHECK_POSTCONDITION(index < mThreadStates.size())
             << "Too many calls to adopt(). No more adoptable threads!";
 
@@ -701,20 +700,16 @@ void JobSystem::adopt() {
     // however, it's not a problem since mThreadState is pre-initialized and valid
     // (e.g.: the queue is empty).
 
-    {
-        LockGuard const lock(mThreadMapLock);
-        mThreadMap[tid] = &mThreadStates[index];
-    }
+    mThreadMap.set(uint32_t(index), &mThreadStates[index]);
 }
 
 void JobSystem::emancipate() {
-    const auto tid = std::this_thread::get_id();
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(tid);
-    ThreadState const* const state = iter ==  mThreadMap.end() ? nullptr : iter->second;
+    ThreadState const* const state = mThreadMap.get();
     FILAMENT_CHECK_PRECONDITION(state) << "this thread is not an adopted thread";
     FILAMENT_CHECK_PRECONDITION(state->js == this) << "this thread is not adopted by us";
-    mThreadMap.erase(iter);
+    size_t const index = std::distance(mThreadStates.data(), const_cast<ThreadState*>(state));
+    mThreadMap.erase();
+    mAdoptableSlotsMask.fetch_or(1u << index, std::memory_order_release);
 }
 
 io::ostream& operator<<(io::ostream& out, JobSystem const& js) {

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -291,7 +291,8 @@ void JobSystem::decRef(Job const* job) noexcept {
 void JobSystem::requestExit() noexcept {
     mExitRequested.store(true);
     LockGuard const lock(mWaiterLock);
-    mWaiterCondition.notify_all();
+    mWorkCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 inline bool JobSystem::exitRequested() const noexcept {
@@ -307,11 +308,24 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
     return (job->runningJobCount.load(std::memory_order_acquire) & JOB_COUNT_MASK) == 0;
 }
 
-inline void JobSystem::wait(UniqueLock& lock) noexcept {
+inline void JobSystem::waitForWork(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
-    mSleepingThreads.fetch_add(1, std::memory_order_relaxed);
-    mWaiterCondition.wait(lock);
-    mSleepingThreads.fetch_sub(1, std::memory_order_relaxed);
+    mSleepingWorkers.fetch_add(1, std::memory_order_relaxed);
+    mWorkCondition.wait(lock);
+    mSleepingWorkers.fetch_sub(1, std::memory_order_relaxed);
+}
+
+inline void JobSystem::waitForJob(UniqueLock& lock, Job const* const job, uint32_t const expected) noexcept UTILS_NO_THREAD_SAFETY_ANALYSIS {
+    HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+    if constexpr (Futex::HAS_FUTEX) {
+        lock.unlock();
+        Futex::wait(&job->runningJobCount, expected);
+        lock.lock();
+    } else {
+        mSleepingWaiters.fetch_add(1, std::memory_order_relaxed);
+        mJobCondition.wait(lock);
+        mSleepingWaiters.fetch_sub(1, std::memory_order_relaxed);
+    }
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
@@ -322,31 +336,28 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
         return job->runningJobCount.load(std::memory_order_acquire);
     }
 
-    uint32_t runningJobCount =
-            job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
+    uint32_t runningJobCount = job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
 
     if (runningJobCount & JOB_COUNT_MASK) {
-        wait(lock);
+        waitForJob(lock, job, runningJobCount + (1 << WAITER_COUNT_SHIFT));
     }
 
-    runningJobCount =
-            job->runningJobCount.fetch_sub(1 << WAITER_COUNT_SHIFT, std::memory_order_acquire);
-
+    runningJobCount = job->runningJobCount.fetch_sub(1 << WAITER_COUNT_SHIFT, std::memory_order_acquire);
     assert_invariant((runningJobCount >> WAITER_COUNT_SHIFT) >= 1);
 
     return runningJobCount;
 }
 
 UTILS_NOINLINE
-void JobSystem::wakeAll() noexcept {
-    // wakeAll() is called when a job finishes (to wake up any thread that might be waiting on it)
+void JobSystem::wakeWaiters() noexcept {
+    // wakeWaiters() is called when a job finishes (to wake up any thread that might be waiting on it)
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     mWaiterLock.lock();
     // this empty critical section is needed -- it guarantees that notify_all() happens
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_all() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 void JobSystem::wakeOne() noexcept {
@@ -357,7 +368,13 @@ void JobSystem::wakeOne() noexcept {
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_one() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_one();
+    if (mSleepingWorkers.load(std::memory_order_relaxed) > 0) {
+        mWorkCondition.notify_one();
+    } else if constexpr (!Futex::HAS_FUTEX) {
+        if (mSleepingWaiters.load(std::memory_order_relaxed) > 0) {
+            mJobCondition.notify_one();
+        }
+    }
 }
 
 inline JobSystem::ThreadState& JobSystem::getState() {
@@ -389,7 +406,11 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
     // Only wake a sleeping thread if there are more sleeping threads than previously
     // queued active jobs. This ensures we wake at most as many threads as are sleeping,
     // avoiding redundant wakeOne() calls during batch job submissions (e.g. parallel_for).
-    if (UTILS_UNLIKELY(prevActiveJobs < int32_t(mSleepingThreads.load(std::memory_order_relaxed)))) {
+    uint32_t totalSleeping = mSleepingWorkers.load(std::memory_order_relaxed);
+    if constexpr (!Futex::HAS_FUTEX) {
+        totalSleeping += mSleepingWaiters.load(std::memory_order_relaxed);
+    }
+    if (UTILS_UNLIKELY(prevActiveJobs < int32_t(totalSleeping))) {
         wakeOne();
     }
 }
@@ -530,7 +551,7 @@ void JobSystem::loop(ThreadState* state) {
             }
             UniqueLock lock(mWaiterLock);
             while (!exitRequested() && !hasActiveJobs()) {
-                wait(lock);
+                waitForWork(lock);
             }
         }
     } while (!exitRequested());
@@ -540,7 +561,7 @@ UTILS_NOINLINE
 void JobSystem::finish(Job* job) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
 
-    bool notify = false;
+    uint32_t totalWaiters = 0;
 
     // terminate this job and notify its parent
     Job* const storage = mJobStorageBase;
@@ -554,8 +575,12 @@ void JobSystem::finish(Job* job) noexcept {
         if (runningJobCount == 1) {
             // no more work, destroy this job and notify its parent
             uint32_t const waiters = v >> WAITER_COUNT_SHIFT;
-            if (waiters) {
-                notify = true;
+            if (UTILS_UNLIKELY(waiters)) {
+                if constexpr (Futex::HAS_FUTEX) {
+                    Futex::wakeAll(&job->runningJobCount);
+                } else {
+                    totalWaiters += waiters;
+                }
             }
             Job* const parent = job->parent == 0x7FFF ? nullptr : &storage[job->parent];
             decRef(job);
@@ -566,10 +591,12 @@ void JobSystem::finish(Job* job) noexcept {
         }
     } while (job);
 
-    // wake-up all threads that could potentially be waiting on this job finishing
-    if (UTILS_UNLIKELY(notify)) {
-        // but avoid calling notify_all() at all cost, because it's always expensive
-        wakeAll();
+    if constexpr (!Futex::HAS_FUTEX) {
+        // wake-up threads that could potentially be waiting on this job finishing
+        if (UTILS_UNLIKELY(totalWaiters > 0)) {
+            // but avoid calling notify_all() at all cost, because it's always expensive
+            wakeWaiters();
+        }
     }
 }
 

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -400,3 +400,212 @@ TEST(JobSystem, JobSystemConcurrentStress) {
 
     EXPECT_EQ(totalSum.load(), expectedTotal);
 }
+
+TEST(JobSystem, JobSystemBurstyWake) {
+    JobSystem js(4, 1);
+    js.adopt();
+
+    std::atomic<uint32_t> completedJobs{0};
+
+    // Part 1: Submit 1 job, wait for completion, sleep to ensure workers go to sleep, repeat
+    for (size_t i = 0; i < 30; ++i) {
+        JobSystem::Job* job = js.createJob(nullptr, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.runAndWait(job);
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+
+    EXPECT_EQ(30u, completedJobs.load());
+
+    // Part 2: Sudden burst of 100 jobs after idle period
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    for (size_t i = 0; i < 100; ++i) {
+        JobSystem::Job* child = js.createJob(root, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.run(child);
+    }
+    js.runAndWait(root);
+
+    EXPECT_EQ(130u, completedJobs.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemDeepTreeMultiWait) {
+    JobSystem js(8, 8);
+    js.adopt();
+
+    std::atomic<uint32_t> leafCount{0};
+
+    auto buildTree = [&](auto& self, JobSystem::Job* parent, int depth) -> void {
+        if (depth == 0) {
+            JobSystem::Job* leaf = js.createJob(parent, [&leafCount](JobSystem&, JobSystem::Job*) {
+                leafCount.fetch_add(1, std::memory_order_relaxed);
+            });
+            js.run(leaf);
+            return;
+        }
+        for (int i = 0; i < 4; ++i) {
+            JobSystem::Job* node = js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
+            self(self, node, depth - 1);
+            js.run(node);
+        }
+    };
+
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    buildTree(buildTree, root, 4); // 4^4 = 256 leaves
+
+    // Retain root so we can wait on it from multiple threads
+    js.retain(root);
+    js.retain(root);
+    js.retain(root);
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> waitingThreads;
+    for (int t = 0; t < 3; ++t) {
+        waitingThreads.emplace_back([&, root]() {
+            js.adopt();
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            JobSystem::Job* r = root;
+            js.waitAndRelease(r);
+            js.emancipate();
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    js.runAndWait(root);
+
+    for (auto& t : waitingThreads) {
+        t.join();
+    }
+
+    EXPECT_EQ(256u, leafCount.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemPoolExhaustionAndChurn) {
+    JobSystem js(8, 8);
+
+    constexpr size_t THREAD_COUNT = 8;
+    constexpr size_t BATCH_SIZE = 1200; // 8 * 1200 = 9600 active jobs simultaneously
+    std::atomic<uint32_t> jobsExecuted{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            js.adopt();
+            for (size_t iter = 0; iter < 3; ++iter) {
+                JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+                for (size_t i = 0; i < BATCH_SIZE; ++i) {
+                    JobSystem::Job* child = js.createJob(root, [&jobsExecuted](JobSystem&, JobSystem::Job*) {
+                        jobsExecuted.fetch_add(1, std::memory_order_relaxed);
+                    });
+                    js.run(child);
+                }
+                js.runAndWait(root);
+            }
+            js.emancipate();
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * BATCH_SIZE * 3, jobsExecuted.load());
+}
+
+TEST(JobSystem, JobSystemSingleThreaded) {
+    JobSystem js(JobSystem::SINGLE_THREADED);
+    js.adopt();
+
+    std::vector<uint32_t> data(512, 10);
+    auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* slice, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    slice[i] += 5;
+                }
+            }, CountSplitter<4>());
+    js.runAndWait(job);
+
+    for (uint32_t val : data) {
+        EXPECT_EQ(15u, val);
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemMultipleInstances) {
+    JobSystem js1(4, 4);
+    JobSystem js2(4, 4);
+
+    std::atomic<uint32_t> count1{0};
+    std::atomic<uint32_t> count2{0};
+
+    std::thread t1([&]() {
+        js1.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js1.createJob(nullptr, [&count1](JobSystem&, JobSystem::Job*) {
+                count1.fetch_add(1, std::memory_order_relaxed);
+            });
+            js1.runAndWait(job);
+        }
+        js1.emancipate();
+    });
+
+    std::thread t2([&]() {
+        js2.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js2.createJob(nullptr, [&count2](JobSystem&, JobSystem::Job*) {
+                count2.fetch_add(1, std::memory_order_relaxed);
+            });
+            js2.runAndWait(job);
+        }
+        js2.emancipate();
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(100u, count1.load());
+    EXPECT_EQ(100u, count2.load());
+}
+
+TEST(JobSystem, JobSystemRapidAdoptEmancipate) {
+    JobSystem js(4, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 100;
+
+    std::atomic<uint32_t> jobsCompleted{0};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+                JobSystem::Job* job = js.createJob(nullptr, [&jobsCompleted](JobSystem&, JobSystem::Job*) {
+                    jobsCompleted.fetch_add(1, std::memory_order_relaxed);
+                });
+                js.runAndWait(job);
+                js.emancipate();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * ITERATIONS, jobsCompleted.load());
+}
+

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
+#include <utils/Allocator.h>
 #include <utils/JobSystem.h>
 #include <utils/WorkStealingDequeue.h>
 
-#include <math/vec3.h>
 #include <math/mat3.h>
+#include <math/vec3.h>
+
+#include <gtest/gtest.h>
 
 #include <array>
 #include <thread>
-#include <utils/Allocator.h>
 
 using namespace utils;
 using namespace jobs;
@@ -343,4 +343,60 @@ TEST(JobSystem, JobSystemDelegates) {
 
 
     js.emancipate();
+}
+
+TEST(JobSystem, JobSystemConcurrentStress) {
+    // 8 worker threads + 16 adoptable user threads
+    JobSystem js(8, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 20;
+    constexpr size_t ARRAY_SIZE = 1024;
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    std::atomic<uint64_t> totalSum{0};
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&, t]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+
+                std::vector<uint32_t> data(ARRAY_SIZE, uint32_t(t + 1));
+                auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+                        [](uint32_t* slice, size_t count) {
+                            for (size_t i = 0; i < count; ++i) {
+                                slice[i] *= 2;
+                            }
+                        }, CountSplitter<4>());
+                js.runAndWait(job);
+
+                uint64_t localSum = 0;
+                for (uint32_t val : data) {
+                    localSum += val;
+                }
+                totalSum.fetch_add(localSum, std::memory_order_relaxed);
+
+                js.emancipate();
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    uint64_t expectedTotal = 0;
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        expectedTotal += uint64_t(t + 1) * 2 * ARRAY_SIZE * ITERATIONS;
+    }
+
+    EXPECT_EQ(totalSum.load(), expectedTotal);
 }

--- a/libs/utils/test/test_ThreadMap.cpp
+++ b/libs/utils/test/test_ThreadMap.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/ThreadMap.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace utils;
+
+TEST(ThreadMapTest, BasicOperations) {
+    ThreadMap<int, 4> map;
+    EXPECT_EQ(4u, map.getCapacity());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Current thread should not be present initially
+    EXPECT_FALSE(map.contains());
+    EXPECT_EQ(nullptr, map.find());
+    EXPECT_EQ(0, map.get());
+    EXPECT_EQ((decltype(map)::INVALID_INDEX), map.findIndex());
+
+    // Register current thread at slot 0
+    map.set(0, 42);
+    EXPECT_FALSE(map.empty());
+    EXPECT_EQ(1u, map.size());
+    EXPECT_TRUE(map.contains());
+    EXPECT_EQ(0u, map.findIndex());
+    EXPECT_EQ(42, map.get());
+
+    int* val = map.find();
+    ASSERT_NE(nullptr, val);
+    EXPECT_EQ(42, *val);
+
+    // Modify value via pointer
+    *val = 100;
+    EXPECT_EQ(100, map.get());
+
+    // Erase current thread
+    EXPECT_TRUE(map.erase());
+    EXPECT_FALSE(map.contains());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Erasing non-existent thread returns false
+    EXPECT_FALSE(map.erase());
+}
+
+TEST(ThreadMapTest, EmplaceAndCapacity) {
+    ThreadMap<std::string, 2> map;
+    EXPECT_EQ(2u, map.getCapacity());
+
+    // Create unique artificial thread IDs via threads
+    std::thread t1([] {});
+    std::thread t2([] {});
+    std::thread t3([] {});
+    const auto tid1 = t1.get_id();
+    const auto tid2 = t2.get_id();
+    const auto tid3 = t3.get_id();
+    t1.join();
+    t2.join();
+    t3.join();
+
+    // Emplace first thread
+    uint32_t const idx1 = map.emplace("thread1", tid1);
+    EXPECT_NE((decltype(map)::INVALID_INDEX), idx1);
+    EXPECT_EQ(1u, map.size());
+    EXPECT_EQ("thread1", map.get(tid1));
+
+    // Emplace second thread
+    uint32_t const idx2 = map.emplace("thread2", tid2);
+    EXPECT_NE((decltype(map)::INVALID_INDEX), idx2);
+    EXPECT_NE(idx1, idx2);
+    EXPECT_EQ(2u, map.size());
+    EXPECT_EQ("thread2", map.get(tid2));
+
+    // Emplace third thread should fail (capacity exceeded)
+    uint32_t const idx3 = map.emplace("thread3", tid3);
+    EXPECT_EQ((decltype(map)::INVALID_INDEX), idx3);
+    EXPECT_EQ(2u, map.size());
+
+    // Re-emplacing an existing thread should update value and return same index
+    uint32_t const idx1_re = map.emplace("thread1_updated", tid1);
+    EXPECT_EQ(idx1, idx1_re);
+    EXPECT_EQ("thread1_updated", map.get(tid1));
+
+    // Erase at slot index
+    map.eraseAt(idx1);
+    EXPECT_FALSE(map.contains(tid1));
+    EXPECT_EQ(1u, map.size());
+
+    // Now third thread can be emplaced
+    uint32_t const idx3_new = map.emplace("thread3", tid3);
+    EXPECT_EQ(idx1, idx3_new);
+    EXPECT_TRUE(map.contains(tid3));
+    EXPECT_EQ("thread3", map.get(tid3));
+
+    // Clear map
+    map.clear();
+    EXPECT_TRUE(map.empty());
+    EXPECT_FALSE(map.contains(tid2));
+    EXPECT_FALSE(map.contains(tid3));
+}
+
+TEST(ThreadMapTest, MultiThreadedConcurrentAccess) {
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 1000;
+
+    ThreadMap<size_t, THREAD_COUNT> map;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&map, &start, i]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                // Register
+                uint32_t const slot = map.emplace(i * 10000 + iter);
+                EXPECT_NE((decltype(map)::INVALID_INDEX), slot);
+
+                // Verify self lookup
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(i * 10000 + iter, map.get());
+                EXPECT_EQ(slot, map.findIndex());
+
+                // Unregister
+                EXPECT_TRUE(map.erase());
+                EXPECT_FALSE(map.contains());
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, MultiThreadedStaticSlots) {
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 5000;
+
+    ThreadMap<size_t, THREAD_COUNT> map;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&map, &start, i]() {
+            // Assign dedicated slot for each thread
+            map.set(i, i * 42);
+
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(i * 42, map.get());
+                EXPECT_EQ(i, map.findIndex());
+            }
+
+            map.eraseAt(i);
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}


### PR DESCRIPTION
Our goal is to significantly reduce calls into the kernel (i.e. locks when they block, condition's wait and notify). Blocking calls make JobSystem prone to priority inversions in addition to cost a large amount of CPU compared to the actual work done in jobs.

So there are two main set of changes. Some  remove uses of lock altogether by using lockless primitives when possible, another set avoids calls to wakeOne().  Each change has it own small-ish CL.