### PR TITLE
VK: Flush the command buffer scope states after a resize.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -3179,6 +3179,10 @@ void VulkanDriver::resetState(int) {
 
 void VulkanDriver::endCommandRecording() {
     mCommands.flush();
+    invalidateBoundState();
+}
+
+void VulkanDriver::invalidateBoundState() {
     mPipelineCache.resetBoundPipeline();
     mDescriptorSetCache.resetCachedState();
 }
@@ -3196,6 +3200,12 @@ bool VulkanDriver::acquireNextSwapchainImage() {
     auto const [acquired, backingChanged] = mCurrentSwapChain->acquire();
     if (backingChanged) {
         mFramebufferCache.resetFramebuffers();
+
+        if (mPlatform->getCustomization().flushAndWaitOnWindowResize) {
+            // In this scenario the command buffer was flushed, so we need
+            // to set again the pipeline state and descriptor set state.
+            invalidateBoundState();
+        }
     }
     // Note that ordering this after the above lines is necessary since we set the swapchain image
     // to the render target in bindSwapChain().

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -159,8 +159,13 @@ private:
     // binding (for external samplers) and commits descriptor sets.
     void prepareDraw();
 
-    // Flush the current command buffer and reset the pipeline state.
+    // Flushes the current command buffer and resets the states whose scope is at the command
+    // buffer level.
     void endCommandRecording();
+
+    // Invalidates all the states whose scope is at the command buffer level
+    // (pipeline, descriptor sets, etc..).
+    void invalidateBoundState();
 
     // Returns whether the acquire was successful
     bool acquireNextSwapchainImage();


### PR DESCRIPTION
In some cases when a swapchain is resized, a new
one is created and the current command buffer is
flushed and the bound state is not valid anymore.

In this cases we need to make sure to reset any
state that is at the command buffer scope