### PR TITLE
webgpu: fix scissor/rendertarget bug

### DIFF
--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -1352,6 +1352,10 @@ void WebGPUDriver::beginRenderPass(Handle<HwRenderTarget> renderTargetHandle,
             mSwapChainView = mSwapChain->isHeadless() ?
                 mSwapChain->getNextTextureView() :
                 mSwapChain->getNextTextureView(mPlatform.getSurfaceExtent(mNativeWindow));
+
+            // We need to set the extent for the render target for use in scissor()
+            renderTarget->width = mSwapChain->getWidth();
+            renderTarget->height = mSwapChain->getHeight();
         }
         defaultColorView  = mSwapChainView;
         defaultDepthStencilView = mSwapChain->getDepthTextureView();
@@ -2132,13 +2136,20 @@ void WebGPUDriver::scissor(Viewport scissor) {
     assert_invariant(mRenderPassEncoder);
     assert_invariant(mCurrentRenderTarget);
 
-    uint32_t rtHeight = mCurrentRenderTarget->height;
-    uint32_t rtWidth = mCurrentRenderTarget->width;
-    uint32_t left = std::max(0, scissor.left);
-    uint32_t bottom = std::max(0, scissor.bottom);
-    uint32_t top = rtHeight > (bottom + scissor.height) ? rtHeight - bottom - scissor.height : 0;
-    uint32_t width = std::min((uint32_t)scissor.width, rtWidth - left);
-    uint32_t height = std::min((uint32_t)scissor.height, rtHeight - top);
+    uint32_t const rtWidth = mCurrentRenderTarget->width;
+    uint32_t const rtHeight = mCurrentRenderTarget->height;
+
+    uint32_t const left = std::clamp(scissor.left, 0, int32_t(rtWidth));
+    uint32_t const right = std::clamp(scissor.left + int32_t(scissor.width), 0, int32_t(rtWidth));
+
+    // Filament gives us bottom-left-origin coordinates, we need to convert it to WebGPU's top-left
+    // coordinates.
+    uint32_t const bottom = rtHeight - std::clamp(scissor.bottom, 0, int32_t(rtHeight));
+    uint32_t const top =
+            rtHeight - std::clamp(scissor.bottom + int32_t(scissor.height), 0, int32_t(rtHeight));
+
+    uint32_t const width = right - left;
+    uint32_t const height = bottom - top;
 
     mRenderPassEncoder.SetScissorRect(left, top, width, height);
 }


### PR DESCRIPTION
Swapchain request was moved to beginRenderPass. We need to also update the default renderTarget dimension in the same block.

Also refactor the scissor logic for clarity.

This fixes the c++ samples that did not use post processing (i.e. rendering directly to swapchain), including hellotriangle.