### PR TITLE
JobSystem optimizations

### DIFF
--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -306,7 +306,7 @@ void FScene::prepare(JobSystem& js,
 
     auto* lightJob = parallel_for(js, rootJob,
             lightInstances.data(), lightInstances.size(),
-            std::cref(lightWork), jobs::CountSplitter<32, 5>());
+            std::cref(lightWork), jobs::CountSplitter<32>());
 
     js.run(renderableJob);
     js.run(lightJob);

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -15,13 +15,12 @@
  */
 
 
-#include <ibl/CubemapIBL.h>
+#include "CubemapUtilsImpl.h"
 
 #include <ibl/Cubemap.h>
+#include <ibl/CubemapIBL.h>
 #include <ibl/CubemapUtils.h>
 #include <ibl/utilities.h>
-
-#include "CubemapUtilsImpl.h"
 
 #include <utils/JobSystem.h>
 
@@ -1032,7 +1031,7 @@ void CubemapIBL::DFG(JobSystem& js, Image& dst, bool multiscatter, bool cloth) {
                         *data = r;
                     }
                 }
-            }, jobs::CountSplitter<1, 8>());
+            }, jobs::CountSplitter<1>());
     js.runAndWait(job);
 }
 

--- a/libs/ibl/src/CubemapUtils.cpp
+++ b/libs/ibl/src/CubemapUtils.cpp
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <ibl/CubemapUtils.h>
-
 #include "CubemapUtilsImpl.h"
 
+#include <ibl/CubemapUtils.h>
 #include <ibl/utilities.h>
 
 #include <utils/JobSystem.h>
@@ -263,7 +262,7 @@ void CubemapUtils::cubemapToEquirectangular(JobSystem& js, Image& dst, const Cub
     };
 
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
-            std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
+            std::ref(parallelJobTask), jobs::CountSplitter<1>());
     js.runAndWait(job);
 }
 
@@ -297,7 +296,7 @@ void CubemapUtils::cubemapToOctahedron(JobSystem& js, Image& dst, const Cubemap&
     };
 
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
-            std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
+            std::ref(parallelJobTask), jobs::CountSplitter<1>());
     js.runAndWait(job);
 }
 

--- a/libs/ibl/src/CubemapUtilsImpl.h
+++ b/libs/ibl/src/CubemapUtilsImpl.h
@@ -64,7 +64,7 @@ void CubemapUtils::process(
             if (UTILS_LIKELY(isStateLess)) {
                 // create the job, copying it by value
                 auto job = jobs::parallel_for(js, parent, 0, uint32_t(dim),
-                        parallelJobTask, jobs::CountSplitter<64, 8>());
+                        parallelJobTask, jobs::CountSplitter<64>());
                 // not need to signal here, since we're just scheduling work
                 js.run(job);
             } else {

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -229,6 +229,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_BinaryTreeArray.cpp
             test/test_Status.cpp
             test/test_Mutex.cpp
+            test/test_ThreadMap.cpp
     )
 
     if (WASM_PTHREADS)

--- a/libs/utils/include/private/utils/ThreadMap.h
+++ b/libs/utils/include/private/utils/ThreadMap.h
@@ -44,11 +44,12 @@ namespace utils {
  * association without relying on compiler-dependent thread_local storage (which is
  * problematic on some platforms and dynamic libraries).
  *
- * Sized dynamically at construction time, thread IDs and values are stored in
- * cache-line-packed arrays synchronized via an atomic 3-state slot lifecycle (EMPTY, WRITING, VALID).
- * Lookups perform a linear scan over the capacity. For typical thread counts (e.g. <= 32-64
- * threads), all thread IDs fit in 1-4 L1 cache lines, allowing lookups to complete in ~1-2
- * nanoseconds without any mutex locking or hash table overhead on the critical path.
+ * Sized dynamically at construction time, entries are stored in a contiguous array of
+ * structures (AoS) synchronized via a seqlock version counter and atomic 3-state slot lifecycle
+ * (EMPTY, WRITING, VALID). Lookups perform a linear scan over the capacity. For typical thread
+ * counts (e.g. <= 32-64 threads), the entire map fits in 12-24 L1 cache lines, allowing lookups
+ * to complete in ~1-2 nanoseconds without any mutex locking or hash table overhead on the
+ * critical path.
  *
  * Usage Example:
  * --------------
@@ -74,7 +75,7 @@ namespace utils {
  * threadMap.erase(); // unregisters std::this_thread::get_id()
  */
 template <typename VALUE>
-class UTILS_PUBLIC ThreadMap {
+class ThreadMap {
 public:
     using value_type = VALUE;
     using size_type = uint32_t;
@@ -88,49 +89,34 @@ public:
         VALID = 2
     };
 
+    struct Entry {
+        std::atomic<uint32_t> version{0};
+        std::atomic<SlotState> state{SlotState::EMPTY};
+        std::atomic<key_type> tid{};
+        value_type value{};
+    };
+
     /**
      * Constructs a ThreadMap with the specified maximum thread capacity.
      *
      * @param capacity Maximum number of threads that can be registered simultaneously.
      * @note Not thread-safe. Standard C++ object lifecycle rules apply.
      */
-    explicit ThreadMap(size_type const capacity = 0)
-            : mCapacity(capacity),
-              mStates(capacity ? new std::atomic<SlotState>[capacity]{} : nullptr),
-              mThreadIds(capacity ? new key_type[capacity]{} : nullptr),
-              mValues(capacity ? new value_type[capacity]{} : nullptr) {
-    }
-
-    ~ThreadMap() = default;
+    explicit ThreadMap(size_type capacity = 0);
+    ~ThreadMap();
 
     ThreadMap(const ThreadMap&) = delete;
     ThreadMap& operator=(const ThreadMap&) = delete;
 
-    ThreadMap(ThreadMap&& rhs) noexcept
-            : mCapacity(std::exchange(rhs.mCapacity, 0)),
-              mStates(std::move(rhs.mStates)),
-              mThreadIds(std::move(rhs.mThreadIds)),
-              mValues(std::move(rhs.mValues)) {
-    }
-
-    ThreadMap& operator=(ThreadMap&& rhs) noexcept {
-        if (this != &rhs) {
-            mCapacity = std::exchange(rhs.mCapacity, 0);
-            mStates = std::move(rhs.mStates);
-            mThreadIds = std::move(rhs.mThreadIds);
-            mValues = std::move(rhs.mValues);
-        }
-        return *this;
-    }
+    ThreadMap(ThreadMap&& rhs) noexcept;
+    ThreadMap& operator=(ThreadMap&& rhs) noexcept;
 
     /**
      * Returns the maximum thread capacity.
      *
      * @note Thread-safe (wait-free, read-only).
      */
-    size_type getCapacity() const noexcept {
-        return mCapacity;
-    }
+    size_type getCapacity() const noexcept;
 
     /**
      * Associates the specified slot index with a thread ID and value.
@@ -141,15 +127,8 @@ public:
      * @note Thread-safe (wait-free) across distinct slot indices and against concurrent readers.
      *       Concurrent calls to set() with the same slot index are not thread-safe.
      */
-    void set(size_type const index, value_type value,
-            key_type const tid = std::this_thread::get_id()) noexcept {
-        assert_invariant(index < mCapacity);
-        assert_invariant(tid != key_type{});
-        mStates[index].store(SlotState::WRITING, std::memory_order_release);
-        mThreadIds[index] = tid;
-        mValues[index] = std::move(value);
-        mStates[index].store(SlotState::VALID, std::memory_order_release);
-    }
+    void set(size_type index, value_type value,
+            key_type tid = std::this_thread::get_id()) noexcept;
 
     /**
      * Registers a thread into the first available (empty) slot.
@@ -160,31 +139,7 @@ public:
      * @note Thread-safe (lock-free). Multiple threads may call emplace() concurrently.
      */
     size_type emplace(value_type value,
-            key_type const tid = std::this_thread::get_id()) noexcept {
-        assert_invariant(tid != key_type{});
-        for (size_type i = 0; i < mCapacity; ++i) {
-            SlotState expected = SlotState::EMPTY;
-            if (mStates[i].compare_exchange_strong(expected, SlotState::WRITING,
-                    std::memory_order_acquire, std::memory_order_relaxed)) {
-                mThreadIds[i] = tid;
-                mValues[i] = std::move(value);
-                mStates[i].store(SlotState::VALID, std::memory_order_release);
-                return i;
-            }
-            if (expected == SlotState::VALID &&
-                mStates[i].load(std::memory_order_acquire) == SlotState::VALID &&
-                mThreadIds[i] == tid) {
-                SlotState stateExpected = SlotState::VALID;
-                if (mStates[i].compare_exchange_strong(stateExpected, SlotState::WRITING,
-                        std::memory_order_acquire, std::memory_order_relaxed)) {
-                    mValues[i] = std::move(value);
-                    mStates[i].store(SlotState::VALID, std::memory_order_release);
-                    return i;
-                }
-            }
-        }
-        return INVALID_INDEX;
-    }
+            key_type tid = std::this_thread::get_id()) noexcept;
 
     /**
      * Finds the pointer to the value associated with the specified thread ID.
@@ -194,10 +149,10 @@ public:
      * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
      *       mutates or erases that specific slot is not thread-safe.
      */
-    value_type* find(key_type const tid = std::this_thread::get_id()) noexcept {
+    inline value_type* find(key_type const tid = std::this_thread::get_id()) noexcept {
         size_type const idx = findIndex(tid);
-        if (idx != INVALID_INDEX && mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
-            return &mValues[idx];
+        if (idx != INVALID_INDEX) {
+            return &mEntries[idx].value;
         }
         return nullptr;
     }
@@ -210,10 +165,10 @@ public:
      * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
      *       mutates or erases that specific slot is not thread-safe.
      */
-    const value_type* find(key_type const tid = std::this_thread::get_id()) const noexcept {
+    inline const value_type* find(key_type const tid = std::this_thread::get_id()) const noexcept {
         size_type const idx = findIndex(tid);
-        if (idx != INVALID_INDEX && mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
-            return &mValues[idx];
+        if (idx != INVALID_INDEX) {
+            return &mEntries[idx].value;
         }
         return nullptr;
     }
@@ -227,12 +182,29 @@ public:
      * @note Thread-safe (wait-free). Safe to call concurrently with all mutating operations
      *       for pointer or trivially copyable value types.
      */
-    value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
-        size_type const idx = findIndex(tid);
-        if (idx != INVALID_INDEX) {
-            value_type val = mValues[idx];
-            if (mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
-                return val;
+    inline value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
+        if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
+            return value_type{};
+        }
+        for (size_type i = 0; i < mCapacity; ++i) {
+            Entry const& entry = mEntries[i];
+            for (int retry = 0; retry < 64; ++retry) {
+                uint32_t const v1 = entry.version.load(std::memory_order_acquire);
+                if (v1 & 1) {
+                    continue;
+                }
+                if (entry.state.load(std::memory_order_acquire) != SlotState::VALID) {
+                    break;
+                }
+                if (entry.tid.load(std::memory_order_relaxed) != tid) {
+                    break;
+                }
+                value_type val = entry.value;
+                uint32_t const v2 = entry.version.load(std::memory_order_acquire);
+                if (v1 == v2 && entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
+                    entry.tid.load(std::memory_order_relaxed) == tid) {
+                    return val;
+                }
             }
         }
         return value_type{};
@@ -245,13 +217,26 @@ public:
      * @return The slot index if found, or INVALID_INDEX if not registered.
      * @note Thread-safe (wait-free).
      */
-    size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
+    inline size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
         if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
             return INVALID_INDEX;
         }
         for (size_type i = 0; i < mCapacity; ++i) {
-            if (mStates[i].load(std::memory_order_acquire) == SlotState::VALID) {
-                if (UTILS_LIKELY(mThreadIds[i] == tid)) {
+            Entry const& entry = mEntries[i];
+            for (int retry = 0; retry < 64; ++retry) {
+                uint32_t const v1 = entry.version.load(std::memory_order_acquire);
+                if (v1 & 1) {
+                    continue;
+                }
+                if (entry.state.load(std::memory_order_acquire) != SlotState::VALID) {
+                    break;
+                }
+                if (entry.tid.load(std::memory_order_relaxed) != tid) {
+                    break;
+                }
+                uint32_t const v2 = entry.version.load(std::memory_order_acquire);
+                if (v1 == v2 && entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
+                    entry.tid.load(std::memory_order_relaxed) == tid) {
                     return i;
                 }
             }
@@ -265,7 +250,7 @@ public:
      * @param tid The thread ID to check (defaults to current thread).
      * @note Thread-safe (wait-free).
      */
-    bool contains(key_type const tid = std::this_thread::get_id()) const noexcept {
+    inline bool contains(key_type const tid = std::this_thread::get_id()) const noexcept {
         return findIndex(tid) != INVALID_INDEX;
     }
 
@@ -276,13 +261,7 @@ public:
      * @return true if the thread was found and unregistered, false otherwise.
      * @note Thread-safe (lock-free).
      */
-    bool erase(key_type const tid = std::this_thread::get_id()) noexcept {
-        size_type const idx = findIndex(tid);
-        if (idx != INVALID_INDEX) {
-            return eraseAt(idx);
-        }
-        return false;
-    }
+    bool erase(key_type tid = std::this_thread::get_id()) noexcept;
 
     /**
      * Unregisters the thread at a specific slot index.
@@ -291,60 +270,182 @@ public:
      * @return true if the slot was valid and cleared, false otherwise.
      * @note Thread-safe (lock-free).
      */
-    bool eraseAt(size_type const index) noexcept {
-        assert_invariant(index < mCapacity);
-        SlotState expected = SlotState::VALID;
-        if (mStates[index].compare_exchange_strong(expected, SlotState::WRITING,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
-            mThreadIds[index] = key_type{};
-            mValues[index] = value_type{};
-            mStates[index].store(SlotState::EMPTY, std::memory_order_release);
-            return true;
-        }
-        return false;
-    }
+    bool eraseAt(size_type index) noexcept;
 
     /**
      * Clears all registered threads from the map.
      *
      * @note Thread-safe (lock-free).
      */
-    void clear() noexcept {
-        for (size_type i = 0; i < mCapacity; ++i) {
-            eraseAt(i);
-        }
-    }
+    void clear() noexcept;
 
     /**
      * Returns the number of currently registered threads.
      *
      * @note Thread-safe (wait-free). Returns an instantaneous snapshot count.
      */
-    size_type size() const noexcept {
-        size_type count = 0;
-        for (size_type i = 0; i < mCapacity; ++i) {
-            if (mStates[i].load(std::memory_order_relaxed) == SlotState::VALID) {
-                ++count;
-            }
-        }
-        return count;
-    }
+    size_type size() const noexcept;
 
     /**
      * Returns true if no threads are currently registered.
      *
      * @note Thread-safe (wait-free).
      */
-    bool empty() const noexcept {
-        return size() == 0;
-    }
+    bool empty() const noexcept;
 
 private:
     size_type mCapacity = 0;
-    std::unique_ptr<std::atomic<SlotState>[]> mStates;
-    std::unique_ptr<key_type[]> mThreadIds;
-    std::unique_ptr<value_type[]> mValues;
+    std::unique_ptr<Entry[]> mEntries;
 };
+
+// ------------------------------------------------------------------------------------------------
+// Out-of-line method definitions
+// ------------------------------------------------------------------------------------------------
+
+template <typename VALUE>
+ThreadMap<VALUE>::ThreadMap(size_type const capacity)
+        : mCapacity(capacity),
+          mEntries(capacity ? std::make_unique<Entry[]>(capacity) : nullptr) {
+}
+
+template <typename VALUE>
+ThreadMap<VALUE>::~ThreadMap() = default;
+
+template <typename VALUE>
+ThreadMap<VALUE>::ThreadMap(ThreadMap&& rhs) noexcept
+        : mCapacity(std::exchange(rhs.mCapacity, 0)),
+          mEntries(std::move(rhs.mEntries)) {
+}
+
+template <typename VALUE>
+ThreadMap<VALUE>& ThreadMap<VALUE>::operator=(ThreadMap&& rhs) noexcept {
+    if (this != &rhs) {
+        mCapacity = std::exchange(rhs.mCapacity, 0);
+        mEntries = std::move(rhs.mEntries);
+    }
+    return *this;
+}
+
+template <typename VALUE>
+typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::getCapacity() const noexcept {
+    return mCapacity;
+}
+
+template <typename VALUE>
+void ThreadMap<VALUE>::set(size_type const index, value_type value, key_type const tid) noexcept {
+    assert_invariant(index < mCapacity);
+    assert_invariant(tid != key_type{});
+
+    Entry& entry = mEntries[index];
+    entry.version.fetch_add(1, std::memory_order_acq_rel);
+    entry.state.store(SlotState::WRITING, std::memory_order_release);
+
+    entry.tid.store(tid, std::memory_order_relaxed);
+    entry.value = std::move(value);
+
+    entry.state.store(SlotState::VALID, std::memory_order_release);
+    entry.version.fetch_add(1, std::memory_order_release);
+}
+
+template <typename VALUE>
+typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::emplace(value_type value,
+        key_type const tid) noexcept {
+    assert_invariant(tid != key_type{});
+
+    while (true) {
+        bool writingObserved = false;
+        for (size_type i = 0; i < mCapacity; ++i) {
+            Entry& entry = mEntries[i];
+            SlotState expected = SlotState::EMPTY;
+            if (entry.state.compare_exchange_strong(expected, SlotState::WRITING,
+                    std::memory_order_acquire, std::memory_order_relaxed)) {
+                entry.version.fetch_add(1, std::memory_order_acq_rel);
+
+                entry.tid.store(tid, std::memory_order_relaxed);
+                entry.value = std::move(value);
+
+                entry.state.store(SlotState::VALID, std::memory_order_release);
+                entry.version.fetch_add(1, std::memory_order_release);
+                return i;
+            }
+            if (expected == SlotState::VALID &&
+                entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
+                entry.tid.load(std::memory_order_relaxed) == tid) {
+                SlotState stateExpected = SlotState::VALID;
+                if (entry.state.compare_exchange_strong(stateExpected, SlotState::WRITING,
+                        std::memory_order_acquire, std::memory_order_relaxed)) {
+                    entry.version.fetch_add(1, std::memory_order_acq_rel);
+
+                    entry.value = std::move(value);
+
+                    entry.state.store(SlotState::VALID, std::memory_order_release);
+                    entry.version.fetch_add(1, std::memory_order_release);
+                    return i;
+                }
+            }
+            if (expected == SlotState::WRITING ||
+                entry.state.load(std::memory_order_relaxed) == SlotState::WRITING) {
+                writingObserved = true;
+            }
+        }
+        if (!writingObserved) {
+            return INVALID_INDEX;
+        }
+        std::this_thread::yield();
+    }
+}
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::erase(key_type const tid) noexcept {
+    size_type const idx = findIndex(tid);
+    if (idx != INVALID_INDEX) {
+        return eraseAt(idx);
+    }
+    return false;
+}
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::eraseAt(size_type const index) noexcept {
+    assert_invariant(index < mCapacity);
+
+    Entry& entry = mEntries[index];
+    SlotState expected = SlotState::VALID;
+    if (entry.state.compare_exchange_strong(expected, SlotState::WRITING,
+            std::memory_order_acquire, std::memory_order_relaxed)) {
+        entry.version.fetch_add(1, std::memory_order_acq_rel);
+
+        entry.tid.store(key_type{}, std::memory_order_relaxed);
+        entry.value = value_type{};
+
+        entry.state.store(SlotState::EMPTY, std::memory_order_release);
+        entry.version.fetch_add(1, std::memory_order_release);
+        return true;
+    }
+    return false;
+}
+
+template <typename VALUE>
+void ThreadMap<VALUE>::clear() noexcept {
+    for (size_type i = 0; i < mCapacity; ++i) {
+        eraseAt(i);
+    }
+}
+
+template <typename VALUE>
+typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::size() const noexcept {
+    size_type count = 0;
+    for (size_type i = 0; i < mCapacity; ++i) {
+        if (mEntries[i].state.load(std::memory_order_relaxed) == SlotState::VALID) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::empty() const noexcept {
+    return size() == 0;
+}
 
 } // namespace utils
 

--- a/libs/utils/include/private/utils/ThreadMap.h
+++ b/libs/utils/include/private/utils/ThreadMap.h
@@ -73,6 +73,19 @@ namespace utils {
  *
  * // When shutting down or when a thread exits:
  * threadMap.erase(); // unregisters std::this_thread::get_id()
+ *
+ * Thread Safety & ThreadSanitizer (TSAN):
+ * ---------------------------------------
+ * ThreadMap uses an optimistic seqlock protocol. Readers (get(), findIndex()) speculatively read
+ * non-atomic slot payload data (Entry::value) concurrently with mutating operations (set(),
+ * emplace(), eraseAt()). Consistency is validated via the version counter (Entry::version) and
+ * acquire/release memory fences. If a concurrent write occurs during the read, the version
+ * mismatch or odd parity is detected and the speculative payload is discarded.
+ *
+ * In the formal C++ memory model, concurrent non-atomic reads and writes constitute a data race.
+ * Because ThreadSanitizer (TSAN) cannot infer seqlock version validation and would otherwise flag
+ * these benign optimistic reads as fatal data races, seqlock methods are annotated with
+ * UTILS_NO_SANITIZE_THREAD.
  */
 template <typename VALUE>
 class ThreadMap {
@@ -127,6 +140,7 @@ public:
      * @note Thread-safe (wait-free) across distinct slot indices and against concurrent readers.
      *       Concurrent calls to set() with the same slot index are not thread-safe.
      */
+    UTILS_NO_SANITIZE_THREAD
     void set(size_type index, value_type value,
             key_type tid = std::this_thread::get_id()) noexcept;
 
@@ -138,6 +152,7 @@ public:
      * @return The slot index where the thread was registered, or INVALID_INDEX if full.
      * @note Thread-safe (lock-free). Multiple threads may call emplace() concurrently.
      */
+    UTILS_NO_SANITIZE_THREAD
     size_type emplace(value_type value,
             key_type tid = std::this_thread::get_id()) noexcept;
 
@@ -149,6 +164,7 @@ public:
      * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
      *       mutates or erases that specific slot is not thread-safe.
      */
+    UTILS_NO_SANITIZE_THREAD
     inline value_type* find(key_type const tid = std::this_thread::get_id()) noexcept {
         size_type const idx = findIndex(tid);
         if (idx != INVALID_INDEX) {
@@ -165,6 +181,7 @@ public:
      * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
      *       mutates or erases that specific slot is not thread-safe.
      */
+    UTILS_NO_SANITIZE_THREAD
     inline const value_type* find(key_type const tid = std::this_thread::get_id()) const noexcept {
         size_type const idx = findIndex(tid);
         if (idx != INVALID_INDEX) {
@@ -180,9 +197,15 @@ public:
      * @param tid The thread ID to look up (defaults to current thread).
      * @return The associated value, or value_type{} if not found.
      * @note Thread-safe (wait-free). Safe to call concurrently with all mutating operations
-     *       for pointer or trivially copyable value types.
+     *       for pointer or trivially copyable value types. Uses an optimistic seqlock loop
+     *       with a bounded number of retries (64). If a concurrent writer continuously
+     *       mutates the targeted slot across all retries, get() will return value_type{}
+     *       (spurious miss) rather than blocking.
      */
+    UTILS_NO_SANITIZE_THREAD
     inline value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
+        static_assert(std::is_trivially_copyable_v<VALUE>,
+                "get() requires VALUE to be trivially copyable for wait-free concurrent read safety");
         if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
             return value_type{};
         }
@@ -193,15 +216,16 @@ public:
                 if (v1 & 1) {
                     continue;
                 }
-                if (entry.state.load(std::memory_order_acquire) != SlotState::VALID) {
+                if (entry.state.load(std::memory_order_relaxed) != SlotState::VALID) {
                     break;
                 }
                 if (entry.tid.load(std::memory_order_relaxed) != tid) {
                     break;
                 }
                 value_type val = entry.value;
-                uint32_t const v2 = entry.version.load(std::memory_order_acquire);
-                if (v1 == v2 && entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
+                std::atomic_thread_fence(std::memory_order_acquire);
+                uint32_t const v2 = entry.version.load(std::memory_order_relaxed);
+                if (v1 == v2 && entry.state.load(std::memory_order_relaxed) == SlotState::VALID &&
                     entry.tid.load(std::memory_order_relaxed) == tid) {
                     return val;
                 }
@@ -215,8 +239,11 @@ public:
      *
      * @param tid The thread ID to look up (defaults to current thread).
      * @return The slot index if found, or INVALID_INDEX if not registered.
-     * @note Thread-safe (wait-free).
+     * @note Thread-safe (wait-free). Uses an optimistic seqlock loop with a bounded number of
+     *       retries (64). If a concurrent writer continuously mutates the targeted slot across
+     *       all retries, findIndex() will return INVALID_INDEX (spurious miss) rather than blocking.
      */
+    UTILS_NO_SANITIZE_THREAD
     inline size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
         if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
             return INVALID_INDEX;
@@ -228,14 +255,15 @@ public:
                 if (v1 & 1) {
                     continue;
                 }
-                if (entry.state.load(std::memory_order_acquire) != SlotState::VALID) {
+                if (entry.state.load(std::memory_order_relaxed) != SlotState::VALID) {
                     break;
                 }
                 if (entry.tid.load(std::memory_order_relaxed) != tid) {
                     break;
                 }
-                uint32_t const v2 = entry.version.load(std::memory_order_acquire);
-                if (v1 == v2 && entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
+                std::atomic_thread_fence(std::memory_order_acquire);
+                uint32_t const v2 = entry.version.load(std::memory_order_relaxed);
+                if (v1 == v2 && entry.state.load(std::memory_order_relaxed) == SlotState::VALID &&
                     entry.tid.load(std::memory_order_relaxed) == tid) {
                     return i;
                 }
@@ -261,6 +289,7 @@ public:
      * @return true if the thread was found and unregistered, false otherwise.
      * @note Thread-safe (lock-free).
      */
+    UTILS_NO_SANITIZE_THREAD
     bool erase(key_type tid = std::this_thread::get_id()) noexcept;
 
     /**
@@ -270,6 +299,7 @@ public:
      * @return true if the slot was valid and cleared, false otherwise.
      * @note Thread-safe (lock-free).
      */
+    UTILS_NO_SANITIZE_THREAD
     bool eraseAt(size_type index) noexcept;
 
     /**
@@ -332,6 +362,7 @@ typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::getCapacity() const noexc
 }
 
 template <typename VALUE>
+UTILS_NO_SANITIZE_THREAD
 void ThreadMap<VALUE>::set(size_type const index, value_type value, key_type const tid) noexcept {
     assert_invariant(index < mCapacity);
     assert_invariant(tid != key_type{});
@@ -348,6 +379,7 @@ void ThreadMap<VALUE>::set(size_type const index, value_type value, key_type con
 }
 
 template <typename VALUE>
+UTILS_NO_SANITIZE_THREAD
 typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::emplace(value_type value,
         key_type const tid) noexcept {
     assert_invariant(tid != key_type{});
@@ -370,10 +402,15 @@ typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::emplace(value_type value,
             }
             if (expected == SlotState::VALID &&
                 entry.state.load(std::memory_order_acquire) == SlotState::VALID &&
-                entry.tid.load(std::memory_order_relaxed) == tid) {
+                entry.tid.load(std::memory_order_acquire) == tid) {
                 SlotState stateExpected = SlotState::VALID;
                 if (entry.state.compare_exchange_strong(stateExpected, SlotState::WRITING,
                         std::memory_order_acquire, std::memory_order_relaxed)) {
+                    if (entry.tid.load(std::memory_order_relaxed) != tid) {
+                        // ABA: slot was erased and claimed by another thread before our CAS.
+                        entry.state.store(SlotState::VALID, std::memory_order_release);
+                        continue;
+                    }
                     entry.version.fetch_add(1, std::memory_order_acq_rel);
 
                     entry.value = std::move(value);
@@ -396,15 +433,34 @@ typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::emplace(value_type value,
 }
 
 template <typename VALUE>
+UTILS_NO_SANITIZE_THREAD
 bool ThreadMap<VALUE>::erase(key_type const tid) noexcept {
     size_type const idx = findIndex(tid);
     if (idx != INVALID_INDEX) {
-        return eraseAt(idx);
+        Entry& entry = mEntries[idx];
+        SlotState expected = SlotState::VALID;
+        if (entry.state.compare_exchange_strong(expected, SlotState::WRITING,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            if (entry.tid.load(std::memory_order_relaxed) != tid) {
+                // ABA: slot was erased and claimed by another thread before our CAS.
+                entry.state.store(SlotState::VALID, std::memory_order_release);
+                return false;
+            }
+            entry.version.fetch_add(1, std::memory_order_acq_rel);
+
+            entry.tid.store(key_type{}, std::memory_order_relaxed);
+            entry.value = value_type{};
+
+            entry.version.fetch_add(1, std::memory_order_release);
+            entry.state.store(SlotState::EMPTY, std::memory_order_release);
+            return true;
+        }
     }
     return false;
 }
 
 template <typename VALUE>
+UTILS_NO_SANITIZE_THREAD
 bool ThreadMap<VALUE>::eraseAt(size_type const index) noexcept {
     assert_invariant(index < mCapacity);
 
@@ -417,8 +473,8 @@ bool ThreadMap<VALUE>::eraseAt(size_type const index) noexcept {
         entry.tid.store(key_type{}, std::memory_order_relaxed);
         entry.value = value_type{};
 
-        entry.state.store(SlotState::EMPTY, std::memory_order_release);
         entry.version.fetch_add(1, std::memory_order_release);
+        entry.state.store(SlotState::EMPTY, std::memory_order_release);
         return true;
     }
     return false;

--- a/libs/utils/include/private/utils/ThreadMap.h
+++ b/libs/utils/include/private/utils/ThreadMap.h
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_THREADMAP_H
+#define TNT_UTILS_THREADMAP_H
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Panic.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+#include <assert.h>
+#include <stdint.h>
+
+namespace utils {
+
+/**
+ * ThreadMap is a bounded-capacity, lock-free and wait-free associative mapping from
+ * std::thread::id to a value of type T (such as pointers, handles, or small structs).
+ *
+ * Designed for high-performance multithreading subsystems (such as job systems, thread pools,
+ * and memory allocators) where a small, bounded number of threads need fast thread-local
+ * association without relying on compiler-dependent thread_local storage (which is
+ * problematic on some platforms and dynamic libraries).
+ *
+ * Sized dynamically at construction time, thread IDs and values are stored in
+ * cache-line-packed arrays synchronized via an atomic 3-state slot lifecycle (EMPTY, WRITING, VALID).
+ * Lookups perform a linear scan over the capacity. For typical thread counts (e.g. <= 32-64
+ * threads), all thread IDs fit in 1-4 L1 cache lines, allowing lookups to complete in ~1-2
+ * nanoseconds without any mutex locking or hash table overhead on the critical path.
+ *
+ * Usage Example:
+ * --------------
+ *
+ * struct WorkerState {
+ *     int workerId;
+ *     WorkQueue queue;
+ * };
+ *
+ * // Create a map with capacity for 8 threads
+ * utils::ThreadMap<WorkerState*> threadMap(8);
+ *
+ * // In each worker thread:
+ * threadMap.set(slotIndex, &localState);
+ *
+ * // Later, in any worker or caller thread:
+ * WorkerState* state = threadMap.get(); // looks up std::this_thread::get_id()
+ * if (state) {
+ *     state->queue.push(...);
+ * }
+ *
+ * // When shutting down or when a thread exits:
+ * threadMap.erase(); // unregisters std::this_thread::get_id()
+ */
+template <typename VALUE>
+class UTILS_PUBLIC ThreadMap {
+public:
+    using value_type = VALUE;
+    using size_type = uint32_t;
+    using key_type = std::thread::id;
+
+    static constexpr size_type INVALID_INDEX = std::numeric_limits<size_type>::max();
+
+    enum class SlotState : uint8_t {
+        EMPTY = 0,
+        WRITING = 1,
+        VALID = 2
+    };
+
+    /**
+     * Constructs a ThreadMap with the specified maximum thread capacity.
+     *
+     * @param capacity Maximum number of threads that can be registered simultaneously.
+     * @note Not thread-safe. Standard C++ object lifecycle rules apply.
+     */
+    explicit ThreadMap(size_type const capacity = 0)
+            : mCapacity(capacity),
+              mStates(capacity ? new std::atomic<SlotState>[capacity]{} : nullptr),
+              mThreadIds(capacity ? new key_type[capacity]{} : nullptr),
+              mValues(capacity ? new value_type[capacity]{} : nullptr) {
+    }
+
+    ~ThreadMap() = default;
+
+    ThreadMap(const ThreadMap&) = delete;
+    ThreadMap& operator=(const ThreadMap&) = delete;
+
+    ThreadMap(ThreadMap&& rhs) noexcept
+            : mCapacity(std::exchange(rhs.mCapacity, 0)),
+              mStates(std::move(rhs.mStates)),
+              mThreadIds(std::move(rhs.mThreadIds)),
+              mValues(std::move(rhs.mValues)) {
+    }
+
+    ThreadMap& operator=(ThreadMap&& rhs) noexcept {
+        if (this != &rhs) {
+            mCapacity = std::exchange(rhs.mCapacity, 0);
+            mStates = std::move(rhs.mStates);
+            mThreadIds = std::move(rhs.mThreadIds);
+            mValues = std::move(rhs.mValues);
+        }
+        return *this;
+    }
+
+    /**
+     * Returns the maximum thread capacity.
+     *
+     * @note Thread-safe (wait-free, read-only).
+     */
+    size_type getCapacity() const noexcept {
+        return mCapacity;
+    }
+
+    /**
+     * Associates the specified slot index with a thread ID and value.
+     *
+     * @param index Slot index (must be < getCapacity()).
+     * @param value The value to associate with the thread.
+     * @param tid The thread ID (defaults to the current calling thread).
+     * @note Thread-safe (wait-free) across distinct slot indices and against concurrent readers.
+     *       Concurrent calls to set() with the same slot index are not thread-safe.
+     */
+    void set(size_type const index, value_type value,
+            key_type const tid = std::this_thread::get_id()) noexcept {
+        assert_invariant(index < mCapacity);
+        assert_invariant(tid != key_type{});
+        mStates[index].store(SlotState::WRITING, std::memory_order_release);
+        mThreadIds[index] = tid;
+        mValues[index] = std::move(value);
+        mStates[index].store(SlotState::VALID, std::memory_order_release);
+    }
+
+    /**
+     * Registers a thread into the first available (empty) slot.
+     *
+     * @param value The value to associate with the thread.
+     * @param tid The thread ID (defaults to the current calling thread).
+     * @return The slot index where the thread was registered, or INVALID_INDEX if full.
+     * @note Thread-safe (lock-free). Multiple threads may call emplace() concurrently.
+     */
+    size_type emplace(value_type value,
+            key_type const tid = std::this_thread::get_id()) noexcept {
+        assert_invariant(tid != key_type{});
+        for (size_type i = 0; i < mCapacity; ++i) {
+            SlotState expected = SlotState::EMPTY;
+            if (mStates[i].compare_exchange_strong(expected, SlotState::WRITING,
+                    std::memory_order_acquire, std::memory_order_relaxed)) {
+                mThreadIds[i] = tid;
+                mValues[i] = std::move(value);
+                mStates[i].store(SlotState::VALID, std::memory_order_release);
+                return i;
+            }
+            if (expected == SlotState::VALID &&
+                mStates[i].load(std::memory_order_acquire) == SlotState::VALID &&
+                mThreadIds[i] == tid) {
+                SlotState stateExpected = SlotState::VALID;
+                if (mStates[i].compare_exchange_strong(stateExpected, SlotState::WRITING,
+                        std::memory_order_acquire, std::memory_order_relaxed)) {
+                    mValues[i] = std::move(value);
+                    mStates[i].store(SlotState::VALID, std::memory_order_release);
+                    return i;
+                }
+            }
+        }
+        return INVALID_INDEX;
+    }
+
+    /**
+     * Finds the pointer to the value associated with the specified thread ID.
+     *
+     * @param tid The thread ID to look up (defaults to the current calling thread).
+     * @return Pointer to the stored value if found, or nullptr if not found.
+     * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
+     *       mutates or erases that specific slot is not thread-safe.
+     */
+    value_type* find(key_type const tid = std::this_thread::get_id()) noexcept {
+        size_type const idx = findIndex(tid);
+        if (idx != INVALID_INDEX && mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
+            return &mValues[idx];
+        }
+        return nullptr;
+    }
+
+    /**
+     * Finds the const pointer to the value associated with the specified thread ID.
+     *
+     * @param tid The thread ID to look up (defaults to the current calling thread).
+     * @return Const pointer to the stored value if found, or nullptr if not found.
+     * @note Thread-safe (wait-free). Dereferencing the returned pointer while another thread
+     *       mutates or erases that specific slot is not thread-safe.
+     */
+    const value_type* find(key_type const tid = std::this_thread::get_id()) const noexcept {
+        size_type const idx = findIndex(tid);
+        if (idx != INVALID_INDEX && mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
+            return &mValues[idx];
+        }
+        return nullptr;
+    }
+
+    /**
+     * Retrieves the value associated with the specified thread ID.
+     * Convenience method when value_type is a pointer or default-constructible type.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The associated value, or value_type{} if not found.
+     * @note Thread-safe (wait-free). Safe to call concurrently with all mutating operations
+     *       for pointer or trivially copyable value types.
+     */
+    value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
+        size_type const idx = findIndex(tid);
+        if (idx != INVALID_INDEX) {
+            value_type val = mValues[idx];
+            if (mStates[idx].load(std::memory_order_acquire) == SlotState::VALID) {
+                return val;
+            }
+        }
+        return value_type{};
+    }
+
+    /**
+     * Finds the slot index of the specified thread ID.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The slot index if found, or INVALID_INDEX if not registered.
+     * @note Thread-safe (wait-free).
+     */
+    size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
+        if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
+            return INVALID_INDEX;
+        }
+        for (size_type i = 0; i < mCapacity; ++i) {
+            if (mStates[i].load(std::memory_order_acquire) == SlotState::VALID) {
+                if (UTILS_LIKELY(mThreadIds[i] == tid)) {
+                    return i;
+                }
+            }
+        }
+        return INVALID_INDEX;
+    }
+
+    /**
+     * Returns true if the specified thread is registered in this map.
+     *
+     * @param tid The thread ID to check (defaults to current thread).
+     * @note Thread-safe (wait-free).
+     */
+    bool contains(key_type const tid = std::this_thread::get_id()) const noexcept {
+        return findIndex(tid) != INVALID_INDEX;
+    }
+
+    /**
+     * Unregisters the specified thread ID from the map and resets its slot to empty.
+     *
+     * @param tid The thread ID to unregister (defaults to current thread).
+     * @return true if the thread was found and unregistered, false otherwise.
+     * @note Thread-safe (lock-free).
+     */
+    bool erase(key_type const tid = std::this_thread::get_id()) noexcept {
+        size_type const idx = findIndex(tid);
+        if (idx != INVALID_INDEX) {
+            return eraseAt(idx);
+        }
+        return false;
+    }
+
+    /**
+     * Unregisters the thread at a specific slot index.
+     *
+     * @param index The slot index to clear (must be < getCapacity()).
+     * @return true if the slot was valid and cleared, false otherwise.
+     * @note Thread-safe (lock-free).
+     */
+    bool eraseAt(size_type const index) noexcept {
+        assert_invariant(index < mCapacity);
+        SlotState expected = SlotState::VALID;
+        if (mStates[index].compare_exchange_strong(expected, SlotState::WRITING,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            mThreadIds[index] = key_type{};
+            mValues[index] = value_type{};
+            mStates[index].store(SlotState::EMPTY, std::memory_order_release);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Clears all registered threads from the map.
+     *
+     * @note Thread-safe (lock-free).
+     */
+    void clear() noexcept {
+        for (size_type i = 0; i < mCapacity; ++i) {
+            eraseAt(i);
+        }
+    }
+
+    /**
+     * Returns the number of currently registered threads.
+     *
+     * @note Thread-safe (wait-free). Returns an instantaneous snapshot count.
+     */
+    size_type size() const noexcept {
+        size_type count = 0;
+        for (size_type i = 0; i < mCapacity; ++i) {
+            if (mStates[i].load(std::memory_order_relaxed) == SlotState::VALID) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Returns true if no threads are currently registered.
+     *
+     * @note Thread-safe (wait-free).
+     */
+    bool empty() const noexcept {
+        return size() == 0;
+    }
+
+private:
+    size_type mCapacity = 0;
+    std::unique_ptr<std::atomic<SlotState>[]> mStates;
+    std::unique_ptr<key_type[]> mThreadIds;
+    std::unique_ptr<value_type[]> mValues;
+};
+
+} // namespace utils
+
+#endif // TNT_UTILS_THREADMAP_H

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -365,6 +365,13 @@ public:
     AtomicFreeList(const AtomicFreeList& rhs) = delete;
     AtomicFreeList& operator=(const AtomicFreeList& rhs) = delete;
 
+    // We disable TSAN instrumentation on pop() and push() because in a lock-free tagged
+    // freelist, pop() speculatively reads node.next from memory that might concurrently
+    // be written to by another thread (either in push() or by user code writing to the
+    // allocated memory). In the C++ memory model, this constitutes a data race, even though
+    // it is logically benign because any corrupted/stale read is discarded when the subsequent
+    // compare_exchange_weak() on the tagged pointer fails.
+    UTILS_NO_SANITIZE_THREAD
     void* pop() noexcept {
         Node* const pStorage = mStorage;
 
@@ -374,7 +381,6 @@ public:
             // thread raced ahead of us. But in that case, the computed "newHead" will be discarded
             // since compare_exchange_weak() fails. Then this thread will loop with the updated
             // value of currentHead, and try again.
-            // TSAN complains if we don't use a local variable here.
             Node const node = pStorage[currentHead.offset];
             Node const* const pNext = node.next;
             const HeadPtr newHead{ pNext ? int32_t(pNext - pStorage) : -1, currentHead.tag + 1 };
@@ -397,6 +403,7 @@ public:
         return p;
     }
 
+    UTILS_NO_SANITIZE_THREAD
     void push(void* p) noexcept {
         Node* const storage = mStorage;
         assert(p && p >= storage);

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -414,7 +414,12 @@ public:
         return mParallelSplitCount;
     }
 
-    size_t getThreadCount() const { return mThreadCount; }
+    size_t getThreadCount() const noexcept { return mThreadCount; }
+
+    // returns the high-water mark of active threads (pool threads + adopted threads)
+    size_t getActiveThreadCount() const noexcept {
+        return mActiveThreadCount.load(std::memory_order_relaxed);
+    }
 
     // returns the current ThreadId, which can be used with run(). This method can only be
     // called from a job's function.
@@ -586,25 +591,32 @@ public:
 
 namespace details {
 
-// Traits helper to detect if a splitter provides a custom getChunkSize() method.
-// If absent, computes an adaptive chunk size targeting ~4 chunks per available worker thread.
+// Traits helper to extract the chunk size from a splitter.
+// Splitters must define getChunkSize() or getChunkSize(count, threadCount).
 template<typename S>
 struct SplitterTraits {
     template<typename T>
-    static auto test(int) -> decltype(std::declval<T>().getChunkSize(), std::true_type{});
+    static auto test_0(int) -> decltype(std::declval<T>().getChunkSize(), std::true_type{});
     template<typename>
-    static auto test(...) -> std::false_type;
+    static auto test_0(...) -> std::false_type;
 
-    static constexpr bool has_chunk_size = decltype(test<S>(0))::value;
+    template<typename T>
+    static auto test_2(int) -> decltype(std::declval<T>().getChunkSize(uint32_t(), uint32_t()), std::true_type{});
+    template<typename>
+    static auto test_2(...) -> std::false_type;
+
+    static constexpr bool has_chunk_size_0 = decltype(test_0<S>(0))::value;
+    static constexpr bool has_chunk_size_2 = decltype(test_2<S>(0))::value;
+
+    static_assert(has_chunk_size_0 || has_chunk_size_2,
+            "Custom splitter must define getChunkSize() or getChunkSize(count, threadCount). "
+            "The old split() method is no longer supported.");
 
     static uint32_t getChunkSize(const S& splitter, uint32_t const totalCount, uint32_t const threadCount) noexcept {
-        if constexpr (has_chunk_size) {
+        if constexpr (has_chunk_size_2) {
+            return uint32_t(std::max<size_t>(1, splitter.getChunkSize(totalCount, threadCount)));
+        } else if constexpr (has_chunk_size_0) {
             return uint32_t(std::max<size_t>(1, splitter.getChunkSize()));
-        } else {
-            // Adaptive chunking: split into 4 chunks per thread to balance load while
-            // keeping atomic fetch_add contention low.
-            uint32_t const targetChunks = std::max<uint32_t>(1, threadCount * 4);
-            return std::max<uint32_t>(1, totalCount / targetChunks);
         }
     }
 };
@@ -751,11 +763,14 @@ JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
         return js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
     }
 
-    uint32_t const threadCount = uint32_t(js.getThreadCount());
-    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, threadCount);
+    uint32_t const poolThreads = uint32_t(js.getThreadCount());
+    uint32_t const totalThreads = (poolThreads == 0) ? 0 :
+            std::max(poolThreads, uint32_t(js.getActiveThreadCount()));
+
+    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, totalThreads);
     uint32_t const numChunks = (count + chunkSize - 1) / chunkSize;
-    uint32_t const helperCount = (threadCount > 0 && numChunks > 1) ?
-            std::min<uint32_t>(threadCount, numChunks - 1) : 0;
+    uint32_t const helperCount = (totalThreads > 0 && numChunks > 1) ?
+            std::min<uint32_t>(totalThreads - 1, numChunks - 1) : 0;
     uint32_t const totalWorkers = helperCount + 1;
 
     using JobData = details::ParallelForJobData<S, F>;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -27,10 +27,9 @@
 #include <utils/Slice.h>
 #include <utils/WorkStealingDequeue.h>
 
-#include <tsl/robin_map.h>
-
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <type_traits>
@@ -43,7 +42,11 @@
 
 namespace utils {
 
+template <typename VALUE>
+class ThreadMap;
+
 class JobSystem {
+    static constexpr uint32_t MAX_THREADS = 32;
     static constexpr size_t MAX_JOB_COUNT = 1 << 14; // 16384
     static constexpr uint32_t JOB_COUNT_MASK = MAX_JOB_COUNT - 1;
     static constexpr uint32_t WAITER_COUNT_SHIFT = 24;
@@ -475,14 +478,13 @@ private:
     alignas(16) // at least we align to half (or quarter) cache-line
     aligned_vector<ThreadState> mThreadStates;          // actual data is stored offline
     std::atomic<bool> mExitRequested = { false };       // this one is almost never written
-    std::atomic<uint16_t> mAdoptedThreads = { 0 };      // this one is almost never written
+    std::atomic<uint32_t> mAdoptableSlotsMask = { 0 };  // available slots for adoptable threads
     Job* const mJobStorageBase;                         // Base for conversion to indices
     uint16_t mThreadCount = 0;                          // total # of threads in the pool
     uint8_t mParallelSplitCount = 0;                    // # of split allowable in parallel_for
     Job* mRootJob = nullptr;
 
-    Mutex mThreadMapLock; // this should have very little contention
-    tsl::robin_map<std::thread::id, ThreadState *> mThreadMap UTILS_GUARDED_BY(mThreadMapLock);
+    std::unique_ptr<ThreadMap<ThreadState*>> mThreadMap;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -455,16 +455,23 @@ private:
 
     [[nodiscard]]
     uint32_t wait(UniqueLock& lock, Job* job) noexcept;
-    void wait(UniqueLock& lock) noexcept;
-    void wakeAll() noexcept;
+    void waitForWork(UniqueLock& lock) noexcept;
+    void waitForJob(UniqueLock& lock) noexcept;
+    void wakeWaiters() noexcept;
     void wakeOne() noexcept;
+
+    static constexpr uint32_t SLEEPING_WORKER_ONE = 1 << 16;
+    static constexpr uint32_t SLEEPING_WAITER_ONE = 1;
+    static constexpr uint32_t SLEEPING_WORKER_MASK = 0xFFFF0000;
+    static constexpr uint32_t SLEEPING_WAITER_MASK = 0x0000FFFF;
 
     // these have thread contention, keep them together
     Mutex mWaiterLock;
-    Condition mWaiterCondition;
+    Condition mWorkCondition;
+    Condition mJobCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    std::atomic<uint32_t> mSleepingThreads = { 0 };
+    std::atomic<uint32_t> mSleepingCounts = { 0 };
     Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -45,6 +45,11 @@ namespace utils {
 template <typename VALUE>
 class ThreadMap;
 
+namespace jobs::details {
+template<typename S, typename F>
+struct ParallelForJobData;
+}
+
 class JobSystem {
     static constexpr uint32_t MAX_THREADS = 32;
     static constexpr size_t MAX_JOB_COUNT = 1 << 14; // 16384
@@ -72,15 +77,15 @@ public:
         Job(const Job&) = delete;
         Job(Job&&) = delete;
 
-    private:
-        friend class JobSystem;
-
         // Size is chosen so that we can store at least std::function<>
         // the alignas() qualifier ensures we're multiple of a cache-line.
         static constexpr size_t JOB_STORAGE_SIZE_BYTES =
                 sizeof(std::function<void()>) > 48 ? sizeof(std::function<void()>) : 48;
         static constexpr size_t JOB_STORAGE_SIZE_WORDS =
                 (JOB_STORAGE_SIZE_BYTES + sizeof(void*) - 1) / sizeof(void*);
+
+    private:
+        friend class JobSystem;
 
         // keep it first, so it's correctly aligned with all architectures
         // this is where we store the job's data, typically a std::function<>
@@ -270,6 +275,17 @@ public:
             that->~T();
         });
         if (job) {
+            new(job->storage) T(std::forward<ARGS>(args)...);
+        }
+        return job;
+    }
+
+    // creates a job with in-place storage initialized with ARGS, without automatic destruction
+    template<typename T, typename ... ARGS>
+    Job* emplaceJobRaw(Job* parent, JobFunc const func, ARGS&& ... args) noexcept {
+        static_assert(sizeof(T) <= sizeof(Job::storage), "user data too large");
+        Job* job = create(parent, func);
+        if (UTILS_LIKELY(job)) {
             new(job->storage) T(std::forward<ARGS>(args)...);
         }
         return job;
@@ -539,104 +555,266 @@ JobSystem::Job* createJob(JobSystem& js, JobSystem::Job* parent,
 }
 
 
+/**
+ * Policy for dividing parallel work into fixed-size chunks.
+ *
+ * @tparam COUNT Chunk size (number of elements per work unit) dynamically claimed by threads.
+ */
+template<size_t COUNT>
+class CountSplitter {
+public:
+    static constexpr size_t CHUNK_SIZE = COUNT;
+    size_t getChunkSize() const noexcept {
+        return COUNT;
+    }
+};
+
 namespace details {
 
+// Traits helper to detect if a splitter provides a custom getChunkSize() method.
+// If absent, computes an adaptive chunk size targeting ~4 chunks per available worker thread.
+template<typename S>
+struct SplitterTraits {
+    template<typename T>
+    static auto test(int) -> decltype(std::declval<T>().getChunkSize(), std::true_type{});
+    template<typename>
+    static auto test(...) -> std::false_type;
+
+    static constexpr bool has_chunk_size = decltype(test<S>(0))::value;
+
+    static uint32_t getChunkSize(const S& splitter, uint32_t const totalCount, uint32_t const threadCount) noexcept {
+        if constexpr (has_chunk_size) {
+            return uint32_t(std::max<size_t>(1, splitter.getChunkSize()));
+        } else {
+            // Adaptive chunking: split into 4 chunks per thread to balance load while
+            // keeping atomic fetch_add contention low.
+            uint32_t const targetChunks = std::max<uint32_t>(1, threadCount * 4);
+            return std::max<uint32_t>(1, totalCount / targetChunks);
+        }
+    }
+};
+
+/*
+ * ParallelForJobData coordinates dynamic range-based work stealing across threads.
+ *
+ * Architecture & Concurrency Model:
+ * 1. Range-Based Stealing:
+ *    Instead of recursively splitting child jobs into an O(N) binary tree, parallel_for creates
+ *    a single root job and at most (threadCount - 1) child helper jobs.
+ *    All workers share a single atomic iteration cursor (nextIndex). Each worker claims
+ *    contiguous slices of chunkSize items via relaxed fetch_add until nextIndex >= endIndex.
+ *
+ * 2. Memory Layout & Zero Heap Allocation:
+ *    For functors <= 32 bytes (which covers almost all lambdas capturing a few pointers/references),
+ *    ParallelForJobData fits entirely within Job::storage (48 bytes).
+ *    Its header is packed into 12 bytes (16 with alignment), so emplaceJobRaw constructs it
+ *    directly inside the root Job without any heap allocation (IS_INLINE == true).
+ *    If the functor is larger (> 32 bytes), parallel_for falls back to a single heap allocation.
+ *
+ * 3. Distributed Lifetime Management & Deallocation:
+ *    Because the root thread and helper tasks execute asynchronously, the lifetime of
+ *    ParallelForJobData is ref-counted by activeWorkers. There are two deallocation sites:
+ *    a) finishWorker() [delete this]: Normal execution path. Every finishing worker (root or helper)
+ *       atomically decrements activeWorkers with acq_rel. Whichever thread drops the count to 0
+ *       is guaranteed to be the last one accessing the state; if heap-allocated, it calls `delete this`
+ *       (or `~ParallelForJobData()` if stored inline in Job::storage).
+ *    b) parallel_for() [delete data]: Early-failure path. If JobSystem fails to allocate the root Job
+ *       (e.g., job pool exhaustion), root never runs, so finishWorker() is never invoked.
+ *       parallel_for() detects root == nullptr and deletes data immediately to prevent a leak.
+ */
 template<typename S, typename F>
 struct ParallelForJobData {
-    using SplitterType = S;
     using Functor = F;
-    using JobData = ParallelForJobData;
-    using size_type = uint32_t;
 
-    ParallelForJobData(size_type const start, size_type const count, uint8_t const splits,
-            Functor functor,
-            const SplitterType& splitter) noexcept
-            : start(start), count(count),
-              functor(std::move(functor)),
-              splits(splits),
-              splitter(splitter) {
+    ParallelForJobData(uint32_t const start, uint32_t const count, uint32_t const chunkSize,
+            uint32_t const totalWorkers, Functor functor) noexcept
+            : nextIndex(start),
+              endIndex(start + count),
+              activeWorkers(uint16_t(totalWorkers)),
+              chunkSize(uint16_t(chunkSize)),
+              functor(std::move(functor)) {
     }
 
-    void parallelWithJobs(JobSystem& js, JobSystem::Job* parent) noexcept {
-        assert(parent);
-
-        // this branch is often miss-predicted (it both sides happen 50% of the calls)
-right_side:
-        if (splitter.split(splits, count)) {
-            const size_type lc = count / 2;
-            JobSystem::Job* l = js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-                    start, lc, splits + uint8_t(1), functor, splitter);
-            if (UTILS_UNLIKELY(l == nullptr)) {
-                // couldn't create a job, just pretend we're done splitting
-                goto execute;
-            }
-
-            // start the left side before attempting the right side, so we parallelize in case
-            // of job creation failure -- rare, but still.
-            js.run(l, JobSystem::getThreadId(parent));
-
-            // don't spawn a job for the right side, just reuse us -- spawning jobs is more
-            // costly than we'd like.
-            start += lc;
-            count -= lc;
-            ++splits;
-            goto right_side;
-
-        } else {
-execute:
-            // we're done splitting, do the real work here!
-            functor(start, count);
+    // Work-stealing loop: dynamically claims slices of chunkSize items until exhaustion.
+    void process() noexcept {
+        uint32_t current;
+        while ((current = nextIndex.fetch_add(chunkSize, std::memory_order_relaxed)) < endIndex) {
+            uint32_t const chunk = std::min<uint32_t>(chunkSize, endIndex - current);
+            functor(current, chunk);
         }
     }
 
-private:
-    size_type start;            // 4
-    size_type count;            // 4
-    Functor functor;            // ?
-    uint8_t splits;             // 1
-    SplitterType splitter;      // 1
+    // Invoked by the root job: spawns helper jobs for other threads, then processes chunks itself.
+    void runRoot(JobSystem& js, JobSystem::Job* root) noexcept {
+        uint32_t const total = activeWorkers.load(std::memory_order_relaxed);
+        uint32_t const helperCount = total > 0 ? total - 1 : 0;
+
+        for (uint32_t i = 0; i < helperCount; ++i) {
+            JobSystem::Job* helper =
+                    js.createJob<ParallelForJobData, &ParallelForJobData::runHelper>(root, this);
+            if (UTILS_LIKELY(helper)) {
+                js.run(helper);
+            } else {
+                // Failed to allocate a helper job; decrement active workers refcount.
+                finishWorker();
+            }
+        }
+
+        process();
+        finishWorker();
+    }
+
+    // Invoked by child helper jobs on other worker threads.
+    void runHelper(JobSystem&, JobSystem::Job*) noexcept {
+        process();
+        finishWorker();
+    }
+
+    // Decrements active worker count and destroys/deallocates when the last worker finishes.
+    void finishWorker() noexcept {
+        if (activeWorkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            if constexpr (sizeof(ParallelForJobData) <= JobSystem::Job::JOB_STORAGE_SIZE_BYTES) {
+                // Inline storage: explicitly call the destructor. The memory is owned
+                // by the Job pool and recycled when the root Job's refCount hits 0.
+                this->~ParallelForJobData();
+            } else {
+                // Heap storage: this worker is the last one running across all threads.
+                // Safely deallocate the shared heap payload.
+                delete this;
+            }
+        }
+    }
+
+    // Raw job entry point for inline storage in the root Job.
+    static void jobFuncInline(void* storage, JobSystem& js, JobSystem::Job* root) noexcept {
+        auto* const that = static_cast<ParallelForJobData*>(storage);
+        that->runRoot(js, root);
+    }
+
+    // Packed struct members: total header = 12 bytes (+4 bytes padding for 8-byte aligned Functor)
+    std::atomic<uint32_t> nextIndex = { 0 };
+    uint32_t endIndex = 0;
+    std::atomic<uint16_t> activeWorkers = { 0 };
+    uint16_t chunkSize = 1;
+    Functor functor;
 };
+
+// Check whether this struct fits inline inside Job::storage (typically 48 bytes).
+template<typename S, typename F>
+inline constexpr bool IsParallelForInline =
+        (sizeof(ParallelForJobData<S, F>) <= JobSystem::Job::JOB_STORAGE_SIZE_BYTES);
 
 } // namespace details
 
 
-// parallel jobs with start/count indices
+/**
+ * Execute a function in parallel over a range of indices [start, start + count).
+ *
+ * The range is divided into chunks and dynamically claimed by available worker threads
+ * using lock-free range-based stealing.
+ *
+ * The functor is invoked with `(uint32_t start, uint32_t count)` representing contiguous,
+ * non-overlapping sub-ranges covering the entire iteration space.
+ *
+ * If the functor payload fits in Job storage (<= 48 bytes), zero heap allocations are performed.
+ * Larger functors automatically fall back to a single shared heap allocation.
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param start First index of the range.
+ * @param count Total number of items to process.
+ * @param functor Callable invoked with `(uint32_t start, uint32_t count)`.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation.
+ */
 template<typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
-        uint32_t start, uint32_t count, F functor, const S& splitter) noexcept {
+        uint32_t const start, uint32_t const count, F functor, const S& splitter) noexcept {
+    if (UTILS_UNLIKELY(count == 0)) {
+        return js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
+    }
+
+    uint32_t const threadCount = uint32_t(js.getThreadCount());
+    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, threadCount);
+    uint32_t const numChunks = (count + chunkSize - 1) / chunkSize;
+    uint32_t const helperCount = (threadCount > 0 && numChunks > 1) ?
+            std::min<uint32_t>(threadCount, numChunks - 1) : 0;
+    uint32_t const totalWorkers = helperCount + 1;
+
     using JobData = details::ParallelForJobData<S, F>;
-    return js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-            start, count, 0, std::move(functor), splitter);
+
+    if constexpr (details::IsParallelForInline<S, F>) {
+        return js.emplaceJobRaw<JobData>(parent, &JobData::jobFuncInline,
+                start, count, chunkSize, totalWorkers, std::move(functor));
+    } else {
+        auto* data = new JobData(start, count, chunkSize, totalWorkers, std::move(functor));
+        JobSystem::Job* root = js.createJob<JobData, &JobData::runRoot>(parent, data);
+        if (UTILS_UNLIKELY(!root)) {
+            // Early failure: Job pool exhausted, so root will never execute and finishWorker()
+            // will never be called. Clean up the heap-allocated payload immediately.
+            delete data;
+        }
+        return root;
+    }
 }
 
-// parallel jobs with pointer/count
+template<typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        uint32_t const start, uint32_t const count, F functor) noexcept {
+    return parallel_for(js, parent, start, count, std::move(functor), CountSplitter<16>{});
+}
+
+/**
+ * Execute a function in parallel over an array of elements [data, data + count).
+ *
+ * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param data Pointer to the start of the data array.
+ * @param count Total number of elements.
+ * @param functor Callable invoked with `(T* data, size_t count)`.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation.
+ */
 template<typename T, typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
-        T* data, uint32_t count, F functor, const S& splitter) noexcept {
-    auto user = [data, f = std::move(functor)](uint32_t s, uint32_t c) {
+        T* const data, uint32_t const count, F functor, const S& splitter) noexcept {
+    auto user = [data, f = std::move(functor)](uint32_t const s, uint32_t const c) {
         f(data + s, c);
     };
-    using JobData = details::ParallelForJobData<S, decltype(user)>;
-    return js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-            0, count, 0, std::move(user), splitter);
+    return parallel_for(js, parent, 0, count, std::move(user), splitter);
 }
 
-// parallel jobs on a Slice<>
+template<typename T, typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        T* const data, uint32_t const count, F functor) noexcept {
+    return parallel_for(js, parent, data, count, std::move(functor), CountSplitter<16>{});
+}
+
+/**
+ * Execute a function in parallel over a Slice<T>.
+ *
+ * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param slice Slice of elements to process.
+ * @param functor Callable invoked with `(T* data, size_t count)`.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation.
+ */
 template<typename T, typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
         Slice<T> slice, F functor, const S& splitter) noexcept {
-    return parallel_for(js, parent, slice.data(), slice.size(), functor, splitter);
+    return parallel_for(js, parent, slice.data(), uint32_t(slice.size()), std::move(functor), splitter);
 }
 
-
-template<size_t COUNT, size_t MAX_SPLITS = 12>
-class CountSplitter {
-public:
-    bool split(size_t const splits, size_t const count) const noexcept {
-        return (splits < MAX_SPLITS && count >= COUNT * 2);
-    }
-};
-
+template<typename T, typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        Slice<T> slice, F functor) noexcept {
+    return parallel_for(js, parent, slice.data(), uint32_t(slice.size()), std::move(functor), CountSplitter<16>{});
+}
 } // namespace jobs
 } // namespace utils
 

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -614,7 +614,7 @@ struct SplitterTraits {
 
     static uint32_t getChunkSize(const S& splitter, uint32_t const totalCount, uint32_t const threadCount) noexcept {
         if constexpr (has_chunk_size_2) {
-            return uint32_t(std::max<size_t>(1, splitter.getChunkSize(totalCount, threadCount)));
+            return uint32_t(std::max<size_t>(1, splitter.getChunkSize(totalCount, std::max(1u, threadCount))));
         } else if constexpr (has_chunk_size_0) {
             return uint32_t(std::max<size_t>(1, splitter.getChunkSize()));
         }
@@ -767,9 +767,10 @@ JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
     uint32_t const poolThreads = uint32_t(js.getThreadCount());
     uint32_t const totalThreads = (poolThreads == 0) ? 0 :
             std::max(poolThreads, uint32_t(js.getActiveThreadCount()));
+    uint32_t const effectiveThreads = std::max(1u, totalThreads);
 
-    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, totalThreads);
-    uint32_t const numChunks = (count + chunkSize - 1) / chunkSize;
+    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, effectiveThreads);
+    uint32_t const numChunks = ((count - 1) / chunkSize) + 1;
     uint32_t const helperCount = (totalThreads > 0 && numChunks > 1) ?
             std::min<uint32_t>(totalThreads - 1, numChunks - 1) : 0;
     uint32_t const totalWorkers = helperCount + 1;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -464,6 +464,7 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
+    std::atomic<uint32_t> mSleepingThreads = { 0 };
     Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -461,7 +461,7 @@ private:
     Condition mWaiterCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    Arena<ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
+    Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>
     using aligned_vector = std::vector<T, STLAlignedAllocator<T>>;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -675,12 +675,13 @@ struct ParallelForJobData {
     void runRoot(JobSystem& js, JobSystem::Job* root) noexcept {
         uint32_t const total = activeWorkers.load(std::memory_order_relaxed);
         uint32_t const helperCount = total > 0 ? total - 1 : 0;
+        JobSystem::ThreadId const id = JobSystem::getThreadId(root);
 
         for (uint32_t i = 0; i < helperCount; ++i) {
             JobSystem::Job* helper =
                     js.createJob<ParallelForJobData, &ParallelForJobData::runHelper>(root, this);
             if (UTILS_LIKELY(helper)) {
-                js.run(helper);
+                js.run(helper, id);
             } else {
                 // Failed to allocate a helper job; decrement active workers refcount.
                 finishWorker();

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -716,13 +716,15 @@ inline constexpr bool IsParallelForInline =
  * The functor is invoked with `(uint32_t start, uint32_t count)` representing contiguous,
  * non-overlapping sub-ranges covering the entire iteration space.
  *
+ * If count is 0, a valid no-op job is returned and functor is not invoked.
+ *
  * If the functor payload fits in Job storage (<= 48 bytes), zero heap allocations are performed.
  * Larger functors automatically fall back to a single shared heap allocation.
  *
  * @param js The JobSystem instance.
  * @param parent Optional parent job.
  * @param start First index of the range.
- * @param count Total number of items to process.
+ * @param count Total number of items to process (if 0, functor is not called).
  * @param functor Callable invoked with `(uint32_t start, uint32_t count)`.
  * @param splitter Chunking policy (default: CountSplitter<16>).
  * @return The root JobSystem::Job* representing this parallel operation.
@@ -768,11 +770,12 @@ JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
  * Execute a function in parallel over an array of elements [data, data + count).
  *
  * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ * If count is 0, a valid no-op job is returned and functor is not invoked.
  *
  * @param js The JobSystem instance.
  * @param parent Optional parent job.
  * @param data Pointer to the start of the data array.
- * @param count Total number of elements.
+ * @param count Total number of elements (if 0, functor is not called).
  * @param functor Callable invoked with `(T* data, size_t count)`.
  * @param splitter Chunking policy (default: CountSplitter<16>).
  * @return The root JobSystem::Job* representing this parallel operation.
@@ -796,10 +799,11 @@ JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
  * Execute a function in parallel over a Slice<T>.
  *
  * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ * If slice is empty (size 0), a valid no-op job is returned and functor is not invoked.
  *
  * @param js The JobSystem instance.
  * @param parent Optional parent job.
- * @param slice Slice of elements to process.
+ * @param slice Slice of elements to process (if empty, functor is not called).
  * @param functor Callable invoked with `(T* data, size_t count)`.
  * @param splitter Chunking policy (default: CountSplitter<16>).
  * @return The root JobSystem::Job* representing this parallel operation.

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -109,13 +109,28 @@ public:
      * Special value for userThreadCount to configure the JobSystem in single-threaded mode.
      */
     static constexpr uint32_t SINGLE_THREADED = std::numeric_limits<uint32_t>::max();
-
     /**
-     * Create a JobSystem and initializes its thread pool. The pool can have zero threads if SINGLE_THREADED is used
-     * as the userThreadCount, in that case adoptableThreadsCount is forced to 1.
+     * Create a JobSystem and initialize its thread pool.
      *
-     * @param userThreadCount number of threads in the JobSystem thread pool.
-     * @param adoptableThreadsCount number of calling threads outside the thread pool.
+     * Total thread capacity across pool workers and adopted threads is capped at MAX_THREADS (32).
+     *
+     * Parameter constraints & behavior:
+     * - `userThreadCount`: Number of dedicated worker threads to spawn in the pool.
+     *   - `0` (default): Automatically selects `(hardware_concurrency - 1)`.
+     *   - `SINGLE_THREADED`: Configures the JobSystem in single-threaded mode with 0 pool worker
+     *     threads and forces `adoptableThreadsCount` to 1.
+     *   - In multi-threaded mode (any value other than `SINGLE_THREADED`), the thread pool is
+     *     guaranteed to contain at least 1 worker thread (subject to system threading support).
+     * - `adoptableThreadsCount`: Maximum number of external calling threads that can concurrently
+     *   call `adopt()`.
+     *   - Must be between 1 and `MAX_THREADS - 1` (31) in multi-threaded mode to ensure capacity
+     *     for at least 1 pool worker thread.
+     *   - If `adoptableThreadsCount >= MAX_THREADS`, it is clamped to `MAX_THREADS - 1` with an error.
+     *   - If `userThreadCount + adoptableThreadsCount > MAX_THREADS`, `userThreadCount` is clamped to
+     *     `(MAX_THREADS - adoptableThreadsCount)` with a warning.
+     *
+     * @param userThreadCount Number of worker threads in the pool, 0 for auto-detect, or SINGLE_THREADED.
+     * @param adoptableThreadsCount Maximum number of external threads that can be adopted concurrently (max: MAX_THREADS - 1).
      */
     explicit JobSystem(uint32_t userThreadCount = 0, uint32_t adoptableThreadsCount = 1) noexcept;
 

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -480,6 +480,7 @@ private:
     aligned_vector<ThreadState> mThreadStates;          // actual data is stored offline
     std::atomic<bool> mExitRequested = { false };       // this one is almost never written
     std::atomic<uint32_t> mAdoptableSlotsMask = { 0 };  // available slots for adoptable threads
+    std::atomic<uint16_t> mActiveThreadCount = { 0 };   // high-water mark of active threads
     Job* const mJobStorageBase;                         // Base for conversion to indices
     uint16_t mThreadCount = 0;                          // total # of threads in the pool
     uint8_t mParallelSplitCount = 0;                    // # of split allowable in parallel_for

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -417,12 +417,14 @@ private:
         }
     };
 
-    struct alignas(CACHELINE_SIZE) ThreadState {    // this causes 40-bytes padding
-        // make sure storage is cache-line aligned
+    struct alignas(CACHELINE_SIZE) ThreadState {
+        // Keep nextJob at the beginning so that nextJob, workQueue's top/bottom indices,
+        // and the initial workQueue slots all share the first 64-byte cache line.
+        std::atomic<uint16_t> nextJob = { 0 };
         WorkQueue workQueue;
 
-        // these are not accessed by the worker threads
-        alignas(CACHELINE_SIZE)         // this causes 56-bytes padding
+        // these are not accessed frequently by other threads
+        alignas(CACHELINE_SIZE)         // this causes 40-bytes padding
         JobSystem* js;                  // this is in fact const and always initialized
         std::thread thread;             // unused for adopted threads
         default_random_engine rndGen;
@@ -449,9 +451,9 @@ private:
     Job* steal(ThreadState& state) noexcept;
     void finish(Job* job) noexcept;
 
-    void put(WorkQueue& workQueue, Job const* job) noexcept;
-    Job* pop(WorkQueue& workQueue) noexcept;
-    Job* steal(WorkQueue& workQueue) noexcept;
+    void put(ThreadState& state, Job const* job) noexcept;
+    Job* pop(ThreadState& state) noexcept;
+    Job* stealFrom(ThreadState& victim) noexcept;
 
     [[nodiscard]]
     uint32_t wait(UniqueLock& lock, Job* job) noexcept;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -630,8 +630,8 @@ struct ParallelForJobData {
             uint32_t const totalWorkers, Functor functor) noexcept
             : nextIndex(start),
               endIndex(start + count),
-              activeWorkers(uint16_t(totalWorkers)),
-              chunkSize(uint16_t(chunkSize)),
+              chunkSize(std::max<uint32_t>(1, chunkSize)),
+              activeWorkers(totalWorkers),
               functor(std::move(functor)) {
     }
 
@@ -691,11 +691,11 @@ struct ParallelForJobData {
         that->runRoot(js, root);
     }
 
-    // Packed struct members: total header = 12 bytes (+4 bytes padding for 8-byte aligned Functor)
+    // Packed struct members: total header = 16 bytes (4 x 4-byte fields)
     std::atomic<uint32_t> nextIndex = { 0 };
     uint32_t endIndex = 0;
-    std::atomic<uint16_t> activeWorkers = { 0 };
-    uint16_t chunkSize = 1;
+    uint32_t chunkSize = 1;
+    std::atomic<uint32_t> activeWorkers = { 0 };
     Functor functor;
 };
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -82,7 +82,7 @@
 #endif
 
 #define UTILS_NO_SANITIZE_THREAD
-#if __has_feature(thread_sanitizer)
+#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
 #undef UTILS_NO_SANITIZE_THREAD
 #define UTILS_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
 #endif

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -320,7 +320,11 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     // signal we are waiting
 
-    if (hasActiveJobs() || exitRequested()) {
+    // Note: Do NOT check hasActiveJobs() here to abort waiting. The caller has already
+    // executed execute() and found no work to run. If we returned immediately because
+    // unrelated active jobs exist in other queues, the caller would loop in a 100% CPU
+    // busy-spin without ever sleeping on the condition variable.
+    if (exitRequested()) {
         return job->runningJobCount.load(std::memory_order_acquire);
     }
 
@@ -520,6 +524,12 @@ void JobSystem::loop(ThreadState* state) {
     // run our main loop...
     do {
         if (!execute(*state)) {
+            // Note: Do NOT check hasActiveJobs() here before taking the lock to "double-check".
+            // If execute() failed to acquire a job (e.g. random steal probe missed or the owner
+            // is descheduled), immediately continuing on hasActiveJobs() creates a tight 100% CPU
+            // user-space busy-spin loop. This starves the thread holding the active job, turning
+            // transient contention into priority inversion livelocks. Instead, we proceed to
+            // take mWaiterLock and sleep in wait(lock).
             UniqueLock lock(mWaiterLock);
             while (!exitRequested() && !hasActiveJobs()) {
                 wait(lock);
@@ -647,10 +657,14 @@ void JobSystem::waitAndRelease(Job*& job) noexcept {
     ThreadState& state(getState());
     do {
         if (UTILS_UNLIKELY(!execute(state))) {
-            // test if job has completed first, to possibly avoid taking the lock
-            if (hasJobCompleted(job)) {
+            // test if job has completed or exit was requested first, to possibly avoid taking the lock
+            if (hasJobCompleted(job) || exitRequested()) {
                 break;
             }
+
+            // Note: Do NOT check hasActiveJobs() here to loop again. If execute() found no work,
+            // we must proceed to wait on the job's condition variable rather than
+            // busy-spinning at 100% CPU.
 
             // the only way we can be here is if the job we're waiting on it being handled
             // by another thread:

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -390,20 +390,24 @@ JobSystem::Job* JobSystem::allocateJob() noexcept {
     return mJobPool.make<Job>();
 }
 
-void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
+void JobSystem::put(ThreadState& state, Job const* job) noexcept {
     assert(job);
     assert(job >= mJobStorageBase && job < mJobStorageBase + MAX_JOB_COUNT);
 
-    size_t const index = job - mJobStorageBase;
+    uint16_t const index = uint16_t(job - mJobStorageBase + 1);
 
-    // put the job into the queue
-    workQueue.push(uint16_t(index + 1));
+    // Try to put into the fast 1-slot nextJob cache
+    uint16_t const prev = state.nextJob.exchange(index, std::memory_order_release);
+    if (UTILS_UNLIKELY(prev != 0)) {
+        // If nextJob was already occupied, push the older job into the workQueue
+        state.workQueue.push(prev);
+    }
 
     // Increase our active job count. We MUST use std::memory_order_release here.
     // If we used relaxed, the compiler or CPU could reorder this increment to happen 
-    // BEFORE workQueue.push(). If a preemption happened right there, other threads 
-    // would see mActiveJobs > 0, enter the steal() loop, fail to find the job, and 
-    // spin infinitely, recreating the exact same priority inversion lockup on the push side!
+    // BEFORE nextJob.exchange() or workQueue.push(). If a preemption happened right there,
+    // other threads would see mActiveJobs > 0, enter the steal() loop, fail to find the job,
+    // and spin infinitely, recreating the exact same priority inversion lockup on the push side!
     mActiveJobs.fetch_add(1, std::memory_order_release);
 
     // Only wake a sleeping thread if there is at least one thread sleeping (worker or waiter).
@@ -413,13 +417,21 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
     }
 }
 
-JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
+JobSystem::Job* JobSystem::pop(ThreadState& state) noexcept {
+    // 1. First check our 1-slot nextJob continuation bypass
+    uint16_t const nextIdx = state.nextJob.exchange(0, std::memory_order_acquire);
+    if (UTILS_LIKELY(nextIdx != 0)) {
+        mActiveJobs.fetch_sub(1, std::memory_order_relaxed);
+        return &mJobStorageBase[nextIdx - 1];
+    }
+
+    // 2. Fall back to popping from our workQueue
     // By design, the owner thread must always attempt to pop from its own queue first without
     // inspecting or decrementing mActiveJobs. Popping from our own queue is wait-free and
     // contention-free. Gating pop() on global active job counters would cause owner threads to
     // starve and falsely skip their own runnable jobs if a concurrent stealer has speculatively
     // decremented mActiveJobs.
-    size_t const index = workQueue.pop();
+    size_t const index = state.workQueue.pop();
     assert(index <= MAX_JOB_COUNT);
     Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
     if (UTILS_LIKELY(job)) {
@@ -428,10 +440,24 @@ JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
     return job;
 }
 
-JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
-    size_t const index = workQueue.steal();
-    assert_invariant(index <= MAX_JOB_COUNT);
-    return !index ? nullptr : &mJobStorageBase[index - 1];
+JobSystem::Job* JobSystem::stealFrom(ThreadState& victim) noexcept {
+    // 1. Try to steal from victim's workQueue
+    size_t const index = victim.workQueue.steal();
+    if (index != 0) {
+        assert_invariant(index <= MAX_JOB_COUNT);
+        return &mJobStorageBase[index - 1];
+    }
+
+    // 2. If workQueue is empty, try to steal victim's nextJob
+    uint16_t victimNext = victim.nextJob.load(std::memory_order_relaxed);
+    if (victimNext != 0) {
+        if (victim.nextJob.compare_exchange_strong(victimNext, 0,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            return &mJobStorageBase[victimNext - 1];
+        }
+    }
+
+    return nullptr;
 }
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
@@ -485,7 +511,7 @@ JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     size_t attempts = 0;
     do {
         if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
-            job = steal(stateToStealFrom->workQueue);
+            job = stealFrom(*stateToStealFrom);
         } else {
             break;
         }
@@ -503,7 +529,7 @@ JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
 bool JobSystem::execute(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
 
-    Job* job = pop(state.workQueue);
+    Job* job = pop(state);
 
     // It is beneficial for some benchmarks to poll on steal() for a bit, because going back to
     // sleep and waking up is pretty expensive. However, it is unclear it helps in practice with
@@ -638,7 +664,7 @@ void JobSystem::run(Job*& job) noexcept {
 
     ThreadState& state(getState());
 
-    put(state.workQueue, job);
+    put(state, job);
 
     // after run() returns, the job is virtually invalid (it'll die on its own)
     job = nullptr;
@@ -650,7 +676,7 @@ void JobSystem::run(Job*& job, uint8_t const id) noexcept {
     ThreadState& state = mThreadStates[id];
     assert_invariant(&state == &getState());
 
-    put(state.workQueue, job);
+    put(state, job);
 
     // after run() returns, the job is virtually invalid (it'll die on its own)
     job = nullptr;

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -829,4 +829,6 @@ io::ostream& operator<<(io::ostream& out, JobSystem const& js) {
     return out;
 }
 
+template class ThreadMap<JobSystem::ThreadState*>;
+
 } // namespace utils

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -28,8 +28,10 @@
 
 #include <utils/JobSystem.h>
 
+#include <private/utils/ThreadMap.h>
 #include <private/utils/Tracing.h>
 
+#include <utils/algorithm.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Log.h>
@@ -201,21 +203,31 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
             // one of the thread will be the user thread
             threadPoolCount = hwThreads - 1;
         }
-        // make sure we have at least one thread in the thread pool
-        threadPoolCount = std::max(1u, threadPoolCount);
-        // and also limit the pool to 32 threads
-        threadPoolCount = std::min(UTILS_HAS_THREADING ? 32u : 0u, threadPoolCount);
+        // clamp adoptableThreadsCount so it does not exceed MAX_THREADS
+        adoptableThreadsCount = std::min(adoptableThreadsCount, MAX_THREADS);
+        // limit the pool such that threadPoolCount + adoptableThreadsCount <= MAX_THREADS
+        const uint32_t maxThreadPoolCount = MAX_THREADS - adoptableThreadsCount;
+        // make sure we have at least one thread in the thread pool if capacity permits
+        threadPoolCount = std::max(maxThreadPoolCount > 0 ? 1u : 0u, threadPoolCount);
+        threadPoolCount = std::min(UTILS_HAS_THREADING ? maxThreadPoolCount : 0u, threadPoolCount);
     } else {
         threadPoolCount = 0;
         adoptableThreadsCount = 1;
     }
 
     mThreadStates = aligned_vector<ThreadState>(threadPoolCount + adoptableThreadsCount);
+    mThreadMap = std::make_unique<ThreadMap<ThreadState*>>(threadPoolCount + adoptableThreadsCount);
     mThreadCount = uint16_t(threadPoolCount);
     mParallelSplitCount = uint8_t(std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount))));
 
+    uint32_t adoptableMask = 0;
+    for (uint32_t i = 0; i < adoptableThreadsCount; ++i) {
+        adoptableMask |= (1u << (threadPoolCount + i));
+    }
+    mAdoptableSlotsMask.store(adoptableMask, std::memory_order_relaxed);
+
     static_assert(std::atomic<bool>::is_always_lock_free);
-    static_assert(std::atomic<uint16_t>::is_always_lock_free);
+    static_assert(std::atomic<uint32_t>::is_always_lock_free);
 
     const size_t hardwareThreadCount = mThreadCount;
     auto& states = mThreadStates;
@@ -349,10 +361,9 @@ void JobSystem::wakeOne() noexcept {
 }
 
 inline JobSystem::ThreadState& JobSystem::getState() {
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(std::this_thread::get_id());
-    FILAMENT_CHECK_PRECONDITION(iter != mThreadMap.end()) << "This thread has not been adopted.";
-    return *iter->second;
+    ThreadState* const state = mThreadMap->get();
+    FILAMENT_CHECK_PRECONDITION(state) << "This thread has not been adopted.";
+    return *state;
 }
 
 JobSystem::Job* JobSystem::allocateJob() noexcept {
@@ -413,10 +424,7 @@ JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
     auto& threadStates = mThreadStates;
-    // memory_order_relaxed is okay because we don't take any action that has data dependency
-    // on this value (in particular mThreadStates, is always initialized properly).
-    uint16_t const adopted = mAdoptedThreads.load(std::memory_order_relaxed);
-    uint16_t const threadCount = mThreadCount + adopted;
+    uint16_t const threadCount = uint16_t(threadStates.size());
 
     ThreadState* stateToStealFrom = nullptr;
 
@@ -478,13 +486,8 @@ void JobSystem::loop(ThreadState* state) {
     setThreadPriority(Priority::DISPLAY);
 
     // record our work queue
-    bool inserted;
-    {
-        LockGuard const lock(mThreadMapLock);
-        inserted = mThreadMap.emplace(std::this_thread::get_id(), state).second;
-    }
-
-    FILAMENT_CHECK_PRECONDITION(inserted) << "This thread is already in a loop.";
+    size_t const index = std::distance(mThreadStates.data(), state);
+    mThreadMap->set(uint32_t(index), state);
 
     // run our main loop...
     do {
@@ -663,15 +666,7 @@ void JobSystem::runAndWait(Job*& job) noexcept {
 }
 
 void JobSystem::adopt() {
-    const auto tid = std::this_thread::get_id();
-
-    ThreadState const* state = nullptr;
-    {
-        LockGuard const lock(mThreadMapLock);
-        auto const iter = mThreadMap.find(tid);
-        state = iter ==  mThreadMap.end() ? nullptr : iter->second;
-    }
-
+    ThreadState const* const state = mThreadMap->get();
     if (state) {
         // we're already part of a JobSystem, do nothing.
         FILAMENT_CHECK_PRECONDITION(this == state->js)
@@ -680,10 +675,16 @@ void JobSystem::adopt() {
         return;
     }
 
-    // memory_order_relaxed is safe because we don't take action on this value.
-    uint16_t const adopted = mAdoptedThreads.fetch_add(1, std::memory_order_relaxed);
-    size_t const index = mThreadCount + adopted;
+    uint32_t mask = mAdoptableSlotsMask.load(std::memory_order_relaxed);
+    uint32_t bit = 0;
+    do {
+        FILAMENT_CHECK_POSTCONDITION(mask != 0)
+                << "Too many calls to adopt(). No more adoptable threads!";
+        bit = 1u << utils::ctz(mask);
+    } while (!mAdoptableSlotsMask.compare_exchange_weak(mask, mask & ~bit,
+            std::memory_order_acquire, std::memory_order_relaxed));
 
+    size_t const index = utils::ctz(bit);
     FILAMENT_CHECK_POSTCONDITION(index < mThreadStates.size())
             << "Too many calls to adopt(). No more adoptable threads!";
 
@@ -694,20 +695,16 @@ void JobSystem::adopt() {
     // however, it's not a problem since mThreadState is pre-initialized and valid
     // (e.g.: the queue is empty).
 
-    {
-        LockGuard const lock(mThreadMapLock);
-        mThreadMap[tid] = &mThreadStates[index];
-    }
+    mThreadMap->set(uint32_t(index), &mThreadStates[index]);
 }
 
 void JobSystem::emancipate() {
-    const auto tid = std::this_thread::get_id();
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(tid);
-    ThreadState const* const state = iter ==  mThreadMap.end() ? nullptr : iter->second;
+    ThreadState const* const state = mThreadMap->get();
     FILAMENT_CHECK_PRECONDITION(state) << "this thread is not an adopted thread";
     FILAMENT_CHECK_PRECONDITION(state->js == this) << "this thread is not adopted by us";
-    mThreadMap.erase(iter);
+    size_t const index = std::distance(mThreadStates.data(), const_cast<ThreadState*>(state));
+    mThreadMap->erase();
+    mAdoptableSlotsMask.fetch_or(1u << index, std::memory_order_release);
 }
 
 io::ostream& operator<<(io::ostream& out, JobSystem const& js) {

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -219,6 +219,7 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
     mThreadMap = std::make_unique<ThreadMap<ThreadState*>>(threadPoolCount + adoptableThreadsCount);
     mThreadCount = uint16_t(threadPoolCount);
     mParallelSplitCount = uint8_t(std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount))));
+    mActiveThreadCount.store(mThreadCount, std::memory_order_relaxed);
 
     uint32_t adoptableMask = 0;
     for (uint32_t i = 0; i < adoptableThreadsCount; ++i) {
@@ -423,7 +424,7 @@ JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
     auto& threadStates = mThreadStates;
-    uint16_t const threadCount = uint16_t(threadStates.size());
+    uint16_t const threadCount = mActiveThreadCount.load(std::memory_order_relaxed);
 
     ThreadState* stateToStealFrom = nullptr;
 
@@ -432,7 +433,7 @@ inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state
         do {
             // This is biased, but frankly, we don't care. It's fast.
             uint16_t const index = uint16_t(state.rndGen() % threadCount);
-            assert(index < threadStates.size());
+            assert_invariant(index < threadStates.size());
             stateToStealFrom = &threadStates[index];
             // don't steal from our own queue
         } while (stateToStealFrom == &state);
@@ -729,6 +730,11 @@ void JobSystem::adopt() {
     size_t const index = utils::ctz(bit);
     FILAMENT_CHECK_POSTCONDITION(index < mThreadStates.size())
             << "Too many calls to adopt(). No more adoptable threads!";
+
+    uint16_t const targetCount = uint16_t(index + 1);
+    uint16_t current = mActiveThreadCount.load(std::memory_order_relaxed);
+    while (targetCount > current && !mActiveThreadCount.compare_exchange_weak(current, targetCount,
+            std::memory_order_relaxed, std::memory_order_relaxed)) {}
 
     // all threads adopted by the JobSystem need to run at the same priority
     setThreadPriority(Priority::DISPLAY);

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -469,8 +469,10 @@ inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state
     // don't try to steal from someone else if we're the only thread (infinite loop)
     if (threadCount >= 2) {
         do {
-            // This is biased, but frankly, we don't care. It's fast.
-            uint16_t const index = uint16_t(state.rndGen() % threadCount);
+            // Fast range reduction (Lemire 2016, "Fast Random Integer Generation in an Interval",
+            // ACM Transactions on Modeling and Computer Simulation): avoids expensive hardware
+            // integer division (%) by scaling the 31-bit random integer as a fixed-point fraction.
+            uint16_t const index = uint16_t((uint64_t(state.rndGen()) * threadCount) >> 31);
             assert_invariant(index < threadStates.size());
             stateToStealFrom = &threadStates[index];
             // don't steal from our own queue

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -597,7 +597,7 @@ void JobSystem::loop(ThreadState* state) {
             // This guarantees that any concurrent producer in put() will observe
             // mSleepingCounts > 0 and call wakeOne() if it publishes work after our check.
             mSleepingCounts.fetch_add(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);
-            while (!exitRequested() && mActiveJobs.load(std::memory_order_seq_cst) == 0) {
+            while (!exitRequested() && mActiveJobs.load(std::memory_order_seq_cst) <= 0) {
                 waitForWork(lock);
             }
             mSleepingCounts.fetch_sub(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -313,16 +313,17 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
 
 inline void JobSystem::waitForWork(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
-    mSleepingCounts.fetch_add(SLEEPING_WORKER_ONE, std::memory_order_relaxed);
     mWorkCondition.wait(lock);
-    mSleepingCounts.fetch_sub(SLEEPING_WORKER_ONE, std::memory_order_relaxed);
 }
 
 inline void JobSystem::waitForJob(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
-    mSleepingCounts.fetch_add(SLEEPING_WAITER_ONE, std::memory_order_relaxed);
+    // Sequentially consistent store-load pairing (Dekker pattern):
+    // Announce sleeping waiter count with memory_order_seq_cst so put() observes
+    // sleeping waiters when checking whether to invoke wakeOne().
+    mSleepingCounts.fetch_add(SLEEPING_WAITER_ONE, std::memory_order_seq_cst);
     mJobCondition.wait(lock);
-    mSleepingCounts.fetch_sub(SLEEPING_WAITER_ONE, std::memory_order_relaxed);
+    mSleepingCounts.fetch_sub(SLEEPING_WAITER_ONE, std::memory_order_seq_cst);
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
@@ -403,16 +404,15 @@ void JobSystem::put(ThreadState& state, Job const* job) noexcept {
         state.workQueue.push(prev);
     }
 
-    // Increase our active job count. We MUST use std::memory_order_release here.
-    // If we used relaxed, the compiler or CPU could reorder this increment to happen 
-    // BEFORE nextJob.exchange() or workQueue.push(). If a preemption happened right there,
-    // other threads would see mActiveJobs > 0, enter the steal() loop, fail to find the job,
-    // and spin infinitely, recreating the exact same priority inversion lockup on the push side!
-    mActiveJobs.fetch_add(1, std::memory_order_release);
+    // Sequentially consistent write-read pairing (Dekker pattern):
+    // Producer writes mActiveJobs (W1) before reading mSleepingCounts (R1).
+    // Worker in loop() writes mSleepingCounts (W2) before reading mActiveJobs (R2).
+    // Using memory_order_seq_cst guarantees that if the worker observes mActiveJobs == 0
+    // and prepares to sleep, the producer is guaranteed to observe mSleepingCounts > 0
+    // and invoke wakeOne(), preventing lost wakeups without acquiring mWaiterLock.
+    mActiveJobs.fetch_add(1, std::memory_order_seq_cst);
 
-    // Only wake a sleeping thread if there is at least one thread sleeping (worker or waiter).
-    // If all threads are already awake and running, wakeOne() and its internal mWaiterLock are completely bypassed.
-    if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_relaxed) > 0)) {
+    if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_seq_cst) > 0)) {
         wakeOne();
     }
 }
@@ -573,9 +573,16 @@ void JobSystem::loop(ThreadState* state) {
             // transient contention into priority inversion livelocks. Instead, we proceed to
             // take mWaiterLock and sleep in wait(lock).
             UniqueLock lock(mWaiterLock);
-            while (!exitRequested() && !hasActiveJobs()) {
+            // Sequentially consistent write-read pairing (Dekker pattern):
+            // 1. Announce intent to sleep by incrementing mSleepingCounts (seq_cst).
+            // 2. Check mActiveJobs (seq_cst) before sleeping on mWorkCondition.
+            // This guarantees that any concurrent producer in put() will observe
+            // mSleepingCounts > 0 and call wakeOne() if it publishes work after our check.
+            mSleepingCounts.fetch_add(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);
+            while (!exitRequested() && mActiveJobs.load(std::memory_order_seq_cst) == 0) {
                 waitForWork(lock);
             }
+            mSleepingCounts.fetch_sub(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);
         }
     } while (!exitRequested());
 }

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -397,32 +397,24 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
 }
 
 JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
-    // We speculatively decrement mActiveJobs before taking the job.
-    // If a thread is preempted here, mActiveJobs is temporarily undercounted.
-    // This is safe and desirable: it allows other idle threads to see 0 and go to sleep
-    // (yielding the CPU) instead of spinning infinitely on hasActiveJobs(),
-    // completely preventing priority inversion lockups.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    // By design, the owner thread must always attempt to pop from its own queue first without
+    // inspecting or decrementing mActiveJobs. Popping from our own queue is wait-free and
+    // contention-free. Gating pop() on global active job counters would cause owner threads to
+    // starve and falsely skip their own runnable jobs if a concurrent stealer has speculatively
+    // decremented mActiveJobs.
     size_t const index = workQueue.pop();
     assert(index <= MAX_JOB_COUNT);
     Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
-    if (UTILS_UNLIKELY(!job)) {
-        // If we didn't actually get a job, restore the count.
-        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+    if (UTILS_LIKELY(job)) {
+        mActiveJobs.fetch_sub(1, std::memory_order_relaxed);
     }
     return job;
 }
 
 JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
-    // See JobSystem::pop() for why we pre-decrement mActiveJobs.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
     size_t const index = workQueue.steal();
     assert_invariant(index <= MAX_JOB_COUNT);
-    Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
-    if (UTILS_UNLIKELY(!job)) {
-        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
-    }
-    return job;
+    return !index ? nullptr : &mJobStorageBase[index - 1];
 }
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
@@ -446,14 +438,47 @@ inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state
 
 JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+
+    // Fast check: if no jobs are active, avoid attempting to steal or touch atomics.
+    if (UTILS_UNLIKELY(!hasActiveJobs())) {
+        return nullptr;
+    }
+
+    // Speculatively claim one job count before searching across queues.
+    // If preempted while stealing or executing, mActiveJobs is already decremented,
+    // allowing other threads to sleep rather than spin (preventing priority inversions).
+    int32_t const prevActiveJobs = mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    if (UTILS_UNLIKELY(prevActiveJobs <= 0)) {
+        // Another thread took the last available job; restore count and exit immediately.
+        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+        return nullptr;
+    }
+
     Job* job = nullptr;
+    auto const& threadStates = mThreadStates;
+    uint16_t const threadCount = uint16_t(threadStates.size());
+
+    // Search queues for the job we claimed, bounded strictly to threadCount attempts.
+    // Note: It is incorrect to check hasActiveJobs() in this loop because:
+    // 1) mActiveJobs was already speculatively decremented above (so it may read 0 even if
+    //    our claimed job is waiting in another queue).
+    // 2) Checking hasActiveJobs() would turn this into an unbounded busy loop whenever jobs
+    //    remain in other queues.
+    // Bounding strictly to threadCount guarantees prompt termination while giving a high
+    // probability of finding available work.
+    size_t attempts = 0;
     do {
         if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
             job = steal(stateToStealFrom->workQueue);
         }
-        // nullptr -> nothing to steal in that queue either, if there are active jobs,
-        // continue to try stealing one.
-    } while (!job && hasActiveJobs());
+        attempts++;
+    } while (!job && attempts < threadCount);
+
+    if (UTILS_UNLIKELY(!job)) {
+        // If we couldn't find a job (e.g. consumed concurrently), restore the count.
+        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+    }
+
     return job;
 }
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -203,12 +203,30 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
             // one of the thread will be the user thread
             threadPoolCount = hwThreads - 1;
         }
-        // clamp adoptableThreadsCount so it does not exceed MAX_THREADS
-        adoptableThreadsCount = std::min(adoptableThreadsCount, MAX_THREADS);
+        // Clamp adoptableThreadsCount so it does not exceed MAX_THREADS - 1, ensuring room
+        // for at least one pool worker thread.
+        if (adoptableThreadsCount >= MAX_THREADS) {
+            LOG(ERROR) << "JobSystem: adoptableThreadsCount (" << adoptableThreadsCount
+                       << ") exceeds MAX_THREADS - 1 (" << (MAX_THREADS - 1)
+                       << "), clamping.";
+            adoptableThreadsCount = MAX_THREADS - 1;
+        } else if (adoptableThreadsCount == 0) {
+            adoptableThreadsCount = 1;
+        }
+
+        // make sure we have at least one thread in the thread pool
+        threadPoolCount = std::max(1u, threadPoolCount);
+
         // limit the pool such that threadPoolCount + adoptableThreadsCount <= MAX_THREADS
         const uint32_t maxThreadPoolCount = MAX_THREADS - adoptableThreadsCount;
-        // make sure we have at least one thread in the thread pool if capacity permits
-        threadPoolCount = std::max(maxThreadPoolCount > 0 ? 1u : 0u, threadPoolCount);
+        if (threadPoolCount > maxThreadPoolCount) {
+            LOG(WARNING) << "JobSystem: threadPoolCount (" << threadPoolCount
+                         << ") + adoptableThreadsCount (" << adoptableThreadsCount
+                         << ") exceeds MAX_THREADS (" << MAX_THREADS
+                         << "), clamping pool count to " << maxThreadPoolCount;
+            threadPoolCount = maxThreadPoolCount;
+        }
+
         threadPoolCount = std::min(UTILS_HAS_THREADING ? maxThreadPoolCount : 0u, threadPoolCount);
     } else {
         threadPoolCount = 0;

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -460,24 +460,25 @@ JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     }
 
     Job* job = nullptr;
-    auto const& threadStates = mThreadStates;
-    uint16_t const threadCount = uint16_t(threadStates.size());
+    uint16_t const activeThreads = mActiveThreadCount.load(std::memory_order_relaxed);
 
-    // Search queues for the job we claimed, bounded strictly to threadCount attempts.
+    // Search queues for the job we claimed, bounded strictly to activeThreads attempts.
     // Note: It is incorrect to check hasActiveJobs() in this loop because:
     // 1) mActiveJobs was already speculatively decremented above (so it may read 0 even if
     //    our claimed job is waiting in another queue).
     // 2) Checking hasActiveJobs() would turn this into an unbounded busy loop whenever jobs
     //    remain in other queues.
-    // Bounding strictly to threadCount guarantees prompt termination while giving a high
+    // Bounding strictly to activeThreads guarantees prompt termination while giving a high
     // probability of finding available work.
     size_t attempts = 0;
     do {
         if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
             job = steal(stateToStealFrom->workQueue);
+        } else {
+            break;
         }
         attempts++;
-    } while (!job && attempts < threadCount);
+    } while (!job && attempts < activeThreads);
 
     if (UTILS_UNLIKELY(!job)) {
         // If we couldn't find a job (e.g. consumed concurrently), restore the count.

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -294,7 +294,8 @@ void JobSystem::decRef(Job const* job) noexcept {
 void JobSystem::requestExit() noexcept {
     mExitRequested.store(true);
     LockGuard const lock(mWaiterLock);
-    mWaiterCondition.notify_all();
+    mWorkCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 inline bool JobSystem::exitRequested() const noexcept {
@@ -310,11 +311,18 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
     return (job->runningJobCount.load(std::memory_order_acquire) & JOB_COUNT_MASK) == 0;
 }
 
-inline void JobSystem::wait(UniqueLock& lock) noexcept {
+inline void JobSystem::waitForWork(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
-    mSleepingThreads.fetch_add(1, std::memory_order_relaxed);
-    mWaiterCondition.wait(lock);
-    mSleepingThreads.fetch_sub(1, std::memory_order_relaxed);
+    mSleepingCounts.fetch_add(SLEEPING_WORKER_ONE, std::memory_order_relaxed);
+    mWorkCondition.wait(lock);
+    mSleepingCounts.fetch_sub(SLEEPING_WORKER_ONE, std::memory_order_relaxed);
+}
+
+inline void JobSystem::waitForJob(UniqueLock& lock) noexcept {
+    HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+    mSleepingCounts.fetch_add(SLEEPING_WAITER_ONE, std::memory_order_relaxed);
+    mJobCondition.wait(lock);
+    mSleepingCounts.fetch_sub(SLEEPING_WAITER_ONE, std::memory_order_relaxed);
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
@@ -333,7 +341,7 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
             job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
 
     if (runningJobCount & JOB_COUNT_MASK) {
-        wait(lock);
+        waitForJob(lock);
     }
 
     runningJobCount =
@@ -345,15 +353,15 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
 }
 
 UTILS_NOINLINE
-void JobSystem::wakeAll() noexcept {
-    // wakeAll() is called when a job finishes (to wake up any thread that might be waiting on it)
+void JobSystem::wakeWaiters() noexcept {
+    // wakeWaiters() is called when a job finishes (to wake up any thread that might be waiting on it)
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     mWaiterLock.lock();
     // this empty critical section is needed -- it guarantees that notify_all() happens
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_all() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 void JobSystem::wakeOne() noexcept {
@@ -364,7 +372,12 @@ void JobSystem::wakeOne() noexcept {
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_one() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_one();
+    uint32_t const sleeping = mSleepingCounts.load(std::memory_order_relaxed);
+    if (sleeping & SLEEPING_WORKER_MASK) {
+        mWorkCondition.notify_one();
+    } else if (sleeping & SLEEPING_WAITER_MASK) {
+        mJobCondition.notify_one();
+    }
 }
 
 inline JobSystem::ThreadState& JobSystem::getState() {
@@ -393,10 +406,9 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
     // spin infinitely, recreating the exact same priority inversion lockup on the push side!
     mActiveJobs.fetch_add(1, std::memory_order_release);
 
-    // Only wake a sleeping thread if there is at least one thread sleeping.
-    // If all worker threads are already awake and running (mSleepingThreads == 0),
-    // wakeOne() and its internal mWaiterLock are completely bypassed.
-    if (UTILS_UNLIKELY(mSleepingThreads.load(std::memory_order_relaxed) > 0)) {
+    // Only wake a sleeping thread if there is at least one thread sleeping (worker or waiter).
+    // If all threads are already awake and running, wakeOne() and its internal mWaiterLock are completely bypassed.
+    if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_relaxed) > 0)) {
         wakeOne();
     }
 }
@@ -534,7 +546,7 @@ void JobSystem::loop(ThreadState* state) {
             // take mWaiterLock and sleep in wait(lock).
             UniqueLock lock(mWaiterLock);
             while (!exitRequested() && !hasActiveJobs()) {
-                wait(lock);
+                waitForWork(lock);
             }
         }
     } while (!exitRequested());
@@ -573,7 +585,7 @@ void JobSystem::finish(Job* job) noexcept {
     // wake-up all threads that could potentially be waiting on this job finishing
     if (UTILS_UNLIKELY(notify)) {
         // but avoid calling notify_all() at all cost, because it's always expensive
-        wakeAll();
+        wakeWaiters();
     }
 }
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -311,7 +311,9 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
 
 inline void JobSystem::wait(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+    mSleepingThreads.fetch_add(1, std::memory_order_relaxed);
     mWaiterCondition.wait(lock);
+    mSleepingThreads.fetch_sub(1, std::memory_order_relaxed);
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
@@ -326,7 +328,7 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
             job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
 
     if (runningJobCount & JOB_COUNT_MASK) {
-        mWaiterCondition.wait(lock);
+        wait(lock);
     }
 
     runningJobCount =
@@ -386,11 +388,12 @@ void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
     // spin infinitely, recreating the exact same priority inversion lockup on the push side!
     mActiveJobs.fetch_add(1, std::memory_order_release);
 
-    // Note: it's absolutely possible for mActiveJobs to be 0 here, because the job could have
-    // been handled by a zealous worker already. In that case we could avoid calling wakeOne(),
-    // but that is not the common case.
-
-    wakeOne();
+    // Only wake a sleeping thread if there is at least one thread sleeping.
+    // If all worker threads are already awake and running (mSleepingThreads == 0),
+    // wakeOne() and its internal mWaiterLock are completely bypassed.
+    if (UTILS_UNLIKELY(mSleepingThreads.load(std::memory_order_relaxed) > 0)) {
+        wakeOne();
+    }
 }
 
 JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -25,6 +25,13 @@
 
 #include <array>
 #include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <time.h>
+#endif
 
 using namespace utils;
 using namespace jobs;
@@ -693,5 +700,88 @@ TEST(JobSystem, JobSystemStealFromEmancipatedQueue) {
 
     EXPECT_TRUE(finished);
 }
+
+namespace {
+
+static double getThreadCpuTimeMs() noexcept {
+#if defined(_WIN32)
+    FILETIME creationTime, exitTime, kernelTime, userTime;
+    if (GetThreadTimes(GetCurrentThread(), &creationTime, &exitTime, &kernelTime, &userTime)) {
+        ULARGE_INTEGER kernel, user;
+        kernel.LowPart = kernelTime.dwLowDateTime;
+        kernel.HighPart = kernelTime.dwHighDateTime;
+        user.LowPart = userTime.dwLowDateTime;
+        user.HighPart = userTime.dwHighDateTime;
+        return double(kernel.QuadPart + user.QuadPart) / 10000.0;
+    }
+    return 0.0;
+#elif defined(CLOCK_THREAD_CPUTIME_ID)
+    struct timespec ts {};
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0) {
+        return (double(ts.tv_sec) * 1000.0) + (double(ts.tv_nsec) / 1000000.0);
+    }
+    return 0.0;
+#else
+    return 0.0;
+#endif
+}
+
+} // namespace
+
+TEST(JobSystem, JobSystemWaitAndReleaseDoesNotBusySpin) {
+    JobSystem js(4, 28);
+    js.adopt();
+
+    // 4 worker threads run 100ms tasks
+    std::atomic<int> runningWorkers{0};
+    JobSystem::Job* targetJob = nullptr;
+    for (int i = 0; i < 4; ++i) {
+        JobSystem::Job* w = js.createJob(nullptr, [&](JobSystem&, JobSystem::Job*) {
+            runningWorkers.fetch_add(1, std::memory_order_relaxed);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        });
+        if (i == 0) {
+            targetJob = js.runAndRetain(w);
+        } else {
+            js.run(w);
+        }
+    }
+
+    while (runningWorkers.load(std::memory_order_relaxed) < 4) {
+        std::this_thread::yield();
+    }
+
+    // Push 1 job into a separate adopted thread's queue
+    std::atomic<bool> bgDone{false};
+    std::thread bgThread([&]() {
+        js.adopt();
+        JobSystem::Job* extra = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        js.run(extra);
+        while (!bgDone.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        js.emancipate();
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    double const startCpuTime = getThreadCpuTimeMs();
+
+    js.waitAndRelease(targetJob);
+
+    double const endCpuTime = getThreadCpuTimeMs();
+
+    bgDone.store(true, std::memory_order_release);
+    bgThread.join();
+
+    double const cpuTimeMs = endCpuTime - startCpuTime;
+
+    EXPECT_LT(cpuTimeMs, 30.0)
+            << "waitAndRelease() busy-spun at 100% CPU! Consumed " << cpuTimeMs
+            << "ms CPU time while waiting for 100ms child job.";
+
+    js.emancipate();
+}
+
 
 

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -783,5 +783,32 @@ TEST(JobSystem, JobSystemWaitAndReleaseDoesNotBusySpin) {
     js.emancipate();
 }
 
+TEST(JobSystem, JobSystemStealingWithManyAdoptableSlots) {
+    bool const finished = runWithTimeout([]() {
+        // 4 pool threads, 28 adoptable slots (32 total)
+        JobSystem js(4, 28);
+        js.adopt();
+
+        std::atomic<uint32_t> completed{0};
+        constexpr size_t JOB_COUNT = 2000;
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        for (size_t i = 0; i < JOB_COUNT; ++i) {
+            JobSystem::Job* child = js.createJob(root, [&completed](JobSystem&, JobSystem::Job*) {
+                completed.fetch_add(1, std::memory_order_relaxed);
+            });
+            js.run(child);
+        }
+        js.runAndWait(root);
+
+        EXPECT_EQ(JOB_COUNT, completed.load());
+
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+
+
 
 

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -327,6 +327,23 @@ TEST(JobSystem, JobSystemParallelForLargeChunkSize) {
     js.emancipate();
 }
 
+TEST(JobSystem, JobSystemParallelForEmptyCount) {
+    JobSystem js;
+    js.adopt();
+
+    bool called = false;
+    JobSystem::Job* job = parallel_for(js, nullptr, 0, 0,
+            [&called](uint32_t, uint32_t) {
+                called = true;
+            });
+    ASSERT_NE(job, nullptr);
+    js.runAndWait(job);
+
+    EXPECT_FALSE(called);
+
+    js.emancipate();
+}
+
 TEST(JobSystem, JobSystemDelegates) {
     JobSystem js;
     js.adopt();

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -809,6 +809,56 @@ TEST(JobSystem, JobSystemStealingWithManyAdoptableSlots) {
     EXPECT_TRUE(finished);
 }
 
+TEST(JobSystem, JobSystemLostWakeupRace) {
+    bool const finished = runWithTimeout([]() {
+        constexpr size_t WORKER_COUNT = 1;
+        constexpr size_t PRODUCER_COUNT = 4;
+        constexpr size_t ITERATIONS = 5000;
 
+        JobSystem js(WORKER_COUNT, PRODUCER_COUNT);
 
+        for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+            std::atomic<uint32_t> completed{0};
+            std::atomic<bool> startFlag{false};
+            std::vector<std::thread> producers;
+            producers.reserve(PRODUCER_COUNT);
+
+            for (size_t p = 0; p < PRODUCER_COUNT; ++p) {
+                producers.emplace_back([&js, &completed, &startFlag]() {
+                    js.adopt();
+                    while (!startFlag.load(std::memory_order_acquire)) {
+                        std::this_thread::yield();
+                    }
+                    JobSystem::Job* job = js.createJob(nullptr, [&completed](JobSystem&, JobSystem::Job*) {
+                        completed.fetch_add(1, std::memory_order_relaxed);
+                    });
+                    js.run(job);
+                    js.emancipate();
+                });
+            }
+
+            // Let worker enter sleep state
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+            // Release all producers simultaneously to race with worker sleep
+            startFlag.store(true, std::memory_order_release);
+
+            for (auto& t : producers) {
+                t.join();
+            }
+
+            auto const start = std::chrono::steady_clock::now();
+            while (completed.load(std::memory_order_relaxed) < PRODUCER_COUNT) {
+                if (std::chrono::steady_clock::now() - start > std::chrono::milliseconds(200)) {
+                    FAIL() << "Lost wakeup at iteration " << iter << ": completed "
+                           << completed.load() << " / " << PRODUCER_COUNT << " jobs!";
+                    return;
+                }
+                std::this_thread::yield();
+            }
+        }
+    }, std::chrono::seconds(10));
+
+    EXPECT_TRUE(finished);
+}
 

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -400,3 +400,273 @@ TEST(JobSystem, JobSystemConcurrentStress) {
 
     EXPECT_EQ(totalSum.load(), expectedTotal);
 }
+
+TEST(JobSystem, JobSystemBurstyWake) {
+    JobSystem js(4, 1);
+    js.adopt();
+
+    std::atomic<uint32_t> completedJobs{0};
+
+    // Part 1: Submit 1 job, wait for completion, sleep to ensure workers go to sleep, repeat
+    for (size_t i = 0; i < 30; ++i) {
+        JobSystem::Job* job = js.createJob(nullptr, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.runAndWait(job);
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+
+    EXPECT_EQ(30u, completedJobs.load());
+
+    // Part 2: Sudden burst of 100 jobs after idle period
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    for (size_t i = 0; i < 100; ++i) {
+        JobSystem::Job* child = js.createJob(root, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.run(child);
+    }
+    js.runAndWait(root);
+
+    EXPECT_EQ(130u, completedJobs.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemDeepTreeMultiWait) {
+    JobSystem js(8, 8);
+    js.adopt();
+
+    std::atomic<uint32_t> leafCount{0};
+
+    auto buildTree = [&](auto& self, JobSystem::Job* parent, int depth) -> void {
+        if (depth == 0) {
+            JobSystem::Job* leaf = js.createJob(parent, [&leafCount](JobSystem&, JobSystem::Job*) {
+                leafCount.fetch_add(1, std::memory_order_relaxed);
+            });
+            js.run(leaf);
+            return;
+        }
+        for (int i = 0; i < 4; ++i) {
+            JobSystem::Job* node = js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
+            self(self, node, depth - 1);
+            js.run(node);
+        }
+    };
+
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    buildTree(buildTree, root, 4); // 4^4 = 256 leaves
+
+    // Retain root so we can wait on it from multiple threads
+    js.retain(root);
+    js.retain(root);
+    js.retain(root);
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> waitingThreads;
+    for (int t = 0; t < 3; ++t) {
+        waitingThreads.emplace_back([&, root]() {
+            js.adopt();
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            JobSystem::Job* r = root;
+            js.waitAndRelease(r);
+            js.emancipate();
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    js.runAndWait(root);
+
+    for (auto& t : waitingThreads) {
+        t.join();
+    }
+
+    EXPECT_EQ(256u, leafCount.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemPoolExhaustionAndChurn) {
+    JobSystem js(8, 8);
+
+    constexpr size_t THREAD_COUNT = 8;
+    constexpr size_t BATCH_SIZE = 1200; // 8 * 1200 = 9600 active jobs simultaneously
+    std::atomic<uint32_t> jobsExecuted{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            js.adopt();
+            for (size_t iter = 0; iter < 3; ++iter) {
+                JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+                for (size_t i = 0; i < BATCH_SIZE; ++i) {
+                    JobSystem::Job* child = js.createJob(root, [&jobsExecuted](JobSystem&, JobSystem::Job*) {
+                        jobsExecuted.fetch_add(1, std::memory_order_relaxed);
+                    });
+                    js.run(child);
+                }
+                js.runAndWait(root);
+            }
+            js.emancipate();
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * BATCH_SIZE * 3, jobsExecuted.load());
+}
+
+TEST(JobSystem, JobSystemSingleThreaded) {
+    JobSystem js(JobSystem::SINGLE_THREADED);
+    js.adopt();
+
+    std::vector<uint32_t> data(512, 10);
+    auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* slice, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    slice[i] += 5;
+                }
+            }, CountSplitter<4>());
+    js.runAndWait(job);
+
+    for (uint32_t val : data) {
+        EXPECT_EQ(15u, val);
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemMultipleInstances) {
+    JobSystem js1(4, 4);
+    JobSystem js2(4, 4);
+
+    std::atomic<uint32_t> count1{0};
+    std::atomic<uint32_t> count2{0};
+
+    std::thread t1([&]() {
+        js1.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js1.createJob(nullptr, [&count1](JobSystem&, JobSystem::Job*) {
+                count1.fetch_add(1, std::memory_order_relaxed);
+            });
+            js1.runAndWait(job);
+        }
+        js1.emancipate();
+    });
+
+    std::thread t2([&]() {
+        js2.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js2.createJob(nullptr, [&count2](JobSystem&, JobSystem::Job*) {
+                count2.fetch_add(1, std::memory_order_relaxed);
+            });
+            js2.runAndWait(job);
+        }
+        js2.emancipate();
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(100u, count1.load());
+    EXPECT_EQ(100u, count2.load());
+}
+
+TEST(JobSystem, JobSystemRapidAdoptEmancipate) {
+    JobSystem js(4, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 100;
+
+    std::atomic<uint32_t> jobsCompleted{0};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+                JobSystem::Job* job = js.createJob(nullptr, [&jobsCompleted](JobSystem&, JobSystem::Job*) {
+                    jobsCompleted.fetch_add(1, std::memory_order_relaxed);
+                });
+                js.runAndWait(job);
+                js.emancipate();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * ITERATIONS, jobsCompleted.load());
+}
+
+template<typename F>
+static bool runWithTimeout(F&& fn, std::chrono::milliseconds timeout) {
+    std::atomic<bool> completed{false};
+    std::thread t([&]() {
+        fn();
+        completed.store(true, std::memory_order_release);
+    });
+    auto const start = std::chrono::steady_clock::now();
+    while (!completed.load(std::memory_order_acquire)) {
+        if (std::chrono::steady_clock::now() - start > timeout) {
+            t.detach();
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    t.join();
+    return true;
+}
+
+TEST(JobSystem, JobSystemWorkerWakeOnSubsequentPut) {
+    bool const finished = runWithTimeout([]() {
+        // 3 worker threads in the pool, 1 adoptable
+        JobSystem js(3, 1);
+        js.adopt();
+
+        // Ensure all 3 workers are idle and sleeping
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+
+        std::atomic<int> concurrentWorkers{0};
+        std::atomic<int> maxConcurrent{0};
+
+        auto jobFunc = [&](JobSystem&, JobSystem::Job*) {
+            int const cur = concurrentWorkers.fetch_add(1, std::memory_order_relaxed) + 1;
+            int prevMax = maxConcurrent.load(std::memory_order_relaxed);
+            while (cur > prevMax && !maxConcurrent.compare_exchange_weak(prevMax, cur,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {}
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            concurrentWorkers.fetch_sub(1, std::memory_order_relaxed);
+        };
+
+        // Push 10 jobs in rapid succession
+        for (int i = 0; i < 10; ++i) {
+            JobSystem::Job* j = js.createJob(root, jobFunc);
+            js.run(j);
+        }
+
+        // Wait for all 10 jobs to complete via root
+        js.runAndWait(root);
+
+        // With 3 pool workers and 1 caller thread in runAndWait, all 3 pool workers should be woken
+        EXPECT_GE(maxConcurrent.load(), 3)
+                << "Not all sleeping workers were woken! maxConcurrent: " << maxConcurrent.load();
+
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -291,6 +291,42 @@ TEST(JobSystem, JobSystemParallelFor) {
     js.emancipate();
 }
 
+TEST(JobSystem, JobSystemParallelForLargeChunkSize) {
+    JobSystem js;
+    js.adopt();
+
+    constexpr size_t COUNT = 131072;
+    std::vector<uint32_t> data(COUNT, 0);
+
+    // Test with chunkSize = 65536 (exact multiple of 2^16, which would truncate to 0 in uint16_t)
+    JobSystem::Job* job1 = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 1;
+                }
+            }, CountSplitter<65536>());
+    js.runAndWait(job1);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 1u);
+    }
+
+    // Test with chunkSize = 70000 (> 2^16)
+    JobSystem::Job* job2 = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 2;
+                }
+            }, CountSplitter<70000>());
+    js.runAndWait(job2);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 3u);
+    }
+
+    js.emancipate();
+}
+
 TEST(JobSystem, JobSystemDelegates) {
     JobSystem js;
     js.adopt();

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -670,3 +670,28 @@ TEST(JobSystem, JobSystemWorkerWakeOnSubsequentPut) {
     EXPECT_TRUE(finished);
 }
 
+TEST(JobSystem, JobSystemStealFromEmancipatedQueue) {
+    bool const finished = runWithTimeout([]() {
+        JobSystem js(4, 2);
+        js.adopt();
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        JobSystem::Job* child = js.createJob(root, [](JobSystem&, JobSystem::Job*) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        });
+
+        std::thread runner([&]() {
+            js.adopt();
+            js.run(child);
+            js.emancipate();
+        });
+        runner.join();
+
+        js.runAndWait(root);
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+
+

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
+#include <utils/Allocator.h>
 #include <utils/JobSystem.h>
 #include <utils/WorkStealingDequeue.h>
 
-#include <math/vec3.h>
 #include <math/mat3.h>
+#include <math/vec3.h>
+
+#include <gtest/gtest.h>
 
 #include <array>
 #include <thread>
-#include <utils/Allocator.h>
 
 using namespace utils;
 using namespace jobs;
@@ -343,4 +343,60 @@ TEST(JobSystem, JobSystemDelegates) {
 
 
     js.emancipate();
+}
+
+TEST(JobSystem, JobSystemConcurrentStress) {
+    // 8 worker threads + 16 adoptable user threads
+    JobSystem js(8, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 20;
+    constexpr size_t ARRAY_SIZE = 1024;
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    std::atomic<uint64_t> totalSum{0};
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&, t]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+
+                std::vector<uint32_t> data(ARRAY_SIZE, uint32_t(t + 1));
+                auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+                        [](uint32_t* slice, size_t count) {
+                            for (size_t i = 0; i < count; ++i) {
+                                slice[i] *= 2;
+                            }
+                        }, CountSplitter<4>());
+                js.runAndWait(job);
+
+                uint64_t localSum = 0;
+                for (uint32_t val : data) {
+                    localSum += val;
+                }
+                totalSum.fetch_add(localSum, std::memory_order_relaxed);
+
+                js.emancipate();
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    uint64_t expectedTotal = 0;
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        expectedTotal += uint64_t(t + 1) * 2 * ARRAY_SIZE * ITERATIONS;
+    }
+
+    EXPECT_EQ(totalSum.load(), expectedTotal);
 }

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -915,3 +915,16 @@ TEST(JobSystem, JobSystemLostWakeupRace) {
     EXPECT_TRUE(finished);
 }
 
+TEST(JobSystem, JobSystemThreadBudgetClamping) {
+    // 1. Requesting adoptableThreadsCount >= MAX_THREADS (32) must still ensure at least 1 pool worker.
+    JobSystem js1(0, 32);
+    EXPECT_GE(js1.getThreadCount(), 1u);
+
+    // 2. Requesting large userThreadCount and large adoptableThreadsCount must clamp total to MAX_THREADS (32).
+    JobSystem js2(32, 16);
+    EXPECT_EQ(js2.getThreadCount(), 16u);
+
+    // 3. SINGLE_THREADED mode must have 0 pool workers.
+    JobSystem jsSingle(JobSystem::SINGLE_THREADED, 1);
+    EXPECT_EQ(jsSingle.getThreadCount(), 0u);
+}

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -344,6 +344,90 @@ TEST(JobSystem, JobSystemParallelForEmptyCount) {
     js.emancipate();
 }
 
+TEST(JobSystem, JobSystemParallelForAdoptedThreads) {
+    JobSystem js(1, 3);
+    js.adopt();
+
+    std::atomic<bool> bgRunning{true};
+    std::atomic<int> bgAdoptedCount{0};
+    std::vector<std::thread> bgThreads;
+    for (int i = 0; i < 2; ++i) {
+        bgThreads.emplace_back([&js, &bgRunning, &bgAdoptedCount]() {
+            js.adopt();
+            bgAdoptedCount.fetch_add(1, std::memory_order_release);
+            while (bgRunning.load(std::memory_order_relaxed)) {
+                std::this_thread::yield();
+            }
+            js.emancipate();
+        });
+    }
+
+    while (bgAdoptedCount.load(std::memory_order_acquire) < 2) {
+        std::this_thread::yield();
+    }
+
+    EXPECT_GE(js.getActiveThreadCount(), 3u);
+
+    constexpr size_t COUNT = 1000;
+    std::vector<uint32_t> data(COUNT, 0);
+    JobSystem::Job* job = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 1;
+                }
+            }, CountSplitter<10>());
+    js.runAndWait(job);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 1u);
+    }
+
+    bgRunning.store(false, std::memory_order_release);
+    for (auto& t : bgThreads) {
+        t.join();
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemCustomSplitters) {
+    JobSystem js;
+    js.adopt();
+
+    struct CustomFixedSplitter {
+        size_t getChunkSize() const noexcept { return 8; }
+    };
+
+    struct CustomDynamicSplitter {
+        size_t getChunkSize(uint32_t count, uint32_t threadCount) const noexcept {
+            return std::max<uint32_t>(1, count / (threadCount * 2));
+        }
+    };
+
+    constexpr size_t COUNT = 128;
+    std::vector<uint32_t> data1(COUNT, 0);
+    std::vector<uint32_t> data2(COUNT, 0);
+
+    JobSystem::Job* job1 = parallel_for(js, nullptr, data1.data(), data1.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) ptr[i] += 1;
+            }, CustomFixedSplitter{});
+    js.runAndWait(job1);
+
+    JobSystem::Job* job2 = parallel_for(js, nullptr, data2.data(), data2.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) ptr[i] += 2;
+            }, CustomDynamicSplitter{});
+    js.runAndWait(job2);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data1[i], 1u);
+        EXPECT_EQ(data2[i], 2u);
+    }
+
+    js.emancipate();
+}
+
 TEST(JobSystem, JobSystemDelegates) {
     JobSystem js;
     js.adopt();

--- a/libs/utils/test/test_ThreadMap.cpp
+++ b/libs/utils/test/test_ThreadMap.cpp
@@ -137,8 +137,10 @@ TEST(ThreadMapTest, MultiThreadedConcurrentAccess) {
 
             for (size_t iter = 0; iter < ITERATIONS; ++iter) {
                 // Register
-                uint32_t const slot = map.emplace(i * 10000 + iter);
-                EXPECT_NE((decltype(map)::INVALID_INDEX), slot);
+                uint32_t slot;
+                do {
+                    slot = map.emplace(i * 10000 + iter);
+                } while (slot == decltype(map)::INVALID_INDEX);
 
                 // Verify self lookup
                 EXPECT_TRUE(map.contains());
@@ -199,8 +201,13 @@ TEST(ThreadMapTest, MultiThreadedStaticSlots) {
 }
 
 struct Payload {
-    uint64_t id = 0;
-    bool valid() const { return id != 0; }
+    uint64_t v[4] = {0, 0, 0, 0};
+    Payload() = default;
+    explicit Payload(uint64_t val) : v{val, val, val, val} {}
+    bool valid() const {
+        return (v[0] == 0 && v[1] == 0 && v[2] == 0 && v[3] == 0) ||
+               (v[0] != 0 && v[0] == v[1] && v[1] == v[2] && v[2] == v[3]);
+    }
 };
 
 TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
@@ -214,7 +221,7 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
             const auto tid = writerTid.load(std::memory_order_relaxed);
             if (tid != std::thread::id{}) {
                 Payload const p = map.get(tid);
-                if (p.id != 0 && !p.valid()) {
+                if (!p.valid()) {
                     failures.fetch_add(1, std::memory_order_relaxed);
                 }
             }
@@ -223,9 +230,8 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
 
     std::thread writer([&]() {
         writerTid.store(std::this_thread::get_id(), std::memory_order_release);
-        for (size_t i = 1; i <= 20000; ++i) {
-            Payload p{i};
-            map.emplace(p);
+        for (size_t i = 1; i <= 50000; ++i) {
+            map.emplace(Payload(i));
             map.erase();
         }
         done.store(true, std::memory_order_release);
@@ -234,7 +240,110 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
     writer.join();
     reader.join();
 
-    EXPECT_EQ(0u, failures.load()) << "Reader observed uninitialized or partially written value in emplace()!";
+    EXPECT_EQ(0u, failures.load()) << "Reader observed torn or uninitialized payload in emplace()!";
+}
+
+TEST(ThreadMapTest, ConcurrentGetAfterSlotReassignment) {
+    ThreadMap<int> map(1);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> abaErrors{0};
+
+    std::thread t1([] {});
+    std::thread t2([] {});
+    auto const tid1 = t1.get_id();
+    auto const tid2 = t2.get_id();
+    t1.join();
+    t2.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            int const val = map.get(tid1);
+            if (val == 200) {
+                abaErrors.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread mutator([&]() {
+        for (size_t i = 0; i < 500000; ++i) {
+            map.set(0, 100, tid1);
+            map.eraseAt(0);
+            map.set(0, 200, tid2);
+            map.eraseAt(0);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    mutator.join();
+    reader.join();
+
+    EXPECT_EQ(0u, abaErrors.load()) << "get(tid1) returned value belonging to tid2 after slot reuse!";
+}
+
+TEST(ThreadMapTest, ConcurrentSetAndFindIndexDataRace) {
+    ThreadMap<int> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> invalidFinds{0};
+
+    std::thread t1([] {});
+    std::thread t2([] {});
+    auto const tid1 = t1.get_id();
+    auto const tid2 = t2.get_id();
+    t1.join();
+    t2.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            uint32_t const idx = map.findIndex(tid2);
+            if (idx == 0) {
+                invalidFinds.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        for (size_t i = 0; i < 50000; ++i) {
+            map.set(0, 42, tid1);
+            map.eraseAt(0);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    writer.join();
+    reader.join();
+
+    EXPECT_EQ(0u, invalidFinds.load()) << "findIndex(tid2) erroneously returned slot 0 during concurrent set/erase!";
+}
+
+TEST(ThreadMapTest, ConcurrentSetReaderDataRace) {
+    ThreadMap<Payload> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> tornReads{0};
+
+    std::thread t1([] {});
+    auto const tid1 = t1.get_id();
+    t1.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            Payload const p = map.get(tid1);
+            if (!p.valid()) {
+                tornReads.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        for (size_t i = 1; i <= 500000; ++i) {
+            map.set(0, Payload(i), tid1);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    writer.join();
+    reader.join();
+
+    EXPECT_EQ(0u, tornReads.load()) << "Reader observed torn payload in set()!";
 }
 
 TEST(ThreadMapTest, EraseDestroysResource) {

--- a/libs/utils/test/test_ThreadMap.cpp
+++ b/libs/utils/test/test_ThreadMap.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -65,7 +66,7 @@ TEST(ThreadMapTest, BasicOperations) {
 }
 
 TEST(ThreadMapTest, EmplaceAndCapacity) {
-    ThreadMap<std::string> map(2);
+    ThreadMap<std::string_view> map(2);
     EXPECT_EQ(2u, map.getCapacity());
 
     // Create unique artificial thread IDs via threads
@@ -214,6 +215,7 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
     ThreadMap<Payload> map(2);
     std::atomic<bool> done{false};
     std::atomic<uint32_t> failures{0};
+    std::atomic<uint32_t> nonZeroReads{0};
     std::atomic<std::thread::id> writerTid{};
 
     std::thread reader([&]() {
@@ -223,6 +225,8 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
                 Payload const p = map.get(tid);
                 if (!p.valid()) {
                     failures.fetch_add(1, std::memory_order_relaxed);
+                } else if (p.v[0] != 0) {
+                    nonZeroReads.fetch_add(1, std::memory_order_relaxed);
                 }
             }
         }
@@ -241,6 +245,7 @@ TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
     reader.join();
 
     EXPECT_EQ(0u, failures.load()) << "Reader observed torn or uninitialized payload in emplace()!";
+    EXPECT_GT(nonZeroReads.load(), 100u) << "Reader should have observed valid non-zero payloads during emplace!";
 }
 
 TEST(ThreadMapTest, ConcurrentGetAfterSlotReassignment) {
@@ -319,6 +324,7 @@ TEST(ThreadMapTest, ConcurrentSetReaderDataRace) {
     ThreadMap<Payload> map(2);
     std::atomic<bool> done{false};
     std::atomic<uint32_t> tornReads{0};
+    std::atomic<uint32_t> validNonZeroReads{0};
 
     std::thread t1([] {});
     auto const tid1 = t1.get_id();
@@ -329,6 +335,8 @@ TEST(ThreadMapTest, ConcurrentSetReaderDataRace) {
             Payload const p = map.get(tid1);
             if (!p.valid()) {
                 tornReads.fetch_add(1, std::memory_order_relaxed);
+            } else if (p.v[0] != 0) {
+                validNonZeroReads.fetch_add(1, std::memory_order_relaxed);
             }
         }
     });
@@ -344,6 +352,7 @@ TEST(ThreadMapTest, ConcurrentSetReaderDataRace) {
     reader.join();
 
     EXPECT_EQ(0u, tornReads.load()) << "Reader observed torn payload in set()!";
+    EXPECT_GT(validNonZeroReads.load(), 50u) << "Reader should have observed valid non-zero payloads during set()!";
 }
 
 TEST(ThreadMapTest, EraseDestroysResource) {
@@ -376,5 +385,100 @@ TEST(ThreadMapTest, ReEmplaceUpdatesValueSafely) {
 
     map.erase(tid);
     EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, EraseAbaProtection) {
+    ThreadMap<uint64_t> map(1);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> stolenSlots{0};
+
+    std::thread dummyA([] {});
+    std::thread dummyB([] {});
+    auto const tidA = dummyA.get_id();
+    auto const tidB = dummyB.get_id();
+    dummyA.join();
+    dummyB.join();
+
+    std::thread t1([&]() {
+        for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+            if (map.emplace(111, tidA) != decltype(map)::INVALID_INDEX) {
+                map.erase(tidA);
+            }
+            map.erase(tidA);
+        }
+    });
+
+    std::thread t2([&]() {
+        for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+            if (map.emplace(222, tidB) != decltype(map)::INVALID_INDEX) {
+                // If erase(tidA) has an ABA bug, it could erase tidB while t2 is holding it.
+                if (!map.contains(tidB) || map.get(tidB) != 222) {
+                    stolenSlots.fetch_add(1, std::memory_order_relaxed);
+                }
+                map.erase(tidB);
+            }
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(0u, stolenSlots.load())
+            << "erase(tidA) suffered from an ABA race and unregistered tidB's slot!";
+}
+
+TEST(ThreadMapTest, ReEmplaceAbaProtection) {
+    ThreadMap<uint64_t> map(1);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> corruptedPayloads{0};
+
+    std::thread dummyA([] {});
+    std::thread dummyB([] {});
+    auto const tidA = dummyA.get_id();
+    auto const tidB = dummyB.get_id();
+    dummyA.join();
+    dummyB.join();
+
+    std::vector<std::thread> workers;
+    workers.reserve(8);
+
+    // 4 threads calling emplace/re-emplace on tidA
+    for (int t = 0; t < 4; ++t) {
+        workers.emplace_back([&]() {
+            for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+                map.emplace(111, tidA);
+                map.emplace(999, tidA);
+                map.erase(tidA);
+            }
+        });
+    }
+
+    // 4 threads calling emplace on tidB and asserting payload integrity
+    for (int t = 0; t < 4; ++t) {
+        workers.emplace_back([&]() {
+            for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+                if (map.emplace(222, tidB) != decltype(map)::INVALID_INDEX) {
+                    for (int k = 0; k < 5; ++k) {
+                        uint64_t const v = map.get(tidB);
+                        if (v != 222 && v != 0) {
+                            corruptedPayloads.fetch_add(1, std::memory_order_relaxed);
+                        }
+                    }
+                    map.erase(tidB);
+                }
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    done.store(true, std::memory_order_release);
+
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    EXPECT_EQ(0u, corruptedPayloads.load())
+            << "emplace(tidA) re-emplace path suffered from an ABA race and corrupted tidB's payload!";
 }
 

--- a/libs/utils/test/test_ThreadMap.cpp
+++ b/libs/utils/test/test_ThreadMap.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <private/utils/ThreadMap.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace utils;
+
+TEST(ThreadMapTest, BasicOperations) {
+    ThreadMap<int> map(4);
+    EXPECT_EQ(4u, map.getCapacity());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Current thread should not be present initially
+    EXPECT_FALSE(map.contains());
+    EXPECT_EQ(nullptr, map.find());
+    EXPECT_EQ(0, map.get());
+    EXPECT_EQ((decltype(map)::INVALID_INDEX), map.findIndex());
+
+    // Register current thread at slot 0
+    map.set(0, 42);
+    EXPECT_FALSE(map.empty());
+    EXPECT_EQ(1u, map.size());
+    EXPECT_TRUE(map.contains());
+    EXPECT_EQ(0u, map.findIndex());
+    EXPECT_EQ(42, map.get());
+
+    int* val = map.find();
+    ASSERT_NE(nullptr, val);
+    EXPECT_EQ(42, *val);
+
+    // Modify value via pointer
+    *val = 100;
+    EXPECT_EQ(100, map.get());
+
+    // Erase current thread
+    EXPECT_TRUE(map.erase());
+    EXPECT_FALSE(map.contains());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Erasing non-existent thread returns false
+    EXPECT_FALSE(map.erase());
+}
+
+TEST(ThreadMapTest, EmplaceAndCapacity) {
+    ThreadMap<std::string> map(2);
+    EXPECT_EQ(2u, map.getCapacity());
+
+    // Create unique artificial thread IDs via threads
+    std::thread t1([] {});
+    std::thread t2([] {});
+    std::thread t3([] {});
+    const auto tid1 = t1.get_id();
+    const auto tid2 = t2.get_id();
+    const auto tid3 = t3.get_id();
+    t1.join();
+    t2.join();
+    t3.join();
+
+    // Emplace first thread
+    uint32_t const idx1 = map.emplace("thread1", tid1);
+    EXPECT_NE((decltype(map)::INVALID_INDEX), idx1);
+    EXPECT_EQ(1u, map.size());
+    EXPECT_EQ("thread1", map.get(tid1));
+
+    // Emplace second thread
+    uint32_t const idx2 = map.emplace("thread2", tid2);
+    EXPECT_NE((decltype(map)::INVALID_INDEX), idx2);
+    EXPECT_NE(idx1, idx2);
+    EXPECT_EQ(2u, map.size());
+    EXPECT_EQ("thread2", map.get(tid2));
+
+    // Emplace third thread should fail (capacity exceeded)
+    uint32_t const idx3 = map.emplace("thread3", tid3);
+    EXPECT_EQ((decltype(map)::INVALID_INDEX), idx3);
+    EXPECT_EQ(2u, map.size());
+
+    // Re-emplacing an existing thread should update value and return same index
+    uint32_t const idx1_re = map.emplace("thread1_updated", tid1);
+    EXPECT_EQ(idx1, idx1_re);
+    EXPECT_EQ("thread1_updated", map.get(tid1));
+
+    // Erase at slot index
+    map.eraseAt(idx1);
+    EXPECT_FALSE(map.contains(tid1));
+    EXPECT_EQ(1u, map.size());
+
+    // Now third thread can be emplaced
+    uint32_t const idx3_new = map.emplace("thread3", tid3);
+    EXPECT_EQ(idx1, idx3_new);
+    EXPECT_TRUE(map.contains(tid3));
+    EXPECT_EQ("thread3", map.get(tid3));
+
+    // Clear map
+    map.clear();
+    EXPECT_TRUE(map.empty());
+    EXPECT_FALSE(map.contains(tid2));
+    EXPECT_FALSE(map.contains(tid3));
+}
+
+TEST(ThreadMapTest, MultiThreadedConcurrentAccess) {
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 1000;
+
+    ThreadMap<size_t> map(THREAD_COUNT);
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&map, &start, i]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                // Register
+                uint32_t const slot = map.emplace(i * 10000 + iter);
+                EXPECT_NE((decltype(map)::INVALID_INDEX), slot);
+
+                // Verify self lookup
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(i * 10000 + iter, map.get());
+                EXPECT_EQ(slot, map.findIndex());
+
+                // Unregister
+                EXPECT_TRUE(map.erase());
+                EXPECT_FALSE(map.contains());
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, MultiThreadedStaticSlots) {
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 5000;
+
+    ThreadMap<size_t> map(THREAD_COUNT);
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&map, &start, i]() {
+            // Assign dedicated slot for each thread
+            map.set(i, i * 42);
+
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(i * 42, map.get());
+                EXPECT_EQ(i, map.findIndex());
+            }
+
+            map.eraseAt(i);
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}
+
+struct Payload {
+    uint64_t id = 0;
+    bool valid() const { return id != 0; }
+};
+
+TEST(ThreadMapTest, ConcurrentEmplaceReaderDataRace) {
+    ThreadMap<Payload> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> failures{0};
+    std::atomic<std::thread::id> writerTid{};
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            const auto tid = writerTid.load(std::memory_order_relaxed);
+            if (tid != std::thread::id{}) {
+                Payload const p = map.get(tid);
+                if (p.id != 0 && !p.valid()) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        writerTid.store(std::this_thread::get_id(), std::memory_order_release);
+        for (size_t i = 1; i <= 20000; ++i) {
+            Payload p{i};
+            map.emplace(p);
+            map.erase();
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    writer.join();
+    reader.join();
+
+    EXPECT_EQ(0u, failures.load()) << "Reader observed uninitialized or partially written value in emplace()!";
+}
+
+TEST(ThreadMapTest, EraseDestroysResource) {
+    struct Resource {
+        std::shared_ptr<int> ref;
+    };
+
+    ThreadMap<Resource> map(4);
+    auto val = std::make_shared<int>(42);
+    EXPECT_EQ(1, val.use_count());
+
+    map.emplace(Resource{val});
+    EXPECT_EQ(2, val.use_count());
+
+    map.erase();
+    EXPECT_EQ(1, val.use_count()) << "erase() must destroy the stored resource payload!";
+}
+
+TEST(ThreadMapTest, ReEmplaceUpdatesValueSafely) {
+    ThreadMap<int> map(4);
+    auto const tid = std::this_thread::get_id();
+
+    EXPECT_EQ(0u, map.emplace(100, tid));
+    EXPECT_EQ(100, map.get(tid));
+
+    // Re-emplace same tid with a new value
+    EXPECT_EQ(0u, map.emplace(200, tid));
+    EXPECT_EQ(200, map.get(tid));
+    EXPECT_EQ(1u, map.size());
+
+    map.erase(tid);
+    EXPECT_TRUE(map.empty());
+}
+

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -168,7 +168,7 @@ void populateTextureWithPerlin(Texture* texture, Engine& engine, float time, Par
     };
 
     auto job = jobs::parallel_for(*js, nullptr, 0, dimension * dimension, std::cref(work),
-            jobs::CountSplitter<64, 32>());
+            jobs::CountSplitter<64>());
     js->runAndWait(job);
 
     Texture::PixelBufferDescriptor::PixelDataFormat format {};


### PR DESCRIPTION
## Overview & Goals

This change modernizes Filament's JobSystem and parallel_for subsystem to eliminate synchronization bottlenecks, lock contention, memory bloat, and cacheline churn across multicore desktop and mobile architectures.

The primary goals of this overhaul:
1. **Redesign `parallel_for`**: Replace recursive binary-tree job splitting with dynamic, range-based chunk stealing to eliminate job pool exhaustion and allocation overhead.
2. **Lock-Free Concurrency**: Remove all remaining mutex locks from the job lifecycle, job allocation pool, and thread-local state lookups.
3. **Hot-Path Work-Stealing Latency**: Minimize atomic churn, bypass deque contention on immediate continuations, and optimize pseudo-random victim selection.
4. **Mobile Memory & Cache Efficiency**: Dynamically size thread structures so mobile targets only allocate the memory needed for their active core count.

---

## Benchmark Results

### `parallel_for` Execution Time (4,096 Items)
* **macOS (Apple Silicon)**: **36x speedup** (3.71 ms -> 0.10 ms)
* **Android (Pixel 8 Pro ARM64)**: **6.4x speedup** (3.98 ms -> 0.62 ms)
  * CPU cycles: **58x reduction** (3.86 M cycles -> 66.5 k cycles)
  * Instructions: **37x reduction** (6.02 M insn -> 162.7 k insn)

### Work-Stealing Throughput (`BM_JobSystemAsChildren4k`)
* **Android (Pixel 8 Pro ARM64)**: **~30% overall speedup** (5.92 ms -> 4.14 ms)

### Memory & Allocation Reductions
* **99.8% fewer jobs allocated** during parallel loops (4,095 -> 8 jobs for 4K items).
* **Zero heap allocations** for standard `parallel_for` invocations.
* **Reduced memory footprint**: Dynamic thread state structures scale to target thread counts (~160 KB on mobile vs ~1 MB).
