### PR TITLE
Fix stb duplicate symbols

### DIFF
--- a/libs/fgviewer/src/DebugServer.cpp
+++ b/libs/fgviewer/src/DebugServer.cpp
@@ -19,6 +19,7 @@
 
 #include "ApiHandler.h"
 
+#define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 

--- a/libs/filamentapp/src/display_managers/HtmlDisplayManager.cpp
+++ b/libs/filamentapp/src/display_managers/HtmlDisplayManager.cpp
@@ -23,6 +23,7 @@
 #include <utils/Mutex.h>
 #include <utils/Panic.h>
 
+#define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 


### PR DESCRIPTION
To fix ld: warning: duplicate symbol '_stbi__flip_vertically_on_write'

We need to add STB_IMAGE_WRITE_STATIC before the include