### PR TITLE
vulkan: bounce readPixels staging through a cached copy before reshape

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 - backend: re-enable the `backend_test` build on iOS (opt-in via `INSTALL_BACKEND_TEST`) and record its golden-image hashes
+- vulkan: fix very slow `readPixels` on devices without host-cached staging memory (e.g. PowerVR)

--- a/filament/backend/src/vulkan/VulkanReadPixels.cpp
+++ b/filament/backend/src/vulkan/VulkanReadPixels.cpp
@@ -371,6 +371,10 @@ void VulkanReadPixels::run(fvkmemory::resource_ptr<VulkanTexture> srcTexture, ui
         VkResult status = vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
         if (status != VK_SUCCESS) {
             FVK_LOGE << "Failed to wait for readPixels fence";
+            vkDestroyBuffer(device, stagingBuffer, VKALLOC);
+            vkFreeMemory(device, stagingMemory, VKALLOC);
+            vkDestroyFence(device, fence, VKALLOC);
+            vkFreeCommandBuffers(device, cmdpool, 1, &cmdbuffer);
             return;
         }
 

--- a/filament/backend/src/vulkan/VulkanReadPixels.cpp
+++ b/filament/backend/src/vulkan/VulkanReadPixels.cpp
@@ -27,6 +27,9 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
+#include <cstring>
+#include <memory>
+
 using namespace bluevk;
 
 namespace filament::backend {
@@ -255,14 +258,16 @@ void VulkanReadPixels::run(fvkmemory::resource_ptr<VulkanTexture> srcTexture, ui
     uint32_t memoryTypeIndex = selectMemoryFunc(memReqs.memoryTypeBits,
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
                     | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+    bool hostCachedStaging = true;
 
     // If VK_MEMORY_PROPERTY_HOST_CACHED_BIT is not supported, we try only
     // HOST_VISIBLE+HOST_COHERENT.  HOST_CACHED helps a lot with readpixels performance.
     if (memoryTypeIndex >= VK_MAX_MEMORY_TYPES) {
         memoryTypeIndex = selectMemoryFunc(memReqs.memoryTypeBits,
                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-        FVK_LOGW
-                << "readPixels is slow because VK_MEMORY_PROPERTY_HOST_CACHED_BIT is not available";
+        hostCachedStaging = false;
+        FVK_LOGW << "readPixels: VK_MEMORY_PROPERTY_HOST_CACHED_BIT is not available; "
+                    "reshaping through a cached bounce copy";
     }
 
     FILAMENT_CHECK_POSTCONDITION(memoryTypeIndex < VK_MAX_MEMORY_TYPES)
@@ -362,7 +367,7 @@ void VulkanReadPixels::run(fvkmemory::resource_ptr<VulkanTexture> srcTexture, ui
     };
     auto waitFenceFunc = [device, width, height, swizzle, stagingBuffer, stagingMemory, cmdpool,
                                  cmdbuffer, pUserBuffer, bpp, componentType, componentCount,
-                                 fence = readCompleteFence]() mutable {
+                                 hostCachedStaging, fence = readCompleteFence]() mutable {
         VkResult status = vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
         if (status != VK_SUCCESS) {
             FVK_LOGE << "Failed to wait for readPixels fence";
@@ -379,8 +384,21 @@ void VulkanReadPixels::run(fvkmemory::resource_ptr<VulkanTexture> srcTexture, ui
         // pixels). So we can simply ask DataReshaper to read width * height elements with standard
         // row pitch!
         int const rowPitch = width * bpp;
-        if (!DataReshaper::reshapeImage(&p, componentType, componentCount, srcPixels, rowPitch,
-                    static_cast<int>(width), static_cast<int>(height), swizzle)) {
+
+        // Without HOST_CACHED the mapping is uncached, and DataReshaper's per-texel loop turns
+        // every 2-4 byte load into its own memory transaction. Bounce the mapped range into
+        // cached heap memory with one bulk memcpy (which the CPU can issue as wide, streaming
+        // loads) and reshape from there; reshape only ever reads the first sample plane.
+        uint8_t const* reshapeSrc = srcPixels;
+        std::unique_ptr<uint8_t[]> cachedCopy;
+        if (!hostCachedStaging) {
+            size_t const size = size_t(rowPitch) * height;
+            cachedCopy = std::make_unique_for_overwrite<uint8_t[]>(size);
+            memcpy(cachedCopy.get(), srcPixels, size);
+            reshapeSrc = cachedCopy.get();
+        }
+        if (!DataReshaper::reshapeImage(&p, componentType, componentCount, reshapeSrc,
+                    rowPitch, static_cast<int>(width), static_cast<int>(height), swizzle)) {
             FVK_LOGE << "Unsupported PixelDataFormat or PixelDataType";
         }
 


### PR DESCRIPTION
Without `VK_MEMORY_PROPERTY_HOST_CACHED_BIT` (optional, absent on e.g. PowerVR) the readPixels staging mapping is uncached, and DataReshaper's per-texel loop turns every 2-4 byte load into its own memory transaction. When the uncached fallback memory type is selected, bounce the staging buffer into cached heap memory with one bulk memcpy and reshape from there; when `HOST_CACHED` is available, the path is unchanged.

Measured on a Google TV Streamer (PowerVR GE9215): a 1024x1024 R16F readback drops from ~190 ms to the cost of a 2 MB memcpy. The fallback branch was validated on that device; CI drivers all expose `HOST_CACHED`, so they exercise the unchanged path.

This change was developed with the assistance of Claude Code.