### PR TITLE
samples: make parameter definition re-usable

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -225,6 +225,9 @@ target_sources(gltf-demo-resources PRIVATE ${RESGEN_SOURCE})
 
 add_library(samples-common STATIC
     common/arguments.cpp
+    common/arguments.h
+    common/Parameter.h
+    common/SampleConfig.h
 )
 
 target_include_directories(samples-common PRIVATE

--- a/samples/animation.cpp
+++ b/samples/animation.cpp
@@ -168,11 +168,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "animation";
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto fApp = createSampleApp(config, dm.get(), nullptr);
     fApp->run();

--- a/samples/common/Parameter.h
+++ b/samples/common/Parameter.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_SAMPLES_PARAMETER_H
+#define TNT_SAMPLES_PARAMETER_H
+
+#include <utils/CString.h>
+#include <utils/FixedCapacityVector.h>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+namespace samples {
+
+enum class ParameterType : uint8_t {
+    BOOL,
+    INT,
+    FLOAT,
+    STRING,
+    ENUM
+};
+
+struct IntRange {
+    int min = std::numeric_limits<int>::min();
+    int max = std::numeric_limits<int>::max();
+    int step = 1;
+};
+
+struct FloatRange {
+    float min = -std::numeric_limits<float>::infinity();
+    float max = std::numeric_limits<float>::infinity();
+    float step = 0.01f;
+};
+
+using ParameterValue = std::variant<bool, int, float, utils::CString>;
+
+/**
+ * Represents a typed command-line configuration parameter for a sample application.
+ *
+ * Defines parameter metadata, type information, default values, optional numerical
+ * ranges or discrete enum choices, and command-line flags (both long name and optional
+ * single-character shorthand). Used to declaratively configure, validate, parse, and
+ * document sample-specific and common options across Filament samples.
+ */
+struct Parameter {
+    utils::CString name;
+    char shorthand = '\0';
+    utils::CString description;
+    ParameterType type = ParameterType::BOOL;
+
+    ParameterValue value = false;
+    ParameterValue defaultValue = false;
+
+    std::optional<IntRange> intRange;
+    std::optional<FloatRange> floatRange;
+    utils::FixedCapacityVector<utils::CString> choices;
+    bool required = false;
+
+    static bool isValidName(std::string_view name) {
+        if (name.empty() || name.front() < 'a' || name.front() > 'z' || name.back() == '-') {
+            return false;
+        }
+        bool prevHyphen = false;
+        for (char c : name) {
+            if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+                prevHyphen = false;
+            } else if (c == '-') {
+                if (prevHyphen) return false;
+                prevHyphen = true;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool isValidValue(const ParameterValue& val) const {
+        switch (type) {
+            case ParameterType::BOOL:
+                return std::holds_alternative<bool>(val);
+            case ParameterType::INT: {
+                if (!std::holds_alternative<int>(val)) return false;
+                int v = std::get<int>(val);
+                return !intRange || (v >= intRange->min && v <= intRange->max);
+            }
+            case ParameterType::FLOAT: {
+                if (!std::holds_alternative<float>(val)) return false;
+                float v = std::get<float>(val);
+                return !floatRange || (v >= floatRange->min && v <= floatRange->max);
+            }
+            case ParameterType::STRING:
+                return std::holds_alternative<utils::CString>(val);
+            case ParameterType::ENUM: {
+                if (!std::holds_alternative<utils::CString>(val)) return false;
+                const auto& v = std::get<utils::CString>(val);
+                for (const auto& choice : choices) {
+                    if (choice == v) return true;
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+
+    static Parameter makeBool(utils::CString name, char shorthand, utils::CString description,
+            bool defaultValue = false, bool required = false) {
+        return Parameter{
+            .name = std::move(name),
+            .shorthand = shorthand,
+            .description = std::move(description),
+            .type = ParameterType::BOOL,
+            .value = defaultValue,
+            .defaultValue = defaultValue,
+            .intRange = std::nullopt,
+            .floatRange = std::nullopt,
+            .choices = {},
+            .required = required
+        };
+    }
+
+    static Parameter makeInt(utils::CString name, char shorthand, utils::CString description,
+            int defaultValue, std::optional<int> min = std::nullopt,
+            std::optional<int> max = std::nullopt, int step = 1, bool required = false) {
+        std::optional<IntRange> range;
+        if (min || max) {
+            range = IntRange{
+                min.value_or(std::numeric_limits<int>::min()),
+                max.value_or(std::numeric_limits<int>::max()),
+                step
+            };
+        }
+        return Parameter{
+            .name = std::move(name),
+            .shorthand = shorthand,
+            .description = std::move(description),
+            .type = ParameterType::INT,
+            .value = defaultValue,
+            .defaultValue = defaultValue,
+            .intRange = range,
+            .floatRange = std::nullopt,
+            .choices = {},
+            .required = required
+        };
+    }
+
+    static Parameter makeFloat(utils::CString name, char shorthand, utils::CString description,
+            float defaultValue, std::optional<float> min = std::nullopt,
+            std::optional<float> max = std::nullopt, float step = 0.01f, bool required = false) {
+        std::optional<FloatRange> range;
+        if (min || max) {
+            range = FloatRange{
+                min.value_or(-std::numeric_limits<float>::infinity()),
+                max.value_or(std::numeric_limits<float>::infinity()),
+                step
+            };
+        }
+        return Parameter{
+            .name = std::move(name),
+            .shorthand = shorthand,
+            .description = std::move(description),
+            .type = ParameterType::FLOAT,
+            .value = defaultValue,
+            .defaultValue = defaultValue,
+            .intRange = std::nullopt,
+            .floatRange = range,
+            .choices = {},
+            .required = required
+        };
+    }
+
+    static Parameter makeString(utils::CString name, char shorthand, utils::CString description,
+            utils::CString defaultValue = "", bool required = false) {
+        return Parameter{
+            .name = std::move(name),
+            .shorthand = shorthand,
+            .description = std::move(description),
+            .type = ParameterType::STRING,
+            .value = defaultValue,
+            .defaultValue = defaultValue,
+            .intRange = std::nullopt,
+            .floatRange = std::nullopt,
+            .choices = {},
+            .required = required
+        };
+    }
+
+    static Parameter makeEnum(utils::CString name, char shorthand, utils::CString description,
+            utils::CString defaultValue, utils::FixedCapacityVector<utils::CString> choices,
+            bool required = false) {
+        return Parameter{
+            .name = std::move(name),
+            .shorthand = shorthand,
+            .description = std::move(description),
+            .type = ParameterType::ENUM,
+            .value = defaultValue,
+            .defaultValue = defaultValue,
+            .intRange = std::nullopt,
+            .floatRange = std::nullopt,
+            .choices = std::move(choices),
+            .required = required
+        };
+    }
+};
+
+using SampleParameters = utils::FixedCapacityVector<Parameter>;
+
+} // namespace samples
+
+#endif // TNT_SAMPLES_PARAMETER_H

--- a/samples/common/SampleConfig.h
+++ b/samples/common/SampleConfig.h
@@ -1,6 +1,8 @@
 #ifndef SAMPLE_CONFIG_H
 #define SAMPLE_CONFIG_H
 
+#include "Parameter.h"
+
 #include <filament/Engine.h>
 
 #include <camutils/Manipulator.h>
@@ -30,7 +32,40 @@ struct SampleConfig {
     DisplayManager displayManager = DisplayManager::SDL;
     filament::backend::AsynchronousMode asynchronousMode =
             filament::backend::AsynchronousMode::NONE;
-    utils::CString fileName;
-    std::unordered_map<utils::CString, utils::CString> customArgs;
+    utils::FixedCapacityVector<utils::CString> positionalArgs;
+    std::unordered_map<utils::CString, samples::Parameter> parameters;
+
+    bool getBool(const utils::CString& name, bool fallback = false) const {
+        auto it = parameters.find(name);
+        if (it != parameters.end() && std::holds_alternative<bool>(it->second.value)) {
+            return std::get<bool>(it->second.value);
+        }
+        return fallback;
+    }
+
+    int getInt(const utils::CString& name, int fallback = 0) const {
+        auto it = parameters.find(name);
+        if (it != parameters.end() && std::holds_alternative<int>(it->second.value)) {
+            return std::get<int>(it->second.value);
+        }
+        return fallback;
+    }
+
+    float getFloat(const utils::CString& name, float fallback = 0.0f) const {
+        auto it = parameters.find(name);
+        if (it != parameters.end() && std::holds_alternative<float>(it->second.value)) {
+            return std::get<float>(it->second.value);
+        }
+        return fallback;
+    }
+
+    utils::CString getString(const utils::CString& name,
+            const utils::CString& fallback = "") const {
+        auto it = parameters.find(name);
+        if (it != parameters.end() && std::holds_alternative<utils::CString>(it->second.value)) {
+            return std::get<utils::CString>(it->second.value);
+        }
+        return fallback;
+    }
 };
 #endif

--- a/samples/common/arguments.cpp
+++ b/samples/common/arguments.cpp
@@ -21,20 +21,17 @@
 
 #include <filament/Engine.h>
 
+#include <utils/debug.h>
+#include <utils/FixedCapacityVector.h>
 #include <utils/getopt.h>
 #include <utils/Path.h>
 
 #include <algorithm>
 #include <iostream>
-#include <string>
+#include <limits>
 #include <vector>
 
 namespace {
-
-utils::CString getBackendAPIArgumentsUsage() {
-    return "   --api, -a\n"
-           "       Specify the backend API: opengl, vulkan, metal, or webgpu\n\n";
-}
 
 filament::Engine::Backend parseArgumentsForBackend(const utils::CString& backend) {
     if (backend == "metal") {
@@ -72,18 +69,121 @@ filament::Engine::Backend resolveBackend(filament::Engine::Backend backend) {
     return backend;
 }
 
+samples::SampleParameters getCommonParameters() {
+    return {
+        samples::Parameter::makeEnum("api", 'a', "Specify the backend API", "default",
+                { "opengl", "vulkan", "metal", "webgpu" }),
+        samples::Parameter::makeInt("feature-level", 'f', "Specify feature level", 3, 1, 3, 1),
+        samples::Parameter::makeBool("headless", 'e', "Run in headless mode", false),
+        samples::Parameter::makeString("ibl", 'i', "Path to directory containing IBL", ""),
+        samples::Parameter::makeEnum("camera", 'c', "Specify camera mode", "orbit",
+                { "orbit", "flight" }),
+        samples::Parameter::makeInt("eyes", 'y', "Stereoscopic eye count", 2, 1, 4, 1),
+        samples::Parameter::makeBool("split-view", 'v', "Enable split-view", false),
+        samples::Parameter::makeString("vulkan-gpu-hint", 'g',
+                "Vulkan physical device selection hint", ""),
+        samples::Parameter::makeEnum("webgpu-backend", 'w', "Forced WebGPU backend", "default",
+                { "opengl", "vulkan", "metal", "webgpu" }),
+        samples::Parameter::makeBool("remote", 'x', "Run web server and enable remote control",
+                false),
+    };
+}
+
+void printParameterHelp(const samples::Parameter& param) {
+    std::cout << "   --" << param.name.c_str();
+    if (param.shorthand != '\0') {
+        std::cout << ", -" << param.shorthand;
+    }
+    switch (param.type) {
+        case samples::ParameterType::INT:
+            std::cout << " <integer>";
+            break;
+        case samples::ParameterType::FLOAT:
+            std::cout << " <float>";
+            break;
+        case samples::ParameterType::STRING:
+            std::cout << " <string>";
+            break;
+        case samples::ParameterType::ENUM:
+            std::cout << " <choice>";
+            break;
+        case samples::ParameterType::BOOL:
+            break;
+    }
+    if (param.required) {
+        std::cout << " (required)";
+    }
+    std::cout << "\n       " << param.description.c_str();
+
+    if (param.type == samples::ParameterType::ENUM && !param.choices.empty()) {
+        std::cout << " [";
+        for (size_t i = 0; i < param.choices.size(); ++i) {
+            if (i > 0) std::cout << "|";
+            std::cout << param.choices[i].c_str();
+        }
+        std::cout << "]";
+    } else if (param.type == samples::ParameterType::INT && param.intRange) {
+        if (param.intRange->min != std::numeric_limits<int>::min() &&
+                param.intRange->max != std::numeric_limits<int>::max()) {
+            std::cout << " [" << param.intRange->min << ".." << param.intRange->max << "]";
+        }
+    } else if (param.type == samples::ParameterType::FLOAT && param.floatRange) {
+        if (param.floatRange->min != -std::numeric_limits<float>::infinity() &&
+                param.floatRange->max != std::numeric_limits<float>::infinity()) {
+            std::cout << " [" << param.floatRange->min << ".." << param.floatRange->max << "]";
+        }
+    }
+    std::cout << "\n\n";
+}
+
+void validateSpecification(const samples::CommandLineSpecification& spec) {
+    auto commonParams = getCommonParameters();
+
+    for (size_t i = 0; i < spec.parameters.size(); ++i) {
+        const auto& param = spec.parameters[i];
+        assert_invariant(samples::Parameter::isValidName(param.name.c_str()));
+        assert_invariant(param.name != "help");
+
+        if (param.shorthand != '\0') {
+            assert_invariant(param.shorthand != 'h');
+
+            // Check against other sample parameters
+            for (size_t j = i + 1; j < spec.parameters.size(); ++j) {
+                const auto& other = spec.parameters[j];
+                assert_invariant(param.name != other.name);
+                if (other.shorthand != '\0') {
+                    assert_invariant(param.shorthand != other.shorthand);
+                }
+            }
+
+            // Check against common parameters
+            for (const auto& cp : commonParams) {
+                if (cp.shorthand != '\0' && param.name != cp.name) {
+                    assert_invariant(param.shorthand != cp.shorthand);
+                }
+            }
+        }
+    }
+}
+
 } // namespace
 
 namespace samples {
 
 void printUsage(const char* name, const CommandLineSpecification& spec) {
+    validateSpecification(spec);
+
     utils::CString exec_name(utils::Path(name).getName().c_str());
-    utils::CString apiUsage = getBackendAPIArgumentsUsage();
     std::cout << exec_name.c_str() << "\n"
               << "Usage:\n"
               << "    " << exec_name.c_str_safe() << " [options]";
-    if (!spec.positionalArgsDescription.empty()) {
-        std::cout << " " << spec.positionalArgsDescription.c_str_safe();
+    for (size_t i = 0; i < spec.positionalArgsDescription.size(); ++i) {
+        const auto& desc = spec.positionalArgsDescription[i];
+        if (i < static_cast<size_t>(spec.requiredPositionalArgCount)) {
+            std::cout << " <" << desc.c_str_safe() << ">";
+        } else {
+            std::cout << " [" << desc.c_str_safe() << "]";
+        }
     }
     std::cout << "\n\n";
     if (!spec.sampleDescription.empty()) {
@@ -91,10 +191,28 @@ void printUsage(const char* name, const CommandLineSpecification& spec) {
     }
     std::cout << "Options:\n"
               << "   --help, -h\n"
-              << "       Prints this message\n\n"
-              << apiUsage.c_str();
-    if (!spec.customOptionsHelp.empty()) {
-        std::cout << spec.customOptionsHelp.c_str_safe() << "\n";
+              << "       Prints this message\n\n";
+
+    if (!spec.parameters.empty()) {
+        std::cout << "Sample Options:\n";
+        for (const auto& param: spec.parameters) {
+            printParameterHelp(param);
+        }
+    }
+
+    std::cout << "Common Options:\n";
+    auto commonParams = getCommonParameters();
+    for (const auto& param: commonParams) {
+        bool overridden = false;
+        for (const auto& sp: spec.parameters) {
+            if (sp.name == param.name) {
+                overridden = true;
+                break;
+            }
+        }
+        if (!overridden) {
+            printParameterHelp(param);
+        }
     }
 }
 
@@ -134,178 +252,256 @@ std::unique_ptr<filament::app::DisplayManager> getDisplayManager(const SampleCon
 
 int handleCommandLineArguments(int argc, char* argv[], SampleConfig* config,
         const CommandLineSpecification& spec) {
+    validateSpecification(spec);
 
-    static constexpr const char* DEFAULT_OPTSTR = "ha:f:i:usc:rt:y:b:evg:dw:x";
-    utils::CString optstr(DEFAULT_OPTSTR);
-    if (spec.customOptStr && spec.customOptStr[0] != '\0') {
-        utils::CString custom(spec.customOptStr);
-        for (size_t i = 0; i < custom.length(); ++i) {
-            char c = custom[i];
-            if (c == ':') continue;
-            const char* p = strchr(optstr.c_str(), c);
-            if (p) {
-                size_t pos = p - optstr.c_str();
-                utils::CString newOpt(optstr.c_str(), pos);
-                if (pos + 1 < optstr.length() && optstr[pos + 1] == ':') {
-                    newOpt += utils::CString(optstr.c_str() + pos + 2, optstr.length() - pos - 2);
-                } else {
-                    newOpt += utils::CString(optstr.c_str() + pos + 1, optstr.length() - pos - 1);
-                }
-                optstr = newOpt;
+    auto commonParams = getCommonParameters();
+    auto activeCommonParams = SampleParameters::with_capacity(commonParams.size());
+    for (const auto& cp: commonParams) {
+        bool overridden = false;
+        for (const auto& sp: spec.parameters) {
+            if (sp.name == cp.name) {
+                overridden = true;
+                break;
             }
         }
-        optstr += spec.customOptStr;
-    }
-
-    static const utils::getopt::option OPTIONS[] = {
-        { "help", utils::getopt::no_argument, nullptr, 'h' },
-        { "api", utils::getopt::required_argument, nullptr, 'a' },
-        { "feature-level", utils::getopt::required_argument, nullptr, 'f' },
-        { "batch", utils::getopt::required_argument, nullptr, 'b' },
-        { "headless", utils::getopt::no_argument, nullptr, 'e' },
-        { "ibl", utils::getopt::required_argument, nullptr, 'i' },
-        { "ubershader", utils::getopt::no_argument, nullptr, 'u' },
-        { "actual-size", utils::getopt::no_argument, nullptr, 's' },
-        { "camera", utils::getopt::required_argument, nullptr, 'c' },
-        { "eyes", utils::getopt::required_argument, nullptr, 'y' },
-        { "recompute-aabb", utils::getopt::no_argument, nullptr, 'r' },
-        { "settings", utils::getopt::required_argument, nullptr, 't' },
-        { "split-view", utils::getopt::no_argument, nullptr, 'v' },
-        { "vulkan-gpu-hint", utils::getopt::required_argument, nullptr, 'g' },
-        { "screenshot-as-ppm", utils::getopt::no_argument, nullptr, 'd' },
-        { "webgpu-backend", utils::getopt::required_argument, nullptr, 'w' },
-        { "remote", utils::getopt::no_argument, nullptr, 'x' },
-        { nullptr, 0, nullptr, 0 },
-    };
-
-    std::vector<utils::getopt::option> options;
-    for (size_t i = 0; OPTIONS[i].name != nullptr; ++i) {
-        options.push_back(OPTIONS[i]);
-    }
-    if (spec.customOptions) {
-        for (size_t i = 0; spec.customOptions[i].name != nullptr; ++i) {
-            options.push_back(spec.customOptions[i]);
+        if (!overridden) {
+            activeCommonParams.push_back(cp);
         }
     }
-    options.push_back({ nullptr, 0, nullptr, 0 });
+
+    std::vector<utils::getopt::option> longOptions;
+    utils::CString optstr("h");
+
+    longOptions.push_back({ "help", utils::getopt::no_argument, nullptr, 'h' });
+
+    int nextOptionVal = 1000;
+
+    struct OptionMapping {
+        int val;
+        bool isCommon;
+        size_t index;
+    };
+    std::vector<OptionMapping> optionMappings;
+
+    for (size_t i = 0; i < activeCommonParams.size(); ++i) {
+        const auto& cp = activeCommonParams[i];
+        int val = (cp.shorthand != '\0') ? cp.shorthand : nextOptionVal++;
+        int hasArg = (cp.type == ParameterType::BOOL) ? utils::getopt::no_argument
+                                                      : utils::getopt::required_argument;
+        longOptions.push_back({ cp.name.c_str(), hasArg, nullptr, val });
+        optionMappings.push_back({ val, true, i });
+
+        if (cp.shorthand != '\0') {
+            optstr += cp.shorthand;
+            if (hasArg == utils::getopt::required_argument) {
+                optstr += ":";
+            }
+        }
+    }
+
+    for (size_t i = 0; i < spec.parameters.size(); ++i) {
+        const auto& sp = spec.parameters[i];
+        int val = (sp.shorthand != '\0') ? sp.shorthand : nextOptionVal++;
+        int hasArg = (sp.type == ParameterType::BOOL) ? utils::getopt::no_argument
+                                                      : utils::getopt::required_argument;
+        longOptions.push_back({ sp.name.c_str(), hasArg, nullptr, val });
+        optionMappings.push_back({ val, false, i });
+
+        if (sp.shorthand != '\0') {
+            optstr += sp.shorthand;
+            if (hasArg == utils::getopt::required_argument) {
+                optstr += ":";
+            }
+        }
+
+        config->parameters[sp.name] = sp;
+    }
+
+    longOptions.push_back({ nullptr, 0, nullptr, 0 });
 
     int opt;
     int option_index = 0;
-    std::vector<int> seenOptions;
-    while ((opt = utils::getopt::getopt_long(argc, argv, optstr.c_str(), options.data(),
+    std::vector<bool> seenSampleParams(spec.parameters.size(), false);
+
+    while ((opt = utils::getopt::getopt_long(argc, argv, optstr.c_str(), longOptions.data(),
                     &option_index)) >= 0) {
-        seenOptions.push_back(opt);
         utils::CString const arg(utils::getopt::optarg ? utils::getopt::optarg : "");
 
-        if (spec.customHandler && spec.customHandler(opt, arg)) {
+        if (opt == 'h') {
+            printUsage(argv[0], spec);
+            exit(0);
+        }
+
+        const OptionMapping* mapping = nullptr;
+        for (const auto& m: optionMappings) {
+            if (m.val == opt) {
+                mapping = &m;
+                break;
+            }
+        }
+
+        if (!mapping) {
             continue;
         }
 
-        switch (opt) {
-            default:
-            case 'h':
-                printUsage(argv[0], spec);
-                exit(0);
-            case 'a':
+        if (mapping->isCommon) {
+            const auto& cp = activeCommonParams[mapping->index];
+            if (cp.name == "api") {
                 config->backend = parseArgumentsForBackend(arg);
-                break;
-            case 'f':
-                if (arg == "1") {
+            } else if (cp.name == "feature-level") {
+                int fl = 3;
+                try {
+                    fl = std::stoi(arg.c_str());
+                } catch (...) {
+                }
+                if (fl == 1) {
                     config->featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_1;
-                } else if (arg == "2") {
+                } else if (fl == 2) {
                     config->featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_2;
-                } else if (arg == "3") {
+                } else if (fl == 3) {
                     config->featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
                 } else {
                     std::cerr << "Unrecognized feature level. Must be 1, 2 or 3.\n";
+                    exit(1);
                 }
-                break;
-            case 'c':
+            } else if (cp.name == "camera") {
                 if (arg == "flight") {
                     config->cameraMode = filament::camutils::Mode::FREE_FLIGHT;
                 } else if (arg == "orbit") {
                     config->cameraMode = filament::camutils::Mode::ORBIT;
                 } else {
                     std::cerr << "Unrecognized camera mode. Must be 'flight'|'orbit'.\n";
+                    exit(1);
                 }
-                break;
-            case 'y': {
+            } else if (cp.name == "eyes") {
                 int eyeCount = 0;
                 try {
                     eyeCount = std::stoi(arg.c_str());
-                } catch (std::invalid_argument& e) {
+                } catch (...) {
                 }
                 if (eyeCount >= 1 && eyeCount <= 4) {
                     config->stereoscopicEyeCount = eyeCount;
                 } else {
                     std::cerr << "Eye count must be between 1 and 4.\n";
+                    exit(1);
                 }
-                break;
-            }
-            case 'e':
+            } else if (cp.name == "headless") {
                 config->headless = true;
-                break;
-            case 'i':
+            } else if (cp.name == "ibl") {
                 config->iblDirectory = arg;
-                break;
-            case 'u':
-                config->customArgs["ubershader"] = utils::CString("true");
-                break;
-            case 's':
-                config->customArgs["actualSize"] = utils::CString("true");
-                break;
-            case 'r':
-                config->customArgs["recomputeAabb"] = utils::CString("true");
-                break;
-            case 't':
-                config->customArgs["settings"] = utils::CString(arg.c_str());
-                break;
-            case 'b': {
-                config->customArgs["batch"] = utils::CString(arg.c_str());
-                break;
-            }
-            case 'v': {
+            } else if (cp.name == "split-view") {
                 config->splitView = true;
-                break;
-            }
-            case 'g': {
+            } else if (cp.name == "vulkan-gpu-hint") {
                 config->vulkanGPUHint = arg;
-                break;
-            }
-            case 'd': {
-                config->customArgs["screenshotAsPPM"] = utils::CString("true");
-                break;
-            }
-            case 'w': {
+            } else if (cp.name == "webgpu-backend") {
                 config->forcedWebGPUBackend = parseArgumentsForBackend(arg);
-                break;
-            }
-            case 'x': {
+            } else if (cp.name == "remote") {
                 config->displayManager = SampleConfig::DisplayManager::WEB;
                 config->headless = true;
-                break;
             }
+        } else {
+            seenSampleParams[mapping->index] = true;
+            const auto& sp = spec.parameters[mapping->index];
+            Parameter parsedParam = sp;
+            switch (sp.type) {
+                case ParameterType::BOOL:
+                    parsedParam.value = true;
+                    break;
+                case ParameterType::INT: {
+                    int val = 0;
+                    try {
+                        val = std::stoi(arg.c_str());
+                    } catch (...) {
+                        std::cerr << "Invalid integer value '" << arg.c_str() << "' for option --"
+                                  << sp.name.c_str() << "\n";
+                        exit(1);
+                    }
+                    if (sp.intRange && (val < sp.intRange->min || val > sp.intRange->max)) {
+                        std::cerr << "Value " << val << " for option --" << sp.name.c_str()
+                                  << " is out of range [" << sp.intRange->min << ".."
+                                  << sp.intRange->max << "]\n";
+                        exit(1);
+                    }
+                    parsedParam.value = val;
+                    break;
+                }
+                case ParameterType::FLOAT: {
+                    float val = 0.0f;
+                    try {
+                        val = std::stof(arg.c_str());
+                    } catch (...) {
+                        std::cerr << "Invalid float value '" << arg.c_str() << "' for option --"
+                                  << sp.name.c_str() << "\n";
+                        exit(1);
+                    }
+                    if (sp.floatRange && (val < sp.floatRange->min || val > sp.floatRange->max)) {
+                        std::cerr << "Value " << val << " for option --" << sp.name.c_str()
+                                  << " is out of range [" << sp.floatRange->min << ".."
+                                  << sp.floatRange->max << "]\n";
+                        exit(1);
+                    }
+                    parsedParam.value = val;
+                    break;
+                }
+                case ParameterType::STRING:
+                    parsedParam.value = arg;
+                    break;
+                case ParameterType::ENUM: {
+                    bool matched = false;
+                    for (const auto& choice: sp.choices) {
+                        if (choice == arg) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    if (!matched) {
+                        std::cerr << "Invalid choice '" << arg.c_str() << "' for option --"
+                                  << sp.name.c_str() << ". Allowed choices: [";
+                        for (size_t c = 0; c < sp.choices.size(); ++c) {
+                            if (c > 0) std::cerr << "|";
+                            std::cerr << sp.choices[c].c_str();
+                        }
+                        std::cerr << "]\n";
+                        exit(1);
+                    }
+                    parsedParam.value = arg;
+                    break;
+                }
+            }
+            config->parameters[sp.name] = parsedParam;
         }
     }
 
-    bool missingRequiredFlag = false;
-    for (char reqFlag: spec.requiredFlags) {
-        if (std::find(seenOptions.begin(), seenOptions.end(), int(reqFlag)) == seenOptions.end()) {
-            missingRequiredFlag = true;
-            break;
+    bool missingRequiredParam = false;
+    for (size_t i = 0; i < spec.parameters.size(); ++i) {
+        if (spec.parameters[i].required && !seenSampleParams[i]) {
+            std::cerr << "Error: Missing required option: --" << spec.parameters[i].name.c_str();
+            if (spec.parameters[i].shorthand != '\0') {
+                std::cerr << " (-" << spec.parameters[i].shorthand << ")";
+            }
+            std::cerr << "\n";
+            missingRequiredParam = true;
         }
     }
+
     int const numPositionalArgs = argc - utils::getopt::optind;
-    if (missingRequiredFlag || numPositionalArgs < spec.requiredPositionalArgCount) {
+    if (missingRequiredParam || numPositionalArgs < spec.requiredPositionalArgCount) {
         printUsage(argv[0], spec);
         exit(1);
     }
 
-    // Make sure that default resolves to a particular backend.
-    config->backend = resolveBackend(config->backend);
+    if (config != nullptr) {
+        config->positionalArgs =
+                utils::FixedCapacityVector<utils::CString>::with_capacity(numPositionalArgs);
+        for (int i = utils::getopt::optind; i < argc; ++i) {
+            config->positionalArgs.push_back(utils::CString(argv[i]));
+        }
+
+        // Make sure that default resolves to a particular backend.
+        config->backend = resolveBackend(config->backend);
+    }
 
     return utils::getopt::optind;
 }
-
 
 } // namespace samples

--- a/samples/common/arguments.h
+++ b/samples/common/arguments.h
@@ -17,6 +17,7 @@
 #ifndef TNT_SAMPLES_ARGUMENTS_H
 #define TNT_SAMPLES_ARGUMENTS_H
 
+#include "Parameter.h"
 #include "SampleConfig.h"
 
 #include <filamentapp/AssetLoader.h>
@@ -26,11 +27,9 @@
 #include <filament/Engine.h>
 
 #include <utils/CString.h>
-#include <utils/getopt.h>
+#include <utils/FixedCapacityVector.h>
 
-#include <functional>
 #include <memory>
-#include <vector>
 
 namespace samples {
 
@@ -39,17 +38,11 @@ FilamentApp2::Builder getBuilder(const SampleConfig& config,
 
 std::unique_ptr<filament::app::DisplayManager> getDisplayManager(const SampleConfig& config);
 
-using CustomArgumentHandler = std::function<bool(int opt, const utils::CString& arg)>;
-
 struct CommandLineSpecification {
     utils::CString sampleDescription;
-    utils::CString positionalArgsDescription;
+    utils::FixedCapacityVector<utils::CString> positionalArgsDescription;
     int requiredPositionalArgCount = 0;
-    std::vector<char> requiredFlags;
-    utils::CString customOptionsHelp;
-    CustomArgumentHandler customHandler = nullptr;
-    const char* customOptStr = "";
-    const utils::getopt::option* customOptions = nullptr;
+    SampleParameters parameters;
 };
 
 void printUsage(const char* execName, const CommandLineSpecification& spec = {});

--- a/samples/depthtesting.cpp
+++ b/samples/depthtesting.cpp
@@ -177,11 +177,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "depthtesting";
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto fApp = createSampleApp(config, dm.get(), nullptr);
     fApp->run();

--- a/samples/frame_generator.cpp
+++ b/samples/frame_generator.cpp
@@ -82,8 +82,6 @@
 #include <map>
 #include <memory>
 #include <sstream>
-#include <stdexcept>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -108,7 +106,6 @@ struct Param {
 
 constexpr int FRAME_TO_SKIP = 10;
 
-std::vector<Path> g_filenames;
 std::vector<char> g_materialBuffer;
 Path g_materialPath;
 Path g_paramsPath;
@@ -224,14 +221,14 @@ std::vector<float> parseFloats(std::istream& stream) {
 void readParameters() {
     std::ifstream in(g_paramsPath.c_str(), std::ifstream::in);
     if (in.is_open()) {
-        std::string line;
-        while (std::getline(in, line)) {
-            if (line.empty() || line[0] == '#' || (line.length() > 1 && line[0] == '/' && line[1] == '/')) continue;
+        char line[512];
+        while (in.getline(line, sizeof(line))) {
+            if (line[0] == '\0' || line[0] == '#' || (line[0] == '/' && line[1] == '/')) continue;
             std::istringstream lineStream(line);
             Param param;
-            std::string tempName;
+            char tempName[256];
             lineStream >> tempName;
-            param.name = utils::CString(tempName.c_str());
+            param.name = utils::CString(tempName);
             param.start = parseFloats(lineStream);
             param.end = parseFloats(lineStream);
 
@@ -281,7 +278,8 @@ void setup(Engine* engine, View*, Scene* scene) {
         return;
     }
 
-    for (auto& filename : g_filenames) {
+    for (const auto& fname : g_config.positionalArgs) {
+        Path filename(fname.c_str_safe());
         g_meshSet->addFromFile(filename, g_meshMaterialInstances);
     }
 
@@ -379,17 +377,15 @@ void postRender(Engine*, View* view, Scene*, Renderer* renderer) {
 
                     int const digits = int(log10(double(g_materialVariantCount))) + 1;
 
-                    std::ostringstream stringStream;
-                    stringStream << "./" << g_prefix.c_str_safe();
-                    stringStream << std::setfill('0') << std::setw(digits);
-                    stringStream << std::to_string(state->currentFrame);
-                    stringStream << ".png";
-
-                    std::string const name = stringStream.str();
-                    Path const out(name);
+                    char nameBuf[512];
+                    snprintf(nameBuf, sizeof(nameBuf), "./%s%0*d.png", g_prefix.c_str_safe(),
+                            digits, state->currentFrame);
+                    utils::CString const name(nameBuf);
+                    Path const out(name.c_str());
 
                     std::ofstream outputStream(out, std::ios::binary | std::ios::trunc);
-                    ImageEncoder::encode(outputStream, ImageEncoder::Format::PNG, image, "", name);
+                    ImageEncoder::encode(outputStream, ImageEncoder::Format::PNG, image, "",
+                            name.c_str());
 
                     delete[] static_cast<uint8_t*>(buffer);
                     delete state;
@@ -417,7 +413,24 @@ void postRender(Engine*, View* view, Scene*, Renderer* renderer) {
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
+    g_config = config;
     app->config = config;
+    g_meshScale = config.getFloat("scale", 1.0f);
+    utils::CString clearColorStr = config.getString("clear-color");
+    if (!clearColorStr.empty()) {
+        char* end = nullptr;
+        g_clearColor = uint32_t(strtoul(clearColorStr.c_str(), &end, 16));
+    }
+    g_width = uint32_t(config.getInt("size", 512));
+    g_height = g_width;
+    g_materialPath = config.getString("material").c_str();
+    g_paramsPath = config.getString("params").c_str();
+    g_prefix = config.getString("prefix");
+    g_lightOn = config.getBool("light-on");
+    if (config.getBool("skybox-off")) {
+        g_skyboxOn = false;
+    }
+    g_materialVariantCount = config.getInt("count", 1);
     config.width = g_width;
     config.height = g_height;
     auto fApp = samples::getBuilder(config, dm, loader)
@@ -431,81 +444,25 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+        samples::Parameter::makeString("clear-color", 'b',
+                "Clear color for the render target [hex]", ""),
+        samples::Parameter::makeInt("size", 'S', "Size of the square render window", 512, 1),
+        samples::Parameter::makeString("material", 'm',
+                "Path to a compiled material file (see matc)", "", true),
+        samples::Parameter::makeString("params", 'p', "Path to a parameters file", "", true),
+        samples::Parameter::makeString("prefix", 'P', "Prefix for the rendered output frames", ""),
+        samples::Parameter::makeBool("light-on", 'l', "Turn on the directional light", false),
+        samples::Parameter::makeBool("skybox-off", 'Y', "Turn off the skybox", false),
+        samples::Parameter::makeInt("count", 'C', "Number of material variants to render", 1, 1,
+                256),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int const argc, char* argv[]) {
-    static constexpr const char* CUSTOM_OPTSTR = "s:b:S:m:p:x:lyc:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { "clear-color", utils::getopt::required_argument, nullptr, 'b' },
-        { "size", utils::getopt::required_argument, nullptr, 'S' },
-        { "material", utils::getopt::required_argument, nullptr, 'm' },
-        { "params", utils::getopt::required_argument, nullptr, 'p' },
-        { "prefix", utils::getopt::required_argument, nullptr, 'x' },
-        { "light-on", utils::getopt::no_argument, nullptr, 'l' },
-        { "skybox-off", utils::getopt::no_argument, nullptr, 'y' },
-        { "count", utils::getopt::required_argument, nullptr, 'c' }, { nullptr, 0, nullptr, 0 }
-    };
-
-    auto customHandler = [](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 's':
-                try {
-                    g_meshScale = std::stof(arg.c_str());
-                } catch (std::invalid_argument& e) {
-                    g_meshScale = 1.0f;
-                } catch (std::out_of_range& e) {
-                    g_meshScale = 1.0f;
-                }
-                return true;
-            case 'b':
-                try {
-                    g_clearColor = uint32_t(std::stoul(arg.c_str(), nullptr, 16));
-                } catch (std::invalid_argument& e) {
-                    g_clearColor = {};
-                } catch (std::out_of_range& e) {
-                    g_clearColor = {};
-                }
-                return true;
-            case 'S':
-                try {
-                    g_width = uint32_t(std::stoul(arg.c_str()));
-                    g_height = g_width;
-                } catch (std::invalid_argument& e) {
-                    g_width = 512;
-                    g_height = 512;
-                } catch (std::out_of_range& e) {
-                    g_width = 512;
-                    g_height = 512;
-                }
-                return true;
-            case 'm':
-                g_materialPath = arg.c_str();
-                return true;
-            case 'p':
-                g_paramsPath = arg.c_str();
-                return true;
-            case 'x':
-                g_prefix = arg;
-                return true;
-            case 'l':
-                g_lightOn = true;
-                return true;
-            case 'y':
-                g_skyboxOn = false;
-                return true;
-            case 'c':
-                try {
-                    g_materialVariantCount = std::min(std::max(1, std::stoi(arg.c_str())), 256);
-                } catch (std::invalid_argument& e) {
-                    g_materialVariantCount = 1;
-                } catch (std::out_of_range& e) {
-                    g_materialVariantCount = 1;
-                }
-                return true;
-        }
-        return false;
-    };
-
     samples::CommandLineSpecification spec = {
         .sampleDescription =
                 "SAMPLE_FRAME_GENERATOR tests a material by varying float parameters\n\n"
@@ -520,48 +477,26 @@ int main(int const argc, char* argv[]) {
                 "       metallic   1.0\n"
                 "       # interpolated\n"
                 "       roughness  0.0 1.0",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx)>",
+        .positionalArgsDescription = { "mesh files (.obj, .fbx)" },
         .requiredPositionalArgCount = 1,
-        .requiredFlags = { 'm', 'p' },
-        .customOptionsHelp = "   --scale=[number], -s [number]\n"
-                             "       Applies uniform scale\n\n"
-                             "   --material=<path>, -m <path>\n"
-                             "       Path to a compiled material file (see matc)\n\n"
-                             "   --params=<path>, -p <path>\n"
-                             "       Path to a parameters file\n"
-                             "       Each line: param_name start end\n\n"
-                             "   --count=[integer > 0 && <= 256], -c [integer > 0 && <= 256]\n"
-                             "       Number of material variants to render\n\n"
-                             "   --light-on, -l\n"
-                             "       Turn on the directional light\n\n"
-                             "   --skybox-off, -y\n"
-                             "       Turn off the skybox\n\n"
-                             "   --prefix=<string>, -x <string>\n"
-                             "       Prefix for the rendered output frames\n\n"
-                             "   --clear-color=[hex], -b [hex]\n"
-                             "       Clear color for the render target\n\n"
-                             "   --size=[uint], -S [uint]\n"
-                             "       Size of the square render window\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .parameters = createAppParameters(),
     };
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &g_config, spec);
-    auto dm = samples::getDisplayManager(g_config);
+    SampleConfig config;
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
+    auto dm = samples::getDisplayManager(config);
 
-    for (int i = optind; i < argc; i++) {
-        Path const filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        Path const filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        g_filenames.push_back(filename);
     }
 
-    g_config.title = "Frame Generator";
-    g_config.headless = true;
-    auto fApp = createSampleApp(g_config, dm.get(), nullptr);
+    config.title = "Frame Generator";
+    config.headless = true;
+    auto fApp = createSampleApp(config, dm.get(), nullptr);
     fApp->run();
 
     return 0;

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -48,7 +48,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <string>
 
 using namespace filament;
 using namespace filament::math;
@@ -93,21 +92,21 @@ std::ifstream::pos_type getFileSize(const char* filename) {
 
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* appLoader) {
+    if (config.iblDirectory.empty()) {
+        config.iblDirectory =
+                utils::CString((FilamentApp2::getRootAssetsPath() + DEFAULT_IBL).c_str());
+    }
     auto app = std::make_shared<App>();
     app->config = config;
-
-    if (config.customArgs.find("instanceToAnimate") != config.customArgs.end()) {
-        app->instanceToAnimate = std::stoi(config.customArgs.at("instanceToAnimate").c_str());
-    }
-    if (config.customArgs.find("instancesCount") != config.customArgs.end()) {
-        app->instances.resize(std::stoi(config.customArgs.at("instancesCount").c_str()));
-    }
-    if (config.customArgs.find("ubershader") != config.customArgs.end()) {
+    app->instanceToAnimate = config.getInt("animate", -1);
+    app->instances.resize(config.getInt("num", 1));
+    if (config.getBool("ubershader")) {
         app->materialSource = UBERSHADER;
     }
 
     auto loadAsset = [app, appLoader]() {
-        utils::Path filename(app->config.fileName.c_str_safe());
+        utils::Path filename(!app->config.positionalArgs.empty() ?
+                app->config.positionalArgs[0].c_str_safe() : "");
         std::vector<uint8_t> buffer = appLoader->load(filename);
         if (buffer.empty()) {
             std::cerr << "Unable to open " << filename << std::endl;
@@ -127,7 +126,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     };
 
     auto loadResources = [app, appLoader]() {
-        utils::Path filename(app->config.fileName.c_str_safe());
+        utils::Path filename(!app->config.positionalArgs.empty() ?
+                app->config.positionalArgs[0].c_str_safe() : "");
         // Load external textures and buffers.
         utils::CString gltfPath = utils::CString(filename.getAbsolutePath().c_str());
         ResourceConfiguration configuration;
@@ -207,7 +207,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                                            UBERARCHIVE_DEFAULT_SIZE);
 
         app->assetLoader = AssetLoader::create({ engine, app->materials, app->names });
-        utils::Path filename(app->config.fileName.c_str_safe());
+        utils::Path filename(!app->config.positionalArgs.empty() ?
+                app->config.positionalArgs[0].c_str_safe() : "");
         if (filename.isEmpty()) {
             app->asset = app->assetLoader->createInstancedAsset(GLTF_DEMO_DAMAGEDHELMET_DATA,
                     GLTF_DEMO_DAMAGEDHELMET_SIZE, app->instances.data(), app->instances.size());
@@ -287,39 +288,28 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeInt("num", 'n', "Number of instances to create", 1, 1),
+        samples::Parameter::makeInt("animate", 'm', "Index of instance to animate (-1 for all)",
+                -1, -1),
+        samples::Parameter::makeBool("ubershader", 'u', "Enable ubershader", false),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "glTF Instancing";
     config.iblDirectory = utils::CString((FilamentApp2::getRootAssetsPath() + DEFAULT_IBL).c_str());
 
-    static constexpr const char* CUSTOM_OPTSTR = "n:m:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "num", utils::getopt::required_argument, nullptr, 'n' },
-        { "animate", utils::getopt::required_argument, nullptr, 'm' }, { nullptr, 0, nullptr, 0 }
+    samples::CommandLineSpecification spec = {
+        .parameters = createAppParameters(),
     };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'm':
-                config.customArgs["instanceToAnimate"] = utils::CString(arg.c_str());
-                return true;
-            case 'n':
-                config.customArgs["instancesCount"] = utils::CString(arg.c_str());
-                return true;
-        }
-        return false;
-    };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config,
-            {
-                .customHandler = customHandler,
-                .customOptStr = CUSTOM_OPTSTR,
-                .customOptions = CUSTOM_OPTIONS,
-            });
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
-    int num_args = argc - optind;
-    if (num_args >= 1) {
-        config.fileName = utils::CString(argv[optind]);
-        utils::Path filename(config.fileName.c_str_safe());
+    if (!config.positionalArgs.empty()) {
+        utils::Path filename(config.positionalArgs[0].c_str_safe());
         if (!filename.exists()) {
             std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -73,7 +73,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
-#include <string>
+#include <string_view>
 
 #if FILAMENT_DISABLE_MATOPT
 #   define OPTIMIZE_MATERIALS false
@@ -183,7 +183,7 @@ void createGroundPlane(Engine* engine, Scene* scene, App* app) {
     auto& viewerOptions = app->viewer->getSettings().viewer;
     shadowMaterial->setDefaultParameter("strength", viewerOptions.groundShadowStrength);
 
-    constexpr uint32_t indices[] = { 0, 1, 2, 2, 3, 0 };
+    static constexpr uint32_t indices[] = { 0, 1, 2, 2, 3, 0 };
 
     Aabb aabb = app->asset->getBoundingBox();
     if (!app->actualSize) {
@@ -193,7 +193,7 @@ void createGroundPlane(Engine* engine, Scene* scene, App* app) {
 
     float3 planeExtent{10.0f * aabb.extent().x, 0.0f, 10.0f * aabb.extent().z};
 
-    const float3 vertices[] = {
+    float3* const vertices = new float3[4]{
         { -planeExtent.x, 0, -planeExtent.z },
         { -planeExtent.x, 0, planeExtent.z },
         { planeExtent.x, 0, planeExtent.z },
@@ -209,7 +209,7 @@ void createGroundPlane(Engine* engine, Scene* scene, App* app) {
                     }
             ).xyzw);
 
-    const short4 normals[]{ tbn, tbn, tbn, tbn };
+    static const short4 normals[]{ tbn, tbn, tbn, tbn };
 
     VertexBuffer* vertexBuffer = VertexBuffer::Builder()
             .vertexCount(4)
@@ -222,7 +222,8 @@ void createGroundPlane(Engine* engine, Scene* scene, App* app) {
             .build(*engine);
 
     vertexBuffer->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(
-            vertices, vertexBuffer->getVertexCount() * sizeof(vertices[0])));
+            vertices, vertexBuffer->getVertexCount() * sizeof(vertices[0]),
+            [](void* buffer, size_t, void*) { delete[] static_cast<float3*>(buffer); }));
     vertexBuffer->setBufferAt(*engine, 1, VertexBuffer::BufferDescriptor(
             normals, vertexBuffer->getVertexCount() * sizeof(normals[0])));
 
@@ -430,23 +431,23 @@ bool checkGLTFAsset(const utils::Path& filename) {
 
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* appLoader) {
+    if (config.iblDirectory.empty()) {
+        config.iblDirectory =
+                utils::CString((FilamentApp2::getRootAssetsPath() + DEFAULT_IBL).c_str());
+    }
     auto app = std::make_shared<App>();
     app->config = config;
 
-    app->materialSource = config.customArgs.find("ubershader") != config.customArgs.end()
-                                  ? UBERSHADER
-                                  : JITSHADER;
-    app->actualSize = config.customArgs.find("actualSize") != config.customArgs.end();
-    app->recomputeAabb = config.customArgs.find("recomputeAabb") != config.customArgs.end();
-    if (config.customArgs.find("settings") != config.customArgs.end())
-        app->settingsFile = utils::CString(config.customArgs["settings"].c_str());
-    if (config.customArgs.find("batch") != config.customArgs.end())
-        app->batchFile = utils::CString(config.customArgs["batch"].c_str());
-    app->screenshotAsPPM = config.customArgs.find("screenshotAsPPM") != config.customArgs.end();
+    app->materialSource = config.getBool("ubershader") ? UBERSHADER : JITSHADER;
+    app->actualSize = config.getBool("actual-size");
+    app->recomputeAabb = config.getBool("recompute-aabb");
+    app->settingsFile = config.getString("settings");
+    app->batchFile = config.getString("batch");
+    app->screenshotAsPPM = config.getBool("screenshot-as-ppm");
 
     utils::Path filename;
-    if (!config.fileName.empty()) {
-        filename = getPathForGLTFAsset(config.fileName.c_str_safe());
+    if (!config.positionalArgs.empty()) {
+        filename = getPathForGLTFAsset(config.positionalArgs[0].c_str_safe());
         if (filename.isEmpty()) {
             std::cerr << "no glTF file found in " << filename << std::endl;
             exit(1);
@@ -1084,11 +1085,11 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
 
     auto postRender = [app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
         if (app->screenshot) {
-            std::ostringstream stringStream;
-            stringStream << "screenshot" << std::setfill('0') << std::setw(2)
-                         << +app->screenshotSeq;
-            std::string const ext = app->screenshotAsPPM ? ".ppm" : ".tif";
-            AutomationEngine::exportScreenshot(view, renderer, stringStream.str() + ext, false,
+            char filenameBuf[64];
+            const char* const ext = app->screenshotAsPPM ? ".ppm" : ".tif";
+            snprintf(filenameBuf, sizeof(filenameBuf), "screenshot%02u%s", +app->screenshotSeq,
+                    ext);
+            AutomationEngine::exportScreenshot(view, renderer, filenameBuf, false,
                     app->automationEngine);
             ++app->screenshotSeq;
             app->screenshot = false;
@@ -1146,18 +1147,31 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeBool("ubershader", 'u', "Enable ubershader", false),
+        samples::Parameter::makeBool("actual-size", 's', "Set window size to actual asset size",
+                false),
+        samples::Parameter::makeBool("recompute-aabb", 'r', "Recompute bounding box", false),
+        samples::Parameter::makeString("settings", 't', "Path to settings JSON file", ""),
+        samples::Parameter::makeString("batch", 'b', "Path to batch file", ""),
+        samples::Parameter::makeBool("screenshot-as-ppm", 'd', "Save screenshot as PPM", false),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "Filament";
     config.iblDirectory = utils::CString((FilamentApp2::getRootAssetsPath() + DEFAULT_IBL).c_str());
+    samples::CommandLineSpecification spec = {
+        .sampleDescription = "GLTF_VIEWER is a tool for viewing glTF models with Filament.",
+        .positionalArgsDescription = { "gltf/glb file" },
+        .parameters = createAppParameters(),
+    };
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
-    int const num_args = argc - optind;
-    if (num_args >= 1) {
-        config.fileName = utils::CString(argv[optind]);
-    }
 
     auto loader = new filament::app::DesktopAssetLoader();
     auto app = createSampleApp(config, dm.get(), loader);

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -398,11 +398,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "Heightfield";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/helloasync.cpp
+++ b/samples/helloasync.cpp
@@ -44,7 +44,6 @@
 
 #include <iostream> // for cerr
 #include <memory>
-#include <string>   // for printing usage/help
 
 using namespace filament;
 using utils::Entity;
@@ -571,12 +570,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "helloasync";
     config.asynchronousMode = backend::AsynchronousMode::THREAD_PREFERRED;
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/hellomorphing.cpp
+++ b/samples/hellomorphing.cpp
@@ -203,11 +203,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "helloMorphing";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -37,7 +37,6 @@
 #include <utils/getopt.h>
 
 #include <iostream>
-#include <string>// for printing usage/help
 
 using namespace filament;
 using namespace filamesh;
@@ -61,6 +60,10 @@ const char* IBL_FOLDER = "assets/ibl/lightroom_14b";
 
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
+    if (config.iblDirectory.empty()) {
+        config.iblDirectory =
+                utils::CString((FilamentApp2::getRootAssetsPath() + IBL_FOLDER).c_str());
+    }
     auto app = std::make_shared<App>();
     app->config = config;
 
@@ -102,6 +105,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     auto cleanup = [app](Engine* engine, View*, Scene*) {
         engine->destroy(app->light);
         engine->destroy(app->mesh.renderable);
+        engine->destroy(app->mesh.vertexBuffer);
+        engine->destroy(app->mesh.indexBuffer);
         engine->destroy(app->materialInstance);
         engine->destroy(app->material);
     };
@@ -121,12 +126,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "hellopbr";
     config.iblDirectory = utils::CString((FilamentApp2::getRootAssetsPath() + IBL_FOLDER).c_str());
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/helloskinning.cpp
+++ b/samples/helloskinning.cpp
@@ -197,12 +197,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "hello skinning";
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/helloskinningbuffer.cpp
+++ b/samples/helloskinningbuffer.cpp
@@ -254,12 +254,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "skinning buffer common for two renderables";
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/helloskinningbuffer_morebones.cpp
+++ b/samples/helloskinningbuffer_morebones.cpp
@@ -260,12 +260,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "skinning buffer common for two renderables";
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/hellostereo.cpp
+++ b/samples/hellostereo.cpp
@@ -88,10 +88,7 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     app->config = config;
 
     auto setup = [app](Engine* engine, View* view, Scene* scene) {
-        uint8_t sampleCount = 1;
-        if (app->config.customArgs.find("msaa") != app->config.customArgs.end()) {
-            sampleCount = std::stoi(app->config.customArgs.at("msaa").c_str());
-        }
+        uint8_t sampleCount = uint8_t(app->config.getInt("samples", 1));
 
         auto& tcm = engine->getTransformManager();
         auto& rcm = engine->getRenderableManager();
@@ -317,6 +314,12 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeInt("samples", 'm', "MSAA sample count (1, 2, 4, 8)", 1, 1, 8),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
 
@@ -327,24 +330,10 @@ int main(int argc, char** argv) {
 
     SampleConfig config;
     config.title = "stereoscopic rendering";
-    static constexpr const char* CUSTOM_OPTSTR = "m:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "samples", utils::getopt::required_argument, nullptr, 'm' }, { nullptr, 0, nullptr, 0 }
+    samples::CommandLineSpecification spec = {
+        .parameters = createAppParameters(),
     };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'm':
-                config.customArgs["msaa"] = utils::CString(arg.c_str());
-                return true;
-        }
-        return false;
-    };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config,
-            {
-                .customHandler = customHandler,
-                .customOptStr = CUSTOM_OPTSTR,
-                .customOptions = CUSTOM_OPTIONS,
-            });
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/hellotriangle.cpp
+++ b/samples/hellotriangle.cpp
@@ -39,7 +39,6 @@
 
 #include <cmath>
 #include <iostream>
-#include <string>// for printing usage/help
 
 using namespace filament;
 using utils::Entity;
@@ -147,12 +146,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "hellotriangle";
     config.featureLevel = backend::FeatureLevel::FEATURE_LEVEL_0;
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/hellouvmorphing.cpp
+++ b/samples/hellouvmorphing.cpp
@@ -87,9 +87,7 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
     app->config = config;
-    if (config.customArgs.find("positions") != config.customArgs.end()) {
-        app->posMorphing = true;
-    }
+    app->posMorphing = config.getBool("positions");
 
     auto setup = [app](Engine* engine, View* view, Scene* scene) {
         app->skybox = Skybox::Builder().color({ 0.1, 0.125, 0.25, 1.0 }).build(*engine);
@@ -294,28 +292,20 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeBool("positions", 'p', "Morph positions", false),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "hellouvmorphing";
-    static constexpr const char* CUSTOM_OPTSTR = "p";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "positions", utils::getopt::no_argument, nullptr, 'p' }, { nullptr, 0, nullptr, 0 }
+    samples::CommandLineSpecification spec = {
+        .parameters = createAppParameters(),
     };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'p':
-                config.customArgs["positions"] = utils::CString("true");
-                return true;
-        }
-        return false;
-    };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config,
-            {
-                .customHandler = customHandler,
-                .customOptStr = CUSTOM_OPTSTR,
-                .customOptions = CUSTOM_OPTIONS,
-            });
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/hybrid_instancing.cpp
+++ b/samples/hybrid_instancing.cpp
@@ -79,7 +79,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <random>
-#include <string>
 #include <vector>
 
 #include <math.h>
@@ -521,8 +520,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
     app->config = config;
-    if (config.customArgs.find("emitters") != config.customArgs.end()) {
-        app->ui.emitterCount = atoi(config.customArgs["emitters"].c_str());
+    if (config.getInt("emitters", 0) > 0) {
+        app->ui.emitterCount = config.getInt("emitters");
     }
 
     auto setup = [app](Engine* engine, View* view, Scene* scene) {
@@ -619,38 +618,20 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeInt("emitters", 'E', "Number of particle emitters", 1, 1),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "Hybrid Instancing";
-    static constexpr const char* CUSTOM_OPTSTR = "e:c:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "emitters", utils::getopt::required_argument, nullptr, 'e' },
-        { "camera", utils::getopt::required_argument, nullptr, 'c' }, { nullptr, 0, nullptr, 0 }
+    samples::CommandLineSpecification spec = {
+        .parameters = createAppParameters(),
     };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'e':
-                config.customArgs["emitters"] = utils::CString(arg.c_str());
-                return true;
-            case 'c':
-                if (arg == "flight") {
-                    config.cameraMode = filament::camutils::Mode::FREE_FLIGHT;
-                } else if (arg == "orbit") {
-                    config.cameraMode = filament::camutils::Mode::ORBIT;
-                } else {
-                    std::cerr << "Unrecognized camera mode. Must be 'flight'|'orbit'.\n";
-                }
-                return true;
-        }
-        return false;
-    };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config,
-            {
-                .customHandler = customHandler,
-                .customOptStr = CUSTOM_OPTSTR,
-                .customOptions = CUSTOM_OPTIONS,
-            });
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/image_viewer.cpp
+++ b/samples/image_viewer.cpp
@@ -54,7 +54,7 @@
 
 #include <fstream>
 #include <iostream>
-#include <string>
+#include <string_view>
 
 using namespace filament;
 using namespace filament::math;
@@ -221,8 +221,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     app->config = config;
 
     Path filename;
-    if (config.customArgs.find("filename") != config.customArgs.end()) {
-        filename = Path(config.customArgs["filename"].c_str());
+    if (!config.positionalArgs.empty()) {
+        filename = Path(config.positionalArgs[0].c_str());
     }
 
     auto setup = [app, filename](Engine* engine, View* view, Scene* scene) {
@@ -343,16 +343,18 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
-    config.title = "Filament Image Viewer";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::CommandLineSpecification spec = {
+        .sampleDescription = "Filament Image Viewer",
+        .positionalArgsDescription = { "image file" },
+        .parameters = createAppParameters(),
+    };
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
-    int num_args = argc - optind;
-    if (num_args >= 1) {
-        config.customArgs["filename"] = utils::CString(argv[optind]);
-    }
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();
     return 0;

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -46,7 +46,6 @@
 
 #include <iostream>
 #include <map>
-#include <string>
 #include <vector>
 
 using namespace filament::math;
@@ -55,6 +54,13 @@ using namespace filamat;
 using namespace utils;
 namespace {
 float g_meshScale = 1.0f;
+
+struct GroundPlane {
+    VertexBuffer* vb = nullptr;
+    IndexBuffer* ib = nullptr;
+    Material* mat = nullptr;
+    Entity renderable;
+};
 
 struct App {
     FilamentApp2* filamentApp;
@@ -65,6 +71,7 @@ struct App {
     std::unique_ptr<Cube> meshAabb;
     std::vector<Sphere> spheres;
     std::vector<Entity> lights;
+    GroundPlane plane;
     Entity discoBallEntity;
     float discoAngle = 0;
     float discoAngularSpeed = 0.25f * float(M_PI);
@@ -80,18 +87,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     auto app = std::make_shared<App>();
     app->config = config;
 
-    app->moreLights = app->config.customArgs["moreLights"] == "true";
-    app->shadowPlane = app->config.customArgs["shadowPlane"] == "true";
-    app->discoBall = app->config.customArgs["discoBall"] == "true";
+    app->moreLights = app->config.getBool("more-lights");
+    app->shadowPlane = app->config.getBool("shadow-plane");
+    app->discoBall = app->config.getBool("disco");
+    g_meshScale = app->config.getFloat("scale", 1.0f);
 
-    std::string_view filenames_str = app->config.customArgs["filenames"].c_str();
-    size_t pos = 0;
-    while ((pos = std::string_view(filenames_str).find(';')) != std::string_view::npos) {
-        app->filenames.push_back(utils::Path(filenames_str.substr(0, pos)));
-        filenames_str.remove_prefix(pos + 1);
-    }
-    if (!filenames_str.empty()) {
-        app->filenames.push_back(utils::Path(filenames_str));
+    for (const auto& filename: app->config.positionalArgs) {
+        app->filenames.push_back(utils::Path(filename.c_str()));
     }
 
     auto cleanup = [app](Engine* engine, View* view, Scene* scene) {
@@ -103,6 +105,20 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         app->meshAabb.reset(nullptr);
 
         auto& em = EntityManager::get();
+
+        if (app->plane.renderable) {
+            engine->destroy(app->plane.renderable);
+            em.destroy(app->plane.renderable);
+        }
+        if (app->plane.mat) {
+            engine->destroy(app->plane.mat);
+        }
+        if (app->plane.vb) {
+            engine->destroy(app->plane.vb);
+        }
+        if (app->plane.ib) {
+            engine->destroy(app->plane.ib);
+        }
 
         app->spheres.clear();
 
@@ -126,13 +142,20 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         for (auto& filename: app->filenames) {
             app->meshSet->addFromFile(filename, app->materialLibrary);
         }
+        if (app->filenames.empty()) {
+            app->meshSet->addFromFile(FilamentApp2::getRootAssetsPath() +
+                                              "assets/models/monkey/monkey.obj",
+                    app->materialLibrary);
+        }
 
         auto& lcm = engine->getLightManager();
 
         auto& tcm = engine->getTransformManager();
-        auto ti = tcm.getInstance(app->meshSet->getRenderables()[0]);
-        tcm.setTransform(ti, mat4f{ mat3f(g_meshScale), float3(0.0f, 0.0f, -4.0f) } *
-                                     tcm.getWorldTransform(ti));
+        if (!app->meshSet->getRenderables().empty()) {
+            auto ti = tcm.getInstance(app->meshSet->getRenderables()[0]);
+            tcm.setTransform(ti, mat4f{ mat3f(g_meshScale), float3(0.0f, 0.0f, -4.0f) } *
+                                         tcm.getWorldTransform(ti));
+        }
 
         auto& rcm = engine->getRenderableManager();
         for (auto renderable: app->meshSet->getRenderables()) {
@@ -271,24 +294,28 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                     tcm.getInstance(discoBall));
         }
 
-        app->meshAabb.reset(
-                new Cube(*engine, app->filamentApp->getTransparentMaterial(), { 0, 0, 1 }));
+        if (!app->meshSet->getRenderables().empty()) {
+            app->meshAabb.reset(
+                    new Cube(*engine, app->filamentApp->getTransparentMaterial(), { 0, 0, 1 }));
 
-        Entity object = app->meshSet->getRenderables()[1];
+            Entity object = app->meshSet->getRenderables().size() > 1
+                                    ? app->meshSet->getRenderables()[1]
+                                    : app->meshSet->getRenderables()[0];
 
-        RenderableManager::Instance ri = rcm.getInstance(object);
-        if (ri) {
-            app->meshAabb->mapAabb(*engine, rcm.getAxisAlignedBoundingBox(ri));
-            scene->addEntity(app->meshAabb->getWireFrameRenderable());
-            scene->addEntity(app->meshAabb->getSolidRenderable());
+            RenderableManager::Instance ri = rcm.getInstance(object);
+            if (ri) {
+                app->meshAabb->mapAabb(*engine, rcm.getAxisAlignedBoundingBox(ri));
+                scene->addEntity(app->meshAabb->getWireFrameRenderable());
+                scene->addEntity(app->meshAabb->getSolidRenderable());
+            }
+
+            tcm.setParent(tcm.getInstance(app->meshAabb->getSolidRenderable()),
+                    tcm.getInstance(object));
+            tcm.setParent(tcm.getInstance(app->meshAabb->getWireFrameRenderable()),
+                    tcm.getInstance(object));
+            rcm.setLayerMask(rcm.getInstance(app->meshAabb->getSolidRenderable()), 0x3, 0x2);
+            rcm.setLayerMask(rcm.getInstance(app->meshAabb->getWireFrameRenderable()), 0x3, 0x2);
         }
-
-        tcm.setParent(tcm.getInstance(app->meshAabb->getSolidRenderable()),
-                tcm.getInstance(object));
-        tcm.setParent(tcm.getInstance(app->meshAabb->getWireFrameRenderable()),
-                tcm.getInstance(object));
-        rcm.setLayerMask(rcm.getInstance(app->meshAabb->getSolidRenderable()), 0x3, 0x2);
-        rcm.setLayerMask(rcm.getInstance(app->meshAabb->getWireFrameRenderable()), 0x3, 0x2);
 
         if (app->shadowPlane) {
             Material* shadowMaterial =
@@ -297,20 +324,20 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                             .build(*engine);
             shadowMaterial->setDefaultParameter("strength", 0.7f);
 
-            constexpr uint32_t indices[] = { 0, 1, 2, 2, 3, 0 };
+            static constexpr uint32_t indices[] = { 0, 1, 2, 2, 3, 0 };
 
-            constexpr filament::math::float3 vertices[] = {
+            static constexpr filament::math::float3 vertices[] = {
                 { -10, 0, -10 },
                 { -10, 0, 10 },
                 { 10, 0, 10 },
                 { 10, 0, -10 },
             };
 
-            short4 tbn = filament::math::packSnorm16(mat3f::packTangentFrame(
+            short4 const tbn = filament::math::packSnorm16(mat3f::packTangentFrame(
                     filament::math::mat3f{ float3{ 1.0f, 0.0f, 0.0f }, float3{ 0.0f, 0.0f, 1.0f },
                         float3{ 0.0f, 1.0f, 0.0f } }).xyzw);
 
-            const filament::math::short4 normals[]{ tbn, tbn, tbn, tbn };
+            static const filament::math::short4 normals[]{ tbn, tbn, tbn, tbn };
 
             VertexBuffer* vertexBuffer = VertexBuffer::Builder()
                                                  .vertexCount(4)
@@ -350,6 +377,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
 
             tcm.setTransform(tcm.getInstance(planeRenderable),
                     filament::math::mat4f::translation(float3{ 0, -1, -4 }));
+
+            app->plane = {
+                .vb = vertexBuffer,
+                .ib = indexBuffer,
+                .mat = shadowMaterial,
+                .renderable = planeRenderable,
+            };
         }
     };
 
@@ -387,63 +421,35 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeBool("more-lights", 'm', "Enable more point lights", false),
+        samples::Parameter::makeBool("disco", 'd', "Enable rotating disco ball", false),
+        samples::Parameter::makeBool("shadow-plane", 'p', "Enable shadow-receiving ground plane",
+                false),
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char* argv[]) {
     SampleConfig config;
-    static constexpr const char* CUSTOM_OPTSTR = "mdps:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "more-lights", utils::getopt::no_argument, nullptr, 'm' },
-        { "disco", utils::getopt::no_argument, nullptr, 'd' },
-        { "shadow-plane", utils::getopt::no_argument, nullptr, 'p' },
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { nullptr, 0, nullptr, 0 },
-    };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'm':
-                config.customArgs["moreLights"] = utils::CString("true");
-                return true;
-            case 'd':
-                config.customArgs["discoBall"] = utils::CString("true");
-                return true;
-            case 's':
-                g_meshScale = std::stof(arg.c_str());
-                return true;
-            case 'p':
-                config.customArgs["shadowPlane"] = utils::CString("true");
-                return true;
-        }
-        return false;
-    };
     samples::CommandLineSpecification spec = {
         .sampleDescription = "LIGHTBULB is a point light and shadow testing tool for Filament.",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx)>",
-        .requiredPositionalArgCount = 1,
-        .customOptionsHelp = "   --more-lights, -m\n"
-                             "       Enable more point lights\n\n"
-                             "   --disco, -d\n"
-                             "       Enable rotating disco ball\n\n"
-                             "   --shadow-plane, -p\n"
-                             "       Enable shadow-receiving ground plane\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .positionalArgsDescription = { "mesh files (.obj, .fbx)" },
+        .parameters = createAppParameters(),
     };
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
-    utils::CString filenames;
-    for (int i = optind; i < argc; i++) {
-        utils::Path filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        utils::Path filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        if (!filenames.empty()) filenames += ";";
-        filenames += argv[i];
     }
-    config.customArgs["filenames"] = utils::CString(filenames.c_str());
 
     config.title = "Lightbulb";
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -55,7 +55,6 @@
 #include <iostream>
 #include <map>
 #include <ranges>
-#include <string>
 #include <vector>
 
 using namespace math;
@@ -69,8 +68,6 @@ struct App {
     FilamentApp2* filamentApp = nullptr;
     SampleConfig config;
 };
-
-std::vector<Path> g_filenames;
 
 Scene* g_scene = nullptr;
 
@@ -92,8 +89,31 @@ constexpr ImVec2 verticalSliderSize(18.0f, 160.0f);
 constexpr ImVec2 plotLinesSize(320.0f, 160.0f);
 constexpr ImVec2 plotLinesWideSize(480.0f, 120.0f);
 
+struct GroundPlane {
+    VertexBuffer* vb = nullptr;
+    IndexBuffer* ib = nullptr;
+    Material* mat = nullptr;
+    Entity renderable;
+};
+
+GroundPlane g_groundPlane;
+
 void cleanup(Engine* engine, View*, Scene*) {
     g_meshSet.reset(nullptr);
+
+    if (g_groundPlane.renderable) {
+        engine->destroy(g_groundPlane.renderable);
+        EntityManager::get().destroy(g_groundPlane.renderable);
+    }
+    if (g_groundPlane.mat) {
+        engine->destroy(g_groundPlane.mat);
+    }
+    if (g_groundPlane.vb) {
+        engine->destroy(g_groundPlane.vb);
+    }
+    if (g_groundPlane.ib) {
+        engine->destroy(g_groundPlane.ib);
+    }
 
     for (const auto& material: g_meshMaterialInstances | std::views::values) {
         engine->destroy(material);
@@ -123,14 +143,22 @@ void setup(Engine* engine, View*, Scene* scene) {
 
     createInstances(g_params, *engine);
 
-    for (auto& filename : g_filenames) {
+    for (const auto& fname : g_config.positionalArgs) {
+        Path filename(fname.c_str_safe());
         g_meshSet->addFromFile(filename, g_meshMaterialInstances);
+    }
+    if (g_config.positionalArgs.empty()) {
+        g_meshSet->addFromFile(FilamentApp2::getRootAssetsPath() +
+                                       "assets/models/material_sphere/material_sphere.obj",
+                g_meshMaterialInstances);
     }
 
     auto& tcm = engine->getTransformManager();
-    auto ei = tcm.getInstance(g_meshSet->getRenderables()[0]);
-    tcm.setTransform(ei, mat4f{ mat3f(g_meshScale), float3(0.0f, 0.0f, -4.0f) } *
-            tcm.getWorldTransform(ei));
+    if (!g_meshSet->getRenderables().empty()) {
+        auto ei = tcm.getInstance(g_meshSet->getRenderables()[0]);
+        tcm.setTransform(ei,
+                mat4f{ mat3f(g_meshScale), float3(0.0f, 0.0f, -4.0f) } * tcm.getWorldTransform(ei));
+    }
 
     size_t count = 0;
     auto& rcm = engine->getRenderableManager();
@@ -146,7 +174,7 @@ void setup(Engine* engine, View*, Scene* scene) {
                 rcm.setMaterialInstanceAt(instance, i, g_params.materialInstance[MATERIAL_LIT]);
             }
         } else {
-            ei = tcm.getInstance(renderable);
+            auto ei = tcm.getInstance(renderable);
             tcm.setTransform(ei, mat4f{ mat3f(g_meshScale), float3(0.0f, 0.0f, -3.0f) } *
                     tcm.getWorldTransform(ei));
         }
@@ -168,18 +196,18 @@ void setup(Engine* engine, View*, Scene* scene) {
                 .build(*engine);
         shadowMaterial->setDefaultParameter("strength", 0.7f);
 
-        constexpr uint32_t indices[] = {
+        static constexpr uint32_t indices[] = {
                 0, 1, 2, 2, 3, 0
         };
 
-        constexpr float3 vertices[] = {
+        static constexpr float3 vertices[] = {
                 { -10, 0, -10 },
                 { -10, 0,  10 },
                 {  10, 0,  10 },
                 {  10, 0, -10 },
         };
 
-        short4 tbn = packSnorm16(
+        short4 const tbn = packSnorm16(
                 mat3f::packTangentFrame(
                         mat3f{
                                 float3{ 1.0f, 0.0f, 0.0f },
@@ -188,7 +216,7 @@ void setup(Engine* engine, View*, Scene* scene) {
                         }
                 ).xyzw);
 
-        const short4 normals[] { tbn, tbn, tbn, tbn };
+        static const short4 normals[] { tbn, tbn, tbn, tbn };
 
         VertexBuffer* vertexBuffer = VertexBuffer::Builder()
                 .vertexCount(4)
@@ -226,6 +254,13 @@ void setup(Engine* engine, View*, Scene* scene) {
 
         tcm.setTransform(tcm.getInstance(planeRenderable),
                 mat4f::translation(float3{ 0, -1, -4 }));
+
+        g_groundPlane = {
+            .vb = vertexBuffer,
+            .ib = indexBuffer,
+            .mat = shadowMaterial,
+            .renderable = planeRenderable,
+        };
     }
 
     if (auto* ibl = g_filamentApp->getIBL()) {
@@ -962,8 +997,12 @@ void preRender(Engine* engine, View* view, Scene*, Renderer* renderer) {
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
-    app->config = config;
     g_config = config;
+    g_shadowPlane = config.getBool("shadow-plane");
+    g_singleMode = config.getBool("single-mode");
+    config.dirt = config.getString("dirt");
+    g_meshScale = config.getFloat("scale", 1.0f);
+    app->config = config;
 
     g_params.bloomOptions.enabled = true;
 
@@ -978,62 +1017,34 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeBool("shadow-plane", 'p', "Enable shadow-receiving ground plane",
+                false),
+        samples::Parameter::makeBool("single-mode", 'n', "Single object mode", false),
+        samples::Parameter::makeString("dirt", 'd', "Path to a dirt texture", ""),
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+    };
+}
+
 #ifndef __ANDROID__
 int main(const int argc, char* argv[]) {
     SampleConfig config;
-    static constexpr const char* CUSTOM_OPTSTR = "pnd:s:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "shadow-plane", utils::getopt::no_argument, nullptr, 'p' },
-        { "single-mode", utils::getopt::no_argument, nullptr, 'n' },
-        { "dirt", utils::getopt::required_argument, nullptr, 'd' },
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { nullptr, 0, nullptr, 0 },
-    };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'p':
-                g_shadowPlane = true;
-                return true;
-            case 'n':
-                g_singleMode = true;
-                return true;
-            case 's':
-                g_meshScale = std::stof(arg.c_str());
-                return true;
-
-            case 'd':
-                config.dirt = arg;
-                return true;
-        }
-        return false;
-    };
     samples::CommandLineSpecification spec = {
         .sampleDescription = "MATERIAL_SANDBOX is a tool for testing Filament materials.",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx, .filamesh)>",
-        .requiredPositionalArgCount = 1,
-        .customOptionsHelp = "   --shadow-plane, -p\n"
-                             "       Enable shadow-receiving ground plane\n\n"
-                             "   --single-mode, -n\n"
-                             "       Single object mode\n\n"
-                             "   --dirt=<path>, -d <path>\n"
-                             "       Path to a dirt texture\n"
-                             "   --scale=[number], -s [number]\n"
-                             "       Applies uniform scale\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .positionalArgsDescription = { "mesh files (.obj, .fbx, .filamesh)" },
+        .parameters = createAppParameters(),
     };
 
-    const int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
-    for (int i = optind; i < argc; i++) {
-        Path filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        Path filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        g_filenames.push_back(filename);
     }
 
     config.title = "Material Sandbox";

--- a/samples/materialinstancestress.cpp
+++ b/samples/materialinstancestress.cpp
@@ -42,7 +42,6 @@
 
 #include <iostream>
 #include <random>
-#include <string>
 #include <vector>
 
 using namespace filament;
@@ -157,6 +156,10 @@ void createSceneObjects(Engine* engine, Scene* scene, App& app) {
 
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
+    if (config.iblDirectory.empty()) {
+        config.iblDirectory = utils::CString(
+                (FilamentApp2::getRootAssetsPath() + "assets/ibl/lightroom_14b").c_str());
+    }
     auto app = std::make_shared<App>();
     app->config = config;
 
@@ -268,13 +271,16 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "Material Instances Stress Test";
     config.iblDirectory = utils::CString(
             (FilamentApp2::getRootAssetsPath() + "assets/ibl/lightroom_14b").c_str());
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto fApp = createSampleApp(config, dm.get(), nullptr);

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -144,6 +144,8 @@ void destroy_window(Window& w, Engine* engine) {
     delete w.ibl;
 
     engine->destroy(w.mesh.renderable);
+    engine->destroy(w.mesh.vertexBuffer);
+    engine->destroy(w.mesh.indexBuffer);
     engine->destroy(w.materialInstance);
     engine->destroy(w.material);
     w.view->setScene(nullptr);
@@ -277,8 +279,9 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     int n = 1;
     int x = 50, y = 50;
     for (auto& w: windows) {
-        auto title = std::string("Filament - Window ") + std::to_string(n);
-        w.sdl_window = SDL_CreateWindow(title.c_str(), x, y, kWidth, kHeight, windowFlags);
+        char title[64];
+        snprintf(title, sizeof(title), "Filament - Window %d", n);
+        w.sdl_window = SDL_CreateWindow(title, x, y, kWidth, kHeight, windowFlags);
         x += 50;
         y += 50;
         n += 1;
@@ -378,10 +381,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return nullptr;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char* argv[]) {
     SampleConfig config;
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto fApp = createSampleApp(config, dm.get(), nullptr);
     if (fApp) {

--- a/samples/point_sprites.cpp
+++ b/samples/point_sprites.cpp
@@ -182,6 +182,7 @@ void cleanup(std::shared_ptr<App> app, Engine* engine) {
     engine->destroy(app->renderable);
     engine->destroy(app->matInstance);
     engine->destroy(app->mat);
+    engine->destroy(app->tex);
     engine->destroy(app->vb);
     engine->destroy(app->ib);
 
@@ -219,11 +220,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "point_sprites";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/procedural_effect.cpp
+++ b/samples/procedural_effect.cpp
@@ -41,7 +41,6 @@
 #include <stb_image.h>
 
 #include <iostream>
-#include <string>
 
 using namespace filament;
 using utils::Entity;
@@ -134,11 +133,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "procedural_effect";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/procedural_texture_quad.cpp
+++ b/samples/procedural_texture_quad.cpp
@@ -41,7 +41,6 @@
 #include <stb_image.h>
 
 #include <iostream>
-#include <string>
 
 using namespace filament;
 using utils::Entity;
@@ -155,11 +154,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "procedural_texture_quad";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -133,10 +133,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     auto app = std::make_shared<App>();
     app->config = config;
 
-    if (config.customArgs.find("mode") != config.customArgs.end()) {
-        if (config.customArgs.at("mode") == "renderables") {
-            app->mode = App::ReflectionMode::RENDERABLES;
-        }
+    if (config.getString("mode") == "renderables") {
+        app->mode = App::ReflectionMode::RENDERABLES;
     }
 
     auto setup = [app](Engine* engine, View* view, Scene* scene) {
@@ -349,30 +347,21 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeEnum("mode", 'm', "Set reflection mode", "camera",
+                { "camera", "renderables" }),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "rendertarget";
-    static constexpr const char* CUSTOM_OPTSTR = "m:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "mode", utils::getopt::required_argument, nullptr, 'm' }, { nullptr, 0, nullptr, 0 }
-    };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'm':
-                config.customArgs["mode"] = arg;
-                return true;
-        }
-        return false;
-    };
     samples::CommandLineSpecification spec = {
-        .customOptionsHelp = "   --mode=<camera|renderables>, -m <camera|renderables>\n"
-                             "       Set reflection mode\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .parameters = createAppParameters(),
     };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -47,7 +47,6 @@
 
 #include <iostream>
 #include <map>
-#include <string>
 #include <vector>
 
 using namespace filament::math;
@@ -77,17 +76,10 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
     app->config = config;
+    g_meshScale = config.getFloat("scale", 1.0f);
 
-    if (config.customArgs.find("filenames") != config.customArgs.end()) {
-        std::string_view filenamesStr = config.customArgs.at("filenames").c_str();
-        size_t pos = 0;
-        while ((pos = std::string_view(filenamesStr).find('|')) != std::string_view::npos) {
-            app->filenames.push_back(utils::Path(filenamesStr.substr(0, pos)));
-            filenamesStr.remove_prefix(pos + 1);
-        }
-        if (!filenamesStr.empty()) {
-            app->filenames.push_back(utils::Path(filenamesStr));
-        }
+    for (const auto& filename: config.positionalArgs) {
+        app->filenames.push_back(utils::Path(filename.c_str()));
     }
 
     auto loadMap = [app](Engine* engine, const char* name, bool sRGB = true) -> Texture* {
@@ -175,8 +167,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         app->materialInstances.getMaterialInstance(defaultMaterialName)
                 ->setParameter("roughnessMap", roughness, sampler);
 
+        auto filenames = app->filenames;
+        if (filenames.empty()) {
+            filenames.push_back(utils::Path(
+                    (FilamentApp2::getRootAssetsPath() + "assets/models/cloth/cloth.obj").c_str()));
+        }
         auto& tcm = engine->getTransformManager();
-        for (const auto& filename: app->filenames) {
+        for (const auto& filename: filenames) {
             MeshReader::Mesh mesh =
                     MeshReader::loadMeshFromFile(engine, filename, app->materialInstances);
             if (mesh.renderable) {
@@ -229,47 +226,30 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char* argv[]) {
     SampleConfig config;
-    static constexpr const char* CUSTOM_OPTSTR = "s:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { nullptr, 0, nullptr, 0 }
-    };
-    auto customHandler = [](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 's':
-                g_meshScale = std::stof(arg.c_str());
-                return true;
-        }
-        return false;
-    };
-
     samples::CommandLineSpecification spec = {
         .sampleDescription = "SAMPLE_CLOTH demonstrates cloth shading in Filament.",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx)>",
-        .requiredPositionalArgCount = 1,
-        .customOptionsHelp = "   --scale=[number], -s [number]\n"
-                             "       Applies uniform scale\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .positionalArgsDescription = { "mesh files (.obj, .fbx)" },
+        .parameters = createAppParameters(),
     };
-    int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
-    utils::CString filenames;
-    for (int i = optind; i < argc; i++) {
-        utils::Path filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        utils::Path filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        if (i > optind) filenames += "|";
-        filenames += argv[i];
     }
-    config.customArgs["filenames"] = utils::CString(filenames.c_str());
 
     config.title = "Cloth shading";
 

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -47,7 +47,6 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <string>
 #include <vector>
 
 using namespace filament::math;
@@ -92,7 +91,7 @@ struct App {
     };
     SampleConfig config;
     struct PbrConfig {
-        std::string materialDir;
+        utils::CString materialDir;
         bool clearCoat = false;
         bool anisotropy = false;
     } pbrConfig;
@@ -106,31 +105,24 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     auto app = std::make_shared<App>();
     app->config = config;
 
-    if (config.customArgs.find("materialDir") != config.customArgs.end()) {
-        app->pbrConfig.materialDir = config.customArgs.at("materialDir").c_str();
+    utils::CString matDir = config.getString("material-dir");
+    if (!matDir.empty()) {
+        app->pbrConfig.materialDir = matDir;
     }
-    if (config.customArgs.find("clearCoat") != config.customArgs.end()) {
+    if (config.getBool("clear-coat")) {
         app->pbrConfig.clearCoat = true;
     }
-    if (config.customArgs.find("anisotropy") != config.customArgs.end()) {
+    if (config.getBool("anisotropy")) {
         app->pbrConfig.anisotropy = true;
     }
-    if (config.customArgs.find("filenames") != config.customArgs.end()) {
-        std::string_view filenamesStr = config.customArgs.at("filenames").c_str();
-        size_t pos = 0;
-        while ((pos = std::string_view(filenamesStr).find('|')) != std::string_view::npos) {
-            app->filenames.push_back(utils::Path(filenamesStr.substr(0, pos)));
-            filenamesStr.remove_prefix(pos + 1);
-        }
-        if (!filenamesStr.empty()) {
-            app->filenames.push_back(utils::Path(filenamesStr));
-        }
+    g_meshScale = config.getFloat("scale", 1.0f);
+    for (const auto& filename: config.positionalArgs) {
+        app->filenames.push_back(utils::Path(filename.c_str()));
     }
 
-    auto loadTexture = [](Engine* engine, const std::string& filePath, Texture** map,
+    auto loadTexture = [](Engine* engine, const utils::Path& path, Texture** map,
                                bool sRGB = true) -> bool {
-        if (!filePath.empty()) {
-            Path const path(filePath);
+        if (!path.isEmpty()) {
             if (path.exists()) {
                 int w, h, n;
                 unsigned char* data = stbi_load(path.getAbsolutePath().c_str(), &w, &h, &n, 3);
@@ -159,8 +151,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     };
 
     auto setup = [app, loadTexture](Engine* engine, View* view, Scene* scene) {
-        Path const path(app->pbrConfig.materialDir);
-        std::string const name(path.getName());
+        Path const path(app->pbrConfig.materialDir.c_str());
+        utils::CString const name(path.getName().c_str());
 
         view->setAmbientOcclusionOptions({ .radius = 0.01f,
             .bilateralThreshold = 0.005f,
@@ -171,9 +163,9 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
 
         bool hasUV = false;
         for (auto& map: app->maps) {
-            if (!loadTexture(engine, path.concat(name + "_" + map.suffix + ".png"), &map.texture,
-                        map.sRGB)) {
-                if (!loadTexture(engine, path.concat(std::string(map.suffix) + ".png"),
+            if (!loadTexture(engine, path.concat((name + "_" + map.suffix + ".png").c_str()),
+                        &map.texture, map.sRGB)) {
+                if (!loadTexture(engine, path.concat((utils::CString(map.suffix) + ".png").c_str()),
                             &map.texture, map.sRGB)) {
                     std::cout << "The texture " << map.suffix << " does not exist" << std::endl;
                 }
@@ -189,7 +181,7 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         bool const hasBentNormalMap = app->maps[MAP_BENT_NORMAL].texture != nullptr;
         bool const hasHeightMap = app->maps[MAP_HEIGHT].texture != nullptr;
 
-        std::string shader = R"SHADER(
+        utils::CString shader = R"SHADER(
             void material(inout MaterialInputs material) {
         )SHADER";
 
@@ -346,6 +338,11 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         for (auto& filename: app->filenames) {
             app->meshSet->addFromFile(filename, app->materialInstances, true);
         }
+        if (app->filenames.empty()) {
+            app->meshSet->addFromFile(FilamentApp2::getRootAssetsPath() +
+                                              "assets/models/material_sphere/material_sphere.obj",
+                    app->materialInstances, true);
+        }
 
         auto& rcm = engine->getRenderableManager();
         auto& tcm = engine->getTransformManager();
@@ -401,63 +398,35 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeString("material-dir", 'm', "Directory containing custom materials",
+                ""),
+        samples::Parameter::makeBool("clear-coat", 'C', "Enable clear coat", false),
+        samples::Parameter::makeBool("anisotropy", 'A', "Enable anisotropy", false),
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char* argv[]) {
     SampleConfig config;
-    static constexpr const char* CUSTOM_OPTSTR = "m:cAs:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "material-dir", utils::getopt::required_argument, nullptr, 'm' },
-        { "clear-coat", utils::getopt::no_argument, nullptr, 'c' },
-        { "anisotropy", utils::getopt::no_argument, nullptr, 'A' },
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { nullptr, 0, nullptr, 0 },
-    };
-    auto customHandler = [&config](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'm':
-                config.customArgs["materialDir"] = arg;
-                return true;
-            case 'c':
-                config.customArgs["clearCoat"] = utils::CString("true");
-                return true;
-            case 'A':
-                config.customArgs["anisotropy"] = utils::CString("true");
-                return true;
-            case 's':
-                g_meshScale = std::stof(arg.c_str());
-                return true;
-        }
-        return false;
-    };
     samples::CommandLineSpecification spec = {
         .sampleDescription = "SAMPLE_FULL_PBR demonstrates physically based rendering in Filament.",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx)>",
-        .requiredPositionalArgCount = 1,
-        .customOptionsHelp = "   --material-dir=<path>, -m <path>\n"
-                             "       Directory containing custom materials\n\n"
-                             "   --clear-coat, -c\n"
-                             "       Enable clear coat\n\n"
-                             "   --anisotropy, -A\n"
-                             "       Enable anisotropy\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .positionalArgsDescription = { "mesh files (.obj, .fbx)" },
+        .parameters = createAppParameters(),
     };
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
-    utils::CString filenames;
-    for (int i = optind; i < argc; i++) {
-        utils::Path const filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        utils::Path const filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        if (i > optind) filenames += "|";
-        filenames += argv[i];
     }
-    config.customArgs["filenames"] = utils::CString(filenames.c_str());
 
     config.title = "PBR";
 

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -47,7 +47,6 @@
 
 #include <iostream>
 #include <map>
-#include <string>
 #include <vector>
 
 using namespace filament::math;
@@ -60,12 +59,10 @@ namespace {
 
 float g_meshScale = 1.0f;
 
-std::vector<Path> g_filenames;
-
 struct NormalConfig {
-    std::string normalMap;
-    std::string clearCoatNormalMap;
-    std::string baseColorMap;
+    utils::CString normalMap;
+    utils::CString clearCoatNormalMap;
+    utils::CString baseColorMap;
 } g_normalConfig;
 
 struct App {
@@ -86,6 +83,13 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
     auto app = std::make_shared<App>();
     app->config = config;
+    utils::CString nm = config.getString("normal-map");
+    if (!nm.empty()) g_normalConfig.normalMap = nm;
+    utils::CString cnm = config.getString("clearcoat-normal-map");
+    if (!cnm.empty()) g_normalConfig.clearCoatNormalMap = cnm;
+    utils::CString bm = config.getString("basecolor-map");
+    if (!bm.empty()) g_normalConfig.baseColorMap = bm;
+    g_meshScale = config.getFloat("scale", 1.0f);
 
     auto cleanup = [app](Engine* engine, View*, Scene*) {
         if (app->baseColorMap) {
@@ -119,9 +123,9 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     };
 
     auto setup = [app](Engine* engine, View*, Scene* scene) {
-        auto loadNormalMap = [](Engine* engine, Texture** normalMap, const std::string& path) {
+        auto loadNormalMap = [](Engine* engine, Texture** normalMap, const utils::CString& path) {
             if (!path.empty()) {
-                Path p(path);
+                Path p(path.c_str());
                 if (p.exists()) {
                     int w, h, n;
                     unsigned char* data = stbi_load(p.getAbsolutePath().c_str(), &w, &h, &n, 3);
@@ -187,7 +191,7 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         bool const hasClearCoatNormalMap = app->clearCoatNormalMap != nullptr;
         bool const hasBaseColorMap = app->baseColorMap != nullptr;
 
-        std::string shader = R"SHADER(
+        utils::CString shader = R"SHADER(
             void material(inout MaterialInputs material) {
         )SHADER";
 
@@ -278,8 +282,17 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                     ->setParameter("baseColorMap", app->baseColorMap, sampler);
         }
 
+        std::vector<utils::Path> filenames;
+        for (const auto& fname : app->config.positionalArgs) {
+            filenames.push_back(utils::Path(fname.c_str_safe()));
+        }
+        if (filenames.empty()) {
+            filenames.push_back(utils::Path(
+                    (FilamentApp2::getRootAssetsPath() + "assets/models/monkey/monkey.obj")
+                            .c_str()));
+        }
         auto& tcm = engine->getTransformManager();
-        for (const auto& filename: g_filenames) {
+        for (const auto& filename: filenames) {
             MeshReader::Mesh mesh =
                     MeshReader::loadMeshFromFile(engine, filename, app->materialInstances);
             if (mesh.renderable) {
@@ -309,59 +322,34 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() {
+    return {
+        samples::Parameter::makeString("normal-map", 'n', "Path to normal map texture", ""),
+        samples::Parameter::makeString("clearcoat-normal-map", 'C',
+                "Path to clearcoat normal map texture", ""),
+        samples::Parameter::makeString("basecolor-map", 'b', "Path to base color texture", ""),
+        samples::Parameter::makeFloat("scale", 's', "Applies uniform scale", 1.0f),
+    };
+}
+
 #ifndef __ANDROID__
 int main(int argc, char* argv[]) {
     SampleConfig config;
-    static constexpr const char* CUSTOM_OPTSTR = "n:c:b:s:";
-    static const utils::getopt::option CUSTOM_OPTIONS[] = {
-        { "normal-map", utils::getopt::required_argument, nullptr, 'n' },
-        { "clearcoat-normal-map", utils::getopt::required_argument, nullptr, 'c' },
-        { "basecolor-map", utils::getopt::required_argument, nullptr, 'b' },
-        { "scale", utils::getopt::required_argument, nullptr, 's' },
-        { nullptr, 0, nullptr, 0 },
-    };
-    auto customHandler = [](int opt, const utils::CString& arg) -> bool {
-        switch (opt) {
-            case 'n':
-                g_normalConfig.normalMap = arg.c_str();
-                return true;
-            case 'c':
-                g_normalConfig.clearCoatNormalMap = arg.c_str();
-                return true;
-            case 'b':
-                g_normalConfig.baseColorMap = arg.c_str();
-                return true;
-            case 's':
-                g_meshScale = std::stof(arg.c_str());
-                return true;
-        }
-        return false;
-    };
     samples::CommandLineSpecification spec = {
         .sampleDescription = "SAMPLE_NORMAL_MAP tests normal mapping and clearcoat normal mapping.",
-        .positionalArgsDescription = "<mesh files (.obj, .fbx)>",
-        .requiredPositionalArgCount = 1,
-        .customOptionsHelp = "   --normal-map=<path>, -n <path>\n"
-                             "       Path to normal map texture\n\n"
-                             "   --clearcoat-normal-map=<path>, -c <path>\n"
-                             "       Path to clearcoat normal map texture\n\n"
-                             "   --basecolor-map=<path>, -b <path>\n"
-                             "       Path to base color texture\n",
-        .customHandler = customHandler,
-        .customOptStr = CUSTOM_OPTSTR,
-        .customOptions = CUSTOM_OPTIONS,
+        .positionalArgsDescription = { "mesh files (.obj, .fbx)" },
+        .parameters = createAppParameters(),
     };
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config, spec);
+    samples::handleCommandLineArguments(argc, argv, &config, spec);
     auto dm = samples::getDisplayManager(config);
 
-    for (int i = optind; i < argc; i++) {
-        utils::Path filename = argv[i];
+    for (const auto& fname : config.positionalArgs) {
+        utils::Path filename(fname.c_str_safe());
         if (!filename.exists()) {
-            std::cerr << "file " << argv[i] << " not found!" << std::endl;
+            std::cerr << "file " << filename << " not found!" << std::endl;
             return 1;
         }
-        g_filenames.push_back(filename);
     }
 
     config.title = "Normal Mapping";

--- a/samples/shadowtest.cpp
+++ b/samples/shadowtest.cpp
@@ -62,7 +62,6 @@ struct App {
 };
 
 constexpr const char* MODEL_FILE = "assets/models/monkey/monkey.obj";
-constexpr const char* IBL_FOLDER = "assets/ibl/lightroom_14b";
 
 constexpr bool ENABLE_SHADOWS = true;
 
@@ -73,19 +72,19 @@ GroundPlane createGroundPlane(Engine* engine) {
                     .build(*engine);
     shadowMaterial->setDefaultParameter("strength", 0.7f);
 
-    constexpr uint32_t indices[]{ 0, 1, 2, 2, 3, 0 };
-    constexpr float3 vertices[]{
+    static constexpr uint32_t indices[]{ 0, 1, 2, 2, 3, 0 };
+    static constexpr float3 vertices[]{
         { -10, 0, -10 },
         { -10, 0,  10 },
         {  10, 0,  10 },
         {  10, 0, -10 },
     };
-    short4 tbn = packSnorm16(
+    short4 const tbn = packSnorm16(
             normalize(positive(mat3f{ float3{ 1.0f, 0.0f, 0.0f }, float3{ 0.0f, 0.0f, 1.0f },
                           float3{ 0.0f, 1.0f,
                               0.0f } }.toQuaternion()))
                     .xyzw);
-    const short4 normals[]{ tbn, tbn, tbn, tbn };
+    static const short4 normals[]{ tbn, tbn, tbn, tbn };
     VertexBuffer* vertexBuffer =
             VertexBuffer::Builder()
                     .vertexCount(4)
@@ -198,14 +197,16 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config{
         .title = "shadowtest",
-        .iblDirectory = utils::CString((FilamentApp2::getRootAssetsPath() + IBL_FOLDER).c_str()),
         .splitView = false,
     };
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/skinningtest.cpp
+++ b/samples/skinningtest.cpp
@@ -626,11 +626,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "skinning test with more than 4 bones per vertex";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
     auto app = createSampleApp(config, dm.get(), nullptr);
     app->run();

--- a/samples/strobecolor.cpp
+++ b/samples/strobecolor.cpp
@@ -48,7 +48,9 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         view->setPostProcessingEnabled(false);
     };
 
-    auto cleanup = [app](Engine*, View*, Scene*) {};
+    auto cleanup = [app](Engine* engine, View*, Scene*) {
+        engine->destroy(app->skybox);
+    };
 
     auto fApp = samples::getBuilder(config, dm, loader)
                         .setup(setup)
@@ -66,11 +68,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "strobecolor";
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
 
     auto dm = samples::getDisplayManager(config);
     auto fApp = createSampleApp(config, dm.get(), nullptr);

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -91,6 +91,10 @@ Texture* loadNormalMap(Engine* engine, const uint8_t* normals, size_t nbytes) {
 
 std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         filament::app::DisplayManager* dm, filament::app::AssetLoader* loader) {
+    if (config.iblDirectory.empty()) {
+        config.iblDirectory =
+                utils::CString((FilamentApp2::getRootAssetsPath() + IBL_FOLDER).c_str());
+    }
     auto app = std::make_shared<App>();
     app->config = config;
 
@@ -155,6 +159,8 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
 
     auto cleanup = [app](Engine* engine, View*, Scene*) {
         engine->destroy(app->mesh.renderable);
+        engine->destroy(app->mesh.vertexBuffer);
+        engine->destroy(app->mesh.indexBuffer);
         engine->destroy(app->materialInstance);
         engine->destroy(app->material);
         engine->destroy(app->albedo);
@@ -173,13 +179,16 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "suzanne";
     config.iblDirectory = utils::CString((FilamentApp2::getRootAssetsPath() + IBL_FOLDER).c_str());
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto fApp = createSampleApp(config, dm.get(), nullptr);

--- a/samples/texturedquad.cpp
+++ b/samples/texturedquad.cpp
@@ -42,7 +42,6 @@
 #include <stb_image.h>
 
 #include <iostream> // for cerr
-#include <string>   // for printing usage/help
 
 using namespace filament;
 using utils::Entity;
@@ -193,11 +192,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "texturedquad";
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto fApp = createSampleApp(config, dm.get(), nullptr);

--- a/samples/vbotest.cpp
+++ b/samples/vbotest.cpp
@@ -132,11 +132,14 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "vbotest";
-    samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
 
     auto dm = samples::getDisplayManager(config);
     auto fApp = createSampleApp(config, dm.get(), nullptr);

--- a/samples/viewtest.cpp
+++ b/samples/viewtest.cpp
@@ -32,7 +32,6 @@
 #include <utils/getopt.h>
 
 #include <iostream>
-#include <string>
 
 using namespace filament;
 
@@ -111,12 +110,15 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     return fApp;
 }
 
+samples::SampleParameters createAppParameters() { return {}; }
+
 #ifndef __ANDROID__
 int main(int argc, char** argv) {
     SampleConfig config;
     config.title = "viewtest";
 
-    int optind = samples::handleCommandLineArguments(argc, argv, &config);
+    samples::handleCommandLineArguments(argc, argv, &config,
+            { .parameters = createAppParameters() });
     auto dm = samples::getDisplayManager(config);
 
     auto app = createSampleApp(config, dm.get(), nullptr);


### PR DESCRIPTION
 - Organize parameters definition into a struct and re-use across all samples.  This is helpful for upcoming Android refactor.
 - Fix command line help message printing.
 - Fix a few leaks and allocations error (stack vs. static) 