### PR TITLE
engine: fix skinning bo leak in VertexBuffer

### DIFF
--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -415,7 +415,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const Builder& builder)
 
 void FVertexBuffer::terminate(FEngine& engine) {
     FEngine::DriverApi& driver = engine.getDriverApi();
-    if (!mBufferObjectsEnabled) {
+    if (!mBufferObjectsEnabled || mAdvancedSkinningEnabled) {
         for (BufferObjectHandle const& bo : mBufferObjects) {
             driver.destroyBufferObject(bo);
         }


### PR DESCRIPTION
When advanced skinning is enabled, the FVertexBuffer allocates buffer objects for BONE_INDICES and BONE_WEIGHTS. This commit ensures that these buffers are properly destroyed in FVertexBuffer::terminate to prevent memory leaks.