### PR TITLE
JobSystem: lock-free redesign and optimizations

### DIFF
--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -306,7 +306,7 @@ void FScene::prepare(JobSystem& js,
 
     auto* lightJob = parallel_for(js, rootJob,
             lightInstances.data(), lightInstances.size(),
-            std::cref(lightWork), jobs::CountSplitter<32, 5>());
+            std::cref(lightWork), jobs::CountSplitter<32>());
 
     js.run(renderableJob);
     js.run(lightJob);

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -15,13 +15,12 @@
  */
 
 
-#include <ibl/CubemapIBL.h>
+#include "CubemapUtilsImpl.h"
 
 #include <ibl/Cubemap.h>
+#include <ibl/CubemapIBL.h>
 #include <ibl/CubemapUtils.h>
 #include <ibl/utilities.h>
-
-#include "CubemapUtilsImpl.h"
 
 #include <utils/JobSystem.h>
 
@@ -1007,11 +1006,10 @@ void CubemapIBL::brdf(utils::JobSystem& js, Cubemap& dst, float linearRoughness)
 
 void CubemapIBL::DFG(JobSystem& js, Image& dst, bool multiscatter, bool cloth) {
     auto dfvFunction = multiscatter ? DFV_Multiscatter : DFV;
-    auto job = jobs::parallel_for<char>(js, nullptr, nullptr, uint32_t(dst.getHeight()),
-            [&dst, dfvFunction, cloth](char const* d, size_t c) {
+    auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(dst.getHeight()),
+            [&dst, dfvFunction, cloth](uint32_t y0, uint32_t c) {
                 const size_t width = dst.getWidth();
                 const size_t height = dst.getHeight();
-                size_t y0 = size_t(d);
                 for (size_t y = y0; y < y0 + c; y++) {
                     Cubemap::Texel* UTILS_RESTRICT data =
                             static_cast<Cubemap::Texel*>(dst.getPixelRef(0, y));
@@ -1032,7 +1030,7 @@ void CubemapIBL::DFG(JobSystem& js, Image& dst, bool multiscatter, bool cloth) {
                         *data = r;
                     }
                 }
-            }, jobs::CountSplitter<1, 8>());
+            }, jobs::CountSplitter<8>());
     js.runAndWait(job);
 }
 

--- a/libs/ibl/src/CubemapUtils.cpp
+++ b/libs/ibl/src/CubemapUtils.cpp
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <ibl/CubemapUtils.h>
-
 #include "CubemapUtilsImpl.h"
 
+#include <ibl/CubemapUtils.h>
 #include <ibl/utilities.h>
 
 #include <utils/JobSystem.h>
@@ -263,7 +262,7 @@ void CubemapUtils::cubemapToEquirectangular(JobSystem& js, Image& dst, const Cub
     };
 
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
-            std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
+            std::ref(parallelJobTask), jobs::CountSplitter<8>());
     js.runAndWait(job);
 }
 
@@ -297,7 +296,7 @@ void CubemapUtils::cubemapToOctahedron(JobSystem& js, Image& dst, const Cubemap&
     };
 
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
-            std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
+            std::ref(parallelJobTask), jobs::CountSplitter<8>());
     js.runAndWait(job);
 }
 

--- a/libs/ibl/src/CubemapUtilsImpl.h
+++ b/libs/ibl/src/CubemapUtilsImpl.h
@@ -41,22 +41,38 @@ void CubemapUtils::process(
         s = prototype;
     }
 
+    struct FaceContext {
+        STATE* s;
+        Image* image;
+        const CubemapUtils::ScanlineProc<STATE>* proc;
+        uint16_t dim;
+        uint8_t faceIndex;
+    };
+
+    FaceContext faceContexts[6];
+    for (size_t i = 0; i < 6; ++i) {
+        faceContexts[i] = {
+            &states[i],
+            &cm.getImageForFace((Cubemap::Face)i),
+            &proc,
+            uint16_t(dim),
+            uint8_t(i)
+        };
+    }
+
     JobSystem::Job* parent = js.createJob();
     for (size_t faceIndex = 0; faceIndex < 6; faceIndex++) {
 
-        auto perFaceJob = [faceIndex, &states, &cm, dim, &proc]
+        auto perFaceJob = [faceIndex, &faceContexts, dim]
                 (utils::JobSystem& js, utils::JobSystem::Job* parent) {
-            STATE& s = states[faceIndex];
-            Image& image(cm.getImageForFace((Cubemap::Face)faceIndex));
+            const FaceContext* ctx = &faceContexts[faceIndex];
 
-            // here we must limit how much we capture so we can use this closure
-            // by value.
-            auto parallelJobTask = [&s, &image, &proc, dim = uint16_t(dim),
-                                    faceIndex = uint8_t(faceIndex)](size_t y0, size_t c) {
+            // Capture only 1 pointer (8 bytes) so ParallelForJobData stays within 32 bytes (<= 48 bytes)
+            auto parallelJobTask = [ctx](size_t y0, size_t c) {
                 for (size_t y = y0; y < y0 + c; y++) {
                     Cubemap::Texel* data =
-                            static_cast<Cubemap::Texel*>(image.getPixelRef(0, y));
-                    proc(s, y, (Cubemap::Face)faceIndex, data, dim);
+                            static_cast<Cubemap::Texel*>(ctx->image->getPixelRef(0, y));
+                    (*ctx->proc)(*ctx->s, y, (Cubemap::Face)ctx->faceIndex, data, ctx->dim);
                 }
             };
 
@@ -64,7 +80,7 @@ void CubemapUtils::process(
             if (UTILS_LIKELY(isStateLess)) {
                 // create the job, copying it by value
                 auto job = jobs::parallel_for(js, parent, 0, uint32_t(dim),
-                        parallelJobTask, jobs::CountSplitter<64, 8>());
+                        parallelJobTask, jobs::CountSplitter<64>());
                 // not need to signal here, since we're just scheduling work
                 js.run(job);
             } else {

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -229,6 +229,7 @@ if (FILAMENT_BUILD_TESTING)
             test/test_BinaryTreeArray.cpp
             test/test_Status.cpp
             test/test_Mutex.cpp
+            test/test_ThreadMap.cpp
     )
 
     if (WASM_PTHREADS)

--- a/libs/utils/include/private/utils/ThreadMap.h
+++ b/libs/utils/include/private/utils/ThreadMap.h
@@ -1,0 +1,315 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_THREADMAP_H
+#define TNT_UTILS_THREADMAP_H
+
+#include <utils/compiler.h>
+#include <utils/debug.h>
+#include <utils/Panic.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+#include <assert.h>
+#include <stdint.h>
+
+namespace utils {
+
+/**
+ * ThreadMap is a bounded-capacity, wait-free associative mapping from std::thread::id to
+ * trivially copyable, lock-free values (such as pointers, handles, or integers).
+ *
+ * Preconditions & Concurrency Model (JobSystem Invariants):
+ * ---------------------------------------------------------
+ * ThreadMap is designed specifically for JobSystem where the following invariants hold:
+ * 1. Fixed Capacity: Capacity is established at construction time (<= MAX_THREADS, typically <= 32)
+ *    and is never dynamically resized.
+ * 2. Exclusive Slot Ownership: Mutating operations (set, eraseAt) on a given slot index are
+ *    performed exclusively by one thread at a time (guaranteed by JobSystem's thread pool
+ *    partitioning and atomic adoptable slot mask). Two threads never concurrently mutate the
+ *    same slot index.
+ * 3. Thread-Bound Registration: Each thread registers itself (std::this_thread::get_id()) via
+ *    set() and unregisters itself via erase()/eraseAt(). Lookups (get()) are predominantly
+ *    invoked by a thread querying its own state.
+ * 4. Lock-Free and Wait-Free: All reads and writes complete in bounded, single-pass O(N) scans
+ *    with acquire-release atomics, without locks, CAS spin loops, seqlocks, version counters,
+ *    or spurious misses.
+ */
+template <typename VALUE>
+class ThreadMap {
+    static_assert(std::is_trivially_copyable_v<VALUE>,
+            "ThreadMap requires VALUE to be trivially copyable (e.g. pointers, handles)");
+    static_assert(std::atomic<VALUE>::is_always_lock_free,
+            "ThreadMap requires std::atomic<VALUE> to be lock-free on this platform");
+    static_assert(std::atomic<std::thread::id>::is_always_lock_free,
+            "ThreadMap requires std::atomic<std::thread::id> to be lock-free on this platform");
+    static_assert(std::has_unique_object_representations_v<std::thread::id>,
+            "ThreadMap requires std::thread::id to have unique object representations (no padding bits)");
+
+public:
+    using value_type = VALUE;
+    using size_type = uint32_t;
+    using key_type = std::thread::id;
+
+    static constexpr size_type INVALID_INDEX = std::numeric_limits<size_type>::max();
+
+    struct Entry {
+        std::atomic<key_type> tid{};
+        std::atomic<value_type> value{};
+    };
+
+    /**
+     * Constructs a ThreadMap with the specified maximum thread capacity.
+     *
+     * @param capacity Maximum number of threads that can be registered simultaneously.
+     * @note Not thread-safe. Standard C++ object lifecycle rules apply.
+     */
+    explicit ThreadMap(size_type capacity = 0);
+    ~ThreadMap();
+
+    ThreadMap(const ThreadMap&) = delete;
+    ThreadMap& operator=(const ThreadMap&) = delete;
+
+    ThreadMap(ThreadMap&& rhs) noexcept;
+    ThreadMap& operator=(ThreadMap&& rhs) noexcept;
+
+    /**
+     * Returns the maximum thread capacity.
+     *
+     * @note Thread-safe (wait-free, read-only).
+     */
+    size_type getCapacity() const noexcept;
+
+    /**
+     * Associates the specified slot index with a thread ID and value.
+     *
+     * Precondition: index < getCapacity(). Two threads must not call set() concurrently
+     * with the same slot index.
+     *
+     * @param index Slot index (must be < getCapacity()).
+     * @param value The value to associate with the thread.
+     * @param tid The thread ID (defaults to the current calling thread).
+     * @note Thread-safe (wait-free) across distinct slot indices and against concurrent readers.
+     */
+    void set(size_type index, value_type value,
+            key_type tid = std::this_thread::get_id()) noexcept;
+
+    /**
+     * Retrieves the value associated with the specified thread ID.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The associated value, or value_type{} if not found.
+     * @note Thread-safe (wait-free). Performs a single bounded O(N) scan.
+     */
+    inline value_type get(key_type const tid = std::this_thread::get_id()) const noexcept {
+        if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
+            return value_type{};
+        }
+        for (size_type i = 0; i < mCapacity; ++i) {
+            Entry const& entry = mEntries[i];
+            if (entry.tid.load(std::memory_order_acquire) == tid) {
+                value_type const val = entry.value.load(std::memory_order_relaxed);
+                if (entry.tid.load(std::memory_order_acquire) == tid) {
+                    return val;
+                }
+            }
+        }
+        return value_type{};
+    }
+
+    /**
+     * Finds the slot index of the specified thread ID.
+     *
+     * @param tid The thread ID to look up (defaults to current thread).
+     * @return The slot index if found, or INVALID_INDEX if not registered.
+     * @note Thread-safe (wait-free). Performs a single bounded O(N) scan.
+     */
+    inline size_type findIndex(key_type const tid = std::this_thread::get_id()) const noexcept {
+        if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
+            return INVALID_INDEX;
+        }
+        for (size_type i = 0; i < mCapacity; ++i) {
+            if (mEntries[i].tid.load(std::memory_order_acquire) == tid) {
+                return i;
+            }
+        }
+        return INVALID_INDEX;
+    }
+
+    /**
+     * Returns true if the specified thread is registered in this map.
+     *
+     * @param tid The thread ID to check (defaults to current thread).
+     * @note Thread-safe (wait-free).
+     */
+    inline bool contains(key_type const tid = std::this_thread::get_id()) const noexcept {
+        return findIndex(tid) != INVALID_INDEX;
+    }
+
+    /**
+     * Unregisters the specified thread ID from the map and resets its slot to empty.
+     *
+     * @param tid The thread ID to unregister (defaults to current thread).
+     * @return true if the thread was found and unregistered, false otherwise.
+     * @note Thread-safe (lock-free).
+     */
+    bool erase(key_type tid = std::this_thread::get_id()) noexcept;
+
+    /**
+     * Resets the slot at the specified index to empty.
+     *
+     * Precondition: index < getCapacity().
+     *
+     * @param index The slot index to reset.
+     * @return true if the slot was occupied and cleared, false if already empty.
+     * @note Thread-safe (wait-free) across distinct slot indices and against concurrent readers.
+     */
+    bool eraseAt(size_type index) noexcept;
+
+    /**
+     * Resets all slots in the map to empty.
+     *
+     * @note Not thread-safe with concurrent mutating operations.
+     */
+    void clear() noexcept;
+
+    /**
+     * Returns the number of registered threads.
+     *
+     * @note Thread-safe (wait-free, approximate snapshot under concurrent mutation).
+     */
+    size_type size() const noexcept;
+
+    /**
+     * Returns true if no threads are currently registered.
+     *
+     * @note Thread-safe (wait-free, approximate snapshot under concurrent mutation).
+     */
+    bool empty() const noexcept;
+
+private:
+    size_type mCapacity = 0;
+    std::unique_ptr<Entry[]> mEntries;
+};
+
+// ------------------------------------------------------------------------------------------------
+// Out-of-line method definitions
+// ------------------------------------------------------------------------------------------------
+
+template <typename VALUE>
+ThreadMap<VALUE>::ThreadMap(size_type const capacity)
+        : mCapacity(capacity),
+          mEntries(capacity ? std::make_unique<Entry[]>(capacity) : nullptr) {
+}
+
+template <typename VALUE>
+ThreadMap<VALUE>::~ThreadMap() = default;
+
+template <typename VALUE>
+ThreadMap<VALUE>::ThreadMap(ThreadMap&& rhs) noexcept
+        : mCapacity(std::exchange(rhs.mCapacity, 0)),
+          mEntries(std::move(rhs.mEntries)) {
+}
+
+template <typename VALUE>
+ThreadMap<VALUE>& ThreadMap<VALUE>::operator=(ThreadMap&& rhs) noexcept {
+    if (this != &rhs) {
+        mCapacity = std::exchange(rhs.mCapacity, 0);
+        mEntries = std::move(rhs.mEntries);
+    }
+    return *this;
+}
+
+template <typename VALUE>
+typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::getCapacity() const noexcept {
+    return mCapacity;
+}
+
+template <typename VALUE>
+void ThreadMap<VALUE>::set(size_type const index, value_type const value, key_type const tid) noexcept {
+    assert_invariant(index < mCapacity);
+    assert_invariant(tid != key_type{});
+
+    Entry& entry = mEntries[index];
+    entry.value.store(value, std::memory_order_relaxed);
+    entry.tid.store(tid, std::memory_order_release);
+}
+
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::erase(key_type const tid) noexcept {
+    if (UTILS_UNLIKELY(tid == key_type{} || mCapacity == 0)) {
+        return false;
+    }
+    for (size_type i = 0; i < mCapacity; ++i) {
+        Entry& entry = mEntries[i];
+        key_type expected = tid;
+        if (entry.tid.compare_exchange_strong(expected, key_type{},
+                std::memory_order_release, std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::eraseAt(size_type const index) noexcept {
+    assert_invariant(index < mCapacity);
+
+    Entry& entry = mEntries[index];
+    key_type expected = entry.tid.load(std::memory_order_relaxed);
+    if (expected != key_type{}) {
+        if (entry.tid.compare_exchange_strong(expected, key_type{},
+                std::memory_order_release, std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename VALUE>
+void ThreadMap<VALUE>::clear() noexcept {
+    for (size_type i = 0; i < mCapacity; ++i) {
+        eraseAt(i);
+    }
+}
+
+template <typename VALUE>
+typename ThreadMap<VALUE>::size_type ThreadMap<VALUE>::size() const noexcept {
+    size_type count = 0;
+    for (size_type i = 0; i < mCapacity; ++i) {
+        if (mEntries[i].tid.load(std::memory_order_relaxed) != key_type{}) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+template <typename VALUE>
+bool ThreadMap<VALUE>::empty() const noexcept {
+    return size() == 0;
+}
+
+} // namespace utils
+
+#endif // TNT_UTILS_THREADMAP_H

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -425,8 +425,10 @@ public:
             // thread raced ahead of us. But in that case, the computed "newHead" will be discarded
             // since compare_exchange_weak() fails. Then this thread will loop with the updated
             // value of currentHead, and try again.
-            // TSAN complains if we don't use a local variable here.
-            Node const node = pStorage[currentHead.offset];
+            // We isolate this speculative read in readNode() with UTILS_NO_SANITIZE_THREAD so
+            // TSAN ignores the benign data race on node.next without disabling TSAN instrumentation
+            // on the acquire/release CAS on mHead below.
+            Node const node = readNode(pStorage, currentHead.offset);
             Node const* const pNext = node.next;
             const HeadPtr newHead{ pNext ? int32_t(pNext - pStorage) : -1, currentHead.tag + 1 };
             // In the rare case that the other thread that raced ahead of us already returned the
@@ -497,6 +499,11 @@ public:
     };
 
 private:
+    UTILS_NO_SANITIZE_THREAD
+    static inline Node readNode(Node const* const storage, int32_t const offset) noexcept {
+        return storage[offset];
+    }
+
     // This struct is using a 32-bit offset into the arena rather than
     // a direct pointer, because together with the 32-bit tag, it needs to 
     // fit into 8 bytes. If it was any larger, it would not be possible to

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -21,16 +21,16 @@
 #include <utils/architecture.h>
 #include <utils/compiler.h>
 #include <utils/Condition.h>
+#include <utils/Logger.h>
 #include <utils/memalign.h>
 #include <utils/Mutex.h>
 #include <utils/ostream.h>
 #include <utils/Slice.h>
 #include <utils/WorkStealingDequeue.h>
 
-#include <tsl/robin_map.h>
-
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <type_traits>
@@ -43,7 +43,16 @@
 
 namespace utils {
 
+template <typename VALUE>
+class ThreadMap;
+
+namespace jobs::details {
+template<typename S, typename F>
+struct ParallelForJobData;
+}
+
 class JobSystem {
+    static constexpr uint32_t MAX_THREADS = 32;
     static constexpr size_t MAX_JOB_COUNT = 1 << 14; // 16384
     static constexpr uint32_t JOB_COUNT_MASK = MAX_JOB_COUNT - 1;
     static constexpr uint32_t WAITER_COUNT_SHIFT = 24;
@@ -69,15 +78,15 @@ public:
         Job(const Job&) = delete;
         Job(Job&&) = delete;
 
-    private:
-        friend class JobSystem;
-
         // Size is chosen so that we can store at least std::function<>
         // the alignas() qualifier ensures we're multiple of a cache-line.
         static constexpr size_t JOB_STORAGE_SIZE_BYTES =
                 sizeof(std::function<void()>) > 48 ? sizeof(std::function<void()>) : 48;
         static constexpr size_t JOB_STORAGE_SIZE_WORDS =
                 (JOB_STORAGE_SIZE_BYTES + sizeof(void*) - 1) / sizeof(void*);
+
+    private:
+        friend class JobSystem;
 
         // keep it first, so it's correctly aligned with all architectures
         // this is where we store the job's data, typically a std::function<>
@@ -101,13 +110,28 @@ public:
      * Special value for userThreadCount to configure the JobSystem in single-threaded mode.
      */
     static constexpr uint32_t SINGLE_THREADED = std::numeric_limits<uint32_t>::max();
-
     /**
-     * Create a JobSystem and initializes its thread pool. The pool can have zero threads if SINGLE_THREADED is used
-     * as the userThreadCount, in that case adoptableThreadsCount is forced to 1.
+     * Create a JobSystem and initialize its thread pool.
      *
-     * @param userThreadCount number of threads in the JobSystem thread pool.
-     * @param adoptableThreadsCount number of calling threads outside the thread pool.
+     * Total thread capacity across pool workers and adopted threads is capped at MAX_THREADS (32).
+     *
+     * Parameter constraints & behavior:
+     * - `userThreadCount`: Number of dedicated worker threads to spawn in the pool.
+     *   - `0` (default): Automatically selects `(hardware_concurrency - 1)`.
+     *   - `SINGLE_THREADED`: Configures the JobSystem in single-threaded mode with 0 pool worker
+     *     threads and forces `adoptableThreadsCount` to 1.
+     *   - In multi-threaded mode (any value other than `SINGLE_THREADED`), the thread pool is
+     *     guaranteed to contain at least 1 worker thread (subject to system threading support).
+     * - `adoptableThreadsCount`: Maximum number of external calling threads that can concurrently
+     *   call `adopt()`.
+     *   - Must be between 1 and `MAX_THREADS - 1` (31) in multi-threaded mode to ensure capacity
+     *     for at least 1 pool worker thread.
+     *   - If `adoptableThreadsCount >= MAX_THREADS`, it is clamped to `MAX_THREADS - 1` with an error.
+     *   - If `userThreadCount + adoptableThreadsCount > MAX_THREADS`, `userThreadCount` is clamped to
+     *     `(MAX_THREADS - adoptableThreadsCount)` with a warning.
+     *
+     * @param userThreadCount Number of worker threads in the pool, 0 for auto-detect, or SINGLE_THREADED.
+     * @param adoptableThreadsCount Maximum number of external threads that can be adopted concurrently (max: MAX_THREADS - 1).
      */
     explicit JobSystem(uint32_t userThreadCount = 0, uint32_t adoptableThreadsCount = 1) noexcept;
 
@@ -272,6 +296,17 @@ public:
         return job;
     }
 
+    // creates a job with in-place storage initialized with ARGS, without automatic destruction
+    template<typename T, typename ... ARGS>
+    Job* emplaceJobRaw(Job* parent, JobFunc const func, ARGS&& ... args) noexcept {
+        static_assert(sizeof(T) <= sizeof(Job::storage), "user data too large");
+        Job* job = create(parent, func);
+        if (UTILS_LIKELY(job)) {
+            new(job->storage) T(std::forward<ARGS>(args)...);
+        }
+        return job;
+    }
+
 
     /*
      * Jobs are normally finished automatically, this can be used to cancel a job before it is run.
@@ -376,11 +411,12 @@ public:
     static void setThreadPriority(Priority priority) noexcept;
     static void setThreadAffinityById(size_t id) noexcept;
 
-    size_t getParallelSplitCount() const noexcept {
-        return mParallelSplitCount;
-    }
+    size_t getThreadCount() const noexcept { return mThreadCount; }
 
-    size_t getThreadCount() const { return mThreadCount; }
+    // returns the high-water mark of active threads (pool threads + adopted threads)
+    size_t getActiveThreadCount() const noexcept {
+        return mActiveThreadCount.load(std::memory_order_relaxed);
+    }
 
     // returns the current ThreadId, which can be used with run(). This method can only be
     // called from a job's function.
@@ -414,12 +450,14 @@ private:
         }
     };
 
-    struct alignas(CACHELINE_SIZE) ThreadState {    // this causes 40-bytes padding
-        // make sure storage is cache-line aligned
+    struct alignas(CACHELINE_SIZE) ThreadState {
+        // Keep nextJob at the beginning so that nextJob, workQueue's top/bottom indices,
+        // and the initial workQueue slots all share the first 64-byte cache line.
+        std::atomic<uint16_t> nextJob = { 0 };
         WorkQueue workQueue;
 
-        // these are not accessed by the worker threads
-        alignas(CACHELINE_SIZE)         // this causes 56-bytes padding
+        // these are not accessed frequently by other threads
+        alignas(CACHELINE_SIZE)         // this causes 40-bytes padding
         JobSystem* js;                  // this is in fact const and always initialized
         std::thread thread;             // unused for adopted threads
         default_random_engine rndGen;
@@ -446,22 +484,30 @@ private:
     Job* steal(ThreadState& state) noexcept;
     void finish(Job* job) noexcept;
 
-    void put(WorkQueue& workQueue, Job const* job) noexcept;
-    Job* pop(WorkQueue& workQueue) noexcept;
-    Job* steal(WorkQueue& workQueue) noexcept;
+    void put(ThreadState& state, Job const* job) noexcept;
+    Job* pop(ThreadState& state) noexcept;
+    Job* stealFrom(ThreadState& victim) noexcept;
 
     [[nodiscard]]
     uint32_t wait(UniqueLock& lock, Job* job) noexcept;
-    void wait(UniqueLock& lock) noexcept;
-    void wakeAll() noexcept;
+    void waitForWork(UniqueLock& lock) noexcept;
+    void waitForJob(UniqueLock& lock) noexcept;
+    void wakeWaiters() noexcept;
     void wakeOne() noexcept;
+
+    static constexpr uint32_t SLEEPING_WORKER_ONE = 1 << 16;
+    static constexpr uint32_t SLEEPING_WAITER_ONE = 1;
+    static constexpr uint32_t SLEEPING_WORKER_MASK = 0xFFFF0000;
+    static constexpr uint32_t SLEEPING_WAITER_MASK = 0x0000FFFF;
 
     // these have thread contention, keep them together
     Mutex mWaiterLock;
-    Condition mWaiterCondition;
+    Condition mWorkCondition;
+    Condition mJobCondition;
 
     std::atomic<int32_t> mActiveJobs = { 0 };
-    Arena<ObjectPoolAllocator<Job>, LockingPolicy::Mutex> mJobPool;
+    std::atomic<uint32_t> mSleepingCounts = { 0 };
+    Arena<ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 
     template <typename T>
     using aligned_vector = std::vector<T, STLAlignedAllocator<T>>;
@@ -475,14 +521,13 @@ private:
     alignas(16) // at least we align to half (or quarter) cache-line
     aligned_vector<ThreadState> mThreadStates;          // actual data is stored offline
     std::atomic<bool> mExitRequested = { false };       // this one is almost never written
-    std::atomic<uint16_t> mAdoptedThreads = { 0 };      // this one is almost never written
+    std::atomic<uint32_t> mAdoptableSlotsMask = { 0 };  // available slots for adoptable threads
+    std::atomic<uint16_t> mActiveThreadCount = { 0 };   // high-water mark of active threads
     Job* const mJobStorageBase;                         // Base for conversion to indices
     uint16_t mThreadCount = 0;                          // total # of threads in the pool
-    uint8_t mParallelSplitCount = 0;                    // # of split allowable in parallel_for
     Job* mRootJob = nullptr;
 
-    Mutex mThreadMapLock; // this should have very little contention
-    tsl::robin_map<std::thread::id, ThreadState *> mThreadMap UTILS_GUARDED_BY(mThreadMapLock);
+    std::unique_ptr<ThreadMap<ThreadState*>> mThreadMap;
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -526,104 +571,298 @@ JobSystem::Job* createJob(JobSystem& js, JobSystem::Job* parent,
 }
 
 
+/**
+ * Policy for dividing parallel work into chunks.
+ *
+ * @tparam COUNT Minimum chunk size (number of elements per work unit) dynamically claimed by threads.
+ * @tparam MAX_SPLITS Maximum split depth (caps the total number of chunks to 2^MAX_SPLITS).
+ */
+template<size_t COUNT = 1, size_t MAX_SPLITS = 12>
+class CountSplitter {
+public:
+    static constexpr size_t CHUNK_SIZE = COUNT;
+    static constexpr size_t MAX_CHUNKS = 1u << MAX_SPLITS;
+
+    size_t getChunkSize(size_t const totalCount, size_t const /* threadCount */) const noexcept {
+        size_t const dynamicChunk = (totalCount + MAX_CHUNKS - 1) >> MAX_SPLITS;
+        return std::max<size_t>(COUNT, dynamicChunk);
+    }
+};
+
 namespace details {
 
+// Traits helper to extract the chunk size from a splitter.
+// Splitters must define getChunkSize() or getChunkSize(count, threadCount).
+template<typename S>
+struct SplitterTraits {
+    template<typename T>
+    static auto test_0(int) -> decltype(std::declval<T>().getChunkSize(), std::true_type{});
+    template<typename>
+    static auto test_0(...) -> std::false_type;
+
+    template<typename T>
+    static auto test_2(int) -> decltype(std::declval<T>().getChunkSize(uint32_t(), uint32_t()), std::true_type{});
+    template<typename>
+    static auto test_2(...) -> std::false_type;
+
+    static constexpr bool has_chunk_size_0 = decltype(test_0<S>(0))::value;
+    static constexpr bool has_chunk_size_2 = decltype(test_2<S>(0))::value;
+
+    static_assert(has_chunk_size_0 || has_chunk_size_2,
+            "Custom splitter must define getChunkSize() or getChunkSize(count, threadCount). "
+            "The old split() method is no longer supported.");
+
+    static uint32_t getChunkSize(const S& splitter, uint32_t const totalCount, uint32_t const threadCount) noexcept {
+        if constexpr (has_chunk_size_2) {
+            return uint32_t(std::max<size_t>(1, splitter.getChunkSize(totalCount, std::max(1u, threadCount))));
+        } else if constexpr (has_chunk_size_0) {
+            return uint32_t(std::max<size_t>(1, splitter.getChunkSize()));
+        }
+    }
+};
+
+/*
+ * ParallelForJobData coordinates dynamic range-based work stealing across threads.
+ *
+ * Architecture & Concurrency Model:
+ * 1. Range-Based Stealing:
+ *    Instead of recursively splitting child jobs into an O(N) binary tree, parallel_for creates
+ *    a single root job and at most (threadCount - 1) child helper jobs.
+ *    All workers share a single atomic iteration cursor (nextOffset). Each worker claims
+ *    contiguous slices of chunkSize items via relaxed fetch_add until nextOffset >= count.
+ *
+ * 2. Memory Layout & Zero Heap Allocation:
+ *    ParallelForJobData is constructed entirely within the root Job's inline storage
+ *    (Job::storage, 48 bytes) with zero dynamic memory allocation.
+ *    Functors must fit in Job::storage (<= 24 bytes for 8-byte aligned closures, or 28 bytes
+ *    for 4-byte aligned closures). Large closures must be passed by reference via
+ *    std::cref() or std::ref() (which are 8 bytes).
+ *
+ * 3. Distributed Lifetime Management:
+ *    Because the root thread and helper tasks execute asynchronously, the lifetime of
+ *    ParallelForJobData in the root Job's storage is ref-counted by activeWorkers.
+ *    Every finishing worker (root or helper) atomically decrements activeWorkers with acq_rel.
+ *    The last worker to finish explicitly calls `~ParallelForJobData()`.
+ *    The Job struct in JobPool is safely reclaimed when all child jobs and the root job finish.
+ */
 template<typename S, typename F>
 struct ParallelForJobData {
-    using SplitterType = S;
     using Functor = F;
-    using JobData = ParallelForJobData;
-    using size_type = uint32_t;
 
-    ParallelForJobData(size_type const start, size_type const count, uint8_t const splits,
-            Functor functor,
-            const SplitterType& splitter) noexcept
-            : start(start), count(count),
-              functor(std::move(functor)),
-              splits(splits),
-              splitter(splitter) {
+    static_assert(std::is_invocable_v<const Functor&, uint32_t, uint32_t>,
+            "parallel_for functor must be const-invocable because a single functor instance "
+            "is shared and invoked concurrently across all worker threads. "
+            "Mutable lambdas or functors with non-const operator() are prohibited. "
+            "If mutable state is required across workers, pass it via thread-safe references (e.g. std::ref) "
+            "with atomic or synchronized operations.");
+
+    ParallelForJobData(uint32_t const start, uint32_t const count, uint32_t const chunkSize,
+            uint32_t const totalWorkers, Functor functor) noexcept
+            : start(start),
+              count(count),
+              chunkSize(std::max<uint32_t>(1, chunkSize)),
+              activeWorkers(totalWorkers),
+              functor(std::move(functor)) {
     }
 
-    void parallelWithJobs(JobSystem& js, JobSystem::Job* parent) noexcept {
-        assert(parent);
-
-        // this branch is often miss-predicted (it both sides happen 50% of the calls)
-right_side:
-        if (splitter.split(splits, count)) {
-            const size_type lc = count / 2;
-            JobSystem::Job* l = js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-                    start, lc, splits + uint8_t(1), functor, splitter);
-            if (UTILS_UNLIKELY(l == nullptr)) {
-                // couldn't create a job, just pretend we're done splitting
-                goto execute;
-            }
-
-            // start the left side before attempting the right side, so we parallelize in case
-            // of job creation failure -- rare, but still.
-            js.run(l, JobSystem::getThreadId(parent));
-
-            // don't spawn a job for the right side, just reuse us -- spawning jobs is more
-            // costly than we'd like.
-            start += lc;
-            count -= lc;
-            ++splits;
-            goto right_side;
-
-        } else {
-execute:
-            // we're done splitting, do the real work here!
-            functor(start, count);
+    // Work-stealing loop: dynamically claims slices of chunkSize items until exhaustion.
+    void process() noexcept {
+        uint32_t offset;
+        while ((offset = nextOffset.fetch_add(chunkSize, std::memory_order_relaxed)) < count) {
+            uint32_t const chunk = std::min<uint32_t>(chunkSize, count - offset);
+            std::as_const(functor)(start + offset, chunk);
         }
     }
 
-private:
-    size_type start;            // 4
-    size_type count;            // 4
-    Functor functor;            // ?
-    uint8_t splits;             // 1
-    SplitterType splitter;      // 1
+    // Invoked by the root job: spawns helper jobs for other threads, then processes chunks itself.
+    void runRoot(JobSystem& js, JobSystem::Job* root) noexcept {
+        uint32_t const total = activeWorkers.load(std::memory_order_relaxed);
+        uint32_t const helperCount = total > 0 ? total - 1 : 0;
+        JobSystem::ThreadId const id = JobSystem::getThreadId(root);
+
+        for (uint32_t i = 0; i < helperCount; ++i) {
+            JobSystem::Job* helper =
+                    js.createJob<ParallelForJobData, &ParallelForJobData::runHelper>(root, this);
+            if (UTILS_LIKELY(helper)) {
+                js.run(helper, id);
+            } else {
+                // Failed to allocate a helper job; decrement active workers refcount.
+                finishWorker();
+            }
+        }
+
+        process();
+        finishWorker();
+    }
+
+    // Invoked by child helper jobs on other worker threads.
+    void runHelper(JobSystem&, JobSystem::Job*) noexcept {
+        process();
+        finishWorker();
+    }
+
+    // Decrements active worker count and destroys when the last worker finishes.
+    void finishWorker() noexcept {
+        if (activeWorkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            this->~ParallelForJobData();
+        }
+    }
+
+    // Raw job entry point for inline storage in the root Job.
+    static void jobFuncInline(void* storage, JobSystem& js, JobSystem::Job* root) noexcept {
+        auto* const that = static_cast<ParallelForJobData*>(storage);
+        that->runRoot(js, root);
+    }
+
+    // Packed struct members: total header = 20 bytes (5 x 4-byte fields)
+    std::atomic<uint32_t> nextOffset = { 0 };
+    uint32_t start = 0;
+    uint32_t count = 0;
+    uint32_t chunkSize = 1;
+    std::atomic<uint32_t> activeWorkers = { 0 };
+    Functor functor;
 };
+
+// Check whether this struct fits inline inside Job::storage (typically 48 bytes).
+template<typename S, typename F>
+inline constexpr bool IsParallelForInline =
+        (sizeof(ParallelForJobData<S, F>) <= JobSystem::Job::JOB_STORAGE_SIZE_BYTES);
 
 } // namespace details
 
 
-// parallel jobs with start/count indices
+/**
+ * Execute a function in parallel over a range of indices [start, start + count).
+ *
+ * The range is divided into chunks and dynamically claimed by available worker threads
+ * using lock-free range-based stealing.
+ *
+ * A single shared instance of the functor is invoked concurrently across all worker threads.
+ * As such, the functor MUST be const-invocable (i.e. have a `const operator()`).
+ * Mutable lambdas or functors with non-const `operator()` are rejected at compile time via static_assert.
+ * If mutable state across workers is necessary, pass it via `std::ref()` with appropriate synchronization.
+ *
+ * The functor is invoked with `(uint32_t start, uint32_t count)` representing contiguous,
+ * non-overlapping sub-ranges covering the entire iteration space.
+ *
+ * If count is 0, a valid no-op job is returned and functor is not invoked.
+ * If count exceeds 2^31 - 1 (0x7FFFFFFF), an error is logged and nullptr is returned.
+ *
+ * ParallelForJobData is stored entirely inline within Job storage with zero heap allocations.
+ * Functors must fit inline (<= 24 bytes for 8-byte aligned closures); pass larger closures
+ * via std::cref() or std::ref().
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param start First index of the range.
+ * @param count Total number of items to process (max 2^31 - 1; start + count must not exceed 2^32; if 0, functor is not called).
+ * @param functor Callable invoked with `(uint32_t start, uint32_t count)`. Must be const-invocable.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation, or nullptr if count or range is invalid.
+ */
 template<typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
-        uint32_t start, uint32_t count, F functor, const S& splitter) noexcept {
+        uint32_t const start, uint32_t const count, F functor, const S& splitter) noexcept {
+    static_assert(details::IsParallelForInline<S, F>,
+            "parallel_for functor too large for inline Job storage. "
+            "Pass large closures by reference via std::cref() or std::ref().");
+
+    if (UTILS_UNLIKELY(count == 0)) {
+        return js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
+    }
+
+    if (UTILS_UNLIKELY(count > 0x7FFFFFFFu || uint64_t(start) + count > 0x100000000ull)) {
+        LOG(ERROR) << "parallel_for: invalid range [start=" << start << ", count=" << count
+                   << "), start + count exceeds 2^32 or count exceeds 2^31 - 1";
+        return nullptr;
+    }
+
+    uint32_t const poolThreads = uint32_t(js.getThreadCount());
+    uint32_t const totalThreads = (poolThreads == 0) ? 0 :
+            std::max(poolThreads, uint32_t(js.getActiveThreadCount()));
+    uint32_t const effectiveThreads = std::max(1u, totalThreads);
+
+    uint32_t const chunkSize = details::SplitterTraits<S>::getChunkSize(splitter, count, effectiveThreads);
+    uint32_t const numChunks = ((count - 1) / chunkSize) + 1;
+    uint32_t const helperCount = (totalThreads > 0 && numChunks > 1) ?
+            std::min<uint32_t>(totalThreads - 1, numChunks - 1) : 0;
+    uint32_t const totalWorkers = helperCount + 1;
+
     using JobData = details::ParallelForJobData<S, F>;
-    return js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-            start, count, 0, std::move(functor), splitter);
+
+    return js.emplaceJobRaw<JobData>(parent, &JobData::jobFuncInline,
+            start, count, chunkSize, totalWorkers, std::move(functor));
 }
 
-// parallel jobs with pointer/count
+template<typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        uint32_t const start, uint32_t const count, F functor) noexcept {
+    return parallel_for(js, parent, start, count, std::move(functor), CountSplitter<16>{});
+}
+
+/**
+ * Execute a function in parallel over an array of elements [data, data + count).
+ *
+ * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ * A single shared instance of the functor is invoked concurrently across all worker threads;
+ * the functor must be const-invocable.
+ * If count is 0, a valid no-op job is returned and functor is not invoked.
+ * If count exceeds 2^31 - 1 (0x7FFFFFFF), an error is logged and nullptr is returned.
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param data Pointer to the start of the data array.
+ * @param count Total number of elements (if 0, functor is not called).
+ * @param functor Callable invoked with `(T* data, size_t count)`. Must be const-invocable.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation, or nullptr if count exceeds 2^31 - 1.
+ */
 template<typename T, typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
-        T* data, uint32_t count, F functor, const S& splitter) noexcept {
-    auto user = [data, f = std::move(functor)](uint32_t s, uint32_t c) {
-        f(data + s, c);
+        T* const data, uint32_t const count, F functor, const S& splitter) noexcept {
+    static_assert(std::is_invocable_v<const std::remove_reference_t<F>&, T*, size_t> ||
+                  std::is_invocable_v<const std::remove_reference_t<F>&, T*, uint32_t>,
+            "parallel_for functor must be const-invocable because a single functor instance "
+            "is shared and invoked concurrently across all worker threads.");
+    auto user = [data, f = std::move(functor)](uint32_t const s, uint32_t const c) {
+        std::as_const(f)(data + s, c);
     };
-    using JobData = details::ParallelForJobData<S, decltype(user)>;
-    return js.emplaceJob<JobData, &JobData::parallelWithJobs>(parent,
-            0, count, 0, std::move(user), splitter);
+    return parallel_for(js, parent, 0, count, std::move(user), splitter);
 }
 
-// parallel jobs on a Slice<>
+template<typename T, typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        T* const data, uint32_t const count, F functor) noexcept {
+    return parallel_for(js, parent, data, count, std::move(functor), CountSplitter<16>{});
+}
+
+/**
+ * Execute a function in parallel over a Slice<T>.
+ *
+ * The functor is invoked with `(T* data, size_t count)` for contiguous sub-slices.
+ * A single shared instance of the functor is invoked concurrently across all worker threads;
+ * the functor must be const-invocable.
+ * If slice is empty (size 0), a valid no-op job is returned and functor is not invoked.
+ * If slice.size() exceeds 2^31 - 1 (0x7FFFFFFF), an error is logged and nullptr is returned.
+ *
+ * @param js The JobSystem instance.
+ * @param parent Optional parent job.
+ * @param slice Slice of elements to process (if empty, functor is not called).
+ * @param functor Callable invoked with `(T* data, size_t count)`. Must be const-invocable.
+ * @param splitter Chunking policy (default: CountSplitter<16>).
+ * @return The root JobSystem::Job* representing this parallel operation, or nullptr if count exceeds 2^31 - 1.
+ */
 template<typename T, typename S, typename F>
 JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
         Slice<T> slice, F functor, const S& splitter) noexcept {
-    return parallel_for(js, parent, slice.data(), slice.size(), functor, splitter);
+    return parallel_for(js, parent, slice.data(), uint32_t(slice.size()), std::move(functor), splitter);
 }
 
-
-template<size_t COUNT, size_t MAX_SPLITS = 12>
-class CountSplitter {
-public:
-    bool split(size_t const splits, size_t const count) const noexcept {
-        return (splits < MAX_SPLITS && count >= COUNT * 2);
-    }
-};
-
+template<typename T, typename F>
+JobSystem::Job* parallel_for(JobSystem& js, JobSystem::Job* parent,
+        Slice<T> slice, F functor) noexcept {
+    return parallel_for(js, parent, slice.data(), uint32_t(slice.size()), std::move(functor), CountSplitter<16>{});
+}
 } // namespace jobs
 } // namespace utils
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -84,7 +84,7 @@
 #endif
 
 #define UTILS_NO_SANITIZE_THREAD
-#if __has_feature(thread_sanitizer)
+#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
 #undef UTILS_NO_SANITIZE_THREAD
 #define UTILS_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
 #endif

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -28,8 +28,10 @@
 
 #include <utils/JobSystem.h>
 
+#include <private/utils/ThreadMap.h>
 #include <private/utils/Tracing.h>
 
+#include <utils/algorithm.h>
 #include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/Log.h>
@@ -201,21 +203,49 @@ JobSystem::JobSystem(uint32_t const userThreadCount, uint32_t adoptableThreadsCo
             // one of the thread will be the user thread
             threadPoolCount = hwThreads - 1;
         }
+        // Clamp adoptableThreadsCount so it does not exceed MAX_THREADS - 1, ensuring room
+        // for at least one pool worker thread.
+        if (adoptableThreadsCount >= MAX_THREADS) {
+            LOG(ERROR) << "JobSystem: adoptableThreadsCount (" << adoptableThreadsCount
+                       << ") exceeds MAX_THREADS - 1 (" << (MAX_THREADS - 1)
+                       << "), clamping.";
+            adoptableThreadsCount = MAX_THREADS - 1;
+        } else if (adoptableThreadsCount == 0) {
+            adoptableThreadsCount = 1;
+        }
+
         // make sure we have at least one thread in the thread pool
         threadPoolCount = std::max(1u, threadPoolCount);
-        // and also limit the pool to 32 threads
-        threadPoolCount = std::min(UTILS_HAS_THREADING ? 32u : 0u, threadPoolCount);
+
+        // limit the pool such that threadPoolCount + adoptableThreadsCount <= MAX_THREADS
+        const uint32_t maxThreadPoolCount = MAX_THREADS - adoptableThreadsCount;
+        if (threadPoolCount > maxThreadPoolCount) {
+            LOG(WARNING) << "JobSystem: threadPoolCount (" << threadPoolCount
+                         << ") + adoptableThreadsCount (" << adoptableThreadsCount
+                         << ") exceeds MAX_THREADS (" << MAX_THREADS
+                         << "), clamping pool count to " << maxThreadPoolCount;
+            threadPoolCount = maxThreadPoolCount;
+        }
+
+        threadPoolCount = std::min(UTILS_HAS_THREADING ? maxThreadPoolCount : 0u, threadPoolCount);
     } else {
         threadPoolCount = 0;
         adoptableThreadsCount = 1;
     }
 
     mThreadStates = aligned_vector<ThreadState>(threadPoolCount + adoptableThreadsCount);
+    mThreadMap = std::make_unique<ThreadMap<ThreadState*>>(threadPoolCount + adoptableThreadsCount);
     mThreadCount = uint16_t(threadPoolCount);
-    mParallelSplitCount = uint8_t(std::ceil((std::log2f(threadPoolCount + adoptableThreadsCount))));
+    mActiveThreadCount.store(mThreadCount, std::memory_order_relaxed);
+
+    uint32_t adoptableMask = 0;
+    for (uint32_t i = 0; i < adoptableThreadsCount; ++i) {
+        adoptableMask |= (1u << (threadPoolCount + i));
+    }
+    mAdoptableSlotsMask.store(adoptableMask, std::memory_order_relaxed);
 
     static_assert(std::atomic<bool>::is_always_lock_free);
-    static_assert(std::atomic<uint16_t>::is_always_lock_free);
+    static_assert(std::atomic<uint32_t>::is_always_lock_free);
 
     const size_t hardwareThreadCount = mThreadCount;
     auto& states = mThreadStates;
@@ -281,7 +311,8 @@ void JobSystem::decRef(Job const* job) noexcept {
 void JobSystem::requestExit() noexcept {
     mExitRequested.store(true);
     LockGuard const lock(mWaiterLock);
-    mWaiterCondition.notify_all();
+    mWorkCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 inline bool JobSystem::exitRequested() const noexcept {
@@ -297,16 +328,34 @@ inline bool JobSystem::hasJobCompleted(Job const* job) noexcept {
     return (job->runningJobCount.load(std::memory_order_acquire) & JOB_COUNT_MASK) == 0;
 }
 
-inline void JobSystem::wait(UniqueLock& lock) noexcept {
+inline void JobSystem::waitForWork(UniqueLock& lock) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
-    mWaiterCondition.wait(lock);
+    mWorkCondition.wait(lock);
+}
+
+inline void JobSystem::waitForJob(UniqueLock& lock) noexcept {
+    HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+    mSleepingCounts.fetch_add(SLEEPING_WAITER_ONE, std::memory_order_seq_cst);
+    // Complete the Dekker handshake before actually sleeping: re-check mActiveJobs
+    // (seq_cst) so a producer -- put(), or steal() restoring a speculatively claimed
+    // count -- either observes our SLEEPING_WAITER_ONE and calls wakeOne(), or we
+    // observe its increment and skip the sleep entirely.
+    //
+    // Note: This must be an `if`, NOT a `while`. Unlike loop() (which wakes only when new work
+    // arrives), a waiter also wakes when its awaited job completes. At that completion moment,
+    // mActiveJobs is legitimately <= 0; a `while` would send the thread straight back to sleep
+    // past finish()'s wake notification, causing a permanent deadlock.
+    if (mActiveJobs.load(std::memory_order_seq_cst) <= 0) {
+        mJobCondition.wait(lock);
+    }
+    mSleepingCounts.fetch_sub(SLEEPING_WAITER_ONE, std::memory_order_seq_cst);
 }
 
 inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     // signal we are waiting
 
-    if (hasActiveJobs() || exitRequested()) {
+    if (exitRequested()) {
         return job->runningJobCount.load(std::memory_order_acquire);
     }
 
@@ -314,7 +363,7 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
             job->runningJobCount.fetch_add(1 << WAITER_COUNT_SHIFT, std::memory_order_relaxed);
 
     if (runningJobCount & JOB_COUNT_MASK) {
-        mWaiterCondition.wait(lock);
+        waitForJob(lock);
     }
 
     runningJobCount =
@@ -326,106 +375,126 @@ inline uint32_t JobSystem::wait(UniqueLock& lock, Job* const job) noexcept {
 }
 
 UTILS_NOINLINE
-void JobSystem::wakeAll() noexcept {
-    // wakeAll() is called when a job finishes (to wake up any thread that might be waiting on it)
+void JobSystem::wakeWaiters() noexcept {
+    // wakeWaiters() is called when a job finishes (to wake up any thread that might be waiting on it)
     FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     mWaiterLock.lock();
     // this empty critical section is needed -- it guarantees that notify_all() happens
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_all() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_all();
+    mJobCondition.notify_all();
 }
 
 void JobSystem::wakeOne() noexcept {
-    // wakeOne() is called when a new job is added to a queue
+    // wakeOne() is called when a new job is added to a queue or an un-stolen active job is restored
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
     mWaiterLock.lock();
     // this empty critical section is needed -- it guarantees that notify_one() happens
     // either before the condition is checked, or after the condition variable sleeps.
     mWaiterLock.unlock();
     // notify_one() can be pretty slow, and it doesn't need to be inside the lock.
-    mWaiterCondition.notify_one();
+    uint32_t const sleeping = mSleepingCounts.load(std::memory_order_relaxed);
+    if (sleeping & SLEEPING_WORKER_MASK) {
+        mWorkCondition.notify_one();
+    } else if (sleeping & SLEEPING_WAITER_MASK) {
+        mJobCondition.notify_one();
+    }
 }
 
 inline JobSystem::ThreadState& JobSystem::getState() {
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(std::this_thread::get_id());
-    FILAMENT_CHECK_PRECONDITION(iter != mThreadMap.end()) << "This thread has not been adopted.";
-    return *iter->second;
+    ThreadState* const state = mThreadMap->get();
+    FILAMENT_CHECK_PRECONDITION(state) << "This thread has not been adopted.";
+    return *state;
 }
 
 JobSystem::Job* JobSystem::allocateJob() noexcept {
     return mJobPool.make<Job>();
 }
 
-void JobSystem::put(WorkQueue& workQueue, Job const* job) noexcept {
+void JobSystem::put(ThreadState& state, Job const* job) noexcept {
     assert(job);
     assert(job >= mJobStorageBase && job < mJobStorageBase + MAX_JOB_COUNT);
 
-    size_t const index = job - mJobStorageBase;
+    uint16_t const index = uint16_t(job - mJobStorageBase + 1);
 
-    // put the job into the queue
-    workQueue.push(uint16_t(index + 1));
+    // Try to put into the fast 1-slot nextJob cache
+    uint16_t const prev = state.nextJob.exchange(index, std::memory_order_release);
+    if (UTILS_UNLIKELY(prev != 0)) {
+        // If nextJob was already occupied, push the older job into the workQueue
+        state.workQueue.push(prev);
+    }
 
-    // Increase our active job count. We MUST use std::memory_order_release here.
-    // If we used relaxed, the compiler or CPU could reorder this increment to happen 
-    // BEFORE workQueue.push(). If a preemption happened right there, other threads 
-    // would see mActiveJobs > 0, enter the steal() loop, fail to find the job, and 
-    // spin infinitely, recreating the exact same priority inversion lockup on the push side!
-    mActiveJobs.fetch_add(1, std::memory_order_release);
+    // Sequentially consistent write-read pairing (Dekker pattern):
+    // Producer writes mActiveJobs (W1) before reading mSleepingCounts (R1).
+    // Worker in loop() writes mSleepingCounts (W2) before reading mActiveJobs (R2).
+    // Using memory_order_seq_cst guarantees that if the worker observes mActiveJobs == 0
+    // and prepares to sleep, the producer is guaranteed to observe mSleepingCounts > 0
+    // and invoke wakeOne(), preventing lost wakeups without acquiring mWaiterLock.
+    mActiveJobs.fetch_add(1, std::memory_order_seq_cst);
 
-    // Note: it's absolutely possible for mActiveJobs to be 0 here, because the job could have
-    // been handled by a zealous worker already. In that case we could avoid calling wakeOne(),
-    // but that is not the common case.
-
-    wakeOne();
+    if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_seq_cst) > 0)) {
+        wakeOne();
+    }
 }
 
-JobSystem::Job* JobSystem::pop(WorkQueue& workQueue) noexcept {
-    // We speculatively decrement mActiveJobs before taking the job.
-    // If a thread is preempted here, mActiveJobs is temporarily undercounted.
-    // This is safe and desirable: it allows other idle threads to see 0 and go to sleep
-    // (yielding the CPU) instead of spinning infinitely on hasActiveJobs(),
-    // completely preventing priority inversion lockups.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
-    size_t const index = workQueue.pop();
+JobSystem::Job* JobSystem::pop(ThreadState& state) noexcept {
+    // 1. First check our 1-slot nextJob continuation bypass
+    uint16_t const nextIdx = state.nextJob.exchange(0, std::memory_order_acquire);
+    if (UTILS_LIKELY(nextIdx != 0)) {
+        mActiveJobs.fetch_sub(1, std::memory_order_relaxed);
+        return &mJobStorageBase[nextIdx - 1];
+    }
+
+    // 2. Fall back to popping from our workQueue
+    // By design, the owner thread must always attempt to pop from its own queue first without
+    // inspecting or decrementing mActiveJobs. Popping from our own queue is wait-free and
+    // contention-free. Gating pop() on global active job counters would cause owner threads to
+    // starve and falsely skip their own runnable jobs if a concurrent stealer has speculatively
+    // decremented mActiveJobs.
+    size_t const index = state.workQueue.pop();
     assert(index <= MAX_JOB_COUNT);
     Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
-    if (UTILS_UNLIKELY(!job)) {
-        // If we didn't actually get a job, restore the count.
-        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+    if (UTILS_LIKELY(job)) {
+        mActiveJobs.fetch_sub(1, std::memory_order_relaxed);
     }
     return job;
 }
 
-JobSystem::Job* JobSystem::steal(WorkQueue& workQueue) noexcept {
-    // See JobSystem::pop() for why we pre-decrement mActiveJobs.
-    mActiveJobs.fetch_sub(1, std::memory_order_acquire);
-    size_t const index = workQueue.steal();
-    assert_invariant(index <= MAX_JOB_COUNT);
-    Job* const job = !index ? nullptr : &mJobStorageBase[index - 1];
-    if (UTILS_UNLIKELY(!job)) {
-        mActiveJobs.fetch_add(1, std::memory_order_relaxed);
+JobSystem::Job* JobSystem::stealFrom(ThreadState& victim) noexcept {
+    // 1. Try to steal from victim's workQueue
+    size_t const index = victim.workQueue.steal();
+    if (index != 0) {
+        assert_invariant(index <= MAX_JOB_COUNT);
+        return &mJobStorageBase[index - 1];
     }
-    return job;
+
+    // 2. If workQueue is empty, try to steal victim's nextJob
+    uint16_t victimNext = victim.nextJob.load(std::memory_order_relaxed);
+    if (victimNext != 0) {
+        if (victim.nextJob.compare_exchange_strong(victimNext, 0,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            return &mJobStorageBase[victimNext - 1];
+        }
+    }
+
+    return nullptr;
 }
 
 inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state) noexcept {
     auto& threadStates = mThreadStates;
-    // memory_order_relaxed is okay because we don't take any action that has data dependency
-    // on this value (in particular mThreadStates, is always initialized properly).
-    uint16_t const adopted = mAdoptedThreads.load(std::memory_order_relaxed);
-    uint16_t const threadCount = mThreadCount + adopted;
+    uint16_t const threadCount = mActiveThreadCount.load(std::memory_order_relaxed);
 
     ThreadState* stateToStealFrom = nullptr;
 
     // don't try to steal from someone else if we're the only thread (infinite loop)
     if (threadCount >= 2) {
         do {
-            // This is biased, but frankly, we don't care. It's fast.
-            uint16_t const index = uint16_t(state.rndGen() % threadCount);
-            assert(index < threadStates.size());
+            // Fast range reduction (Lemire 2016, "Fast Random Integer Generation in an Interval",
+            // ACM Transactions on Modeling and Computer Simulation): avoids expensive hardware
+            // integer division (%) by scaling the 31-bit random integer as a fixed-point fraction.
+            uint16_t const index = uint16_t((uint64_t(state.rndGen()) * threadCount) >> 31);
+            assert_invariant(index < threadStates.size());
             stateToStealFrom = &threadStates[index];
             // don't steal from our own queue
         } while (stateToStealFrom == &state);
@@ -435,21 +504,69 @@ inline JobSystem::ThreadState* JobSystem::getStateToStealFrom(ThreadState& state
 
 JobSystem::Job* JobSystem::steal(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
+
+    // Fast check: if no jobs are active, avoid attempting to steal or touch atomics.
+    if (UTILS_UNLIKELY(!hasActiveJobs())) {
+        return nullptr;
+    }
+
+    // Speculatively claim one job count before searching across queues.
+    // If preempted while stealing or executing, mActiveJobs is already decremented,
+    // allowing other threads to sleep rather than spin (preventing priority inversions).
+    int32_t const prevActiveJobs = mActiveJobs.fetch_sub(1, std::memory_order_acquire);
+    if (UTILS_UNLIKELY(prevActiveJobs <= 0)) {
+        // Another thread took the last available job; restore count and exit immediately.
+        // Use seq_cst and wakeOne() in case a concurrent put() published work while
+        // we were negative, restoring mActiveJobs to > 0.
+        mActiveJobs.fetch_add(1, std::memory_order_seq_cst);
+        if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_seq_cst) > 0)) {
+            wakeOne();
+        }
+        return nullptr;
+    }
+
     Job* job = nullptr;
+    uint16_t const activeThreads = mActiveThreadCount.load(std::memory_order_relaxed);
+
+    // Search queues for the job we claimed, bounded strictly to activeThreads attempts.
+    // Note: It is incorrect to check hasActiveJobs() in this loop because:
+    // 1) mActiveJobs was already speculatively decremented above (so it may read 0 even if
+    //    our claimed job is waiting in another queue).
+    // 2) Checking hasActiveJobs() would turn this into an unbounded busy loop whenever jobs
+    //    remain in other queues.
+    // Bounding strictly to activeThreads guarantees prompt termination while giving a high
+    // probability of finding available work.
+    size_t attempts = 0;
     do {
         if (ThreadState* const stateToStealFrom = getStateToStealFrom(state)) {
-            job = steal(stateToStealFrom->workQueue);
+            job = stealFrom(*stateToStealFrom);
+        } else {
+            break;
         }
-        // nullptr -> nothing to steal in that queue either, if there are active jobs,
-        // continue to try stealing one.
-    } while (!job && hasActiveJobs());
+        attempts++;
+    } while (!job && attempts < activeThreads);
+
+    if (UTILS_UNLIKELY(!job)) {
+        // If we couldn't find a job (e.g. consumed concurrently or missed by bounded probe),
+        // restore the active job count.
+        // Sequentially consistent store-load pairing (Dekker pattern):
+        // We must announce the restored active job count with seq_cst and wake a sleeping worker
+        // or waiter if any exist. If pool workers checked mActiveJobs during our speculative
+        // decrement window (when mActiveJobs was temporarily <= 0) and went to sleep, failing to
+        // wake them here would orphan the active job in its queue, causing a lost-wakeup deadlock.
+        mActiveJobs.fetch_add(1, std::memory_order_seq_cst);
+        if (UTILS_UNLIKELY(mSleepingCounts.load(std::memory_order_seq_cst) > 0)) {
+            wakeOne();
+        }
+    }
+
     return job;
 }
 
 bool JobSystem::execute(ThreadState& state) noexcept {
     HEAVY_FILAMENT_TRACING_CALL(FILAMENT_TRACING_CATEGORY_JOBSYSTEM);
 
-    Job* job = pop(state.workQueue);
+    Job* job = pop(state);
 
     // It is beneficial for some benchmarks to poll on steal() for a bit, because going back to
     // sleep and waking up is pretty expensive. However, it is unclear it helps in practice with
@@ -478,21 +595,23 @@ void JobSystem::loop(ThreadState* state) {
     setThreadPriority(Priority::DISPLAY);
 
     // record our work queue
-    bool inserted;
-    {
-        LockGuard const lock(mThreadMapLock);
-        inserted = mThreadMap.emplace(std::this_thread::get_id(), state).second;
-    }
-
-    FILAMENT_CHECK_PRECONDITION(inserted) << "This thread is already in a loop.";
+    size_t const index = std::distance(mThreadStates.data(), state);
+    mThreadMap->set(uint32_t(index), state);
 
     // run our main loop...
     do {
         if (!execute(*state)) {
             UniqueLock lock(mWaiterLock);
-            while (!exitRequested() && !hasActiveJobs()) {
-                wait(lock);
+            // Sequentially consistent write-read pairing (Dekker pattern):
+            // 1. Announce intent to sleep by incrementing mSleepingCounts (seq_cst).
+            // 2. Check mActiveJobs (seq_cst) before sleeping on mWorkCondition.
+            // This guarantees that any concurrent producer in put() or steal() will observe
+            // mSleepingCounts > 0 and call wakeOne() if it publishes/restores work after our check.
+            mSleepingCounts.fetch_add(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);
+            while (!exitRequested() && mActiveJobs.load(std::memory_order_seq_cst) <= 0) {
+                waitForWork(lock);
             }
+            mSleepingCounts.fetch_sub(SLEEPING_WORKER_ONE, std::memory_order_seq_cst);
         }
     } while (!exitRequested());
 }
@@ -530,7 +649,7 @@ void JobSystem::finish(Job* job) noexcept {
     // wake-up all threads that could potentially be waiting on this job finishing
     if (UTILS_UNLIKELY(notify)) {
         // but avoid calling notify_all() at all cost, because it's always expensive
-        wakeAll();
+        wakeWaiters();
     }
 }
 
@@ -583,7 +702,7 @@ void JobSystem::run(Job*& job) noexcept {
 
     ThreadState& state(getState());
 
-    put(state.workQueue, job);
+    put(state, job);
 
     // after run() returns, the job is virtually invalid (it'll die on its own)
     job = nullptr;
@@ -595,7 +714,7 @@ void JobSystem::run(Job*& job, uint8_t const id) noexcept {
     ThreadState& state = mThreadStates[id];
     assert_invariant(&state == &getState());
 
-    put(state.workQueue, job);
+    put(state, job);
 
     // after run() returns, the job is virtually invalid (it'll die on its own)
     job = nullptr;
@@ -616,20 +735,15 @@ void JobSystem::waitAndRelease(Job*& job) noexcept {
     ThreadState& state(getState());
     do {
         if (UTILS_UNLIKELY(!execute(state))) {
-            // test if job has completed first, to possibly avoid taking the lock
-            if (hasJobCompleted(job)) {
+            // test if job has completed or exit was requested first, to possibly avoid taking the lock
+            if (hasJobCompleted(job) || exitRequested()) {
                 break;
             }
 
-            // the only way we can be here is if the job we're waiting on it being handled
-            // by another thread:
-            //    - we returned from execute() which means all queues are empty
-            //    - yet our job hasn't completed yet
-            //    ergo, it's being run in another thread
-            //
-            // this could take time however, so we will wait with a condition, and
-            // continue to handle more jobs, as they get added.
-
+            // If execute() returned false, either:
+            //   - all queues are empty (mActiveJobs <= 0) and any remaining work is actively running; or
+            //   - work was published or restored concurrently, in which case the Dekker check in
+            //     waitForJob() will prevent sleeping, or the publisher will signal wakeOne().
             UniqueLock lock(mWaiterLock);
             uint32_t const runningJobCount = wait(lock, job);
             // we could be waking up because either:
@@ -663,15 +777,7 @@ void JobSystem::runAndWait(Job*& job) noexcept {
 }
 
 void JobSystem::adopt() {
-    const auto tid = std::this_thread::get_id();
-
-    ThreadState const* state = nullptr;
-    {
-        LockGuard const lock(mThreadMapLock);
-        auto const iter = mThreadMap.find(tid);
-        state = iter ==  mThreadMap.end() ? nullptr : iter->second;
-    }
-
+    ThreadState const* const state = mThreadMap->get();
     if (state) {
         // we're already part of a JobSystem, do nothing.
         FILAMENT_CHECK_PRECONDITION(this == state->js)
@@ -680,12 +786,23 @@ void JobSystem::adopt() {
         return;
     }
 
-    // memory_order_relaxed is safe because we don't take action on this value.
-    uint16_t const adopted = mAdoptedThreads.fetch_add(1, std::memory_order_relaxed);
-    size_t const index = mThreadCount + adopted;
+    uint32_t mask = mAdoptableSlotsMask.load(std::memory_order_relaxed);
+    uint32_t bit = 0;
+    do {
+        FILAMENT_CHECK_POSTCONDITION(mask != 0)
+                << "Too many calls to adopt(). No more adoptable threads!";
+        bit = 1u << utils::ctz(mask);
+    } while (!mAdoptableSlotsMask.compare_exchange_weak(mask, mask & ~bit,
+            std::memory_order_acquire, std::memory_order_relaxed));
 
+    size_t const index = utils::ctz(bit);
     FILAMENT_CHECK_POSTCONDITION(index < mThreadStates.size())
             << "Too many calls to adopt(). No more adoptable threads!";
+
+    uint16_t const targetCount = uint16_t(index + 1);
+    uint16_t current = mActiveThreadCount.load(std::memory_order_relaxed);
+    while (targetCount > current && !mActiveThreadCount.compare_exchange_weak(current, targetCount,
+            std::memory_order_relaxed, std::memory_order_relaxed)) {}
 
     // all threads adopted by the JobSystem need to run at the same priority
     setThreadPriority(Priority::DISPLAY);
@@ -694,20 +811,19 @@ void JobSystem::adopt() {
     // however, it's not a problem since mThreadState is pre-initialized and valid
     // (e.g.: the queue is empty).
 
-    {
-        LockGuard const lock(mThreadMapLock);
-        mThreadMap[tid] = &mThreadStates[index];
-    }
+    mThreadMap->set(uint32_t(index), &mThreadStates[index]);
 }
 
 void JobSystem::emancipate() {
-    const auto tid = std::this_thread::get_id();
-    LockGuard const lock(mThreadMapLock);
-    auto const iter = mThreadMap.find(tid);
-    ThreadState const* const state = iter ==  mThreadMap.end() ? nullptr : iter->second;
+    ThreadState const* const state = mThreadMap->get();
     FILAMENT_CHECK_PRECONDITION(state) << "this thread is not an adopted thread";
     FILAMENT_CHECK_PRECONDITION(state->js == this) << "this thread is not adopted by us";
-    mThreadMap.erase(iter);
+    size_t const index = std::distance(mThreadStates.data(), const_cast<ThreadState*>(state));
+    FILAMENT_CHECK_PRECONDITION(index >= mThreadCount)
+            << "cannot emancipate a pool worker thread (index: " << index
+            << ", threadCount: " << mThreadCount << ")";
+    mThreadMap->erase();
+    mAdoptableSlotsMask.fetch_or(1u << index, std::memory_order_release);
 }
 
 io::ostream& operator<<(io::ostream& out, JobSystem const& js) {
@@ -717,5 +833,7 @@ io::ostream& operator<<(io::ostream& out, JobSystem const& js) {
     }
     return out;
 }
+
+template class ThreadMap<JobSystem::ThreadState*>;
 
 } // namespace utils

--- a/libs/utils/test/test_JobSystem.cpp
+++ b/libs/utils/test/test_JobSystem.cpp
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
+#include <utils/Allocator.h>
 #include <utils/JobSystem.h>
+#include <utils/Panic.h>
 #include <utils/WorkStealingDequeue.h>
 
-#include <math/vec3.h>
 #include <math/mat3.h>
+#include <math/vec3.h>
+
+#include <gtest/gtest.h>
 
 #include <array>
 #include <thread>
-#include <utils/Allocator.h>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <time.h>
+#endif
 
 using namespace utils;
 using namespace jobs;
@@ -284,6 +292,244 @@ TEST(JobSystem, JobSystemParallelFor) {
     js.emancipate();
 }
 
+TEST(JobSystem, JobSystemParallelForLargeChunkSize) {
+    JobSystem js;
+    js.adopt();
+
+    constexpr size_t COUNT = 131072;
+    std::vector<uint32_t> data(COUNT, 0);
+
+    // Test with chunkSize = 65536 (exact multiple of 2^16, which would truncate to 0 in uint16_t)
+    JobSystem::Job* job1 = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 1;
+                }
+            }, CountSplitter<65536>());
+    js.runAndWait(job1);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 1u);
+    }
+
+    // Test with chunkSize = 70000 (> 2^16)
+    JobSystem::Job* job2 = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 2;
+                }
+            }, CountSplitter<70000>());
+    js.runAndWait(job2);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 3u);
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForConstInvocability) {
+    // 1. Regular/const lambdas are const-invocable
+    auto constLambda = [](uint32_t, uint32_t) {};
+    static_assert(std::is_invocable_v<decltype(constLambda) const&, uint32_t, uint32_t>);
+
+    // 2. Mutable lambdas are NOT const-invocable
+    auto mutableLambda = [x = 0](uint32_t, uint32_t) mutable { (void)x; };
+    static_assert(!std::is_invocable_v<decltype(mutableLambda) const&, uint32_t, uint32_t>);
+
+    // 3. std::ref allows explicit thread-safe mutable state sharing
+    struct MutableState {
+        std::atomic<uint32_t> total{0};
+        void operator()(uint32_t, uint32_t count) {
+            total.fetch_add(count, std::memory_order_relaxed);
+        }
+    } state;
+    static_assert(std::is_invocable_v<decltype(std::ref(state)) const&, uint32_t, uint32_t>);
+
+    JobSystem js;
+    js.adopt();
+    JobSystem::Job* job = parallel_for(js, nullptr, 0, 1000, std::ref(state));
+    js.runAndWait(job);
+    EXPECT_EQ(1000u, state.total.load());
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForLargeStartOffset) {
+    JobSystem js;
+    js.adopt();
+
+    std::atomic<uint32_t> itemsProcessed{0};
+    std::atomic<bool> allIndicesValid{true};
+    // Maximum valid 32-bit range ending exactly at 2^32 (index 0xFFFFFFFF)
+    uint32_t const start = 0xFFFFFFE0u;
+    uint32_t const count = 32;
+
+    JobSystem::Job* job = parallel_for(js, nullptr, start, count,
+            [&itemsProcessed, &allIndicesValid, start, count](uint32_t s, uint32_t c) {
+                if (s < start || uint64_t(s) + c > uint64_t(start) + count) {
+                    allIndicesValid.store(false, std::memory_order_relaxed);
+                }
+                itemsProcessed.fetch_add(c, std::memory_order_relaxed);
+            }, CountSplitter<4>());
+    ASSERT_NE(nullptr, job);
+    js.runAndWait(job);
+
+    EXPECT_TRUE(allIndicesValid.load());
+    EXPECT_EQ(32u, itemsProcessed.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForRangeOverflowReturnsNullptr) {
+    JobSystem js;
+    js.adopt();
+
+    // 1. count exceeds 2^31 - 1
+    JobSystem::Job* job1 = parallel_for(js, nullptr, 0, 0x80000000u, [](uint32_t, uint32_t) {});
+    EXPECT_EQ(nullptr, job1);
+
+    // 2. start + count exceeds 2^32 (32-bit range overflow / wrap)
+    JobSystem::Job* job2 = parallel_for(js, nullptr, 0xFFFFFFF0u, 32, [](uint32_t, uint32_t) {});
+    EXPECT_EQ(nullptr, job2);
+
+    // 3. start = UINT32_MAX, count = 2
+    JobSystem::Job* job3 = parallel_for(js, nullptr, 0xFFFFFFFFu, 2, [](uint32_t, uint32_t) {});
+    EXPECT_EQ(nullptr, job3);
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForEmptyCount) {
+    JobSystem js;
+    js.adopt();
+
+    bool called = false;
+    JobSystem::Job* job = parallel_for(js, nullptr, 0, 0,
+            [&called](uint32_t, uint32_t) {
+                called = true;
+            });
+    ASSERT_NE(job, nullptr);
+    js.runAndWait(job);
+
+    EXPECT_FALSE(called);
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForCancel) {
+    JobSystem js;
+    js.adopt();
+
+    std::atomic<bool> called{false};
+    JobSystem::Job* job = parallel_for(js, nullptr, 0, 100,
+            [&called](uint32_t, uint32_t) {
+                called.store(true, std::memory_order_relaxed);
+            });
+    ASSERT_NE(job, nullptr);
+    js.cancel(job);
+    EXPECT_EQ(job, nullptr);
+    EXPECT_FALSE(called.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemParallelForAdoptedThreads) {
+    JobSystem js(1, 3);
+    js.adopt();
+
+    std::atomic<bool> bgRunning{true};
+    std::atomic<int> bgAdoptedCount{0};
+    std::vector<std::thread> bgThreads;
+    for (int i = 0; i < 2; ++i) {
+        bgThreads.emplace_back([&js, &bgRunning, &bgAdoptedCount]() {
+            js.adopt();
+            bgAdoptedCount.fetch_add(1, std::memory_order_release);
+            while (bgRunning.load(std::memory_order_relaxed)) {
+                std::this_thread::yield();
+            }
+            js.emancipate();
+        });
+    }
+
+    while (bgAdoptedCount.load(std::memory_order_acquire) < 2) {
+        std::this_thread::yield();
+    }
+
+    EXPECT_GE(js.getActiveThreadCount(), 3u);
+
+    constexpr size_t COUNT = 1000;
+    std::vector<uint32_t> data(COUNT, 0);
+    JobSystem::Job* job = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] += 1;
+                }
+            }, CountSplitter<10>());
+    js.runAndWait(job);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data[i], 1u);
+    }
+
+    bgRunning.store(false, std::memory_order_release);
+    for (auto& t : bgThreads) {
+        t.join();
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemCustomSplitters) {
+    JobSystem js;
+    js.adopt();
+
+    struct CustomFixedSplitter {
+        size_t getChunkSize() const noexcept { return 8; }
+    };
+
+    struct CustomDynamicSplitter {
+        size_t getChunkSize(uint32_t count, uint32_t threadCount) const noexcept {
+            return std::max<uint32_t>(1, count / (threadCount * 2));
+        }
+    };
+
+    constexpr size_t COUNT = 128;
+    std::vector<uint32_t> data1(COUNT, 0);
+    std::vector<uint32_t> data2(COUNT, 0);
+
+    JobSystem::Job* job1 = parallel_for(js, nullptr, data1.data(), data1.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) ptr[i] += 1;
+            }, CustomFixedSplitter{});
+    js.runAndWait(job1);
+
+    JobSystem::Job* job2 = parallel_for(js, nullptr, data2.data(), data2.size(),
+            [](uint32_t* ptr, size_t count) {
+                for (size_t i = 0; i < count; ++i) ptr[i] += 2;
+            }, CustomDynamicSplitter{});
+    js.runAndWait(job2);
+
+    for (size_t i = 0; i < COUNT; ++i) {
+        EXPECT_EQ(data1[i], 1u);
+        EXPECT_EQ(data2[i], 2u);
+    }
+
+    // Test CountSplitter with 1 and 2 template parameters and max chunk capping
+    CountSplitter<1, 12> defaultSplitter;
+    EXPECT_EQ(1u, defaultSplitter.getChunkSize(1024, 4));
+    // For 1,000,000 items with MAX_SPLITS = 12 (4096 chunks max), chunk size is ceil(1000000 / 4096) = 245
+    EXPECT_EQ(245u, defaultSplitter.getChunkSize(1000000, 4));
+
+    CountSplitter<64, 8> customCappedSplitter;
+    // MAX_SPLITS = 8 (256 chunks max)
+    // For 1,000 items, 1000 / 256 = 4 < 64 (COUNT floor takes precedence)
+    EXPECT_EQ(64u, customCappedSplitter.getChunkSize(1000, 4));
+    // For 100,000 items, ceil(100000 / 256) = 391 >= 64
+    EXPECT_EQ(391u, customCappedSplitter.getChunkSize(100000, 4));
+
+    js.emancipate();
+}
+
 TEST(JobSystem, JobSystemDelegates) {
     JobSystem js;
     js.adopt();
@@ -343,4 +589,701 @@ TEST(JobSystem, JobSystemDelegates) {
 
 
     js.emancipate();
+}
+
+TEST(JobSystem, JobSystemConcurrentStress) {
+    // 8 worker threads + 16 adoptable user threads
+    JobSystem js(8, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 20;
+    constexpr size_t ARRAY_SIZE = 1024;
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    std::atomic<uint64_t> totalSum{0};
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&, t]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+
+                std::vector<uint32_t> data(ARRAY_SIZE, uint32_t(t + 1));
+                auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+                        [](uint32_t* slice, size_t count) {
+                            for (size_t i = 0; i < count; ++i) {
+                                slice[i] *= 2;
+                            }
+                        }, CountSplitter<4>());
+                js.runAndWait(job);
+
+                uint64_t localSum = 0;
+                for (uint32_t val : data) {
+                    localSum += val;
+                }
+                totalSum.fetch_add(localSum, std::memory_order_relaxed);
+
+                js.emancipate();
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    uint64_t expectedTotal = 0;
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        expectedTotal += uint64_t(t + 1) * 2 * ARRAY_SIZE * ITERATIONS;
+    }
+
+    EXPECT_EQ(totalSum.load(), expectedTotal);
+}
+
+TEST(JobSystem, JobSystemBurstyWake) {
+    JobSystem js(4, 1);
+    js.adopt();
+
+    std::atomic<uint32_t> completedJobs{0};
+
+    // Part 1: Submit 1 job, wait for completion, sleep to ensure workers go to sleep, repeat
+    for (size_t i = 0; i < 30; ++i) {
+        JobSystem::Job* job = js.createJob(nullptr, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.runAndWait(job);
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+
+    EXPECT_EQ(30u, completedJobs.load());
+
+    // Part 2: Sudden burst of 100 jobs after idle period
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    for (size_t i = 0; i < 100; ++i) {
+        JobSystem::Job* child = js.createJob(root, [&completedJobs](JobSystem&, JobSystem::Job*) {
+            completedJobs.fetch_add(1, std::memory_order_relaxed);
+        });
+        js.run(child);
+    }
+    js.runAndWait(root);
+
+    EXPECT_EQ(130u, completedJobs.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemDeepTreeMultiWait) {
+    JobSystem js(8, 8);
+    js.adopt();
+
+    std::atomic<uint32_t> leafCount{0};
+
+    auto buildTree = [&](auto& self, JobSystem::Job* parent, int depth) -> void {
+        if (depth == 0) {
+            JobSystem::Job* leaf = js.createJob(parent, [&leafCount](JobSystem&, JobSystem::Job*) {
+                leafCount.fetch_add(1, std::memory_order_relaxed);
+            });
+            js.run(leaf);
+            return;
+        }
+        for (int i = 0; i < 4; ++i) {
+            JobSystem::Job* node = js.createJob(parent, [](JobSystem&, JobSystem::Job*) {});
+            self(self, node, depth - 1);
+            js.run(node);
+        }
+    };
+
+    JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+    buildTree(buildTree, root, 4); // 4^4 = 256 leaves
+
+    // Retain root so we can wait on it from multiple threads
+    js.retain(root);
+    js.retain(root);
+    js.retain(root);
+
+    std::atomic<bool> start{false};
+    std::vector<std::thread> waitingThreads;
+    for (int t = 0; t < 3; ++t) {
+        waitingThreads.emplace_back([&, root]() {
+            js.adopt();
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            JobSystem::Job* r = root;
+            js.waitAndRelease(r);
+            js.emancipate();
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    js.runAndWait(root);
+
+    for (auto& t : waitingThreads) {
+        t.join();
+    }
+
+    EXPECT_EQ(256u, leafCount.load());
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemPoolExhaustionAndChurn) {
+    JobSystem js(8, 8);
+
+    constexpr size_t THREAD_COUNT = 8;
+    constexpr size_t BATCH_SIZE = 1200; // 8 * 1200 = 9600 active jobs simultaneously
+    std::atomic<uint32_t> jobsExecuted{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            js.adopt();
+            for (size_t iter = 0; iter < 3; ++iter) {
+                JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+                for (size_t i = 0; i < BATCH_SIZE; ++i) {
+                    JobSystem::Job* child = js.createJob(root, [&jobsExecuted](JobSystem&, JobSystem::Job*) {
+                        jobsExecuted.fetch_add(1, std::memory_order_relaxed);
+                    });
+                    js.run(child);
+                }
+                js.runAndWait(root);
+            }
+            js.emancipate();
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * BATCH_SIZE * 3, jobsExecuted.load());
+}
+
+TEST(JobSystem, JobSystemSingleThreaded) {
+    JobSystem js(JobSystem::SINGLE_THREADED);
+    js.adopt();
+
+    std::vector<uint32_t> data(512, 10);
+    auto* job = parallel_for(js, nullptr, data.data(), data.size(),
+            [](uint32_t* slice, size_t count) {
+                for (size_t i = 0; i < count; ++i) {
+                    slice[i] += 5;
+                }
+            }, CountSplitter<4>());
+    js.runAndWait(job);
+
+    for (uint32_t val : data) {
+        EXPECT_EQ(15u, val);
+    }
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemMultipleInstances) {
+    JobSystem js1(4, 4);
+    JobSystem js2(4, 4);
+
+    std::atomic<uint32_t> count1{0};
+    std::atomic<uint32_t> count2{0};
+
+    std::thread t1([&]() {
+        js1.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js1.createJob(nullptr, [&count1](JobSystem&, JobSystem::Job*) {
+                count1.fetch_add(1, std::memory_order_relaxed);
+            });
+            js1.runAndWait(job);
+        }
+        js1.emancipate();
+    });
+
+    std::thread t2([&]() {
+        js2.adopt();
+        for (int i = 0; i < 100; ++i) {
+            JobSystem::Job* job = js2.createJob(nullptr, [&count2](JobSystem&, JobSystem::Job*) {
+                count2.fetch_add(1, std::memory_order_relaxed);
+            });
+            js2.runAndWait(job);
+        }
+        js2.emancipate();
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(100u, count1.load());
+    EXPECT_EQ(100u, count2.load());
+}
+
+TEST(JobSystem, JobSystemRapidAdoptEmancipate) {
+    JobSystem js(4, 16);
+
+    constexpr size_t THREAD_COUNT = 16;
+    constexpr size_t ITERATIONS = 100;
+
+    std::atomic<uint32_t> jobsCompleted{0};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (size_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&]() {
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                js.adopt();
+                JobSystem::Job* job = js.createJob(nullptr, [&jobsCompleted](JobSystem&, JobSystem::Job*) {
+                    jobsCompleted.fetch_add(1, std::memory_order_relaxed);
+                });
+                js.runAndWait(job);
+                js.emancipate();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(THREAD_COUNT * ITERATIONS, jobsCompleted.load());
+}
+
+template<typename F>
+static bool runWithTimeout(F&& fn, std::chrono::milliseconds timeout) {
+    struct SharedState {
+        std::atomic<bool> completed{false};
+        std::decay_t<F> func;
+        explicit SharedState(F&& f) : func(std::forward<F>(f)) {}
+    };
+
+    auto state = std::make_shared<SharedState>(std::forward<F>(fn));
+    std::thread t([state]() {
+        state->func();
+        state->completed.store(true, std::memory_order_release);
+    });
+    auto const start = std::chrono::steady_clock::now();
+    while (!state->completed.load(std::memory_order_acquire)) {
+        if (std::chrono::steady_clock::now() - start > timeout) {
+            t.detach();
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    t.join();
+    return true;
+}
+
+TEST(JobSystem, JobSystemWorkerWakeOnSubsequentPut) {
+    bool const finished = runWithTimeout([]() {
+        // 3 worker threads in the pool, 1 adoptable
+        JobSystem js(3, 1);
+        js.adopt();
+
+        // Ensure all 3 workers are idle and sleeping
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+
+        std::atomic<int> concurrentWorkers{0};
+        std::atomic<int> maxConcurrent{0};
+
+        auto jobFunc = [&](JobSystem&, JobSystem::Job*) {
+            int const cur = concurrentWorkers.fetch_add(1, std::memory_order_relaxed) + 1;
+            int prevMax = maxConcurrent.load(std::memory_order_relaxed);
+            while (cur > prevMax && !maxConcurrent.compare_exchange_weak(prevMax, cur,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {}
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            concurrentWorkers.fetch_sub(1, std::memory_order_relaxed);
+        };
+
+        // Push 10 jobs in rapid succession
+        for (int i = 0; i < 10; ++i) {
+            JobSystem::Job* j = js.createJob(root, jobFunc);
+            js.run(j);
+        }
+
+        // Wait for all 10 jobs to complete via root
+        js.runAndWait(root);
+
+        // With 3 pool workers and 1 caller thread in runAndWait, all 3 pool workers should be woken
+        EXPECT_GE(maxConcurrent.load(), 3)
+                << "Not all sleeping workers were woken! maxConcurrent: " << maxConcurrent.load();
+
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+
+TEST(JobSystem, JobSystemStealFromEmancipatedQueue) {
+    bool const finished = runWithTimeout([]() {
+        JobSystem js(4, 2);
+        js.adopt();
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        JobSystem::Job* child = js.createJob(root, [](JobSystem&, JobSystem::Job*) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        });
+
+        std::thread runner([&]() {
+            js.adopt();
+            js.run(child);
+            js.emancipate();
+        });
+        runner.join();
+
+        js.runAndWait(root);
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+
+namespace {
+
+static double getThreadCpuTimeMs() noexcept {
+#if defined(_WIN32)
+    FILETIME creationTime, exitTime, kernelTime, userTime;
+    if (GetThreadTimes(GetCurrentThread(), &creationTime, &exitTime, &kernelTime, &userTime)) {
+        ULARGE_INTEGER kernel, user;
+        kernel.LowPart = kernelTime.dwLowDateTime;
+        kernel.HighPart = kernelTime.dwHighDateTime;
+        user.LowPart = userTime.dwLowDateTime;
+        user.HighPart = userTime.dwHighDateTime;
+        return double(kernel.QuadPart + user.QuadPart) / 10000.0;
+    }
+    return 0.0;
+#elif defined(CLOCK_THREAD_CPUTIME_ID)
+    struct timespec ts {};
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0) {
+        return (double(ts.tv_sec) * 1000.0) + (double(ts.tv_nsec) / 1000000.0);
+    }
+    return 0.0;
+#else
+    return 0.0;
+#endif
+}
+
+} // namespace
+
+TEST(JobSystem, JobSystemWaitAndReleaseDoesNotBusySpin) {
+    JobSystem js(4, 28);
+    js.adopt();
+
+    // 4 worker threads run 100ms tasks
+    std::atomic<int> runningWorkers{0};
+    JobSystem::Job* targetJob = nullptr;
+    for (int i = 0; i < 4; ++i) {
+        JobSystem::Job* w = js.createJob(nullptr, [&](JobSystem&, JobSystem::Job*) {
+            runningWorkers.fetch_add(1, std::memory_order_relaxed);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        });
+        if (i == 0) {
+            targetJob = js.runAndRetain(w);
+        } else {
+            js.run(w);
+        }
+    }
+
+    while (runningWorkers.load(std::memory_order_relaxed) < 4) {
+        std::this_thread::yield();
+    }
+
+    // Push 1 job into a separate adopted thread's queue
+    std::atomic<bool> bgDone{false};
+    std::thread bgThread([&]() {
+        js.adopt();
+        JobSystem::Job* extra = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        js.run(extra);
+        while (!bgDone.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        js.emancipate();
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    double const startCpuTime = getThreadCpuTimeMs();
+
+    js.waitAndRelease(targetJob);
+
+    double const endCpuTime = getThreadCpuTimeMs();
+
+    bgDone.store(true, std::memory_order_release);
+    bgThread.join();
+
+    double const cpuTimeMs = endCpuTime - startCpuTime;
+
+    EXPECT_LT(cpuTimeMs, 30.0)
+            << "waitAndRelease() busy-spun at 100% CPU! Consumed " << cpuTimeMs
+            << "ms CPU time while waiting for 100ms child job.";
+
+    js.emancipate();
+}
+
+TEST(JobSystem, JobSystemStealingWithManyAdoptableSlots) {
+    bool const finished = runWithTimeout([]() {
+        // 4 pool threads, 28 adoptable slots (32 total)
+        JobSystem js(4, 28);
+        js.adopt();
+
+        std::atomic<uint32_t> completed{0};
+        constexpr size_t JOB_COUNT = 2000;
+
+        JobSystem::Job* root = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+        for (size_t i = 0; i < JOB_COUNT; ++i) {
+            JobSystem::Job* child = js.createJob(root, [&completed](JobSystem&, JobSystem::Job*) {
+                completed.fetch_add(1, std::memory_order_relaxed);
+            });
+            js.run(child);
+        }
+        js.runAndWait(root);
+
+        EXPECT_EQ(JOB_COUNT, completed.load());
+
+        js.emancipate();
+    }, std::chrono::seconds(2));
+
+    EXPECT_TRUE(finished);
+}
+
+TEST(JobSystem, JobSystemLostWakeupRace) {
+    bool const finished = runWithTimeout([]() {
+        constexpr size_t WORKER_COUNT = 1;
+        constexpr size_t PRODUCER_COUNT = 4;
+        constexpr size_t ITERATIONS = 5000;
+
+        JobSystem js(WORKER_COUNT, PRODUCER_COUNT);
+
+        std::atomic<uint32_t> completed{0};
+        for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+            std::atomic<bool> startFlag{false};
+            std::vector<std::thread> producers;
+            producers.reserve(PRODUCER_COUNT);
+
+            for (size_t p = 0; p < PRODUCER_COUNT; ++p) {
+                producers.emplace_back([&js, &completed, &startFlag]() {
+                    js.adopt();
+                    while (!startFlag.load(std::memory_order_acquire)) {
+                        std::this_thread::yield();
+                    }
+                    JobSystem::Job* job = js.createJob(nullptr, [&completed](JobSystem&, JobSystem::Job*) {
+                        completed.fetch_add(1, std::memory_order_release);
+                    });
+                    js.run(job);
+                    js.emancipate();
+                });
+            }
+
+            // Let worker enter sleep state
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+            // Release all producers simultaneously to race with worker sleep
+            startFlag.store(true, std::memory_order_release);
+
+            for (auto& t : producers) {
+                t.join();
+            }
+
+            uint32_t const expected = uint32_t((iter + 1) * PRODUCER_COUNT);
+            auto const start = std::chrono::steady_clock::now();
+            while (completed.load(std::memory_order_acquire) < expected) {
+                if (std::chrono::steady_clock::now() - start > std::chrono::milliseconds(200)) {
+                    FAIL() << "Lost wakeup at iteration " << iter << ": completed "
+                           << completed.load() << " / " << expected << " jobs!";
+                    return;
+                }
+                std::this_thread::yield();
+            }
+        }
+    }, std::chrono::seconds(10));
+
+    EXPECT_TRUE(finished);
+}
+
+TEST(JobSystem, JobSystemThreadBudgetClamping) {
+    // 1. Requesting adoptableThreadsCount >= MAX_THREADS (32) must still ensure at least 1 pool worker.
+    JobSystem js1(0, 32);
+    EXPECT_GE(js1.getThreadCount(), 1u);
+
+    // 2. Requesting large userThreadCount and large adoptableThreadsCount must clamp total to MAX_THREADS (32).
+    JobSystem js2(32, 16);
+    EXPECT_EQ(js2.getThreadCount(), 16u);
+
+    // 3. SINGLE_THREADED mode must have 0 pool workers.
+    JobSystem jsSingle(JobSystem::SINGLE_THREADED, 1);
+    EXPECT_EQ(jsSingle.getThreadCount(), 0u);
+}
+
+TEST(JobSystem, StealMissLostWakeupHang) {
+    bool const finished = runWithTimeout([]() {
+        constexpr size_t WORKER_COUNT = 4;
+        constexpr size_t ITERATIONS = 2000;
+
+        JobSystem js(WORKER_COUNT, 1);
+        js.adopt();
+
+        for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+            std::atomic<bool> childExecuted{false};
+
+            JobSystem::Job* parent = js.createJob();
+            JobSystem::Job* trigger = js.createJob(parent, [&js, parent, &childExecuted](JobSystem&, JobSystem::Job*) {
+                // Spawn a child from a worker thread so it is queued in this worker's workQueue
+                JobSystem::Job* child = js.createJob(parent, [&childExecuted](JobSystem&, JobSystem::Job*) {
+                    childExecuted.store(true, std::memory_order_release);
+                });
+                js.run(child);
+            });
+
+            js.run(trigger);
+            js.runAndWait(parent);
+
+            EXPECT_TRUE(childExecuted.load(std::memory_order_acquire));
+        }
+
+        js.emancipate();
+    }, std::chrono::seconds(10));
+
+    EXPECT_TRUE(finished) << "JobSystem hung in runAndWait due to lost wakeup on steal miss!";
+}
+
+TEST(JobSystem, StealEarlyExitLostWakeupRace) {
+    bool const finished = runWithTimeout([]() {
+        constexpr size_t WORKER_COUNT = 1;
+        constexpr size_t ITERATIONS = 2000;
+
+        JobSystem js(WORKER_COUNT, 2);
+
+        for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+            std::atomic<bool> job1Done{false};
+            std::atomic<bool> job2Done{false};
+
+            std::thread stealer([&js]() {
+                js.adopt();
+                // Execute repeatedly to race with worker and producer on active count
+                for (int i = 0; i < 10; ++i) {
+                    JobSystem::Job* dummy = js.createJob(nullptr, [](JobSystem&, JobSystem::Job*) {});
+                    js.run(dummy);
+                }
+                js.emancipate();
+            });
+
+            std::thread producer([&js, &job1Done, &job2Done]() {
+                js.adopt();
+                JobSystem::Job* j1 = js.createJob(nullptr, [&job1Done](JobSystem&, JobSystem::Job*) {
+                    job1Done.store(true, std::memory_order_release);
+                });
+                JobSystem::Job* j2 = js.createJob(nullptr, [&job2Done](JobSystem&, JobSystem::Job*) {
+                    job2Done.store(true, std::memory_order_release);
+                });
+                js.run(j1);
+                std::this_thread::yield();
+                js.run(j2);
+                js.emancipate();
+            });
+
+            stealer.join();
+            producer.join();
+
+            auto const start = std::chrono::steady_clock::now();
+            while (!job1Done.load(std::memory_order_acquire) || !job2Done.load(std::memory_order_acquire)) {
+                if (std::chrono::steady_clock::now() - start > std::chrono::milliseconds(100)) {
+                    FAIL() << "Lost wakeup at iteration " << iter << " on early-exit restore race!";
+                    return;
+                }
+                std::this_thread::yield();
+            }
+        }
+    }, std::chrono::seconds(10));
+
+    EXPECT_TRUE(finished) << "JobSystem hung due to lost wakeup in steal early-exit path!";
+}
+
+TEST(JobSystem, NestedWaiterLostWakeupRace) {
+    bool const finished = runWithTimeout([]() {
+        constexpr size_t WORKER_COUNT = 1;
+        constexpr size_t ITERATIONS = 2000;
+
+        JobSystem js(WORKER_COUNT, 2);
+        js.adopt();
+
+        for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+            std::atomic<bool> childDone{false};
+            std::atomic<bool> workerReady{false};
+
+            JobSystem::Job* child = JobSystem::retain(js.createJob(nullptr, [&childDone](JobSystem&, JobSystem::Job*) {
+                childDone.store(true, std::memory_order_release);
+            }));
+
+            // Run a job on the worker that enters waitAndRelease() waiting on child
+            JobSystem::Job* workerJob = js.createJob(nullptr, [&js, child, &workerReady](JobSystem&, JobSystem::Job*) {
+                workerReady.store(true, std::memory_order_release);
+                JobSystem::Job* c = child;
+                js.waitAndRelease(c);
+            });
+            js.run(workerJob);
+
+            // Wait for worker to enter waitAndRelease()
+            while (!workerReady.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            // An adopted producer publishes child to its own queue and emancipates
+            std::thread producer([&js, child]() {
+                js.adopt();
+                JobSystem::Job* c = child;
+                js.run(c);
+                js.emancipate();
+            });
+
+            producer.join();
+
+            // Wait for child to execute and finish
+            auto const start = std::chrono::steady_clock::now();
+            while (!childDone.load(std::memory_order_acquire)) {
+                if (std::chrono::steady_clock::now() - start > std::chrono::milliseconds(100)) {
+                    FAIL() << "Lost wakeup at iteration " << iter << " on nested waiter path!";
+                    return;
+                }
+                std::this_thread::yield();
+            }
+        }
+
+        js.emancipate();
+    }, std::chrono::seconds(10));
+
+    EXPECT_TRUE(finished) << "JobSystem hung due to lost wakeup in nested waiter path!";
+}
+
+TEST(JobSystem, EmancipatePoolWorkerThrowsPreconditionPanic) {
+#ifndef UTILS_EXCEPTIONS
+    GTEST_SKIP() << "Test requires exception support (UTILS_EXCEPTIONS)";
+#else
+    JobSystem js(1, 1);
+    js.adopt();
+    std::atomic<bool> caught{false};
+    std::string reason;
+    JobSystem::Job* job = js.createJob(nullptr, [&js, &caught, &reason](JobSystem&, JobSystem::Job*) {
+        try {
+            js.emancipate();
+        } catch (PreconditionPanic const& e) {
+            reason = e.what();
+            caught.store(true, std::memory_order_release);
+        }
+    });
+    js.run(job);
+    while (!caught.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    EXPECT_TRUE(caught.load());
+    EXPECT_NE(reason.find("cannot emancipate a pool worker thread"), std::string::npos);
+    js.emancipate();
+#endif
 }

--- a/libs/utils/test/test_ThreadMap.cpp
+++ b/libs/utils/test/test_ThreadMap.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <private/utils/ThreadMap.h>
+
+#include <utils/algorithm.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+using namespace utils;
+
+TEST(ThreadMapTest, BasicOperations) {
+    ThreadMap<int> map(4);
+    EXPECT_EQ(4u, map.getCapacity());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Current thread should not be present initially
+    EXPECT_FALSE(map.contains());
+    EXPECT_EQ(0, map.get());
+    EXPECT_EQ((decltype(map)::INVALID_INDEX), map.findIndex());
+
+    // Register current thread at slot 0
+    map.set(0, 42);
+    EXPECT_FALSE(map.empty());
+    EXPECT_EQ(1u, map.size());
+    EXPECT_TRUE(map.contains());
+    EXPECT_EQ(0u, map.findIndex());
+    EXPECT_EQ(42, map.get());
+
+    // Update value for the current thread at slot 0
+    map.set(0, 100);
+    EXPECT_EQ(100, map.get());
+
+    // Erase current thread
+    EXPECT_TRUE(map.erase());
+    EXPECT_FALSE(map.contains());
+    EXPECT_TRUE(map.empty());
+    EXPECT_EQ(0u, map.size());
+
+    // Erasing non-existent thread returns false
+    EXPECT_FALSE(map.erase());
+}
+
+TEST(ThreadMapTest, MultiThreadedStaticSlots) {
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 5000;
+
+    ThreadMap<size_t> map(THREAD_COUNT);
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&map, &start, i]() {
+            // Assign dedicated slot for each thread (matching JobSystem worker pool)
+            map.set(i, i * 42);
+
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(i * 42, map.get());
+                EXPECT_EQ(i, map.findIndex());
+            }
+
+            map.eraseAt(i);
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, SlotReassignment) {
+    ThreadMap<int> map(1);
+    std::thread t1([] {});
+    std::thread t2([] {});
+    auto const tid1 = t1.get_id();
+    auto const tid2 = t2.get_id();
+    t1.join();
+    t2.join();
+
+    // First thread uses slot 0
+    map.set(0, 100, tid1);
+    EXPECT_EQ(100, map.get(tid1));
+    EXPECT_EQ(0, map.get(tid2));
+
+    // First thread emancipates slot 0
+    EXPECT_TRUE(map.eraseAt(0));
+    EXPECT_EQ(0, map.get(tid1));
+    EXPECT_EQ(0, map.get(tid2));
+
+    // Second thread claims slot 0
+    map.set(0, 200, tid2);
+    EXPECT_EQ(0, map.get(tid1));
+    EXPECT_EQ(200, map.get(tid2));
+
+    EXPECT_TRUE(map.eraseAt(0));
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, ConcurrentReaderWhileOtherThreadActive) {
+    ThreadMap<int> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> errors{0};
+
+    std::thread t1([] {});
+    std::thread t2([] {});
+    auto const tid1 = t1.get_id();
+    auto const tid2 = t2.get_id();
+    t1.join();
+    t2.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            // tid1 is never registered; get(tid1) must always return 0
+            if (map.get(tid1) != 0) {
+                errors.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread worker([&]() {
+        for (int i = 0; i < 200000; ++i) {
+            map.set(0, 42, tid2);
+            map.eraseAt(0);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    worker.join();
+    reader.join();
+
+    EXPECT_EQ(0u, errors.load()) << "Reader querying unregistered tid observed another thread's value!";
+}
+
+TEST(ThreadMapTest, ConcurrentSetAndFindIndexDataRace) {
+    ThreadMap<int> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> invalidFinds{0};
+
+    std::thread t1([] {});
+    std::thread t2([] {});
+    auto const tid1 = t1.get_id();
+    auto const tid2 = t2.get_id();
+    t1.join();
+    t2.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            uint32_t const idx = map.findIndex(tid2);
+            if (idx == 0) {
+                invalidFinds.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        for (size_t i = 0; i < 50000; ++i) {
+            map.set(0, 42, tid1);
+            map.eraseAt(0);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    writer.join();
+    reader.join();
+
+    EXPECT_EQ(0u, invalidFinds.load()) << "findIndex(tid2) erroneously returned slot 0 during concurrent set/erase!";
+}
+
+TEST(ThreadMapTest, ConcurrentSetReaderDataRace) {
+    ThreadMap<uint64_t> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> validNonZeroReads{0};
+
+    std::thread t1([] {});
+    auto const tid1 = t1.get_id();
+    t1.join();
+
+    std::thread reader([&]() {
+        while (!done.load(std::memory_order_relaxed)) {
+            uint64_t const val = map.get(tid1);
+            if (val != 0) {
+                validNonZeroReads.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        for (size_t i = 1; i <= 500000; ++i) {
+            map.set(0, i, tid1);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    writer.join();
+    reader.join();
+
+    EXPECT_GT(validNonZeroReads.load(), 50u) << "Reader should have observed valid non-zero payloads during set()!";
+}
+
+TEST(ThreadMapTest, JobSystemAdoptEmancipatePattern) {
+    constexpr uint32_t CAPACITY = 16;
+    constexpr uint32_t THREAD_COUNT = 8;
+    constexpr size_t ITERATIONS = 2000;
+
+    ThreadMap<uint64_t> map(CAPACITY);
+    std::atomic<uint32_t> slotMask{(1u << CAPACITY) - 1u};
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+
+    for (uint32_t t = 0; t < THREAD_COUNT; ++t) {
+        threads.emplace_back([&map, &slotMask, &start, t]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (size_t iter = 0; iter < ITERATIONS; ++iter) {
+                // 1. Claim a slot from bitmask (simulating JobSystem::adopt)
+                uint32_t mask = slotMask.load(std::memory_order_relaxed);
+                uint32_t slot = 0;
+                while (true) {
+                    if (mask == 0) {
+                        std::this_thread::yield();
+                        mask = slotMask.load(std::memory_order_relaxed);
+                        continue;
+                    }
+                    slot = static_cast<uint32_t>(utils::ctz(mask));
+                    if (slotMask.compare_exchange_weak(mask, mask & ~(1u << slot),
+                            std::memory_order_acquire, std::memory_order_relaxed)) {
+                        break;
+                    }
+                }
+
+                // 2. Set exclusive slot
+                uint64_t const payload = (static_cast<uint64_t>(t) << 32) | iter;
+                map.set(slot, payload);
+
+                // 3. Verify self lookup
+                EXPECT_TRUE(map.contains());
+                EXPECT_EQ(payload, map.get());
+                EXPECT_EQ(slot, map.findIndex());
+
+                // 4. Erase slot (simulating JobSystem::emancipate)
+                EXPECT_TRUE(map.eraseAt(slot));
+                EXPECT_FALSE(map.contains());
+
+                // 5. Release slot back to mask
+                slotMask.fetch_or(1u << slot, std::memory_order_release);
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(ThreadMapTest, EraseAbaProtection) {
+    ThreadMap<uint64_t> map(2);
+    std::atomic<bool> done{false};
+    std::atomic<uint32_t> stolenSlots{0};
+
+    std::thread dummyA([] {});
+    std::thread dummyB([] {});
+    auto const tidA = dummyA.get_id();
+    auto const tidB = dummyB.get_id();
+    dummyA.join();
+    dummyB.join();
+
+    std::thread t1([&]() {
+        for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+            map.set(0, 111, tidA);
+            map.erase(tidA);
+            map.erase(tidA);
+        }
+    });
+
+    std::thread t2([&]() {
+        for (int i = 0; i < 200000 && !done.load(std::memory_order_relaxed); ++i) {
+            map.set(1, 222, tidB);
+            if (!map.contains(tidB) || map.get(tidB) != 222) {
+                stolenSlots.fetch_add(1, std::memory_order_relaxed);
+            }
+            map.erase(tidB);
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(0u, stolenSlots.load())
+            << "erase(tidA) suffered from an race and unregistered tidB's slot!";
+}
+
+
+

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -168,7 +168,7 @@ void populateTextureWithPerlin(Texture* texture, Engine& engine, float time, Par
     };
 
     auto job = jobs::parallel_for(*js, nullptr, 0, dimension * dimension, std::cref(work),
-            jobs::CountSplitter<64, 32>());
+            jobs::CountSplitter<64>());
     js->runAndWait(job);
 
     Texture::PixelBufferDescriptor::PixelDataFormat format {};


### PR DESCRIPTION
Overhaul JobSystem to eliminate lock contention on hot paths, improve overall throughput and latency, and provide resilience against priority inversions.

Key improvements:
- Replace mutex-protected job allocator with a lock-free freelist.
- Replace mutex-guarded thread state lookup with a lock-free ThreadMap.
- Redesign parallel_for with dynamic range-based chunking and inline functor storage, replacing recursive tree splitting.
- Separate worker and waiter condition variables to prevent thundering herds on job completion.
- Add a 1-slot continuation bypass for fast job submission and pickup.
- Restrict work-stealing probing to active worker slots.

Benchmark results (BM_JobSystemParallelFor):
- macOS (Apple Silicon 16-core): 3.71 ms -> 0.10 ms (36x speedup)
- Android (Pixel 8 Pro ARM64): 4.02 ms -> 0.63 ms (6.4x speedup, 58x CPU cycle reduction from 762k to 13k cycles)