### PR TITLE
backend: fix priority override races and demotion

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRCS
         src/Platform.cpp
         src/PlatformFactory.cpp
         src/Program.cpp
+        src/ThreadPriorityOverride.cpp
 )
 
 set(PRIVATE_HDRS
@@ -61,6 +62,7 @@ set(PRIVATE_HDRS
         src/DataReshaper.h
         src/DriverBase.h
         src/JobQueue.h
+        src/ThreadPriorityOverride.h
 )
 
 # ==================================================================================================
@@ -616,6 +618,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_CircularBuffer.cpp
             test/test_CommandBufferQueue.cpp
             test/test_Template.cpp
+            test/test_ThreadPriorityOverride.cpp
             test/test_AsyncUploads.cpp
             test/test_Platform.cpp
         )
@@ -708,6 +711,15 @@ if (FILAMENT_BUILD_TESTING)
         if (FILAMENT_SUPPORTS_WEBGPU)
             target_link_libraries(backend_test_linux PRIVATE webgpu_dawn dawncpp_headers)
         endif()
+    endif()
+
+    if (ANDROID)
+        add_executable(test_ThreadPriorityOverride
+                test/test_ThreadPriorityOverride.cpp
+                ${LIBRARIES}/utils/test/test_utils_main.cpp)
+        target_link_libraries(test_ThreadPriorityOverride PRIVATE backend gtest utils android log)
+        target_include_directories(test_ThreadPriorityOverride PRIVATE ${FILAMENT}/filament/backend/src)
+        set_target_properties(test_ThreadPriorityOverride PROPERTIES FOLDER Tests)
     endif()
 
     # ==================================================================================================

--- a/filament/backend/src/ThreadPriorityOverride.cpp
+++ b/filament/backend/src/ThreadPriorityOverride.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ThreadPriorityOverride.h"
+
+#include <atomic>
+
+#if defined(__APPLE__)
+#include <pthread.h>
+#include <sys/qos.h>
+#elif defined(__ANDROID__)
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+
+#ifndef ANDROID_PRIORITY_URGENT_DISPLAY
+#define ANDROID_PRIORITY_URGENT_DISPLAY (-8)
+#endif
+#ifndef ANDROID_PRIORITY_DISPLAY
+#define ANDROID_PRIORITY_DISPLAY (-4)
+#endif
+#ifndef ANDROID_PRIORITY_NORMAL
+#define ANDROID_PRIORITY_NORMAL (0)
+#endif
+#ifndef ANDROID_PRIORITY_BACKGROUND
+#define ANDROID_PRIORITY_BACKGROUND (10)
+#endif
+
+#elif defined(WIN32)
+#include <windows.h>
+#endif
+
+namespace filament::backend {
+
+ThreadPriorityOverride::ThreadPriorityOverride(bool const enabled) noexcept
+    : mEnabled(enabled) {
+}
+
+ThreadPriorityOverride::~ThreadPriorityOverride() noexcept {
+#if defined(__APPLE__)
+    // Release any active QoS override handle that was not torn down by endOverride().
+    // Uses relaxed ordering because the destructor has exclusive ownership of the object.
+    pthread_override_t override = mOverride.exchange(nullptr, std::memory_order_relaxed);
+    if (override) {
+        pthread_override_qos_class_end_np(override);
+    }
+#elif defined(__ANDROID__)
+    // Restore original priority if the override was active and not previously restored.
+    if (mOverridden.exchange(false, std::memory_order_relaxed)) {
+        pid_t const tid = mTid.load(std::memory_order_relaxed);
+        if (tid) {
+            int const originalNice = mOriginalPriority.load(std::memory_order_relaxed);
+            setpriority(PRIO_PROCESS, tid, originalNice);
+        }
+    }
+#elif defined(WIN32)
+    // Restore original priority if the override was active and not previously restored.
+    if (mOverridden.exchange(false, std::memory_order_relaxed)) {
+        HANDLE const thread = mThread.load(std::memory_order_relaxed);
+        if (thread) {
+            int const originalPriority = mOriginalPriority.load(std::memory_order_relaxed);
+            SetThreadPriority(thread, originalPriority);
+        }
+    }
+    // Close the duplicated thread handle allocated in registerCurrentThread().
+    HANDLE thread = mThread.load(std::memory_order_relaxed);
+    if (thread) {
+        CloseHandle(thread);
+    }
+#endif
+}
+
+void ThreadPriorityOverride::registerCurrentThread() noexcept {
+    if (!mEnabled) {
+        return;
+    }
+#if defined(__APPLE__)
+    pthread_t const self = pthread_self();
+    mThread.store(self, std::memory_order_seq_cst);
+    if (mOverrideRequested.load(std::memory_order_seq_cst)) {
+        applyOverride(self);
+    }
+#elif defined(__ANDROID__)
+    pid_t const tid = gettid();
+    errno = 0;
+    int const originalNice = getpriority(PRIO_PROCESS, 0);
+    if (errno == 0) {
+        mOriginalPriority.store(originalNice, std::memory_order_seq_cst);
+    }
+    mTid.store(tid, std::memory_order_seq_cst);
+    if (mOverrideRequested.load(std::memory_order_seq_cst)) {
+        setpriority(PRIO_PROCESS, tid, ANDROID_PRIORITY_DISPLAY);
+        mOverridden.store(true, std::memory_order_seq_cst);
+    }
+#elif defined(WIN32)
+    HANDLE hRealThread = nullptr;
+    DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &hRealThread,
+            0, FALSE, DUPLICATE_SAME_ACCESS);
+    int const originalPriority = GetThreadPriority(GetCurrentThread());
+    if (originalPriority != THREAD_PRIORITY_ERROR_RETURN) {
+        mOriginalPriority.store(originalPriority, std::memory_order_seq_cst);
+    }
+    mThread.store(hRealThread, std::memory_order_seq_cst);
+    if (hRealThread && mOverrideRequested.load(std::memory_order_seq_cst)) {
+        SetThreadPriority(hRealThread, THREAD_PRIORITY_HIGHEST);
+        mOverridden.store(true, std::memory_order_seq_cst);
+    }
+#endif
+}
+
+void ThreadPriorityOverride::startOverride() noexcept {
+    if (!mEnabled) {
+        return;
+    }
+    mOverrideRequested.store(true, std::memory_order_seq_cst);
+#if defined(__APPLE__)
+    pthread_t const thread = mThread.load(std::memory_order_seq_cst);
+    if (thread) {
+        applyOverride(thread);
+    }
+#elif defined(__ANDROID__)
+    pid_t const tid = mTid.load(std::memory_order_seq_cst);
+    if (tid) {
+        setpriority(PRIO_PROCESS, tid, ANDROID_PRIORITY_DISPLAY);
+        mOverridden.store(true, std::memory_order_seq_cst);
+    }
+#elif defined(WIN32)
+    HANDLE const thread = mThread.load(std::memory_order_seq_cst);
+    if (thread) {
+        SetThreadPriority(thread, THREAD_PRIORITY_HIGHEST);
+        mOverridden.store(true, std::memory_order_seq_cst);
+    }
+#endif
+}
+
+void ThreadPriorityOverride::endOverride() noexcept {
+    if (!mEnabled) {
+        return;
+    }
+#if defined(__APPLE__)
+    pthread_override_t const override = mOverride.exchange(nullptr, std::memory_order_seq_cst);
+    if (override) {
+        pthread_override_qos_class_end_np(override);
+    }
+#elif defined(__ANDROID__)
+    if (mOverridden.exchange(false, std::memory_order_seq_cst)) {
+        pid_t const tid = mTid.load(std::memory_order_seq_cst);
+        if (tid) {
+            int const originalNice = mOriginalPriority.load(std::memory_order_seq_cst);
+            setpriority(PRIO_PROCESS, tid, originalNice);
+        }
+    }
+#elif defined(WIN32)
+    if (mOverridden.exchange(false, std::memory_order_seq_cst)) {
+        HANDLE const thread = mThread.load(std::memory_order_seq_cst);
+        if (thread) {
+            int const originalPriority = mOriginalPriority.load(std::memory_order_seq_cst);
+            SetThreadPriority(thread, originalPriority);
+        }
+    }
+#endif
+}
+
+void ThreadPriorityOverride::restorePriority() noexcept {
+    if (!mEnabled) {
+        return;
+    }
+#if defined(__ANDROID__)
+    if (mOverridden.exchange(false, std::memory_order_seq_cst)) {
+        int const originalNice = mOriginalPriority.load(std::memory_order_seq_cst);
+        // 0 specifies the calling thread (the worker thread).
+        setpriority(PRIO_PROCESS, 0, originalNice);
+    }
+#elif defined(WIN32)
+    if (mOverridden.exchange(false, std::memory_order_seq_cst)) {
+        HANDLE const thread = mThread.load(std::memory_order_seq_cst);
+        if (thread) {
+            int const originalPriority = mOriginalPriority.load(std::memory_order_seq_cst);
+            SetThreadPriority(thread, originalPriority);
+        }
+    }
+#endif
+}
+
+bool ThreadPriorityOverride::isOverrideRequested() const noexcept {
+    return mOverrideRequested.load(std::memory_order_acquire);
+}
+
+bool ThreadPriorityOverride::isOverridden() const noexcept {
+#if defined(__APPLE__)
+    return mOverride.load(std::memory_order_acquire) != nullptr;
+#elif defined(__ANDROID__) || defined(WIN32)
+    return mOverridden.load(std::memory_order_acquire);
+#else
+    return false;
+#endif
+}
+
+#if defined(__APPLE__)
+void ThreadPriorityOverride::applyOverride(pthread_t const thread) noexcept {
+    pthread_override_t expected = nullptr;
+    pthread_override_t const overrideQos =
+            pthread_override_qos_class_start_np(thread, QOS_CLASS_USER_INTERACTIVE, 0);
+    if (overrideQos) {
+        if (!mOverride.compare_exchange_strong(expected, overrideQos, std::memory_order_seq_cst)) {
+            pthread_override_qos_class_end_np(overrideQos);
+        }
+    }
+}
+#endif
+
+} // namespace filament::backend

--- a/filament/backend/src/ThreadPriorityOverride.h
+++ b/filament/backend/src/ThreadPriorityOverride.h
@@ -17,30 +17,12 @@
 #ifndef TNT_FILAMENT_BACKEND_THREADPRIORITYOVERRIDE_H
 #define TNT_FILAMENT_BACKEND_THREADPRIORITYOVERRIDE_H
 
-#include <utils/JobSystem.h>
-
 #include <atomic>
 
 #if defined(__APPLE__)
 #include <pthread.h>
 #elif defined(__ANDROID__)
 #include <sys/types.h>
-#include <unistd.h>
-#include <sys/resource.h>
-
-#ifndef ANDROID_PRIORITY_URGENT_DISPLAY
-#define ANDROID_PRIORITY_URGENT_DISPLAY (-8)
-#endif
-#ifndef ANDROID_PRIORITY_DISPLAY
-#define ANDROID_PRIORITY_DISPLAY (-4)
-#endif
-#ifndef ANDROID_PRIORITY_NORMAL
-#define ANDROID_PRIORITY_NORMAL (0)
-#endif
-#ifndef ANDROID_PRIORITY_BACKGROUND
-#define ANDROID_PRIORITY_BACKGROUND (10)
-#endif
-
 #elif defined(WIN32)
 #include <windows.h>
 #endif
@@ -50,27 +32,49 @@ namespace filament::backend {
 /**
  * ThreadPriorityOverride is a cross-platform helper class to mitigate priority inversion.
  *
- * Priority inversion occurs when a high-priority thread (e.g. the main rendering thread)
- * blocks waiting for a low-priority thread (e.g. a background shader compilation thread).
+ * Priority inversion occurs when a high-priority thread (e.g., the main rendering / GL driver thread)
+ * blocks waiting on a low-priority thread (e.g., a background shader compilation worker).
  *
- * This class allows the waiting thread to temporarily escalate the priority of the compiling
- * thread to USER_INTERACTIVE / DISPLAY level. Once the worker finishes its job, the priority
- * is restored back to the baseline background priority.
+ * Synchronization Model:
+ * ----------------------
+ * There are two cooperating threads per override instance:
+ * 1. Worker Thread: Executes the compilation job. Calls registerCurrentThread() before starting
+ *    and restorePriority() upon completion.
+ * 2. Waiting Thread: Needs the result immediately. Calls startOverride() before waiting on the
+ *    condition variable and endOverride() after waking up.
  *
- * Note: On unsupported platforms (such as standard Linux or WebGL), this class compiles as a no-op.
+ * To avoid race conditions between registration and elevation, a sequentially consistent
+ * (std::memory_order_seq_cst) handshake is used between mOverrideRequested and mTid / mThread:
+ * - If startOverride() executes first: it sets mOverrideRequested = true. When the worker calls
+ *   registerCurrentThread(), it detects mOverrideRequested and escalates its own priority.
+ * - If registerCurrentThread() executes first: it stores mTid / mThread. When the waiting thread
+ *   calls startOverride(), it detects the registered ID and escalates the worker's priority.
+ * - If both run concurrently: sequentially consistent ordering guarantees at least one thread
+ *   will observe the other's flag and apply the priority elevation.
+ *
+ * Calling Thread Protection:
+ * --------------------------
+ * When a job is dequeued and executed synchronously inline by the waiting/driver thread, or when a
+ * background job completes without any thread waiting on it, priority is never escalated.
+ * The mOverridden flag guarantees that priority restoration is strictly a no-op unless priority
+ * was actually elevated. When priority is restored, it returns to the thread's recorded original
+ * baseline priority (rather than a hardcoded background level), preventing calling threads or
+ * workers at arbitrary baseline priorities from being demoted.
+ *
+ * Platform Mechanisms:
+ * --------------------
+ * - Apple (macOS / iOS): Uses pthread_override_qos_class_start_np / end_np to apply reference-counted
+ *   QoS overrides (QOS_CLASS_USER_INTERACTIVE). Atomic handles ensure thread-safe cleanup.
+ * - Android: Uses setpriority(PRIO_PROCESS, tid, ANDROID_PRIORITY_DISPLAY) to elevate the nice value,
+ *   and restores it to the recorded original baseline priority upon completion.
+ * - Windows: Uses DuplicateHandle and SetThreadPriority(THREAD_PRIORITY_HIGHEST), restoring to the
+ *   recorded original baseline priority upon completion.
+ * - Other platforms: Compiles as a lightweight no-op.
  */
 class ThreadPriorityOverride {
 public:
-    ThreadPriorityOverride(bool enabled = true) noexcept : mEnabled(enabled) {}
-
-    ~ThreadPriorityOverride() noexcept {
-#if defined(WIN32)
-        HANDLE thread = mThread.load(std::memory_order_relaxed);
-        if (thread) {
-            CloseHandle(thread);
-        }
-#endif
-    }
+    explicit ThreadPriorityOverride(bool enabled = true) noexcept;
+    ~ThreadPriorityOverride() noexcept;
 
     ThreadPriorityOverride(ThreadPriorityOverride const&) = delete;
     ThreadPriorityOverride& operator=(ThreadPriorityOverride const&) = delete;
@@ -78,124 +82,91 @@ public:
     ThreadPriorityOverride& operator=(ThreadPriorityOverride&&) = delete;
 
     /**
-     * Called by the worker thread to register its native thread handle/ID.
-     * This must be called from the worker thread itself before starting the job.
+     * Called by the worker thread to register its native thread handle/ID and record its
+     * current original priority before any override takes place.
+     * This must be called from the executing thread before beginning the job.
      */
-    void registerCurrentThread() noexcept {
-        if (!mEnabled) {
-            return;
-        }
-#if defined(__APPLE__)
-        mThread.store(pthread_self(), std::memory_order_release);
-#elif defined(__ANDROID__)
-        mTid.store(gettid(), std::memory_order_release);
-#elif defined(WIN32)
-        HANDLE hRealThread = nullptr;
-        DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &hRealThread, 0, FALSE, DUPLICATE_SAME_ACCESS);
-        mThread.store(hRealThread, std::memory_order_release);
-#endif
-    }
+    void registerCurrentThread() noexcept;
 
     /**
      * Called by the waiting thread to temporarily elevate the priority of the registered
      * worker thread to prevent priority inversion.
      */
-    void startOverride() noexcept {
-        if (!mEnabled) {
-            return;
-        }
-#if defined(__APPLE__)
-        pthread_t thread = mThread.load(std::memory_order_acquire);
-        if (thread) {
-            mOverride = pthread_override_qos_class_start_np(thread, QOS_CLASS_USER_INTERACTIVE, 0);
-        }
-#elif defined(__ANDROID__)
-        pid_t tid = mTid.load(std::memory_order_acquire);
-        if (tid) {
-            setpriority(PRIO_PROCESS, tid, ANDROID_PRIORITY_DISPLAY);
-        }
-#elif defined(WIN32)
-        HANDLE thread = mThread.load(std::memory_order_acquire);
-        if (thread) {
-            SetThreadPriority(thread, THREAD_PRIORITY_HIGHEST);
-        }
-#endif
-    }
+    void startOverride() noexcept;
 
     /**
      * Called by the waiting thread to release the temporary priority elevation.
-     * On Apple, this tears down the pthread QoS override.
      */
-    void endOverride() noexcept {
-        if (!mEnabled) {
-            return;
-        }
-#if defined(__APPLE__)
-        if (mOverride) {
-            pthread_override_qos_class_end_np(mOverride);
-            mOverride = nullptr;
-        }
-#endif
-    }
+    void endOverride() noexcept;
 
     /**
-     * Called by the worker thread after completing its job to drop its priority
-     * back to the default background level.
-     * On Android and Windows, this sets the thread nice value/priority back to the target.
+     * Called by the worker thread after completing its job to drop its priority back to its
+     * original baseline level if it was previously overridden.
      */
-    void restoreDefaultPriority(utils::JobSystem::Priority priority) noexcept {
-        if (!mEnabled) {
-            return;
-        }
-#if defined(__ANDROID__)
-        int niceValue = ANDROID_PRIORITY_NORMAL;
-        switch (priority) {
-            case utils::JobSystem::Priority::BACKGROUND:
-                niceValue = ANDROID_PRIORITY_BACKGROUND;
-                break;
-            case utils::JobSystem::Priority::NORMAL:
-                niceValue = ANDROID_PRIORITY_NORMAL;
-                break;
-            case utils::JobSystem::Priority::DISPLAY:
-                niceValue = ANDROID_PRIORITY_DISPLAY;
-                break;
-            case utils::JobSystem::Priority::URGENT_DISPLAY:
-                niceValue = ANDROID_PRIORITY_URGENT_DISPLAY;
-                break;
-        }
-        setpriority(PRIO_PROCESS, 0, niceValue);
-#elif defined(WIN32)
-        HANDLE thread = mThread.load(std::memory_order_acquire);
-        if (thread) {
-            int winPriority = THREAD_PRIORITY_NORMAL;
-            switch (priority) {
-                case utils::JobSystem::Priority::BACKGROUND:
-                    winPriority = THREAD_PRIORITY_BELOW_NORMAL;
-                    break;
-                case utils::JobSystem::Priority::NORMAL:
-                    winPriority = THREAD_PRIORITY_NORMAL;
-                    break;
-                case utils::JobSystem::Priority::DISPLAY:
-                    winPriority = THREAD_PRIORITY_ABOVE_NORMAL;
-                    break;
-                case utils::JobSystem::Priority::URGENT_DISPLAY:
-                    winPriority = THREAD_PRIORITY_HIGHEST;
-                    break;
-            }
-            SetThreadPriority(thread, winPriority);
-        }
-#endif
-    }
+    void restorePriority() noexcept;
+
+    /**
+     * Returns true if an override has been requested by the waiting thread.
+     */
+    bool isOverrideRequested() const noexcept;
+
+    /**
+     * Returns true if priority elevation is currently active on this instance.
+     */
+    bool isOverridden() const noexcept;
 
 private:
-    bool const mEnabled = true;
 #if defined(__APPLE__)
+    void applyOverride(pthread_t thread) noexcept;
+#endif
+
+    bool const mEnabled = true;
+
+    // Set to true by the waiting thread in startOverride().
+    // Read by registerCurrentThread() to detect early override requests.
+    // Memory Order: std::memory_order_seq_cst to prevent reordering with mTid / mThread.
+    std::atomic<bool> mOverrideRequested{false};
+
+#if defined(__APPLE__)
+    // Native pthread handle of the worker thread.
+    // Stored in registerCurrentThread() and read in startOverride().
+    // Memory Order: std::memory_order_seq_cst.
     std::atomic<pthread_t> mThread{nullptr};
-    pthread_override_t mOverride{nullptr};
+
+    // Active QoS override handle returned by pthread_override_qos_class_start_np().
+    // Managed atomically to avoid leaks when startOverride() and registerCurrentThread() race.
+    // Memory Order: std::memory_order_seq_cst on creation/exchange, relaxed on destruction.
+    std::atomic<pthread_override_t> mOverride{nullptr};
 #elif defined(__ANDROID__)
+    // Native Linux thread ID (TID) of the worker thread from gettid().
+    // Stored in registerCurrentThread() and read in startOverride().
+    // Memory Order: std::memory_order_seq_cst.
     std::atomic<pid_t> mTid{0};
+
+    // Original nice value of the worker thread recorded during registerCurrentThread().
+    // Used to restore the exact baseline priority regardless of what priority it started at.
+    // Memory Order: std::memory_order_seq_cst.
+    std::atomic<int> mOriginalPriority{0};
+
+    // Tracks whether this worker thread's nice value was escalated to ANDROID_PRIORITY_DISPLAY.
+    // Guards restorePriority() so that non-elevated or inline calling threads are untouched.
+    // Memory Order: std::memory_order_seq_cst.
+    std::atomic<bool> mOverridden{false};
 #elif defined(WIN32)
+    // Duplicate handle to the worker thread for cross-thread SetThreadPriority() calls.
+    // Stored in registerCurrentThread(), closed in ~ThreadPriorityOverride().
+    // Memory Order: std::memory_order_seq_cst.
     std::atomic<HANDLE> mThread{nullptr};
+
+    // Original thread priority level recorded during registerCurrentThread().
+    // Used to restore the exact baseline priority regardless of what priority it started at.
+    // Memory Order: std::memory_order_seq_cst.
+    std::atomic<int> mOriginalPriority{0};
+
+    // Tracks whether this thread's priority was escalated to THREAD_PRIORITY_HIGHEST.
+    // Guards restorePriority() so that non-elevated or inline calling threads are untouched.
+    // Memory Order: std::memory_order_seq_cst.
+    std::atomic<bool> mOverridden{false};
 #endif
 };
 

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -286,7 +286,6 @@ void ShaderCompilerService::init() noexcept {
         }
 
         mShaderCompilerThreadCount = poolSize;
-        mCompilerThreadPriority = priority;
         mCompilerThreadPool.init(mShaderCompilerThreadCount,
                 [&platform = mDriver.mPlatform, priority] {
                     // give the thread a name
@@ -418,7 +417,7 @@ void ShaderCompilerService::compileProgram(
                         // of the linking. We don't need to check the result of the program here
                         // because it'll be done in the engine thread.
                         token->signal();
-                        token->priorityOverride.restoreDefaultPriority(mCompilerThreadPriority);
+                        token->priorityOverride.restorePriority();
                         // Updates the token's state. If the token is canceled while this function
                         // executes, this update notifies `tick` that GL resource loading is
                         // complete, allowing `tick` to proceed with resource destruction.

--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -128,7 +128,6 @@ private:
 
     uint32_t mShaderCompilerThreadCount = 0u;
     Mode mMode = Mode::UNDEFINED; // valid after init() is called
-    utils::JobSystem::Priority mCompilerThreadPriority = utils::JobSystem::Priority::DISPLAY;
     bool mPriorityOverrideEnabled = true;
 
     bool const mParallelShaderCompileDisabled;

--- a/filament/backend/test/test_ThreadPriorityOverride.cpp
+++ b/filament/backend/test/test_ThreadPriorityOverride.cpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ThreadPriorityOverride.h"
+
+#include <utils/JobSystem.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#if defined(__APPLE__)
+#include <pthread.h>
+#include <sys/qos.h>
+#elif defined(__ANDROID__)
+#include <sys/resource.h>
+#include <unistd.h>
+
+#ifndef ANDROID_PRIORITY_URGENT_DISPLAY
+#define ANDROID_PRIORITY_URGENT_DISPLAY (-8)
+#endif
+#ifndef ANDROID_PRIORITY_DISPLAY
+#define ANDROID_PRIORITY_DISPLAY (-4)
+#endif
+#ifndef ANDROID_PRIORITY_NORMAL
+#define ANDROID_PRIORITY_NORMAL (0)
+#endif
+#ifndef ANDROID_PRIORITY_BACKGROUND
+#define ANDROID_PRIORITY_BACKGROUND (10)
+#endif
+#elif defined(WIN32)
+#include <windows.h>
+#endif
+
+using namespace filament::backend;
+using namespace utils;
+
+namespace {
+
+constexpr bool isPriorityOverrideSupported() {
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(WIN32)
+    return true;
+#else
+    return false;
+#endif
+}
+
+enum class PriorityLevel {
+    BACKGROUND,
+    DISPLAY,
+    DEFAULT_OR_NORMAL
+};
+
+PriorityLevel getCurrentThreadPriorityLevel() {
+#if defined(__APPLE__)
+    qos_class_t const qosClass = qos_class_self();
+    if (qosClass == QOS_CLASS_USER_INTERACTIVE) {
+        return PriorityLevel::DISPLAY;
+    } else if (qosClass == QOS_CLASS_BACKGROUND) {
+        return PriorityLevel::BACKGROUND;
+    }
+    return PriorityLevel::DEFAULT_OR_NORMAL;
+#elif defined(__ANDROID__)
+    errno = 0;
+    int const nice = getpriority(PRIO_PROCESS, 0);
+    if (nice <= ANDROID_PRIORITY_DISPLAY) {
+        return PriorityLevel::DISPLAY;
+    } else if (nice >= ANDROID_PRIORITY_BACKGROUND) {
+        return PriorityLevel::BACKGROUND;
+    }
+    return PriorityLevel::DEFAULT_OR_NORMAL;
+#elif defined(WIN32)
+    int const prio = GetThreadPriority(GetCurrentThread());
+    if (prio >= THREAD_PRIORITY_HIGHEST) {
+        return PriorityLevel::DISPLAY;
+    } else if (prio <= THREAD_PRIORITY_BELOW_NORMAL) {
+        return PriorityLevel::BACKGROUND;
+    }
+    return PriorityLevel::DEFAULT_OR_NORMAL;
+#else
+    return PriorityLevel::DEFAULT_OR_NORMAL;
+#endif
+}
+
+} // namespace
+
+TEST(ThreadPriorityOverrideTest, DisabledOverrideIsNoOp) {
+    JobSystem::setThreadPriority(JobSystem::Priority::DISPLAY);
+    PriorityLevel const initialPriority = getCurrentThreadPriorityLevel();
+
+    ThreadPriorityOverride override(false);
+    EXPECT_FALSE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden());
+
+    override.registerCurrentThread();
+    EXPECT_FALSE(override.isOverridden());
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+
+    override.startOverride();
+    EXPECT_FALSE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden());
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+
+    override.restorePriority();
+    EXPECT_FALSE(override.isOverridden());
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+
+    override.endOverride();
+    EXPECT_FALSE(override.isOverridden());
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+}
+
+TEST(ThreadPriorityOverrideTest, InlineExecutionPreservesPriority) {
+    // Simulates a job dequeued and executed inline on the calling/driver thread.
+    JobSystem::setThreadPriority(JobSystem::Priority::DISPLAY);
+    PriorityLevel const initialPriority = getCurrentThreadPriorityLevel();
+
+    ThreadPriorityOverride override(true);
+    EXPECT_FALSE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden());
+
+    override.registerCurrentThread();
+    EXPECT_FALSE(override.isOverridden());
+
+    // Since startOverride() was never called, restorePriority() must be a no-op.
+    override.restorePriority();
+    EXPECT_FALSE(override.isOverridden());
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+}
+
+TEST(ThreadPriorityOverrideTest, WorkerFirstRegistrationHandshake) {
+    ThreadPriorityOverride override(true);
+    std::atomic<bool> workerRegistered{false};
+    std::atomic<bool> overrideStarted{false};
+    std::atomic<bool> workerObservedOverride{false};
+
+    EXPECT_FALSE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden());
+
+    std::thread worker([&]() {
+        JobSystem::setThreadPriority(JobSystem::Priority::BACKGROUND);
+        override.registerCurrentThread();
+        workerRegistered.store(true, std::memory_order_release);
+
+        // Wait until the waiting thread has applied the override
+        while (!overrideStarted.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        // Record whether the override is active
+        workerObservedOverride.store(override.isOverridden(), std::memory_order_relaxed);
+
+        // Restore priority upon completing the job
+        override.restorePriority();
+    });
+
+    // Wait until worker registers its thread
+    while (!workerRegistered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    override.startOverride();
+    EXPECT_TRUE(override.isOverrideRequested());
+    if constexpr (isPriorityOverrideSupported()) {
+        EXPECT_TRUE(override.isOverridden());
+    } else {
+        EXPECT_FALSE(override.isOverridden());
+    }
+    overrideStarted.store(true, std::memory_order_release);
+
+    worker.join();
+    if constexpr (isPriorityOverrideSupported()) {
+        EXPECT_TRUE(workerObservedOverride.load());
+    } else {
+        EXPECT_FALSE(workerObservedOverride.load());
+    }
+
+    override.endOverride();
+    EXPECT_FALSE(override.isOverridden());
+}
+
+TEST(ThreadPriorityOverrideTest, WaiterFirstRegistrationHandshake) {
+    ThreadPriorityOverride override(true);
+    std::atomic<bool> overrideStarted{false};
+    std::atomic<bool> workerObservedOverride{false};
+
+    EXPECT_FALSE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden());
+
+    // The waiting thread calls startOverride() before worker registers
+    override.startOverride();
+    EXPECT_TRUE(override.isOverrideRequested());
+    EXPECT_FALSE(override.isOverridden()); // Worker not yet registered
+    overrideStarted.store(true, std::memory_order_release);
+
+    std::thread worker([&]() {
+        JobSystem::setThreadPriority(JobSystem::Priority::BACKGROUND);
+
+        // Worker registers after startOverride() was already called
+        override.registerCurrentThread();
+
+        // Priority should have been escalated immediately during registration on supported platforms
+        workerObservedOverride.store(override.isOverridden(), std::memory_order_relaxed);
+
+        // Restore priority upon completing the job
+        override.restorePriority();
+    });
+
+    worker.join();
+    if constexpr (isPriorityOverrideSupported()) {
+        EXPECT_TRUE(workerObservedOverride.load());
+    } else {
+        EXPECT_FALSE(workerObservedOverride.load());
+    }
+
+    override.endOverride();
+    EXPECT_FALSE(override.isOverridden());
+}
+
+TEST(ThreadPriorityOverrideTest, PreservesNormalInitialPriority) {
+    ThreadPriorityOverride override(true);
+    std::atomic<bool> workerRegistered{false};
+    std::atomic<bool> overrideStarted{false};
+    std::atomic<PriorityLevel> workerPriorityAfterRestore{PriorityLevel::BACKGROUND};
+
+    std::thread worker([&]() {
+        JobSystem::setThreadPriority(JobSystem::Priority::NORMAL);
+        PriorityLevel const initialPriority = getCurrentThreadPriorityLevel();
+        override.registerCurrentThread();
+        workerRegistered.store(true, std::memory_order_release);
+
+        while (!overrideStarted.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        // Restore priority upon completing the job; must return to NORMAL, not BACKGROUND
+        override.restorePriority();
+        workerPriorityAfterRestore.store(getCurrentThreadPriorityLevel(), std::memory_order_relaxed);
+    });
+
+    while (!workerRegistered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    override.startOverride();
+    overrideStarted.store(true, std::memory_order_release);
+
+    worker.join();
+    override.endOverride();
+
+    EXPECT_EQ(workerPriorityAfterRestore.load(), PriorityLevel::DEFAULT_OR_NORMAL);
+}
+
+TEST(ThreadPriorityOverrideTest, ConcurrentRegistrationAndOverrideStress) {
+    // Stress test the bidirectional handshake across multiple iterations
+    constexpr size_t ITERATIONS = 100;
+    std::atomic<size_t> completedIterations{0};
+
+    for (size_t i = 0; i < ITERATIONS; ++i) {
+        ThreadPriorityOverride override(true);
+        std::atomic<bool> startFlag{false};
+        std::atomic<bool> workerFinished{false};
+
+        std::thread worker([&]() {
+            while (!startFlag.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            JobSystem::setThreadPriority(JobSystem::Priority::BACKGROUND);
+            override.registerCurrentThread();
+            override.restorePriority();
+            workerFinished.store(true, std::memory_order_release);
+        });
+
+        std::thread waiter([&]() {
+            while (!startFlag.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            override.startOverride();
+            while (!workerFinished.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            override.endOverride();
+        });
+
+        // Release both threads simultaneously to maximize race conditions
+        startFlag.store(true, std::memory_order_release);
+
+        worker.join();
+        waiter.join();
+
+        EXPECT_FALSE(override.isOverridden());
+        completedIterations.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    EXPECT_EQ(completedIterations.load(), ITERATIONS);
+}
+
+TEST(ThreadPriorityOverrideTest, DestructorCleansUpUnendedOverride) {
+    // Verifies that if endOverride() is never called, the destructor cleans up safely
+    JobSystem::setThreadPriority(JobSystem::Priority::BACKGROUND);
+    PriorityLevel const initialPriority = getCurrentThreadPriorityLevel();
+    {
+        ThreadPriorityOverride override(true);
+        override.registerCurrentThread();
+        override.startOverride();
+        if constexpr (isPriorityOverrideSupported()) {
+            EXPECT_TRUE(override.isOverridden());
+        } else {
+            EXPECT_FALSE(override.isOverridden());
+        }
+        // Destructor runs here without calling endOverride()
+    }
+    EXPECT_EQ(getCurrentThreadPriorityLevel(), initialPriority);
+    JobSystem::setThreadPriority(JobSystem::Priority::NORMAL);
+}
+
+TEST(ThreadPriorityOverrideTest, LateOverrideCleanedUpByEndOverride) {
+    // Verifies that if startOverride() executes after restorePriority() has already run,
+    // endOverride() restores the worker thread back to its original baseline priority.
+    ThreadPriorityOverride override(true);
+    std::atomic<bool> workerRestored{false};
+    std::atomic<bool> overrideStarted{false};
+    std::atomic<bool> overrideEnded{false};
+    std::atomic<PriorityLevel> initialPriority{PriorityLevel::DEFAULT_OR_NORMAL};
+    std::atomic<PriorityLevel> workerPriorityAfterEndOverride{PriorityLevel::DISPLAY};
+
+    std::thread worker([&]() {
+        JobSystem::setThreadPriority(JobSystem::Priority::BACKGROUND);
+        initialPriority.store(getCurrentThreadPriorityLevel(), std::memory_order_relaxed);
+        override.registerCurrentThread();
+
+        // 1. Worker calls restorePriority() BEFORE startOverride() has executed.
+        override.restorePriority();
+        workerRestored.store(true, std::memory_order_release);
+
+        // 2. Wait until waiter executes late startOverride().
+        while (!overrideStarted.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        // 3. Wait until waiter calls endOverride().
+        while (!overrideEnded.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+
+        workerPriorityAfterEndOverride.store(getCurrentThreadPriorityLevel(), std::memory_order_relaxed);
+        JobSystem::setThreadPriority(JobSystem::Priority::NORMAL);
+    });
+
+    // Wait until worker has completed its restorePriority() call.
+    while (!workerRestored.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    // Waiter triggers late startOverride() after worker's restorePriority() finished.
+    override.startOverride();
+    if constexpr (isPriorityOverrideSupported()) {
+        EXPECT_TRUE(override.isOverridden());
+    }
+    overrideStarted.store(true, std::memory_order_release);
+
+    // endOverride() must restore the worker's thread priority on Android & Windows.
+    override.endOverride();
+    overrideEnded.store(true, std::memory_order_release);
+    EXPECT_FALSE(override.isOverridden());
+
+    worker.join();
+    EXPECT_EQ(workerPriorityAfterEndOverride.load(), initialPriority.load());
+}
+
+
+
+


### PR DESCRIPTION
Fix two issues in ThreadPriorityOverride:
- Prevent calling/driver thread priority demotion by guarding restoreDefaultPriority() with an mOverridden flag. If a job is executed inline by the driver thread via dequeue() or completes without being waited on, priority restoration is a no-op.
- Fix a race condition where startOverride() ran before the worker registered its thread handle/TID. Using a sequentially consistent handshake between mOverrideRequested and mTid/mThread guarantees priority elevation is never missed.
- Add defensive null handle checks on Windows and harmonize all atomic operations to std::memory_order_seq_cst.
- Add unit test suite covering registration handshakes, inline execution safety, and concurrent stress testing.

FIXES=[548593434]