### PR TITLE
android: expose option fields that never reach the engine

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -405,7 +405,8 @@ Java_com_google_android_filament_View_nSetBlendMode(JNIEnv *, jclass , jlong nat
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetDepthOfFieldOptions(JNIEnv *, jclass,
-        jlong nativeView, jfloat cocScale, jfloat maxApertureDiameter, jboolean enabled, jint filter,
+        jlong nativeView, jfloat cocScale, jfloat cocAspectRatio, jfloat maxApertureDiameter,
+        jboolean enabled, jint filter,
         jboolean nativeResolution, jint foregroundRingCount, jint backgroundRingCount, jint fastGatherRingCount,
         jint maxForegroundCOC, jint maxBackgroundCOC) {
     View* view = (View*) nativeView;
@@ -415,6 +416,7 @@ Java_com_google_android_filament_View_nSetDepthOfFieldOptions(JNIEnv *, jclass,
         eFilter = View::DepthOfFieldOptions::Filter::MEDIAN;
     }
     view->setDepthOfFieldOptions({.cocScale = cocScale,
+            .cocAspectRatio = cocAspectRatio,
             .maxApertureDiameter = maxApertureDiameter, .enabled = (bool)enabled, .filter = eFilter,
             .nativeResolution = (bool)nativeResolution,
             .foregroundRingCount = (uint8_t)foregroundRingCount,

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -310,7 +310,7 @@ public class LightManager {
          * Generally this value shouldn't be changed or at least be small and positive.
          * This is ignored when the View's ShadowType is set to VSM.
          */
-        float polygonOffsetConstant = 0.5f;
+        public float polygonOffsetConstant = 0.5f;
 
         /**
          * Bias based on the change in depth in depth-resolution units by which shadows are moved
@@ -319,7 +319,7 @@ public class LightManager {
          * Setting this value correctly is essential for LISPSM shadow-maps.
          * This is ignored when the View's ShadowType is set to VSM.
          */
-        float polygonOffsetSlope = 2.0f;
+        public float polygonOffsetSlope = 2.0f;
 
         /**
          * Whether screen-space contact shadows are used. This applies regardless of whether a

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1129,7 +1129,7 @@ public class View {
      */
     public void setDepthOfFieldOptions(@NonNull DepthOfFieldOptions options) {
         mDepthOfFieldOptions = options;
-        nSetDepthOfFieldOptions(getNativeObject(), options.cocScale,
+        nSetDepthOfFieldOptions(getNativeObject(), options.cocScale, options.cocAspectRatio,
                 options.maxApertureDiameter, options.enabled, options.filter.ordinal(),
                 options.nativeResolution, options.foregroundRingCount, options.backgroundRingCount,
                 options.fastGatherRingCount, options.maxForegroundCOC, options.maxBackgroundCOC);
@@ -1439,7 +1439,7 @@ public class View {
     private static native void nSetChannelDepthClearEnabled(long nativeView, int channel, boolean enabled);
     private static native boolean nIsChannelDepthClearEnabled(long nativeView, int channel);
     private static native void nSetBlendMode(long nativeView, int blendMode);
-    private static native void nSetDepthOfFieldOptions(long nativeView, float cocScale, float maxApertureDiameter, boolean enabled, int filter,
+    private static native void nSetDepthOfFieldOptions(long nativeView, float cocScale, float cocAspectRatio, float maxApertureDiameter, boolean enabled, int filter,
             boolean nativeResolution, int foregroundRingCount, int backgroundRingCount, int fastGatherRingCount, int maxForegroundCOC, int maxBackgroundCOC);
     private static native void nSetVignetteOptions(long nativeView, float midPoint, float roundness, float feather, float r, float g, float b, float a, boolean enabled);
     private static native void nSetTemporalAntiAliasingOptions(long nativeView, float feedback, float filterWidth, boolean enabled);


### PR DESCRIPTION
Two Android binding fields that can't reach the engine:

- `LightManager.ShadowOptions.polygonOffsetConstant` / `polygonOffsetSlope` are package-private, so they can't be set from outside the package.
- `View.DepthOfFieldOptions.cocAspectRatio` isn't passed to `nSetDepthOfFieldOptions`, so the engine keeps its default.

Fixes #10334, #10335
