### PR TITLE
utils: add multi-level LIFO free to LinearAllocator

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -185,14 +185,18 @@ inline constexpr bool has_wasted_bytes_v = has_wasted_bytes<T>::value;
  * LinearAllocator
  *
  * + Allocates blocks linearly
- * + Cannot free individual blocks
- * + Can free top of memory back up to a specified point
+ * + Can free top allocations in LIFO order (up to STACK_DEPTH levels)
+ * + Can free top of memory back up to a specified point (rewind / reset)
  * + Doesn't call destructors
  * ------------------------------------------------------------------------------------------------
  */
 
 class LinearAllocator {
 public:
+    static constexpr size_t STACK_DEPTH = 8;
+    static constexpr size_t STACK_MASK = STACK_DEPTH - 1;
+    static_assert((STACK_DEPTH & STACK_MASK) == 0, "STACK_DEPTH must be a power of 2");
+
     // use memory area provided
     LinearAllocator(void* begin, void* end) noexcept;
 
@@ -216,16 +220,24 @@ public:
         void* const c = pointermath::add(p, size);
         bool const success = c <= end();
         if (success) {
-            mPrevCur = mCur;
+            mStack[mHead] = mCur;
+            mHead = (mHead + 1) & STACK_MASK;
+            mCount = std::min<uint8_t>(mCount + 1, uint8_t(STACK_DEPTH));
             set_current(c);
         }
         return success ? p : nullptr;
     }
 
     bool free(void* p, size_t const size) noexcept {
-        if (pointermath::add(p, size) == current() && p >= pointermath::add(mBegin, mPrevCur)) {
-            mCur = mPrevCur;
-            return true;
+        if (mCount > 0) {
+            uint8_t const prevIdx = (mHead - 1) & STACK_MASK;
+            uint32_t const prevCur = mStack[prevIdx];
+            if (pointermath::add(p, size) == current() && p >= pointermath::add(mBegin, prevCur)) {
+                mCur = prevCur;
+                mHead = prevIdx;
+                mCount--;
+                return true;
+            }
         }
         return false;
     }
@@ -239,7 +251,8 @@ public:
     void rewind(void* p) UTILS_RESTRICT noexcept {
         assert(p >= mBegin && p < end());
         set_current(p);
-        mPrevCur = mCur;
+        mHead = 0;
+        mCount = 0;
     }
 
     // frees all allocated blocks
@@ -274,7 +287,9 @@ private:
     void* mBegin = nullptr;
     uint32_t mSize = 0;
     uint32_t mCur = 0;
-    uint32_t mPrevCur = 0;
+    uint8_t mHead = 0;
+    uint8_t mCount = 0;
+    uint32_t mStack[STACK_DEPTH] = {};
 };
 
 /* ------------------------------------------------------------------------------------------------

--- a/libs/utils/src/Allocator.cpp
+++ b/libs/utils/src/Allocator.cpp
@@ -52,7 +52,9 @@ void LinearAllocator::swap(LinearAllocator& rhs) noexcept {
     std::swap(mBegin, rhs.mBegin);
     std::swap(mSize, rhs.mSize);
     std::swap(mCur, rhs.mCur);
-    std::swap(mPrevCur, rhs.mPrevCur);
+    std::swap(mHead, rhs.mHead);
+    std::swap(mCount, rhs.mCount);
+    std::swap(mStack, rhs.mStack);
 }
 
 

--- a/libs/utils/test/test_Allocators.cpp
+++ b/libs/utils/test/test_Allocators.cpp
@@ -628,3 +628,111 @@ TEST(AllocatorTest, ArenaAreaMoveSemantics) {
     // After area2 destructs, parent allocation should be safely freed and current rolled back
     EXPECT_EQ(initialCurrent, parent.getAllocator().getCurrent());
 }
+
+TEST(AllocatorTest, LinearAllocatorStackLIFO) {
+    char scratch[1024];
+    LinearAllocator la(scratch, scratch + sizeof(scratch));
+
+    // Allocate 5 blocks of varying sizes
+    void* const p0 = la.alloc(64);
+    void* const p1 = la.alloc(128);
+    void* const p2 = la.alloc(32);
+    void* const p3 = la.alloc(256);
+    void* const p4 = la.alloc(48);
+
+    EXPECT_EQ(scratch, p0);
+    EXPECT_EQ(pointermath::add(scratch, 64), p1);
+    EXPECT_EQ(pointermath::add(scratch, 192), p2);
+    EXPECT_EQ(pointermath::add(scratch, 224), p3);
+    EXPECT_EQ(pointermath::add(scratch, 480), p4);
+    EXPECT_EQ(pointermath::add(scratch, 528), la.getCurrent());
+
+    // Free in LIFO order (all within STACK_DEPTH = 8)
+    EXPECT_TRUE(la.free(p4, 48));
+    EXPECT_EQ(pointermath::add(scratch, 480), la.getCurrent());
+
+    EXPECT_TRUE(la.free(p3, 256));
+    EXPECT_EQ(pointermath::add(scratch, 224), la.getCurrent());
+
+    EXPECT_TRUE(la.free(p2, 32));
+    EXPECT_EQ(pointermath::add(scratch, 192), la.getCurrent());
+
+    EXPECT_TRUE(la.free(p1, 128));
+    EXPECT_EQ(pointermath::add(scratch, 64), la.getCurrent());
+
+    EXPECT_TRUE(la.free(p0, 64));
+    EXPECT_EQ(scratch, la.getCurrent());
+
+    // Once empty, free() returns false
+    EXPECT_FALSE(la.free(p0, 64));
+    EXPECT_EQ(scratch, la.getCurrent());
+
+    // Whole block can be reallocated
+    void* const pAll = la.alloc(1024);
+    EXPECT_EQ(scratch, pAll);
+}
+
+TEST(AllocatorTest, LinearAllocatorStackOverflowFree) {
+    char scratch[2048];
+    LinearAllocator la(scratch, scratch + sizeof(scratch));
+
+    // Allocate 12 blocks (exceeding STACK_DEPTH = 8)
+    constexpr size_t NUM_ALLOCS = 12;
+    constexpr size_t BLOCK_SIZE = 64;
+    void* ptrs[NUM_ALLOCS];
+    for (size_t i = 0; i < NUM_ALLOCS; ++i) {
+        ptrs[i] = la.alloc(BLOCK_SIZE);
+        EXPECT_EQ(pointermath::add(scratch, i * BLOCK_SIZE), ptrs[i]);
+    }
+    EXPECT_EQ(pointermath::add(scratch, NUM_ALLOCS * BLOCK_SIZE), la.getCurrent());
+
+    // Free the 8 most recent allocations in LIFO order (all should succeed)
+    for (size_t i = 0; i < LinearAllocator::STACK_DEPTH; ++i) {
+        size_t const idx = NUM_ALLOCS - 1 - i;
+        EXPECT_TRUE(la.free(ptrs[idx], BLOCK_SIZE));
+        EXPECT_EQ(pointermath::add(scratch, idx * BLOCK_SIZE), la.getCurrent());
+    }
+
+    // Now stack history has been exhausted (mCount == 0).
+    // Attempting to free the 9th allocation (ptrs[3]) must return false.
+    size_t const overflowIdx = NUM_ALLOCS - 1 - LinearAllocator::STACK_DEPTH; // index 3
+    EXPECT_FALSE(la.free(ptrs[overflowIdx], BLOCK_SIZE));
+
+    // Current pointer must remain untouched
+    EXPECT_EQ(pointermath::add(scratch, (overflowIdx + 1) * BLOCK_SIZE), la.getCurrent());
+
+    // Further older allocations also cannot be freed
+    EXPECT_FALSE(la.free(ptrs[0], BLOCK_SIZE));
+}
+
+TEST(AllocatorTest, LinearAllocatorStackInterleaved) {
+    char scratch[1024];
+    LinearAllocator la(scratch, scratch + sizeof(scratch));
+
+    // Allocate A, B, C
+    void* const a = la.alloc(64);
+    void* const b = la.alloc(64);
+    void* const c = la.alloc(64);
+    EXPECT_EQ(pointermath::add(scratch, 192), la.getCurrent());
+
+    // Free C, B
+    EXPECT_TRUE(la.free(c, 64));
+    EXPECT_EQ(pointermath::add(scratch, 128), la.getCurrent());
+    EXPECT_TRUE(la.free(b, 64));
+    EXPECT_EQ(pointermath::add(scratch, 64), la.getCurrent());
+
+    // Allocate D, E
+    void* const d = la.alloc(128);
+    void* const e = la.alloc(128);
+    EXPECT_EQ(pointermath::add(scratch, 64), d);
+    EXPECT_EQ(pointermath::add(scratch, 192), e);
+    EXPECT_EQ(pointermath::add(scratch, 320), la.getCurrent());
+
+    // Free E, D, then A
+    EXPECT_TRUE(la.free(e, 128));
+    EXPECT_EQ(pointermath::add(scratch, 192), la.getCurrent());
+    EXPECT_TRUE(la.free(d, 128));
+    EXPECT_EQ(pointermath::add(scratch, 64), la.getCurrent());
+    EXPECT_TRUE(la.free(a, 64));
+    EXPECT_EQ(scratch, la.getCurrent());
+}


### PR DESCRIPTION
Replace the single-level mPrevCur tracking with an inline circular history stack of size STACK_DEPTH (8 entries).

This allows LinearAllocator::free() to reclaim memory across multiple consecutive LIFO allocations, restoring both payload space and alignment padding without requiring external heap allocations or touching arena memory.

- LinearAllocator: implement circular stack (mStack, mHead, mCount) for LIFO rollback.
- Clear stack state on rewind() and reset().
- Update LinearAllocator::swap to exchange stack state.
- Add unit tests for multi-level LIFO free, interleaved alloc/free, and stack overflow beyond STACK_DEPTH.