### PR TITLE
Improve FrameGraph memory usage

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -635,6 +635,9 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
 
     fg.addPass<StructureMipmapData>("StructureMipmap",
             [&](FrameGraph::Builder& builder, auto& data) {
+                if (levelCount > 1) {
+                    builder.reserveRenderTargets(levelCount - 1);
+                }
                 data.depth = builder.sample(depth);
                 for (size_t i = 1; i < levelCount; i++) {
                     auto out = builder.createSubresource(data.depth, "Structure mip", {
@@ -1341,6 +1344,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::gaussianBlurPass(FrameGraph&
                 // note: we don't systematically use a Sampler2D for the temp buffer because
                 // this could force us to use two different programs below
 
+                builder.reserveRenderTargets(2);
                 data.in = builder.sample(input);
                 data.temp = builder.createTexture("Horizontal temporary buffer", tempDesc);
                 data.temp = builder.sample(data.temp);
@@ -1872,6 +1876,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
     auto const& ppDoFMipmap = fg.addPass<PostProcessDofMipmap>("DoF Mipmap",
             [&](FrameGraph::Builder& builder, auto& data) {
+                builder.reserveRenderTargets(mipmapCount - 1u);
                 data.inOutColor = builder.sample(ppDoFDownsample->outColor);
                 data.inOutCoc   = builder.sample(ppDoFDownsample->outCoc);
                 for (size_t i = 0; i < mipmapCount - 1u; i++) {
@@ -2361,6 +2366,7 @@ PostProcessManager::BloomPassOutput PostProcessManager::bloom(FrameGraph& fg,
 
     auto const& bloomDownsamplePass = fg.addPass<BloomPassData>("Bloom Downsample",
             [&](FrameGraph::Builder& builder, auto& data) {
+                builder.reserveRenderTargets(inoutBloomOptions.levels);
                 data.out = builder.createTexture("Bloom Out Texture", {
                         .width = width,
                         .height = height,
@@ -2429,6 +2435,7 @@ PostProcessManager::BloomPassOutput PostProcessManager::bloom(FrameGraph& fg,
 
     auto const& bloomUpsamplePass = fg.addPass<BloomPassData>("Bloom Upsample",
             [&](FrameGraph::Builder& builder, auto& data) {
+                builder.reserveRenderTargets(inoutBloomOptions.levels);
                 data.out = builder.sample(input);
                 for (size_t i = 0; i < inoutBloomOptions.levels; i++) {
                     auto out = builder.createSubresource(data.out, "Bloom Out Texture mip",

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -680,15 +680,15 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
         // or indirectly via anisotropic filtering.
         // So generate the mipmaps for each layer
         if (UTILS_UNLIKELY(textureRequirements.levels > 1)) {
-            for (size_t level = 0; level < textureRequirements.levels - 1; level++) {
-                // TODO: we could take a list of scissor maybe
-                if (view.hasPCSS()) {
-                    // for PCSS we do a higher quality gaussian mipmap generation
-                    gaussianMipmapPass(engine, fg, prepareShadowPass->shadows, layer, level, textureRequirements.clearColor);
-                } else {
-                    // for EVSM, a regular mipmap is enough
-                    vsmMipmapPass(engine, fg, prepareShadowPass->shadows, layer, level, textureRequirements.clearColor);
-                }
+            // TODO: we could take a list of scissor maybe
+            if (view.hasPCSS()) {
+                // for PCSS we do a higher quality gaussian mipmap generation
+                gaussianMipmapPass(engine, fg, prepareShadowPass->shadows,
+                        layer, textureRequirements.levels, textureRequirements.clearColor);
+            } else {
+                // for EVSM, a regular mipmap is enough
+                vsmMipmapPass(engine, fg, prepareShadowPass->shadows,
+                        layer, textureRequirements.levels, textureRequirements.clearColor);
             }
         }
 
@@ -808,8 +808,12 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianBlurSeparatedPass(
 FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
         FEngine& engine,
         FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> const input, uint8_t layer, size_t const level,
-        float4 clearColor) noexcept {
+        FrameGraphId<FrameGraphTexture> const input, uint8_t const layer, size_t const levelCount,
+        float4 const clearColor) noexcept {
+
+    if (UTILS_UNLIKELY(levelCount <= 1)) {
+        return input;
+    }
 
     struct VsmMipData {
         FrameGraphId<FrameGraphTexture> in;
@@ -818,25 +822,25 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
     auto const& depthMipmapPass = fg.addPass<VsmMipData>("EVSM Mipmap Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.in = builder.sample(input);
-                auto out = builder.createSubresource(data.in, "EVSM Mipmap level", {
-                        .level = uint8_t(level + 1), .layer = layer });
-                out = builder.write(out, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                builder.declareRenderPass(builder.getName(input), {
-                    .attachments = { .color = { out }},
-                    .clearColor = clearColor,
-                    .clearFlags = TargetBufferFlags::COLOR
-                });
+                for (size_t level = 0; level < levelCount - 1; ++level) {
+                    auto out = builder.createSubresource(data.in, "EVSM Mipmap level", {
+                            .level = uint8_t(level + 1), .layer = layer });
+                    out = builder.write(out, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                    builder.declareRenderPass(builder.getName(input), {
+                        .attachments = { .color = { out }},
+                        .clearColor = clearColor,
+                        .clearFlags = TargetBufferFlags::COLOR
+                    });
+                }
             },
             [=, &engine](FrameGraphResources const& resources,
                     auto const& data, DriverApi& driver) {
 
-                auto in = driver.createTextureView(resources.getTexture(data.in), level, 1);
-                auto [target, params] = resources.getRenderPassInfo();
-
                 auto const& inDesc = resources.getDescriptor(data.in);
-                auto width = inDesc.width;
+                auto const width = inDesc.width;
                 assert_invariant(width == inDesc.height);
-                uint32_t const dim = std::max(1u, width >> (level + 1));
+
+                auto const hwIn = resources.getTexture(data.in);
 
                 auto const& ppm = engine.getPostProcessManager();
                 ppm.bindPostProcessDescriptorSet(driver);
@@ -845,28 +849,36 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
                 auto& material = ppm.getPostProcessMaterial("vsmMipmap");
                 FMaterial const* const ma = material.getMaterial(engine);
                 auto const mi = ppm.getMaterialInstance(driver, ma);
-
                 auto const pipeline = ppm.getPipelineState(mi);
-                backend::Viewport const scissor = { 0, 0, dim, dim };
 
-                mi->setParameter("color", in, SamplerParams{
-                        .filterMag = SamplerMagFilter::NEAREST,
-                        .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST
-                });
+                // Invariant uniform across all mip levels
                 mi->setParameter("layer", uint32_t(layer));
-                mi->commit(driver, engine.getUboManager());
 
+                for (size_t level = 0; level < levelCount - 1; ++level) {
+                    auto in = driver.createTextureView(hwIn, level, 1);
+                    auto [target, params] = resources.getRenderPassInfo(level);
 
-                // Do all the horizontal or vertical blur passes for this layer at once
-                driver.beginRenderPass(target, params);
-                {
-                    mi->use(driver);
-                    driver.scissor(scissor);
-                    driver.draw(pipeline, engine.getFullScreenRenderPrimitive(), 0, 3, 1);
+                    uint32_t const dim = std::max(1u, width >> (level + 1));
+                    backend::Viewport const scissor = { 0, 0, dim, dim };
+
+                    mi->setParameter("color", in, SamplerParams{
+                            .filterMag = SamplerMagFilter::NEAREST,
+                            .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST
+                    });
+                    mi->commit(driver, engine.getUboManager());
+
+                    driver.beginRenderPass(target, params);
+                    {
+                        mi->use(driver);
+                        driver.scissor(scissor);
+                        driver.draw(pipeline, engine.getFullScreenRenderPrimitive(), 0, 3, 1);
+                    }
+                    driver.endRenderPass();
+
+                    DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
+                    driver.destroyTexture(in);
                 }
-                driver.endRenderPass();
 
-                driver.destroyTexture(in); // `in` is just a view on `data.in`
                 ppm.unbindAllDescriptorSets(driver);
             });
 
@@ -876,8 +888,12 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
 FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianMipmapPass(
         FEngine& engine,
         FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> const input, uint8_t layer, size_t const level,
-        float4 clearColor) noexcept {
+        FrameGraphId<FrameGraphTexture> const input, uint8_t const layer, size_t const levelCount,
+        float4 const clearColor) noexcept {
+
+    if (UTILS_UNLIKELY(levelCount <= 1)) {
+        return input;
+    }
 
     struct VsmMipData {
         FrameGraphId<FrameGraphTexture> in;
@@ -886,25 +902,25 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianMipmapPass(
     auto const& depthMipmapPass = fg.addPass<VsmMipData>("EVSM Gaussian Mipmap Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.in = builder.sample(input);
-                auto out = builder.createSubresource(data.in, "EVSM Mipmap level", {
-                        .level = uint8_t(level + 1), .layer = layer });
-                out = builder.write(out, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                builder.declareRenderPass(builder.getName(input), {
-                    .attachments = { .color = { out }},
-                    .clearColor = clearColor,
-                    .clearFlags = TargetBufferFlags::COLOR
-                });
+                for (size_t level = 0; level < levelCount - 1; ++level) {
+                    auto out = builder.createSubresource(data.in, "EVSM Gaussian Mipmap level", {
+                            .level = uint8_t(level + 1), .layer = layer });
+                    out = builder.write(out, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                    builder.declareRenderPass(builder.getName(input), {
+                        .attachments = { .color = { out }},
+                        .clearColor = clearColor,
+                        .clearFlags = TargetBufferFlags::COLOR
+                    });
+                }
             },
             [=, &engine](FrameGraphResources const& resources,
                     auto const& data, DriverApi& driver) {
 
-                auto in = driver.createTextureView(resources.getTexture(data.in), level, 1);
-                auto [target, params] = resources.getRenderPassInfo();
-
                 auto const& inDesc = resources.getDescriptor(data.in);
-                auto width = inDesc.width;
+                auto const width = inDesc.width;
                 assert_invariant(width == inDesc.height);
-                uint32_t const dim = std::max(1u, width >> (level + 1));
+
+                auto const hwIn = resources.getTexture(data.in);
 
                 auto const& ppm = engine.getPostProcessManager();
                 ppm.bindPostProcessDescriptorSet(driver);
@@ -912,31 +928,41 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianMipmapPass(
 
                 auto& material = ppm.getPostProcessMaterial("gaussianMipmap");
                 FMaterial const* const ma = material.getMaterial(engine);
-                auto const mi = ppm.getMaterialInstance(driver, ma);
 
-                auto const pipeline = ppm.getPipelineState(mi);
-                backend::Viewport const scissor = { 0, 0, dim, dim };
+                for (size_t level = 0; level < levelCount - 1; ++level) {
+                    auto in = driver.createTextureView(hwIn, level, 1);
+                    auto [target, params] = resources.getRenderPassInfo(level);
 
-                mi->setParameter("color", in, SamplerParams{
-                        .filterMag = SamplerMagFilter::NEAREST,
-                        .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST
-                });
-                // FIXME: use real scissor
-                mi->setParameter("srcRect", int4{ 0, 0, width, width });
-                mi->setParameter("dstRect", int4{ scissor.left, scissor.bottom, scissor.width, scissor.height });
-                mi->setParameter("layer", uint32_t(layer));
-                mi->commit(driver, engine.getUboManager());
+                    uint32_t const srcDim = std::max(1u, width >> level);
+                    uint32_t const dstDim = std::max(1u, width >> (level + 1));
+                    backend::Viewport const scissor = { 0, 0, dstDim, dstDim };
 
-                // Do all the horizontal or vertical blur passes for this layer at once
-                driver.beginRenderPass(target, params);
-                {
-                    mi->use(driver);
-                    driver.scissor(scissor);
-                    driver.draw(pipeline, engine.getFullScreenRenderPrimitive(), 0, 3, 1);
+                    // Fresh MaterialInstance from the pool ensures isolated UBO allocation
+                    auto const mi = ppm.getMaterialInstance(driver, ma);
+                    auto const pipeline = ppm.getPipelineState(mi);
+
+                    mi->setParameter("color", in, SamplerParams{
+                            .filterMag = SamplerMagFilter::NEAREST,
+                            .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST
+                    });
+                    // FIXME: use real scissor if atlas allocator is active
+                    mi->setParameter("srcRect", int4{ 0, 0, srcDim, srcDim });
+                    mi->setParameter("dstRect", int4{ scissor.left, scissor.bottom, scissor.width, scissor.height });
+                    mi->setParameter("layer", uint32_t(layer));
+                    mi->commit(driver, engine.getUboManager());
+
+                    driver.beginRenderPass(target, params);
+                    {
+                        mi->use(driver);
+                        driver.scissor(scissor);
+                        driver.draw(pipeline, engine.getFullScreenRenderPrimitive(), 0, 3, 1);
+                    }
+                    driver.endRenderPass();
+
+                    DescriptorSet::unbind(driver, DescriptorSetBindingPoints::PER_MATERIAL);
+                    driver.destroyTexture(in);
                 }
-                driver.endRenderPass();
 
-                driver.destroyTexture(in); // `in` is just a view on `data.in`
                 ppm.unbindAllDescriptorSets(driver);
             });
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -821,6 +821,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::vsmMipmapPass(
 
     auto const& depthMipmapPass = fg.addPass<VsmMipData>("EVSM Mipmap Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
+                builder.reserveRenderTargets(levelCount - 1);
                 data.in = builder.sample(input);
                 for (size_t level = 0; level < levelCount - 1; ++level) {
                     auto out = builder.createSubresource(data.in, "EVSM Mipmap level", {
@@ -901,6 +902,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::gaussianMipmapPass(
 
     auto const& depthMipmapPass = fg.addPass<VsmMipData>("EVSM Gaussian Mipmap Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
+                builder.reserveRenderTargets(levelCount - 1);
                 data.in = builder.sample(input);
                 for (size_t level = 0; level < levelCount - 1; ++level) {
                     auto out = builder.createSubresource(data.in, "EVSM Gaussian Mipmap level", {

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -150,13 +150,13 @@ public:
     FrameGraphId<FrameGraphTexture> gaussianMipmapPass(
             FEngine& engine,
             FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t level,
+            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t levelCount,
             math::float4 clearColor) noexcept;
 
     FrameGraphId<FrameGraphTexture> vsmMipmapPass(
             FEngine& engine,
             FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t level,
+            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t levelCount,
             math::float4 clearColor) noexcept;
 
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -299,7 +299,7 @@ FEngine::FEngine(Builder const& builder) :
                 builder->mPaused),
         mPerRenderPassArena(
                 "FEngine::mPerRenderPassAllocator",
-                builder->mConfig.perRenderPassArenaSizeMB * MiB),
+                builder->mConfig.perRenderPassArenaSizeMB * MiB + FRenderer::FRAMEGRAPH_ARENA_SIZE),
         mHeapAllocator("FEngine::mHeapAllocator", AreaPolicy::NullArea{}),
         mJobSystem(getJobSystemThreadPoolSize(builder->mConfig)),
         mEngineEpoch(std::chrono::steady_clock::now()),

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -948,7 +948,7 @@ void FRenderer::renderJob(DriverApi& driver, LinearAllocatorArena& arena, FView&
     /*
      * Frame graph
      */
-    FrameGraph fg(arena,
+    FrameGraph fg(arena, FRAMEGRAPH_ARENA_SIZE,
         *mResourceAllocator,
         isProtectedContent ? FrameGraph::Mode::PROTECTED : FrameGraph::Mode::UNPROTECTED);
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -75,6 +75,10 @@ class FRenderer : public Renderer {
     static constexpr unsigned MAX_FRAMETIME_HISTORY = 32u;
 
 public:
+    // The FrameGraph arena size only depends on how the FrameGraph is used. Currently, 512 KiB handles the most
+    // complex graph Renderer can produce.
+    static constexpr size_t FRAMEGRAPH_ARENA_SIZE = 512 * 1024;
+
     explicit FRenderer(FEngine& engine);
 
     ~FRenderer() noexcept;

--- a/filament/src/fg/DependencyGraph.cpp
+++ b/filament/src/fg/DependencyGraph.cpp
@@ -34,8 +34,8 @@ namespace filament {
 
 DependencyGraph::DependencyGraph(FrameGraphAllocator& arena) noexcept
     : mNodes(arena), mEdges(arena)  {
-    mNodes.reserve(128);
-    mEdges.reserve(128);
+    mNodes.reserve(512);
+    mEdges.reserve(1024);
 }
 
 DependencyGraph::~DependencyGraph() noexcept = default;
@@ -130,16 +130,14 @@ void DependencyGraph::cull(FrameGraphAllocator& arena) noexcept {
         Node const* const pNode = stack.back();
         stack.pop_back();
 
-        utils::ArenaScope const stackScope(arena); // safe because stack never reallocates by construction
-        EdgeContainer const incoming = getIncomingEdges(pNode, arena);
-        for (Edge const* edge : incoming) {
+        forEachIncomingEdge(pNode, [this, &stack](Edge const* edge) {
             Node* pLinkedNode = getNode(edge->from);
             if (--pLinkedNode->mRefCount == 0) {
                 assert_invariant(stack.size() < stack.capacity());
                 // note: this is guaranteed to not reallocate
                 stack.push_back(pLinkedNode);
             }
-        }
+        });
     }
 }
 

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -76,15 +76,19 @@ FrameGraphId<FrameGraphTexture> FrameGraph::Builder::declareRenderPass(
     return color;
 }
 
+void FrameGraph::Builder::reserveRenderTargets(size_t const count) noexcept {
+    static_cast<RenderPassNode*>(mPassNode)->reserveRenderTargets(count);
+}
+
 // ------------------------------------------------------------------------------------------------
 
 
 FrameGraph::FrameGraph(
-        LinearAllocatorArena& arena,
+        LinearAllocatorArena& arena, size_t size,
         TextureCacheInterface& resourceAllocator,
         Mode const mode)
         : mResourceAllocator(resourceAllocator),
-          mArena("FrameGraph Arena", {arena, 384 * 1024}), // real max usage about 260KiB
+          mArena("FrameGraph Arena", {arena, size}),
           mGraph(mArena),
           mMode(mode),
           mResourceSlots(mArena),
@@ -92,10 +96,10 @@ FrameGraph::FrameGraph(
           mResourceNodes(mArena),
           mPassNodes(mArena)
 {
-    mResourceSlots.reserve(256);
-    mResources.reserve(256);
-    mResourceNodes.reserve(256);
-    mPassNodes.reserve(64);
+    mResourceSlots.reserve(512);
+    mResources.reserve(512);
+    mResourceNodes.reserve(512);
+    mPassNodes.reserve(128);
 }
 
 #if FILAMENT_ENABLE_FGVIEWER
@@ -168,28 +172,20 @@ FrameGraph& FrameGraph::compile() noexcept {
         first++;
         assert_invariant(!passNode->isCulled());
 
-        { // scope for the temporary allocations
-            utils::ArenaScope const scope(mArena);
-            auto const& reads = dependencyGraph.getIncomingEdges(passNode, mArena);
-            for (auto const& edge : reads) {
-                // all incoming edges should be valid by construction
-                assert_invariant(dependencyGraph.isEdgeValid(edge));
-                auto const pNode = static_cast<ResourceNode*>(dependencyGraph.getNode(edge->from));
-                passNode->registerResource(pNode->resourceHandle);
-            }
-        }
+        dependencyGraph.forEachIncomingEdge(passNode, [&](DependencyGraph::Edge const* edge) {
+            // all incoming edges should be valid by construction
+            assert_invariant(dependencyGraph.isEdgeValid(edge));
+            auto const pNode = static_cast<ResourceNode*>(dependencyGraph.getNode(edge->from));
+            passNode->registerResource(pNode->resourceHandle);
+        });
 
-        { // scope for the temporary allocations
-            utils::ArenaScope const scope(mArena);
-            auto const& writes = dependencyGraph.getOutgoingEdges(passNode, mArena);
-            for (auto const& edge : writes) {
-                // An outgoing edge might be invalid if the node it points to has been culled
-                // but because we are not culled, and we're a pass we add a reference to
-                // the resource we are writing to.
-                auto const pNode = static_cast<ResourceNode*>(dependencyGraph.getNode(edge->to));
-                passNode->registerResource(pNode->resourceHandle);
-            }
-        }
+        dependencyGraph.forEachOutgoingEdge(passNode, [&](DependencyGraph::Edge const* edge) {
+            // An outgoing edge might be invalid if the node it points to has been culled
+            // but because we are not culled, and we're a pass we add a reference to
+            // the resource we are writing to.
+            auto const pNode = static_cast<ResourceNode*>(dependencyGraph.getNode(edge->to));
+            passNode->registerResource(pNode->resourceHandle);
+        });
 
         passNode->resolve();
     }
@@ -204,6 +200,29 @@ FrameGraph& FrameGraph::compile() noexcept {
             if (pFirst && pLast) {
                 assert_invariant(!pFirst->isCulled());
                 assert_invariant(!pLast->isCulled());
+                pFirst->devirtualizeCount++;
+                pLast->destroyCount++;
+            }
+        }
+    }
+
+    for (auto* pPass : mPassNodes) {
+        if (!pPass->isCulled()) {
+            if (pPass->devirtualizeCount) {
+                pPass->devirtualize.reserve(pPass->devirtualize.size() + pPass->devirtualizeCount);
+            }
+            if (pPass->destroyCount) {
+                pPass->destroy.reserve(pPass->destroy.size() + pPass->destroyCount);
+            }
+        }
+    }
+
+    for (auto* pResource : mResources) {
+        VirtualResource* resource = pResource;
+        if (resource->refcount) {
+            PassNode* pFirst = resource->first;
+            PassNode* pLast = resource->last;
+            if (pFirst && pLast) {
                 pFirst->devirtualize.push_back(resource);
                 pLast->destroy.push_back(resource);
             }
@@ -547,32 +566,28 @@ fgviewer::FrameGraphInfo FrameGraph::getFrameGraphInfo(const char* viewName) con
 
         assert_invariant(!pass->isCulled());
         std::vector<fgviewer::ResourceId> reads;
-        auto const &readEdges = mGraph.getIncomingEdges(pass, mArena);
-        for (auto const &edge: readEdges) {
+        mGraph.forEachIncomingEdge(pass, [&](DependencyGraph::Edge const* edge) {
             // all incoming edges should be valid by construction
             assert_invariant(mGraph.isEdgeValid(edge));
             auto resourceNode = static_cast<const ResourceNode*>(mGraph.getNode(edge->from));
             assert_invariant(resourceNode);
-            if (resourceNode->getRefCount() == 0)
-                continue;
-
-            reads.push_back(resourceNode->resourceHandle.index);
-        }
+            if (resourceNode->getRefCount() != 0) {
+                reads.push_back(resourceNode->resourceHandle.index);
+            }
+        });
 
         std::vector<fgviewer::ResourceId> writes;
-        auto const &writeEdges = mGraph.getOutgoingEdges(pass, mArena);
-        for (auto const &edge: writeEdges) {
+        mGraph.forEachOutgoingEdge(pass, [&](DependencyGraph::Edge const* edge) {
             // It is possible that the node we're writing to has been culled.
             // In this case we'd like to ignore the edge.
-            if (!mGraph.isEdgeValid(edge)) {
-                continue;
+            if (mGraph.isEdgeValid(edge)) {
+                auto resourceNode = static_cast<const ResourceNode*>(mGraph.getNode(edge->to));
+                assert_invariant(resourceNode);
+                if (resourceNode->getRefCount() != 0) {
+                    writes.push_back(resourceNode->resourceHandle.index);
+                }
             }
-            auto resourceNode = static_cast<const ResourceNode*>(mGraph.getNode(edge->to));
-            assert_invariant(resourceNode);
-            if (resourceNode->getRefCount() == 0)
-                continue;
-            writes.push_back(resourceNode->resourceHandle.index);
-        }
+        });
         passes.emplace_back(pass->getId(), utils::CString(pass->getName()),
             std::move(reads), std::move(writes), pass->getRenderTargetInfo());
     }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -277,6 +277,7 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
 
 void FrameGraph::addPresentPass(const std::function<void(Builder&)>& setup) noexcept {
     PresentPassNode* node = mArena.make<PresentPassNode>(*this);
+    assert_invariant(node);
     mPassNodes.push_back(node);
     Builder builder(*this, node);
     setup(builder);
@@ -286,6 +287,7 @@ void FrameGraph::addPresentPass(const std::function<void(Builder&)>& setup) noex
 FrameGraph::Builder FrameGraph::addPassInternal(char const* name, FrameGraphPassBase* base) noexcept {
     // record in our pass list and create the builder
     PassNode* node = mArena.make<RenderPassNode>(*this, name, base);
+    assert_invariant(node);
     base->setNode(node);
     mPassNodes.push_back(node);
     return { *this, node };
@@ -300,6 +302,7 @@ FrameGraphHandle FrameGraph::createNewVersion(FrameGraphHandle handle) noexcept 
     slot.version = ++handle.version;    // increase the parent's version
     slot.nid = (ResourceSlot::Index)mResourceNodes.size();   // create the new parent node
     ResourceNode* newNode = mArena.make<ResourceNode>(*this, handle, parent);
+    assert_invariant(newNode);
     mResourceNodes.push_back(newNode);
     return handle;
 }
@@ -312,6 +315,7 @@ ResourceNode* FrameGraph::createNewVersionForSubresourceIfNeeded(ResourceNode* n
         slot.sid = slot.nid; // record the current ResourceNode of the parent
         slot.nid = (ResourceSlot::Index)mResourceNodes.size();   // create the new parent node
         node = mArena.make<ResourceNode>(*this, node->resourceHandle, node->getParentHandle());
+        assert_invariant(node);
         mResourceNodes.push_back(node);
     }
     return node;
@@ -329,6 +333,7 @@ FrameGraphHandle FrameGraph::addSubResourceInternal(FrameGraphHandle parent,
     slot.nid = (ResourceSlot::Index)mResourceNodes.size();
     mResources.push_back(resource);
     ResourceNode* pNode = mArena.make<ResourceNode>(*this, handle, parent);
+    assert_invariant(pNode);
     mResourceNodes.push_back(pNode);
     return handle;
 }
@@ -489,6 +494,7 @@ FrameGraphId<FrameGraphTexture> FrameGraph::import(utils::StaticString name,
                             .width = desc.viewport.width,
                             .height = desc.viewport.height
                     }, desc, target);
+    assert_invariant(vresource);
     return FrameGraphId<FrameGraphTexture>(addResourceInternal(vresource));
 }
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -101,6 +101,11 @@ public:
                 FrameGraphId<FrameGraphTexture> color, uint32_t* index = nullptr);
 
         /**
+         * Reserve space for the specified number of render passes/targets in this pass node.
+         */
+        void reserveRenderTargets(size_t count) noexcept;
+
+        /**
          * Creates a virtual resource of type RESOURCE
          * @tparam RESOURCE Type of the resource to create
          * @param name      A pointer to a null terminated string.
@@ -237,7 +242,7 @@ public:
     };
 
     explicit FrameGraph(
-            LinearAllocatorArena& arena,
+            LinearAllocatorArena& arena, size_t size,
             TextureCacheInterface& resourceAllocator,
             Mode mode = Mode::UNPROTECTED);
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -592,6 +592,7 @@ auto& FrameGraph::addPass(char const* name, Setup setup, Execute&& execute) {
 
     // create the FrameGraph pass
     auto* const pass = mArena.make<FrameGraphPass<Data, Execute>>(std::forward<Execute>(execute));
+    assert_invariant(pass);
 
     Builder builder(addPassInternal(name, pass));
 
@@ -615,6 +616,7 @@ template<typename RESOURCE>
 FrameGraphId<RESOURCE> FrameGraph::create(utils::StaticString name,
         typename RESOURCE::Descriptor const& desc) noexcept {
     VirtualResource* vresource(mArena.make<Resource<RESOURCE>>(name, desc));
+    assert_invariant(vresource);
     return FrameGraphId<RESOURCE>(addResourceInternal(vresource));
 }
 
@@ -623,6 +625,7 @@ FrameGraphId<RESOURCE> FrameGraph::createSubresource(FrameGraphId<RESOURCE> pare
         utils::StaticString name, typename RESOURCE::SubResourceDescriptor const& desc) noexcept {
     auto* parentResource = static_cast<Resource<RESOURCE>*>(getResource(parent));
     VirtualResource* vresource(mArena.make<Resource<RESOURCE>>(parentResource, name, desc));
+    assert_invariant(vresource);
     return FrameGraphId<RESOURCE>(addSubResourceInternal(parent, vresource));
 }
 
@@ -632,6 +635,7 @@ FrameGraphId<RESOURCE> FrameGraph::import(utils::StaticString name,
         typename RESOURCE::Usage usage,
         RESOURCE const& resource) noexcept {
     VirtualResource* vresource(mArena.make<ImportedResource<RESOURCE>>(name, desc, usage, resource));
+    assert_invariant(vresource);
     return FrameGraphId<RESOURCE>(addResourceInternal(vresource));
 }
 

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -36,8 +36,7 @@ PassNode::PassNode(FrameGraph& fg) noexcept
           mFrameGraph(fg),
           devirtualize(fg.getArena()),
           destroy(fg.getArena()) {
-   devirtualize.reserve(8);
-   destroy.reserve(8);
+    // We don't reserve devirtualize/destroy here because we could have a lot of PassNode (allocations are cheap)
 }
 
 PassNode::PassNode(PassNode&& rhs) noexcept = default;
@@ -61,8 +60,8 @@ RenderPassNode::RenderPassNode(FrameGraph& fg, const char* name, FrameGraphPassB
         mName(name),
         mPassBase(base, fg.getArena()),
         mRenderTargetData(fg.getArena()) {
-    // RenderPassData is 416 bytes, with the current FrameGraph we seem to get up to 6.
-    mRenderTargetData.reserve(8);
+    // We don't reserve mRenderTargetData here because we could have a lot of RenderPassNode (allocations are cheap)
+    // and RenderPassData is 160 bytes.
 }
 
 RenderPassNode::RenderPassNode(RenderPassNode&& rhs) noexcept = default;
@@ -87,49 +86,16 @@ void RenderPassNode::execute(FrameGraphResources const& resources, DriverApi& dr
     }
 }
 
-uint32_t RenderPassNode::declareRenderTarget(FrameGraph& fg, FrameGraph::Builder&,
+uint32_t RenderPassNode::declareRenderTarget(FrameGraph&, FrameGraph::Builder&,
         utils::StaticString name, FrameGraphRenderPass::Descriptor const& descriptor) {
-
     RenderPassData data;
     data.name = name;
-    data.descriptor = descriptor;
-
-    // retrieve the ResourceNode of the attachments coming to us -- this will be used later
-    // to compute the discard flags.
-
-    DependencyGraph const& dependencyGraph = fg.getGraph();
-
-    { // scope of the local allocations
-        utils::ArenaScope const scope(fg.getArena());
-        auto incomingEdges = dependencyGraph.getIncomingEdges(this, fg.getArena());
-
-        for (size_t i = 0; i < RenderPassData::ATTACHMENT_COUNT; i++) {
-            FrameGraphId<FrameGraphTexture> const& handle = data.descriptor.attachments[i];
-            if (handle) {
-                data.attachmentInfo[i] = handle;
-
-                // TODO: this is not very efficient
-                auto incomingPos = std::find_if(incomingEdges.begin(), incomingEdges.end(),
-                        [&dependencyGraph, handle](DependencyGraph::Edge const* edge) {
-                            ResourceNode const* node = static_cast<ResourceNode const*>(
-                                dependencyGraph.getNode(edge->from));
-                            return node->resourceHandle == handle;
-                        });
-
-                if (incomingPos != incomingEdges.end()) {
-                    data.incoming[i] = const_cast<ResourceNode*>(
-                        static_cast<ResourceNode const*>(dependencyGraph.getNode((*incomingPos)->from)));
-                }
-
-                // this could be either outgoing or incoming (if there are no outgoing)
-                data.outgoing[i] = fg.getActiveResourceNode(handle);
-                if (data.outgoing[i] == data.incoming[i]) {
-                    data.outgoing[i] = nullptr;
-                }
-            }
-        }
-    }
-
+    data.attachments = descriptor.attachments;
+    data.samples = descriptor.samples;
+    data.layerCount = descriptor.layerCount;
+    data.clearFlags = descriptor.clearFlags;
+    data.backend.params.viewport = descriptor.viewport;
+    data.backend.params.clearColor = descriptor.clearColor;
     uint32_t const id = mRenderTargetData.size();
     mRenderTargetData.push_back(data);
     return id;
@@ -137,6 +103,8 @@ uint32_t RenderPassNode::declareRenderTarget(FrameGraph& fg, FrameGraph::Builder
 
 void RenderPassNode::resolve() noexcept {
     using namespace backend;
+
+    DependencyGraph const& dependencyGraph = mFrameGraph.getGraph();
 
     for (auto& rt : mRenderTargetData) {
 
@@ -158,7 +126,27 @@ void RenderPassNode::resolve() noexcept {
         constexpr size_t STENCIL_INDEX = MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 1;
 
         for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 2; i++) {
-            if (rt.descriptor.attachments[i]) {
+            if (rt.attachments[i]) {
+                FrameGraphId<FrameGraphTexture> const handle = rt.attachments[i];
+
+                DependencyGraph::Edge const* const incomingEdge = dependencyGraph.findIncomingEdge(this,
+                        [&dependencyGraph, handle](DependencyGraph::Edge const* edge) {
+                            auto const* node = static_cast<ResourceNode const*>(
+                                    dependencyGraph.getNode(edge->from));
+                            return node->resourceHandle == handle;
+                        });
+                ResourceNode const* const incomingNode = incomingEdge ?
+                        static_cast<ResourceNode const*>(dependencyGraph.getNode(incomingEdge->from)) : nullptr;
+
+                DependencyGraph::Edge const* const outgoingEdge = dependencyGraph.findOutgoingEdge(this,
+                        [&dependencyGraph, handle](DependencyGraph::Edge const* edge) {
+                            auto const* node = static_cast<ResourceNode const*>(
+                                    dependencyGraph.getNode(edge->to));
+                            return node->resourceHandle == handle;
+                        });
+                ResourceNode const* const outgoingNode = outgoingEdge ?
+                        static_cast<ResourceNode const*>(dependencyGraph.getNode(outgoingEdge->to)) : nullptr;
+
                 const TargetBufferFlags target = getTargetBufferFlagsAt(i);
 
                 rt.targetBufferFlags |= target;
@@ -168,10 +156,10 @@ void RenderPassNode::resolve() noexcept {
                 // attachment might have other readers after us).
                 // TODO: we could set the discard flag if we are the last reader, i.e.
                 //       if rt->incoming[i] last reader is us.
-                if (rt.outgoing[i] && !rt.outgoing[i]->hasActiveReaders()) {
+                if (outgoingNode && !outgoingNode->hasActiveReaders()) {
                     rt.backend.params.flags.discardEnd |= target;
                 }
-                if (!rt.outgoing[i] || !rt.outgoing[i]->hasWriterPass()) {
+                if (!outgoingNode || !outgoingNode->hasWriterPass()) {
                     if (i == DEPTH_INDEX) {
                         rt.backend.params.readOnlyDepthStencil |= RenderPassParams::READONLY_DEPTH;
                     } else if (i == STENCIL_INDEX) {
@@ -179,20 +167,25 @@ void RenderPassNode::resolve() noexcept {
                     }
                 }
                 // Discard at the start if this attachment has no prior writer
-                if (!rt.incoming[i] || !rt.incoming[i]->hasActiveWriters()) {
+                if (!incomingNode || !incomingNode->hasActiveWriters()) {
                     rt.backend.params.flags.discardStart |= target;
                 }
-                VirtualResource* pResource = mFrameGraph.getResource(rt.descriptor.attachments[i]);
-                Resource<FrameGraphTexture>* pTextureResource =
-                        static_cast<Resource<FrameGraphTexture>*>(pResource);
+                VirtualResource* pResource = mFrameGraph.getResource(rt.attachments[i]);
+                Resource<FrameGraphTexture>* pTextureResource = static_cast<Resource<FrameGraphTexture>*>(pResource);
 
                 pImportedRenderTarget = pImportedRenderTarget ?
                         pImportedRenderTarget : pResource->asImportedRenderTarget();
 
+                // FIXME: the code below appears to either a NO-OP, or forcing the sample count to zero.
+                //        Originally the code was
+                //              if (!rt.descriptor.samples && none(...)) {
+                //                  pTextureResource->descriptor.samples = rt.descriptor.samples;
+                //              }
+                //        which has a similar behavior. I don't recall what was the original intent of:
+                //              "update attachment sample count if not specified and usage permits it"
                 // update attachment sample count if not specified and usage permits it
-                if (!rt.descriptor.samples &&
-                    none(pTextureResource->usage & TextureUsage::SAMPLEABLE)) {
-                    pTextureResource->descriptor.samples = rt.descriptor.samples;
+                if (!rt.samples && none(pTextureResource->usage & TextureUsage::SAMPLEABLE)) {
+                    pTextureResource->descriptor.samples = rt.samples;
                 }
 
                 // figure out the min/max dimensions across all attachments
@@ -206,7 +199,7 @@ void RenderPassNode::resolve() noexcept {
         }
         // additionally, clear implies discardStart
         rt.backend.params.flags.discardStart |= (
-                rt.descriptor.clearFlags & rt.targetBufferFlags);
+                rt.clearFlags & rt.targetBufferFlags);
 
         assert_invariant(minWidth == maxWidth);
         assert_invariant(minHeight == maxHeight);
@@ -217,12 +210,12 @@ void RenderPassNode::resolve() noexcept {
         uint32_t const width = maxWidth;
         uint32_t const height = maxHeight;
 
-        // Update the descriptor if no size was specified (auto mode)
-        if (!rt.descriptor.viewport.width) {
-            rt.descriptor.viewport.width = width;
+        // Update the viewport if no size was specified (auto mode)
+        if (!rt.backend.params.viewport.width) {
+            rt.backend.params.viewport.width = width;
         }
-        if (!rt.descriptor.viewport.height) {
-            rt.descriptor.viewport.height = height;
+        if (!rt.backend.params.viewport.height) {
+            rt.backend.params.viewport.height = height;
         }
 
         /*
@@ -235,12 +228,12 @@ void RenderPassNode::resolve() noexcept {
             rt.imported = true;
 
             // override the values we just calculated with the actual values from the imported target
-            rt.targetBufferFlags     = pImportedRenderTarget->importedDesc.attachments;
-            rt.descriptor.viewport   = pImportedRenderTarget->importedDesc.viewport;
-            rt.descriptor.clearColor = pImportedRenderTarget->importedDesc.clearColor;
-            rt.descriptor.clearFlags = pImportedRenderTarget->importedDesc.clearFlags;
-            rt.descriptor.samples    = pImportedRenderTarget->importedDesc.samples;
-            rt.backend.target        = pImportedRenderTarget->target;
+            rt.targetBufferFlags         = pImportedRenderTarget->importedDesc.attachments;
+            rt.backend.params.viewport   = pImportedRenderTarget->importedDesc.viewport;
+            rt.backend.params.clearColor = pImportedRenderTarget->importedDesc.clearColor;
+            rt.clearFlags                = pImportedRenderTarget->importedDesc.clearFlags;
+            rt.samples                   = pImportedRenderTarget->importedDesc.samples;
+            rt.backend.target            = pImportedRenderTarget->target;
 
             // We could end-up here more than once, for instance if the rendertarget is used
             // by multiple passes (this would imply a read-back, btw). In this case, we don't want
@@ -252,9 +245,7 @@ void RenderPassNode::resolve() noexcept {
             rt.backend.params.flags.discardEnd   &= ~pImportedRenderTarget->importedDesc.keepOverrideEnd;
         }
 
-        rt.backend.params.viewport = rt.descriptor.viewport;
-        rt.backend.params.clearColor = rt.descriptor.clearColor;
-        rt.backend.params.flags.clear = rt.descriptor.clearFlags & rt.targetBufferFlags;
+        rt.backend.params.flags.clear = rt.clearFlags & rt.targetBufferFlags;
     }
 }
 
@@ -265,9 +256,9 @@ void RenderPassNode::RenderPassData::devirtualize(FrameGraph& fg,
 
         MRT colorInfo{};
         for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-            if (attachmentInfo[i]) {
+            if (attachments[i]) {
                 auto const* pResource = static_cast<Resource<FrameGraphTexture> const*>(
-                        fg.getResource(attachmentInfo[i]));
+                        fg.getResource(attachments[i]));
                 colorInfo[i].handle = pResource->resource.handle;
                 colorInfo[i].level = pResource->subResourceDescriptor.level;
                 colorInfo[i].layer = pResource->subResourceDescriptor.layer;
@@ -276,9 +267,10 @@ void RenderPassNode::RenderPassData::devirtualize(FrameGraph& fg,
 
         TargetBufferInfo info[2] = {};
         for (size_t i = 0; i < 2; i++) {
-            if (attachmentInfo[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + i]) {
+            size_t const index = MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + i;
+            if (attachments[index]) {
                 auto const* pResource = static_cast<Resource<FrameGraphTexture> const*>(
-                        fg.getResource(attachmentInfo[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + i]));
+                        fg.getResource(attachments[index]));
                 info[i].handle = pResource->resource.handle;
                 info[i].level = pResource->subResourceDescriptor.level;
                 info[i].layer = pResource->subResourceDescriptor.layer;
@@ -289,7 +281,7 @@ void RenderPassNode::RenderPassData::devirtualize(FrameGraph& fg,
                 name, targetBufferFlags,
                 backend.params.viewport.width,
                 backend.params.viewport.height,
-                descriptor.samples, descriptor.layerCount,
+                samples, layerCount,
                 colorInfo, info[0], info[1]);
     }
 }
@@ -357,7 +349,7 @@ std::vector<RenderTargetInfo> RenderPassNode::getRenderTargetInfo() const noexce
             for (size_t i = 0; i < RenderPassData::ATTACHMENT_COUNT; ++i) {
                 TargetBufferFlags mask = getTargetBufferFlagsAt(i);
                 if (any(flags & mask)) {
-                    FrameGraphHandle handle = rt.descriptor.attachments[i];
+                    FrameGraphHandle handle = rt.attachments[i];
                     if (handle) {
                         const char* name = nullptr;
                         if (i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT) name = "color";

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -34,16 +34,17 @@ namespace filament {
 
 ResourceNode::ResourceNode(FrameGraph& fg, FrameGraphHandle const h, FrameGraphHandle const parent) noexcept
         : Node(fg.getGraph()),
-          resourceHandle(h), mFrameGraph(fg), mReaderPasses(fg.getArena()), mParentHandle(parent) {
-    mReaderPasses.reserve(16);
+          resourceHandle(h), mFrameGraph(fg), mParentHandle(parent) {
 }
 
 ResourceNode::~ResourceNode() noexcept {
     VirtualResource* resource = mFrameGraph.getResource(resourceHandle);
     assert_invariant(resource);
     resource->destroyEdge(mWriterPass);
-    for (auto* pEdge : mReaderPasses) {
+    for (ResourceEdgeBase* pEdge = mReaderPassesHead; pEdge; ) {
+        ResourceEdgeBase* const next = pEdge->next;
         resource->destroyEdge(pEdge);
+        pEdge = next;
     }
     delete mParentReadEdge;
     delete mParentWriteEdge;
@@ -70,8 +71,9 @@ char const* ResourceNode::getName() const noexcept {
     return mFrameGraph.getResource(resourceHandle)->name.c_str();
 }
 
-void ResourceNode::addOutgoingEdge(ResourceEdgeBase* edge) noexcept {
-    mReaderPasses.push_back(edge);
+void ResourceNode::addOutgoingEdge(ResourceEdgeBase* const edge) noexcept {
+    edge->next = mReaderPassesHead;
+    mReaderPassesHead = edge;
 }
 
 void ResourceNode::setIncomingEdge(ResourceEdgeBase* edge) noexcept {
@@ -81,40 +83,29 @@ void ResourceNode::setIncomingEdge(ResourceEdgeBase* edge) noexcept {
 
 bool ResourceNode::hasActiveReaders() const noexcept {
     // here we don't use mReaderPasses because this wouldn't account for subresources
-
-    FrameGraph& fg = mFrameGraph;
-    auto& arena = fg.getArena();
-    utils::ArenaScope const scope(arena);
-
-    DependencyGraph& dependencyGraph = fg.getGraph();
-    auto const& readers = dependencyGraph.getOutgoingEdges(this, arena);
-    for (auto const& reader : readers) {
-        if (!dependencyGraph.getNode(reader->to)->isCulled()) {
-            return true;
-        }
-    }
-    return false;
+    DependencyGraph const& dependencyGraph = mFrameGraph.getGraph();
+    return dependencyGraph.findOutgoingEdge(this, [&dependencyGraph](DependencyGraph::Edge const* reader) {
+        return !dependencyGraph.getNode(reader->to)->isCulled();
+    }) != nullptr;
 }
 
 bool ResourceNode::hasActiveWriters() const noexcept {
     // here we don't use mReaderPasses because this wouldn't account for subresources
-
-    FrameGraph& fg = mFrameGraph;
-    auto& arena = fg.getArena();
-    utils::ArenaScope const scope(arena);
-
-    DependencyGraph const& dependencyGraph = fg.getGraph();
-    auto const& writers = dependencyGraph.getIncomingEdges(this, arena);
+    DependencyGraph const& dependencyGraph = mFrameGraph.getGraph();
     // writers are not culled by definition if we're not culled ourselves
-    return !writers.empty();
+    return dependencyGraph.findIncomingEdge(this, [](DependencyGraph::Edge const*) {
+        return true;
+    }) != nullptr;
 }
 
 ResourceEdgeBase* ResourceNode::getReaderEdgeForPass(PassNode const* node) const noexcept {
-    auto pos = std::find_if(mReaderPasses.begin(), mReaderPasses.end(),
-            [node](ResourceEdgeBase const* edge) {
-                return edge->to == node->getId();
-            });
-    return pos != mReaderPasses.end() ? *pos : nullptr;
+    DependencyGraph::NodeID const targetId = node->getId();
+    for (ResourceEdgeBase* edge = mReaderPassesHead; edge; edge = edge->next) {
+        if (edge->to == targetId) {
+            return edge;
+        }
+    }
+    return nullptr;
 }
 
 ResourceEdgeBase* ResourceNode::getWriterEdgeForPass(PassNode const* node) const noexcept {
@@ -149,7 +140,7 @@ void ResourceNode::resolveResourceUsage(DependencyGraph& graph) noexcept {
     VirtualResource* pResource = mFrameGraph.getResource(resourceHandle);
     assert_invariant(pResource);
     if (pResource->refcount) {
-        pResource->resolveUsage(graph, mReaderPasses.data(), mReaderPasses.size(), mWriterPass);
+        pResource->resolveUsage(graph, mReaderPassesHead, mWriterPass);
     }
 }
 

--- a/filament/src/fg/details/DependencyGraph.h
+++ b/filament/src/fg/details/DependencyGraph.h
@@ -157,6 +157,48 @@ public:
      */
     EdgeContainer getOutgoingEdges(Node const* node, FrameGraphAllocator& arena) const noexcept;
 
+    template <typename F>
+    void forEachIncomingEdge(Node const* node, F&& fn) const noexcept {
+        NodeID const nodeId = node->getId();
+        for (Edge const* edge : mEdges) {
+            if (edge->to == nodeId) {
+                fn(edge);
+            }
+        }
+    }
+
+    template <typename F>
+    void forEachOutgoingEdge(Node const* node, F&& fn) const noexcept {
+        NodeID const nodeId = node->getId();
+        for (Edge const* edge : mEdges) {
+            if (edge->from == nodeId) {
+                fn(edge);
+            }
+        }
+    }
+
+    template <typename F>
+    Edge const* findIncomingEdge(Node const* node, F&& predicate) const noexcept {
+        NodeID const nodeId = node->getId();
+        for (Edge const* edge : mEdges) {
+            if (edge->to == nodeId && predicate(edge)) {
+                return edge;
+            }
+        }
+        return nullptr;
+    }
+
+    template <typename F>
+    Edge const* findOutgoingEdge(Node const* node, F&& predicate) const noexcept {
+        NodeID const nodeId = node->getId();
+        for (Edge const* edge : mEdges) {
+            if (edge->from == nodeId && predicate(edge)) {
+                return edge;
+            }
+        }
+        return nullptr;
+    }
+
     Node const* getNode(NodeID id) const noexcept;
 
     Node* getNode(NodeID id) noexcept;

--- a/filament/src/fg/details/PassNode.h
+++ b/filament/src/fg/details/PassNode.h
@@ -72,6 +72,8 @@ public:
         return {};
     }
 #endif
+    uint16_t devirtualizeCount = 0;
+    uint16_t destroyCount = 0;
     Vector<VirtualResource*> devirtualize;         // resources we need to create before executing
     Vector<VirtualResource*> destroy;              // resources we need to destroy after executing
 };
@@ -82,16 +84,16 @@ public:
     public:
         static constexpr size_t ATTACHMENT_COUNT = backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 2;
         utils::StaticString name{};
-        FrameGraphRenderPass::Descriptor descriptor;
-        bool imported = false;
-        backend::TargetBufferFlags targetBufferFlags = {};
-        FrameGraphId<FrameGraphTexture> attachmentInfo[ATTACHMENT_COUNT] = {};
-        ResourceNode* incoming[ATTACHMENT_COUNT] = {};  // nodes of the incoming attachments
-        ResourceNode* outgoing[ATTACHMENT_COUNT] = {};  // nodes of the outgoing attachments
+        FrameGraphRenderPass::Attachments attachments{};
         struct {
             backend::Handle<backend::HwRenderTarget> target;
             backend::RenderPassParams params;
         } backend;
+        backend::TargetBufferFlags targetBufferFlags = {};
+        backend::TargetBufferFlags clearFlags = {};
+        uint8_t samples = 0;
+        uint8_t layerCount = 1;
+        bool imported = false;
 
         void devirtualize(FrameGraph& fg, TextureCacheInterface& textureCache) noexcept;
         void destroy(TextureCacheInterface& textureCache) const noexcept;
@@ -106,6 +108,7 @@ public:
 
     RenderPassData const* getRenderPassData(uint32_t id) const noexcept;
     size_t getRenderTargetCount() const noexcept { return mRenderTargetData.size(); }
+    void reserveRenderTargets(size_t count) noexcept { mRenderTargetData.reserve(count); }
 
     // virtuals from DependencyGraph::Node
     char const* getName() const noexcept override { return mName; }

--- a/filament/src/fg/details/Resource.h
+++ b/filament/src/fg/details/Resource.h
@@ -47,6 +47,7 @@ class ImportedRenderTarget;
 class ResourceEdgeBase : public DependencyGraph::Edge {
 public:
     using Edge::Edge;
+    ResourceEdgeBase* next = nullptr;
 };
 
 /*
@@ -91,7 +92,7 @@ public:
      * calculate its effective usage flags.
      */
     virtual void resolveUsage(DependencyGraph& graph,
-            ResourceEdgeBase const* const* edges, size_t count,
+            ResourceEdgeBase const* readerHead,
             ResourceEdgeBase const* writer) noexcept = 0;
 
     /* Instantiate the concrete resource */
@@ -213,13 +214,13 @@ protected:
      */
 
     void resolveUsage(DependencyGraph& graph,
-            ResourceEdgeBase const* const* edges, size_t const count,
+            ResourceEdgeBase const* readerHead,
             ResourceEdgeBase const* writer) noexcept override {
-        for (size_t i = 0; i < count; i++) {
-            if (graph.isEdgeValid(edges[i])) {
+        for (ResourceEdgeBase const* edge = readerHead; edge; edge = edge->next) {
+            if (graph.isEdgeValid(edge)) {
                 // this Edge is guaranteed to be a ResourceEdge<RESOURCE> by construction
-                ResourceEdge const* const edge = static_cast<ResourceEdge const*>(edges[i]);
-                usage |= edge->usage;
+                ResourceEdge const* const resourceEdge = static_cast<ResourceEdge const*>(edge);
+                usage |= resourceEdge->usage;
             }
         }
 

--- a/filament/src/fg/details/ResourceNode.h
+++ b/filament/src/fg/details/ResourceNode.h
@@ -60,7 +60,7 @@ public:
 
     // is at least one PassNode reading from this ResourceNode
     bool hasReaders() const noexcept {
-        return !mReaderPasses.empty();
+        return mReaderPassesHead != nullptr;
     }
 
     // is any non culled Node (of any type) reading from this ResourceNode
@@ -106,7 +106,7 @@ public:
 
 private:
     FrameGraph& mFrameGraph;
-    Vector<ResourceEdgeBase *> mReaderPasses;
+    ResourceEdgeBase* mReaderPassesHead = nullptr;
     ResourceEdgeBase* mWriterPass = nullptr;
     FrameGraphHandle mParentHandle;
     DependencyGraph::Edge* mParentReadEdge = nullptr;

--- a/filament/src/fg/details/Utilities.h
+++ b/filament/src/fg/details/Utilities.h
@@ -42,7 +42,10 @@ struct Deleter {
 using FrameGraphAllocator = utils::Arena<
         utils::LinearAllocator,
         utils::LockingPolicy::NoLock,
-        utils::TrackingPolicy::DebugAndLeakDetector,
+        utils::TrackingPolicy::Composite<
+            utils::TrackingPolicy::HighWatermark,
+            utils::TrackingPolicy::Debug,
+            utils::TrackingPolicy::LeakDetector>,
         utils::AreaPolicy::ArenaArea<LinearAllocatorArena>>;
 
 #else

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -96,8 +96,8 @@ protected:
     Platform* platform = PlatformFactory::create(&backend);
     CommandStream driverApi = CommandStream{ *platform->createDriver(nullptr, {}), buffer };
     MockResourceAllocator resourceAllocator;
-    LinearAllocatorArena arena{"FrameGraph Test Arena", 512 * 1024};
-    FrameGraph fg{arena, resourceAllocator};
+    LinearAllocatorArena arena{"FrameGraph Test Arena", 1024 * 1024};
+    FrameGraph fg{arena, 1024 * 1024, resourceAllocator};
 };
 
 class DependencyGraphTest : public testing::Test {

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -139,14 +139,45 @@ struct has_active_allocation_bytes<T, std::void_t<decltype(std::declval<T>().get
 template<typename T>
 inline constexpr bool has_active_allocation_bytes_v = has_active_allocation_bytes<T>::value;
 
-template<typename Tracking>
-uint32_t getActiveAllocationBytes(Tracking const& listener) noexcept {
-    if constexpr (has_active_allocation_bytes_v<Tracking>) {
-        return listener.getActiveAllocationBytes();
-    } else {
-        return 0;
-    }
-}
+// Detect alloc(size, alignment, extra, ...)
+template<typename AlwaysVoid, typename Alloc, typename Size1, typename Size2, typename Size3, typename... Args>
+struct has_alloc_with_extra : std::false_type {};
+
+template<typename Alloc, typename Size1, typename Size2, typename Size3, typename... Args>
+struct has_alloc_with_extra<
+            std::void_t<decltype(
+                std::declval<Alloc>().alloc(
+                        std::declval<Size1>(),
+                        std::declval<Size2>(),
+                        std::declval<Size3>(),
+                        std::declval<Args>()...
+                        )
+            )>,
+            Alloc, Size1, Size2, Size3, Args...
+        > : std::true_type {};
+
+template<typename Alloc, typename Size1, typename Size2, typename Size3, typename... Args>
+inline constexpr bool has_alloc_with_extra_v = has_alloc_with_extra<void, Alloc, Size1, Size2, Size3, Args...>::value;
+
+// Detect getHighWatermark()
+template<typename T, typename = void>
+struct has_high_watermark : std::false_type {};
+
+template<typename T>
+struct has_high_watermark<T, std::void_t<decltype(std::declval<T>().getHighWatermark())>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool has_high_watermark_v = has_high_watermark<T>::value;
+
+// Detect getWastedBytes()
+template<typename T, typename = void>
+struct has_wasted_bytes : std::false_type {};
+
+template<typename T>
+struct has_wasted_bytes<T, std::void_t<decltype(std::declval<T>().getWastedBytes())>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool has_wasted_bytes_v = has_wasted_bytes<T>::value;
 
 } // namespace detail
 
@@ -179,13 +210,24 @@ public:
     ~LinearAllocator() noexcept = default;
 
     // our allocator concept
-    void* alloc(size_t const size, size_t const alignment = alignof(std::max_align_t), size_t const extra = 0) UTILS_RESTRICT {
+    [[nodiscard]] void* alloc(size_t const size, size_t const alignment = alignof(std::max_align_t)) UTILS_RESTRICT {
         // branch-less allocation
-        void* const p = pointermath::align(current(), alignment, extra);
+        void* const p = pointermath::align(current(), alignment);
         void* const c = pointermath::add(p, size);
         bool const success = c <= end();
-        set_current(success ? c : current());
+        if (success) {
+            mPrevCur = mCur;
+            set_current(c);
+        }
         return success ? p : nullptr;
+    }
+
+    bool free(void* p, size_t const size) noexcept {
+        if (pointermath::add(p, size) == current() && p >= pointermath::add(mBegin, mPrevCur)) {
+            mCur = mPrevCur;
+            return true;
+        }
+        return false;
     }
 
     // API specific to this allocator
@@ -197,6 +239,7 @@ public:
     void rewind(void* p) UTILS_RESTRICT noexcept {
         assert(p >= mBegin && p < end());
         set_current(p);
+        mPrevCur = mCur;
     }
 
     // frees all allocated blocks
@@ -231,6 +274,7 @@ private:
     void* mBegin = nullptr;
     uint32_t mSize = 0;
     uint32_t mCur = 0;
+    uint32_t mPrevCur = 0;
 };
 
 /* ------------------------------------------------------------------------------------------------
@@ -248,7 +292,7 @@ public:
     explicit HeapAllocator(const AREA&) { }
 
     // our allocator concept
-    void* alloc(size_t const size, size_t const alignment = alignof(std::max_align_t)) {
+    [[nodiscard]] void* alloc(size_t const size, size_t const alignment = alignof(std::max_align_t)) {
         return aligned_alloc(size, alignment);
     }
 
@@ -288,7 +332,14 @@ public:
         reset();
     }
 
-    void* alloc(size_t size, size_t alignment = alignof(std::max_align_t));
+    [[nodiscard]] void* alloc(size_t size, size_t alignment = alignof(std::max_align_t));
+
+    bool free(void* p, size_t const size) noexcept {
+        if (UTILS_LIKELY(!isHeapAllocation(p))) {
+            return LinearAllocator::free(p, size);
+        }
+        return false;
+    }
 
     void *getCurrent() noexcept {
         return LinearAllocator::getCurrent();
@@ -318,7 +369,7 @@ public:
     FreeList(FreeList&& rhs) noexcept = default;
     FreeList& operator=(FreeList&& rhs) noexcept = default;
 
-    void* pop() noexcept {
+    [[nodiscard]] void* pop() noexcept {
         Node* const head = mHead;
         mHead = head ? head->next : nullptr;
         // this could indicate a use after free
@@ -365,7 +416,7 @@ public:
     AtomicFreeList(const AtomicFreeList& rhs) = delete;
     AtomicFreeList& operator=(const AtomicFreeList& rhs) = delete;
 
-    void* pop() noexcept {
+    [[nodiscard]] void* pop() noexcept {
         Node* const pStorage = mStorage;
 
         HeadPtr currentHead = mHead.load(std::memory_order_relaxed);
@@ -472,7 +523,7 @@ class PoolAllocator {
             "ELEMENT_SIZE must accommodate at least a FreeList::Node");
 public:
     // our allocator concept
-    void* alloc(size_t const size = ELEMENT_SIZE,
+    [[nodiscard]] void* alloc(size_t const size = ELEMENT_SIZE,
                 size_t const alignment = ALIGNMENT, size_t const offset = OFFSET) noexcept {
         assert(size <= ELEMENT_SIZE);
         assert(alignment <= ALIGNMENT);
@@ -549,7 +600,7 @@ public:
     }
 
     // our allocator concept
-    void* alloc(size_t size = ELEMENT_SIZE, size_t alignment = ALIGNMENT) noexcept {
+    [[nodiscard]] void* alloc(size_t size = ELEMENT_SIZE, size_t alignment = ALIGNMENT) noexcept {
         void* p = PoolAllocator::alloc(size, alignment);
         if (UTILS_UNLIKELY(!p)) {
             p = HeapAllocator::alloc(size, alignment);
@@ -660,17 +711,25 @@ public:
     ArenaArea(ARENA& arena, size_t const size) : mArena(arena) {
         if (size) {
             mBegin = mArena.alloc(size);
-            mEnd = pointermath::add(mBegin, size);
+            mEnd = mBegin ? pointermath::add(mBegin, size) : nullptr;
         }
     }
 
     ~ArenaArea() noexcept {
-        mArena.free(mBegin, size());
+        if (mBegin) {
+            mArena.free(mBegin, size());
+        }
     }
 
     ArenaArea(const ArenaArea& rhs) = delete;
     ArenaArea& operator=(const ArenaArea& rhs) = delete;
-    ArenaArea(ArenaArea&& rhs) noexcept = default;
+
+    ArenaArea(ArenaArea&& rhs) noexcept
+        : mArena(rhs.mArena),
+          mBegin(std::exchange(rhs.mBegin, nullptr)),
+          mEnd(std::exchange(rhs.mEnd, nullptr)) {
+    }
+
     ArenaArea& operator=(ArenaArea&& rhs) noexcept = delete;
 
     void* data() const noexcept { return mBegin; }
@@ -722,6 +781,10 @@ struct Untracked {
     void onLogicalFree(void const* p, size_t const size) noexcept { (void)p; (void)size; }
     void onReset() noexcept { }
     void onRewind(void const* addr) noexcept { (void)addr; }
+    uint32_t getHighWatermark() const noexcept { return 0; }
+    uint32_t getWastedBytes() const noexcept { return 0; }
+    uint32_t getActiveAllocationCount() const noexcept { return 0; }
+    uint32_t getActiveAllocationBytes() const noexcept { return 0; }
 };
 
 // This just track the max memory usage and logs it in the destructor
@@ -732,59 +795,38 @@ struct HighWatermark {
     ~HighWatermark() noexcept;
     void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept;
     void onFree(void* p, size_t size) noexcept;
-    void onLogicalFree(void const* p, size_t const size) noexcept { (void)p; (void)size; }
+    void onLogicalFree(void const* p, size_t const size) noexcept;
     void onReset() noexcept;
     void onRewind(void const* addr) noexcept;
     uint32_t getHighWatermark() const noexcept { return mHighWaterMark; }
+    uint32_t getWastedBytes() const noexcept { return mWasted; }
+    uint32_t getWastedBytesAtWatermark() const noexcept { return mWastedAtWaterMark; }
+    uint32_t getActiveAllocationCount() const noexcept { return 0; }
+    uint32_t getActiveAllocationBytes() const noexcept { return 0; }
 protected:
     char const* const mName = nullptr;
     void const* const mBase = nullptr;
     uint32_t const mSize = 0;
     uint32_t mCurrent = 0;
     uint32_t mHighWaterMark = 0;
+    uint32_t mWasted = 0;
+    uint32_t mWastedAtWaterMark = 0;
 };
 
 // This just poisons buffers with known values to help catch uninitialized access and use after free.
 struct Debug {
     Debug() noexcept = default;
-    Debug(const char* name, void* base, size_t const size) noexcept
-            : mName(name), mBase(base), mSize(uint32_t(size)) { }
+    Debug(const char* name, void const* base, size_t const size) noexcept
+            : mName(name), mBase(const_cast<void*>(base)), mSize(uint32_t(size)) { }
     void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept;
     void onFree(void* p, size_t size) noexcept;
     void onLogicalFree(void* p, size_t size) noexcept;
     void onReset() noexcept;
-    void onRewind(void* addr) noexcept;
+    void onRewind(void const* addr) noexcept;
 protected:
     char const* const mName = nullptr;
     void* const mBase = nullptr;
     uint32_t const mSize = 0;
-};
-
-struct DebugAndHighWatermark : protected HighWatermark, protected Debug {
-    DebugAndHighWatermark() noexcept = default;
-    DebugAndHighWatermark(const char* name, void* base, size_t const size) noexcept
-            : HighWatermark(name, base, size), Debug(name, base, size) { }
-    void onAlloc(void* p, size_t const size, size_t const alignment, size_t const extra) noexcept {
-        HighWatermark::onAlloc(p, size, alignment, extra);
-        Debug::onAlloc(p, size, alignment, extra);
-    }
-    void onFree(void* p, size_t const size) noexcept {
-        HighWatermark::onFree(p, size);
-        Debug::onFree(p, size);
-    }
-    void onLogicalFree(void* p, size_t const size) noexcept {
-        HighWatermark::onLogicalFree(p, size);
-        Debug::onLogicalFree(p, size);
-    }
-    void onReset() noexcept {
-        HighWatermark::onReset();
-        Debug::onReset();
-    }
-    void onRewind(void* addr) noexcept {
-        HighWatermark::onRewind(addr);
-        Debug::onRewind(addr);
-    }
-    uint32_t getHighWatermark() const noexcept { return HighWatermark::getHighWatermark(); }
 };
 
 enum class LeakDetectorBehavior {
@@ -860,46 +902,99 @@ struct TLeakDetector : public LeakDetectorBase {
 
 using LeakDetector = TLeakDetector<LeakDetectorBehavior::LOG, 3>;
 
-template<LeakDetectorBehavior BEHAVIOR = LeakDetectorBehavior::LOG, size_t IGNORE_FRAMES = 3>
-struct TDebugAndLeakDetector : protected Debug, protected TLeakDetector<BEHAVIOR, IGNORE_FRAMES> {
-    using LeakDetectorType = TLeakDetector<BEHAVIOR, IGNORE_FRAMES>;
+template<typename... Policies>
+struct Composite : public Policies... {
+    Composite() noexcept = default;
 
-    TDebugAndLeakDetector() noexcept = default;
-    TDebugAndLeakDetector(char const* name, void* base, size_t const size) noexcept
-            : Debug(name, base, size), LeakDetectorType(name, base, size) { }
+    Composite(char const* name, void const* base, size_t const size) noexcept
+        : Policies(name, base, size)... { }
 
     void onAlloc(void* p, size_t const size, size_t const alignment = 0, size_t const extra = 0) noexcept {
-        Debug::onAlloc(p, size, alignment, extra);
-        LeakDetectorType::onAlloc(p, size, alignment, extra);
+        (Policies::onAlloc(p, size, alignment, extra), ...);
     }
+
     void onFree(void* p, size_t const size = 0) noexcept {
-        Debug::onFree(p, size);
-        LeakDetectorType::onFree(p, size);
+        (Policies::onFree(p, size), ...);
     }
+
     void onLogicalFree(void* p, size_t const size = 0) noexcept {
-        Debug::onLogicalFree(p, size);
-        LeakDetectorType::onLogicalFree(p, size);
+        (Policies::onLogicalFree(p, size), ...);
     }
+
     void onReset() noexcept {
-        Debug::onReset();
-        LeakDetectorType::onReset();
+        (Policies::onReset(), ...);
     }
-    void onRewind(void* addr) noexcept {
-        Debug::onRewind(addr);
-        LeakDetectorType::onRewind(addr);
+
+    void onRewind(void const* addr) noexcept {
+        (Policies::onRewind(addr), ...);
+    }
+
+    template<typename T>
+    T& get() noexcept {
+        return static_cast<T&>(*this);
+    }
+
+    template<typename T>
+    T const& get() const noexcept {
+        return static_cast<T const&>(*this);
+    }
+
+    uint32_t getHighWatermark() const noexcept {
+        uint32_t result = 0;
+        auto check = [&](auto const& p) {
+            using P = std::decay_t<decltype(p)>;
+            if constexpr (detail::has_high_watermark_v<P>) {
+                result = std::max(result, p.getHighWatermark());
+            }
+        };
+        (check(static_cast<Policies const&>(*this)), ...);
+        return result;
+    }
+
+    uint32_t getWastedBytes() const noexcept {
+        uint32_t result = 0;
+        auto check = [&](auto const& p) {
+            using P = std::decay_t<decltype(p)>;
+            if constexpr (detail::has_wasted_bytes_v<P>) {
+                result += p.getWastedBytes();
+            }
+        };
+        (check(static_cast<Policies const&>(*this)), ...);
+        return result;
     }
 
     uint32_t getActiveAllocationCount() const noexcept {
-        return LeakDetectorType::getActiveAllocationCount();
+        uint32_t result = 0;
+        auto check = [&](auto const& p) {
+            using P = std::decay_t<decltype(p)>;
+            if constexpr (detail::has_active_allocation_count_v<P>) {
+                result += p.getActiveAllocationCount();
+            }
+        };
+        (check(static_cast<Policies const&>(*this)), ...);
+        return result;
     }
+
     uint32_t getActiveAllocationBytes() const noexcept {
-        return LeakDetectorType::getActiveAllocationBytes();
+        uint32_t result = 0;
+        auto check = [&](auto const& p) {
+            using P = std::decay_t<decltype(p)>;
+            if constexpr (detail::has_active_allocation_bytes_v<P>) {
+                result += p.getActiveAllocationBytes();
+            }
+        };
+        (check(static_cast<Policies const&>(*this)), ...);
+        return result;
     }
 };
 
-using DebugAndLeakDetector = TDebugAndLeakDetector<LeakDetectorBehavior::LOG, 3>;
+using DebugAndHighWatermark = Composite<HighWatermark, Debug>;
+using DebugAndLeakDetector = Composite<Debug, LeakDetector>;
 
 } // namespace TrackingPolicy
+
+template<typename... Policies>
+using CompositeTrackingPolicy = TrackingPolicy::Composite<Policies...>;
 
 // ------------------------------------------------------------------------------------------------
 // Arenas
@@ -934,8 +1029,10 @@ public:
 
     // -----------------------------------------------------------------------------
 
-    template<typename ... ARGS>
-    void* alloc(size_t size, size_t alignment, size_t extra, ARGS&& ... args) noexcept {
+    // Available only if AllocatorPolicy supports alloc with extra
+    template<typename ... ARGS, typename A = AllocatorPolicy,
+            std::enable_if_t<detail::has_alloc_with_extra_v<A, size_t, size_t, size_t, ARGS...>, int> = 0>
+    [[nodiscard]] void* alloc(size_t size, size_t alignment, size_t extra, ARGS&& ... args) noexcept {
         std::lock_guard<LockingPolicy> guard(mLock);
         void* p = mAllocator.alloc(size, alignment, extra, std::forward<ARGS>(args) ...);
         mListener.onAlloc(p, size, alignment, extra);
@@ -943,7 +1040,7 @@ public:
     }
 
     // some allocators don't support the "extra" parameter
-    void* alloc(size_t size, size_t alignment = alignof(std::max_align_t)) noexcept {
+    [[nodiscard]] void* alloc(size_t size, size_t alignment = alignof(std::max_align_t)) noexcept {
         std::lock_guard<LockingPolicy> guard(mLock);
         void* p = mAllocator.alloc(size, alignment);
         mListener.onAlloc(p, size, alignment, 0);
@@ -954,8 +1051,9 @@ public:
     // for safety, we disable the object-based alloc method if the object type is not
     // trivially destructible, since free() won't call the destructor and this is allocating
     // an array.
-    template<typename T, typename = std::enable_if_t<std::is_trivially_destructible_v<T>>>
-    T* alloc(size_t const count, size_t const alignment, size_t const extra) noexcept {
+    template<typename T, typename A = AllocatorPolicy,
+            std::enable_if_t<std::is_trivially_destructible_v<T> && detail::has_alloc_with_extra_v<A, size_t, size_t, size_t>, int> = 0>
+    [[nodiscard]] T* alloc(size_t const count, size_t const alignment, size_t const extra) noexcept {
         size_t size;
         if (UTILS_UNLIKELY(UTILS_MUL_OVERFLOW(count, sizeof(T), &size))) {
             return nullptr;
@@ -964,7 +1062,7 @@ public:
     }
 
     template<typename T, typename = std::enable_if_t<std::is_trivially_destructible_v<T>>>
-    T* alloc(size_t const count, size_t const alignment = alignof(T)) noexcept {
+    [[nodiscard]] T* alloc(size_t const count, size_t const alignment = alignof(T)) noexcept {
         size_t size;
         if (UTILS_UNLIKELY(UTILS_MUL_OVERFLOW(count, sizeof(T), &size))) {
             return nullptr;
@@ -978,8 +1076,19 @@ public:
         if (p) {
             std::lock_guard<LockingPolicy> guard(mLock);
             if constexpr (detail::has_variadic_free_v<decltype(mAllocator), void*, size_t, ARGS...>) {
-                mListener.onFree(p, size);
-                mAllocator.free(p, size, std::forward<ARGS>(args)...);
+                using ReturnType = decltype(mAllocator.free(p, size, std::forward<ARGS>(args)...));
+                if constexpr (std::is_same_v<ReturnType, bool>) {
+                    if (mAllocator.free(p, size, std::forward<ARGS>(args)...)) {
+                        mListener.onFree(p, size);
+                    } else {
+                        if constexpr (detail::has_logical_free_v<TrackingPolicy>) {
+                            mListener.onLogicalFree(p, size);
+                        }
+                    }
+                } else {
+                    mListener.onFree(p, size);
+                    mAllocator.free(p, size, std::forward<ARGS>(args)...);
+                }
             } else {
                 if constexpr (detail::has_logical_free_v<TrackingPolicy>) {
                     mListener.onLogicalFree(p, size);
@@ -1008,7 +1117,7 @@ public:
 
     // Allocate and construct an object
     template<typename T, size_t ALIGN = alignof(T), typename... ARGS>
-    T* make(ARGS&& ... args) noexcept {
+    [[nodiscard]] T* make(ARGS&& ... args) noexcept {
         void* const p = this->alloc(sizeof(T), ALIGN);
         return p ? new(p) T(std::forward<ARGS>(args)...) : nullptr;
     }
@@ -1132,7 +1241,7 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
     using propagate_on_container_move_assignment = std::true_type;
-    using is_always_equal = std::true_type;
+    using is_always_equal = std::false_type;
 
     template<typename OTHER>
     struct rebind { using other = STLAllocator<OTHER, ARENA>; };
@@ -1145,7 +1254,7 @@ public:
     template<typename U>
     explicit STLAllocator(STLAllocator<U, ARENA> const& rhs) : mArena(rhs.mArena) { }
 
-    TYPE* allocate(std::size_t const n) {
+    [[nodiscard]] TYPE* allocate(std::size_t const n) {
         auto p = static_cast<TYPE *>(mArena.alloc(n * sizeof(TYPE), alignof(TYPE)));
         assert(p);
         return p;

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -17,6 +17,8 @@
 #ifndef TNT_UTILS_COMPILER_H
 #define TNT_UTILS_COMPILER_H
 
+#include <stddef.h>
+
 // compatibility with non-clang compilers...
 #ifndef __has_attribute
 #define __has_attribute(x) 0
@@ -97,6 +99,28 @@
 #if __has_feature(memory_sanitizer)
 #undef UTILS_HAS_SANITIZE_MEMORY
 #define UTILS_HAS_SANITIZE_MEMORY 1
+#endif
+
+#define UTILS_HAS_SANITIZE_ADDRESS 0
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#undef UTILS_HAS_SANITIZE_ADDRESS
+#define UTILS_HAS_SANITIZE_ADDRESS 1
+#endif
+
+#if UTILS_HAS_SANITIZE_ADDRESS
+#ifdef __cplusplus
+extern "C" {
+#endif
+void __asan_poison_memory_region(void const volatile *addr, size_t size);
+void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+#ifdef __cplusplus
+}
+#endif
+#define UTILS_POISON_MEMORY_REGION(addr, size) __asan_poison_memory_region((addr), (size))
+#define UTILS_UNPOISON_MEMORY_REGION(addr, size) __asan_unpoison_memory_region((addr), (size))
+#else
+#define UTILS_POISON_MEMORY_REGION(addr, size) ((void)0)
+#define UTILS_UNPOISON_MEMORY_REGION(addr, size) ((void)0)
 #endif
 
 /*

--- a/libs/utils/src/Allocator.cpp
+++ b/libs/utils/src/Allocator.cpp
@@ -52,6 +52,7 @@ void LinearAllocator::swap(LinearAllocator& rhs) noexcept {
     std::swap(mBegin, rhs.mBegin);
     std::swap(mSize, rhs.mSize);
     std::swap(mCur, rhs.mCur);
+    std::swap(mPrevCur, rhs.mPrevCur);
 }
 
 
@@ -153,9 +154,12 @@ AtomicFreeList::AtomicFreeList(void* begin, void* end,
 
 // ------------------------------------------------------------------------------------------------
 
-void TrackingPolicy::HighWatermark::onAlloc(void* p, size_t const size, size_t, size_t) noexcept {
+void TrackingPolicy::HighWatermark::onAlloc(void*, size_t const size, size_t, size_t) noexcept {
     mCurrent += uint32_t(size);
-    mHighWaterMark = std::max(mCurrent, mHighWaterMark);
+    if (mCurrent > mHighWaterMark) {
+        mHighWaterMark = mCurrent;
+        mWastedAtWaterMark = mWasted;
+    }
 }
 
 TrackingPolicy::HighWatermark::~HighWatermark() noexcept {
@@ -164,10 +168,18 @@ TrackingPolicy::HighWatermark::~HighWatermark() noexcept {
     if (mSize > 0) {
         size_t usageRatio = (watermark * 100) / mSize;
         if (usageRatio > 80) {
-            LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes (" << usageRatio << "%)";
+            if (mWastedAtWaterMark > 0) {
+                LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes (" << usageRatio << "%), wasted " << mWastedAtWaterMark << " bytes";
+            } else {
+                LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes (" << usageRatio << "%)";
+            }
         }
     } else {
-        LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes";
+        if (mWastedAtWaterMark > 0) {
+            LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes, wasted " << mWastedAtWaterMark << " bytes";
+        } else {
+            LOG(INFO) << mName << " arena: High watermark " << watermark << " bytes";
+        }
     }
 }
 
@@ -176,11 +188,17 @@ void TrackingPolicy::HighWatermark::onFree(void*, size_t const size) noexcept {
     mCurrent -= uint32_t(size);
 }
 
+void TrackingPolicy::HighWatermark::onLogicalFree(void const*, size_t const size) noexcept {
+    mWasted += uint32_t(size);
+}
+
 void TrackingPolicy::HighWatermark::onReset() noexcept {
     // we should never be here if mBase is nullptr because we can't be here if the
     // underlying allocator doesn't have reset().
     assert_invariant(mBase);
     mCurrent = 0;
+    mWasted = 0;
+    mWastedAtWaterMark = 0;
 }
 
 void TrackingPolicy::HighWatermark::onRewind(void const* addr) noexcept {
@@ -197,12 +215,14 @@ void TrackingPolicy::HighWatermark::onRewind(void const* addr) noexcept {
 
 void TrackingPolicy::Debug::onAlloc(void* p, size_t const size, size_t, size_t) noexcept {
     if (p) {
+        UTILS_UNPOISON_MEMORY_REGION(p, size);
         memset(p, 0xeb, size);
     }
 }
 
 void TrackingPolicy::Debug::onFree(void* p, size_t const size) noexcept {
     if (p) {
+        UTILS_UNPOISON_MEMORY_REGION(p, size);
         memset(p, 0xef, size);
     }
 }
@@ -215,16 +235,19 @@ void TrackingPolicy::Debug::onReset() noexcept {
     // we should never be here if mBase is nullptr because we can't be here if the
     // underlying allocator doesn't have reset().
     assert_invariant(mBase);
+    UTILS_UNPOISON_MEMORY_REGION(mBase, mSize);
     memset(mBase, 0xec, mSize);
 }
 
-void TrackingPolicy::Debug::onRewind(void* addr) noexcept {
+void TrackingPolicy::Debug::onRewind(void const* addr) noexcept {
     // we should never be here if mBase is nullptr because we can't be here if the
     // underlying allocator doesn't have rewind().
     assert(mBase);
     // for LinearAllocatorWithFallback we could get pointers outside the range
     if (addr >= mBase && addr < pointermath::add(mBase, mSize)) {
-        memset(addr, 0xed, uintptr_t(mBase) + mSize - uintptr_t(addr));
+        size_t const count = uintptr_t(mBase) + mSize - uintptr_t(addr);
+        UTILS_UNPOISON_MEMORY_REGION(addr, count);
+        memset(const_cast<void*>(addr), 0xed, count);
     }
 }
 

--- a/libs/utils/test/test_Allocators.cpp
+++ b/libs/utils/test/test_Allocators.cpp
@@ -32,57 +32,88 @@ TEST(AllocatorTest, LinearAllocator) {
     void* q = nullptr;
 
     LinearAllocator la(scratch, scratch+sizeof(scratch));
-    p = la.alloc(1024, 1, 0);
+    p = la.alloc(1024, 1);
 
     // check we can allocate the whole block
     EXPECT_EQ(scratch, p);
 
     // check we can free everything and reallocate the whole block
     la.reset();
-    p = la.alloc(1024, 1, 0);
+    p = la.alloc(1024, 1);
     EXPECT_EQ(scratch, p);
 
     // check we can rewind
     la.rewind(scratch + 512);
-    p = la.alloc(512, 1, 0);
+    p = la.alloc(512, 1);
     EXPECT_EQ(scratch + 512, p);
 
     // check we can't allocate more than the area size
     la.reset();
-    p = la.alloc(1025, 1, 0);
+    p = la.alloc(1025, 1);
     EXPECT_EQ(nullptr, p);
 
     // check that after failure, we can allocate to the area size
-    p = la.alloc(1024, 1, 0);
+    p = la.alloc(1024, 1);
     EXPECT_EQ(scratch, p);
 
     // check small allocations
     la.reset();
-    p = la.alloc(1, 1, 0);
+    p = la.alloc(1, 1);
     EXPECT_EQ(scratch, p);
-    p = la.alloc(7, 1, 0);
+    p = la.alloc(7, 1);
     EXPECT_EQ(scratch+1, p);
-    p = la.alloc(8, 1, 0);
+    p = la.alloc(8, 1);
     EXPECT_EQ(scratch+8, p);
 
     // check alignment
-    la.alloc(1, 1, 0);
-    p = la.alloc(24, 32, 0);
+    la.alloc(1, 1);
+    p = la.alloc(24, 32);
     EXPECT_NE(nullptr, p);
     EXPECT_EQ(0, uintptr_t(p) & 31);
 
     // now check that next allocation doesn't overlap previous one
-    q = la.alloc(1, 1, 0);
+    q = la.alloc(1, 1);
     EXPECT_EQ(uintptr_t(q), uintptr_t(p) + 24);
 
-    // check alignment + offset
-    la.alloc(3, 1, 0);
-    p = la.alloc(sizeof(float)*4, 32, 4);
-    EXPECT_EQ(0, uintptr_t(p) & 31);
+    // check free() of the top allocation
+    la.reset();
+    void* const a0 = la.alloc(64);
+    EXPECT_EQ(scratch, a0);
+    EXPECT_EQ(pointermath::add(scratch, 64), la.getCurrent());
 
-    // now check that next allocation doesn't overlap previous one
-    q = la.alloc(1, 1, 0);
-    EXPECT_EQ(uintptr_t(q), uintptr_t(p) + sizeof(float)*4);
+    // freeing top allocation succeeds and rolls back
+    EXPECT_TRUE(la.free(a0, 64));
+    EXPECT_EQ(scratch, la.getCurrent());
+
+    // reallocating reclaims the exact space
+    void* const a1 = la.alloc(64);
+    EXPECT_EQ(scratch, a1);
+
+    // test top allocation free
+    void* const b0 = la.alloc(128);
+    EXPECT_EQ(pointermath::add(a1, 64 + 128), la.getCurrent());
+
+    // freeing b0 (top) succeeds
+    EXPECT_TRUE(la.free(b0, 128));
+    EXPECT_EQ(pointermath::add(a1, 64), la.getCurrent());
+
+    // reallocate and test freeing non-top (buried) allocation fails
+    void* const b1 = la.alloc(128);
+    void* const c1 = la.alloc(256);
+    EXPECT_FALSE(la.free(b1, 128)); // b1 is buried under c1
+    EXPECT_EQ(pointermath::add(c1, 256), la.getCurrent()); // current unchanged
+
+    // test freeing with mismatched size fails
+    EXPECT_FALSE(la.free(c1, 128)); // c1 is 256 bytes, not 128
+    EXPECT_EQ(pointermath::add(c1, 256), la.getCurrent());
+
+    // freeing c1 (top) succeeds
+    EXPECT_TRUE(la.free(c1, 256));
+    EXPECT_EQ(pointermath::add(b1, 128), la.getCurrent());
+
+    // reset cleans up
+    la.reset();
+    EXPECT_EQ(scratch, la.getCurrent());
 }
 
 
@@ -453,4 +484,147 @@ TEST(AllocatorTest, LeakDetectorFreeSizeMismatch) {
     arena.free(p, 32);
     EXPECT_EQ(0u, arena.getListener().getActiveAllocationCount());
     EXPECT_EQ(0u, arena.getListener().getActiveAllocationBytes());
+}
+
+TEST(AllocatorTest, HighWatermarkWastedBytes) {
+    using HwArena = Arena<LinearAllocator, LockingPolicy::NoLock, TrackingPolicy::HighWatermark>;
+    HwArena arena("HwArenaWasted", 1024);
+
+    void* const p0 = arena.alloc(64);
+    void* const p1 = arena.alloc(128);
+    EXPECT_EQ(192u, arena.getListener().getHighWatermark());
+    EXPECT_EQ(0u, arena.getListener().getWastedBytes());
+
+    // Free p0 (buried under p1) -> logically freed, cannot be physically reclaimed -> wasted!
+    arena.free(p0, 64);
+    EXPECT_EQ(192u, arena.getListener().getHighWatermark());
+    EXPECT_EQ(64u, arena.getListener().getWastedBytes());
+
+    // Free p1 (at top) -> physically reclaimed -> not wasted
+    arena.free(p1, 128);
+    EXPECT_EQ(192u, arena.getListener().getHighWatermark());
+    EXPECT_EQ(64u, arena.getListener().getWastedBytes());
+
+    // Reset clears both high watermark current and wasted
+    arena.reset();
+    EXPECT_EQ(0u, arena.getListener().getWastedBytes());
+}
+
+TEST(AllocatorTest, CompositeTrackingPolicy) {
+    using CustomComposite = TrackingPolicy::Composite<
+            TrackingPolicy::HighWatermark,
+            TrackingPolicy::Debug,
+            TrackingPolicy::LeakDetector>;
+
+    using CompArena = Arena<LinearAllocator, LockingPolicy::NoLock, CustomComposite>;
+    CompArena arena("CompArena", 1024);
+
+    void* const p0 = arena.alloc(64);
+    EXPECT_NE(nullptr, p0);
+
+    // Verify HighWatermark part
+    EXPECT_EQ(64u, arena.getListener().getHighWatermark());
+    EXPECT_EQ(0u, arena.getListener().getWastedBytes());
+
+    // Verify LeakDetector part
+    EXPECT_EQ(1u, arena.getListener().getActiveAllocationCount());
+    EXPECT_EQ(64u, arena.getListener().getActiveAllocationBytes());
+
+    // Verify Debug part (memory poisoning)
+    uint8_t const* const bytes0 = static_cast<uint8_t const*>(p0);
+    for (size_t i = 0; i < 64; ++i) {
+        EXPECT_EQ(0xeb, bytes0[i]);
+    }
+
+    void* const p1 = arena.alloc(128);
+    EXPECT_NE(nullptr, p1);
+    EXPECT_EQ(192u, arena.getListener().getHighWatermark());
+    EXPECT_EQ(0u, arena.getListener().getWastedBytes());
+    EXPECT_EQ(2u, arena.getListener().getActiveAllocationCount());
+    EXPECT_EQ(192u, arena.getListener().getActiveAllocationBytes());
+
+    // Free p0 (buried under p1) -> logically freed, not physically freed -> wasted
+    arena.free(p0, 64);
+    EXPECT_EQ(1u, arena.getListener().getActiveAllocationCount());
+    EXPECT_EQ(128u, arena.getListener().getActiveAllocationBytes());
+    EXPECT_EQ(64u, arena.getListener().getWastedBytes());
+    EXPECT_EQ(64u, arena.getListener().get<TrackingPolicy::HighWatermark>().getWastedBytes());
+    for (size_t i = 0; i < 64; ++i) {
+        EXPECT_EQ(0xef, bytes0[i]);
+    }
+
+    // Free p1 (top allocation) -> physically reclaimed -> not added to wasted
+    arena.free(p1, 128);
+    EXPECT_EQ(0u, arena.getListener().getActiveAllocationCount());
+    EXPECT_EQ(0u, arena.getListener().getActiveAllocationBytes());
+    EXPECT_EQ(64u, arena.getListener().getWastedBytes());
+
+    // Reset clears high watermark and wasted
+    arena.reset();
+    EXPECT_EQ(0u, arena.getListener().getWastedBytes());
+    EXPECT_EQ(0u, arena.getListener().getActiveAllocationCount());
+}
+
+TEST(AllocatorTest, LinearAllocatorWithFallbackFree) {
+    char scratch[256];
+    LinearAllocatorWithFallback allocator(scratch, scratch + sizeof(scratch));
+
+    // Multiple allocations within linear buffer
+    void* const p0 = allocator.alloc(64);
+    void* const p1 = allocator.alloc(128);
+    EXPECT_EQ(scratch, p0);
+    EXPECT_EQ(pointermath::add(scratch, 64), p1);
+    EXPECT_FALSE(allocator.isHeapAllocation(p0));
+    EXPECT_FALSE(allocator.isHeapAllocation(p1));
+    EXPECT_EQ(pointermath::add(scratch, 192), allocator.getCurrent());
+
+    // free() on buried linear allocation returns false
+    EXPECT_FALSE(allocator.free(p0, 64));
+    EXPECT_EQ(pointermath::add(scratch, 192), allocator.getCurrent());
+
+    // Freeing top allocation in linear buffer succeeds
+    EXPECT_TRUE(allocator.free(p1, 128));
+    EXPECT_EQ(pointermath::add(scratch, 64), allocator.getCurrent());
+
+    // Exceed remaining linear capacity (192 bytes remaining, request 200 bytes) -> fallback to heap
+    void* const pHeap = allocator.alloc(200);
+    EXPECT_NE(nullptr, pHeap);
+    EXPECT_TRUE(allocator.isHeapAllocation(pHeap));
+
+    // free() on heap allocation returns false (heap allocations are reclaimed on reset/destruction)
+    EXPECT_FALSE(allocator.free(pHeap, 200));
+
+    // reset() cleans up both heap and linear allocations
+    allocator.reset();
+    EXPECT_EQ(scratch, allocator.getCurrent());
+}
+
+TEST(AllocatorTest, ArenaAreaMoveSemantics) {
+    using ParentArena = Arena<LinearAllocator, LockingPolicy::NoLock>;
+    ParentArena parent("ParentArena", 1024);
+
+    void* const initialCurrent = parent.getAllocator().getCurrent();
+
+    {
+        // Allocate an ArenaArea from the parent arena
+        AreaPolicy::ArenaArea<ParentArena> area1(parent, 256);
+        EXPECT_NE(nullptr, area1.begin());
+        EXPECT_EQ(256u, area1.size());
+        EXPECT_EQ(pointermath::add(initialCurrent, 256), parent.getAllocator().getCurrent());
+
+        // Move construct area2 from area1
+        AreaPolicy::ArenaArea<ParentArena> area2(std::move(area1));
+        EXPECT_EQ(nullptr, area1.begin());
+        EXPECT_EQ(0u, area1.size());
+        EXPECT_NE(nullptr, area2.begin());
+        EXPECT_EQ(256u, area2.size());
+
+        // Parent current should still be at 256
+        EXPECT_EQ(pointermath::add(initialCurrent, 256), parent.getAllocator().getCurrent());
+
+        // Destructing moved-from area1 should be a no-op (verified when area2 is still in scope)
+    }
+
+    // After area2 destructs, parent allocation should be safely freed and current rolled back
+    EXPECT_EQ(initialCurrent, parent.getAllocator().getCurrent());
 }


### PR DESCRIPTION
FrameGraph ran out of memory on large scenes, especially those with many shadows. Optimized FrameGraph memory usage so that those scenes could fit without significantly increasing FrameGraph's arena. A particular test scene needed over 2 MiB, but now can work with 512 KiB.

In addition FrameGraph no longer steals space from the per-frame Arena -- like it was before a recent change.