### PR TITLE
webgpu: do not use implicit bool<->Status conversion

### DIFF
--- a/filament/backend/src/webgpu/WebGPUSwapChain.cpp
+++ b/filament/backend/src/webgpu/WebGPUSwapChain.cpp
@@ -261,7 +261,7 @@ WebGPUSwapChain::WebGPUSwapChain(wgpu::Surface&& surface, wgpu::Extent2D const& 
       mNativeWindow{nativeWindow} {
 
     wgpu::SurfaceCapabilities capabilities = {};
-    if (!mSurface.GetCapabilities(adapter, &capabilities)) {
+    if (mSurface.GetCapabilities(adapter, &capabilities) != wgpu::Status::Success) {
         FWGPU_LOGW << "Failed to get WebGPU surface capabilities";
     } else {
 #if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)

--- a/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
+++ b/filament/backend/src/webgpu/platform/WebGPUPlatform.cpp
@@ -414,7 +414,7 @@ void printAdapterDetails(AdapterDetails const& details) {
     }
 #endif
     wgpu::Limits supportedLimits{};
-    if (!details.adapter.GetLimits(&supportedLimits)) {
+    if (details.adapter.GetLimits(&supportedLimits) != wgpu::Status::Success) {
         FWGPU_LOGW << "Failed to get WebGPU adapter supported limits. Request limits:";
     }
     FWGPU_LOGI << "WebGPU adapter supported limits:";
@@ -454,7 +454,8 @@ struct AdapterDetailsHash final {
         return false;
     }
     wgpu::Limits supportedLimits {};
-    FILAMENT_CHECK_POSTCONDITION(details.adapter.GetLimits(&supportedLimits))
+    FILAMENT_CHECK_POSTCONDITION(
+            details.adapter.GetLimits(&supportedLimits) == wgpu::Status::Success)
             << "Failed to get limits for WebGPU adapter: " << toString(details);
     if (!satisfiesLimits(supportedLimits)) {
 #if FWGPU_ENABLED(FWGPU_PRINT_SYSTEM)
@@ -490,7 +491,8 @@ struct AdapterDetailsHash final {
                             << adapterOptionsToString(options) << " Error: " << message.data;
                     if (status == wgpu::RequestAdapterStatus::Success) {
                         AdapterDetails details = AdapterDetails(readyAdapter);
-                        FILAMENT_CHECK_POSTCONDITION(readyAdapter.GetInfo(&details.info))
+                        FILAMENT_CHECK_POSTCONDITION(
+                                readyAdapter.GetInfo(&details.info) == wgpu::Status::Success)
                                 << "Failed to get info for adapter (options: "
                                 << adapterOptionsToString(options) << ")";
                         utils::LockGuard const lock(adaptersMutex);
@@ -703,7 +705,7 @@ wgpu::Device WebGPUPlatform::requestDevice(wgpu::Adapter const& adapter) {
                             "adapter should support them: %s\n",
                 missingFeatures, featureNamesStream.str().data());
     }
-    FILAMENT_CHECK_POSTCONDITION(device.GetLimits(&supportedLimits))
+    FILAMENT_CHECK_POSTCONDITION(device.GetLimits(&supportedLimits) == wgpu::Status::Success)
             << "Failed to get limits for the device?";
     FILAMENT_CHECK_POSTCONDITION(satisfiesLimits(supportedLimits))
             << "WebGPU device failed to statify required limits.";


### PR DESCRIPTION
This conversion mechanism has been removed in dawn upstream.

See https://dawn-review.googlesource.com/c/dawn/+/325755