### PR TITLE
webgpu: bake specialization constants into WGSL overrides

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -304,6 +304,8 @@ if (FILAMENT_SUPPORTS_WEBGPU)
             src/webgpu/SpdMipmapGenerator/SpdMipmapGenerator.cpp
             src/webgpu/utils/AsyncTaskCounter.cpp
             src/webgpu/utils/AsyncTaskCounter.h
+            src/webgpu/utils/SpecializationConstantProcessor.cpp
+            src/webgpu/utils/SpecializationConstantProcessor.h
             src/webgpu/utils/StringPlaceholderTemplateProcessor.cpp
             src/webgpu/utils/StringPlaceholderTemplateProcessor.h
             src/webgpu/WebGPUBlitter.cpp
@@ -636,7 +638,8 @@ if (FILAMENT_BUILD_TESTING)
         if (FILAMENT_SUPPORTS_WEBGPU)
             list(APPEND BACKEND_TEST_SRC
                     test/test_WebGPUAsyncTaskCounter.cpp
-                    test/test_WebGPUComposeSwizzle.cpp)
+                    test/test_WebGPUComposeSwizzle.cpp
+                    test/test_WebGPUSpecializationConstantProcessor.cpp)
         endif()
         if (APPLE)
             # Metal-specific tests

--- a/filament/backend/src/webgpu/WebGPUPipelineCache.cpp
+++ b/filament/backend/src/webgpu/WebGPUPipelineCache.cpp
@@ -293,10 +293,10 @@ wgpu::RenderPipeline WebGPUPipelineCache::createRenderPipeline(
             //    where certain constants may be optimized out of the shader based
             //    on build configuration, etc.
             //
-            // to bypass these problems, we do not use override constants in the
-            // WebGPU backend, instead replacing placeholder constants in the shader
-            // text before creating the shader module (essentially implementing
-            // override constants ourselves)
+            // To bypass the first limitation, filamat emits constants that determine buffer
+            // layouts as ordinary shader constants. To bypass the second, WebGPUProgram applies
+            // the remaining Program specialization constants to WGSL override defaults before
+            // creating the shader module. Therefore, no constants are passed to the pipeline.
             .constantCount = 0,
             .constants = nullptr,
             .bufferCount = request.vertexBufferSlots.size(),

--- a/filament/backend/src/webgpu/WebGPUProgram.cpp
+++ b/filament/backend/src/webgpu/WebGPUProgram.cpp
@@ -20,6 +20,8 @@
 #include "WebGPUConstants.h"
 #include "WebGPUStrings.h"
 
+#include "webgpu/utils/SpecializationConstantProcessor.h"
+
 #include <backend/DriverEnums.h>
 #include <backend/Program.h>
 
@@ -44,8 +46,8 @@ namespace filament::backend {
 namespace {
 
 /**
- * Creates a WebGPU shader module for a given "program" "stage", accounting for override constants.
- * Effectively, this function is responsible for preprocessing the shader source and compiling it.
+ * Creates a WebGPU shader module for a given "program" "stage". Program specialization constants
+ * are applied to WGSL override initializers while preprocessing the shader source.
  * @param device The WebGPU device, which is the WebGPU API entry point for creating/registering
  * a shader module
  * @param program The "program" to compile/create the shader, which includes the shader source
@@ -68,8 +70,16 @@ namespace {
     labelStream << programName << " " << filamentShaderStageToString(stage) << " shader";
     const auto label = labelStream.str();
 
+    // Bake the Program values into the defaults of the WGSL overrides that survived in this stage.
+    // Constants used for WebGPU buffer layouts were emitted as ordinary shader constants by
+    // filamat and therefore do not appear here. Passing every Program constant to the pipeline is
+    // invalid when Tint has optimized some of them out of a shader stage.
+    utils::CString const specializedSource = webgpuutils::specializeShaderSource(
+            std::string_view(reinterpret_cast<const char*>(sourceBytes.data()),
+                    sourceBytes.size() - 1),
+            program.getSpecializationConstants());
     wgpu::ShaderSourceWGSL wgslDescriptor{};
-    wgslDescriptor.code = wgpu::StringView(reinterpret_cast<const char*>(sourceBytes.data()));
+    wgslDescriptor.code = wgpu::StringView(specializedSource.data(), specializedSource.size());
     const wgpu::ShaderModuleDescriptor descriptor{
         .nextInChain = &wgslDescriptor,
         .label = label.data()

--- a/filament/backend/src/webgpu/utils/SpecializationConstantProcessor.cpp
+++ b/filament/backend/src/webgpu/utils/SpecializationConstantProcessor.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SpecializationConstantProcessor.h"
+
+#include <utils/CString.h>
+#include <utils/Panic.h>
+
+#include <string_view>
+#include <variant>
+
+namespace filament::backend::webgpuutils {
+
+namespace {
+
+struct SpecializationConstantFormatter {
+    utils::CString operator()(int32_t const value) const { return utils::to_string(value); }
+    utils::CString operator()(float const value) const { return utils::to_string(value); }
+    utils::CString operator()(bool const value) const {
+        return utils::CString(value ? "true" : "false");
+    }
+};
+
+} // namespace
+
+/**
+ * Specializes WGSL shader source by baking specialization constant values into the defaults of
+ * WGSL `override` declarations.
+ *
+ * Example:
+ *   Given:
+ *     specializationConstants[0] = true;
+ *     specializationConstants[1] = -7;
+ *
+ *   Before specialization:
+ *     @id(0) override dynamic_lighting : bool = false;
+ *     @id(1) override light_count : i32;
+ *
+ *   After specialization:
+ *     @id(0) override dynamic_lighting : bool = true;
+ *     @id(1) override light_count : i32 = -7;
+ */
+utils::CString specializeShaderSource(std::string_view const source,
+        Program::SpecializationConstantsInfo const& specializationConstants) {
+    utils::CString result(source);
+    for (uint32_t id = 0; id < specializationConstants.size(); ++id) {
+        // Build the WGSL override attribute to search for, e.g. "@id(0)".
+        utils::CString const idAttribute = "@id(" + utils::to_string(id) + ")";
+        size_t declarationBegin = 0;
+
+        // Find every occurrence of "@id(N)" in the WGSL shader source.
+        while ((declarationBegin = std::string_view(result).find(idAttribute.c_str_safe(),
+                        declarationBegin)) != std::string_view::npos) {
+            size_t const declarationEnd =
+                    std::string_view(result).find(';', declarationBegin + idAttribute.size());
+            assert_invariant(declarationEnd != std::string_view::npos);
+
+            // Ensure the "override" keyword is present in this declaration statement.
+            size_t const overridePosition =
+                    std::string_view(result).find("override", declarationBegin);
+            if (overridePosition == std::string_view::npos || overridePosition > declarationEnd) {
+                declarationBegin += idAttribute.size();
+                continue;
+            }
+
+            // Format the constant value (bool, int32_t, or float) to its WGSL string representation.
+            utils::CString const value =
+                    std::visit(SpecializationConstantFormatter{}, specializationConstants[id]);
+
+            // Check if an existing initializer ('=') is present before ';'.
+            size_t const initializer = std::string_view(result).find('=', overridePosition);
+            if (initializer == std::string_view::npos || initializer > declarationEnd) {
+                // Case A: No existing initializer (e.g. "@id(0) override enabled : bool;").
+                // Insert " = <value>" directly before the terminating semicolon.
+                result.insert(declarationEnd, " = " + value);
+                declarationBegin = declarationEnd + value.size() + 3;
+                continue;
+            }
+
+            // Case B: Existing initializer (e.g. "@id(0) override enabled : bool = false;").
+            // Replace the old default value between '=' and ';' with " <value>".
+            result.replace(initializer + 1, declarationEnd - initializer - 1, " " + value);
+            declarationBegin = initializer + value.size() + 2;
+        }
+    }
+    return result;
+}
+
+} // namespace filament::backend::webgpuutils

--- a/filament/backend/src/webgpu/utils/SpecializationConstantProcessor.h
+++ b/filament/backend/src/webgpu/utils/SpecializationConstantProcessor.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_WEBGPU_SPECIALIZATIONCONSTANTPROCESSOR_H
+#define TNT_FILAMENT_BACKEND_WEBGPU_SPECIALIZATIONCONSTANTPROCESSOR_H
+
+#include <backend/Program.h>
+
+#include <utils/CString.h>
+
+#include <string_view>
+
+namespace filament::backend::webgpuutils {
+
+// Returns a copy of the WGSL source with Program specialization values written into the default
+// initializers of matching @id(n) override declarations. Constants absent from this shader stage
+// are ignored. The WebGPU backend uses this instead of native pipeline override constants.
+utils::CString specializeShaderSource(std::string_view source,
+        Program::SpecializationConstantsInfo const& specializationConstants);
+
+} // namespace filament::backend::webgpuutils
+
+#endif // TNT_FILAMENT_BACKEND_WEBGPU_SPECIALIZATIONCONSTANTPROCESSOR_H

--- a/filament/backend/test/test_WebGPUSpecializationConstantProcessor.cpp
+++ b/filament/backend/test/test_WebGPUSpecializationConstantProcessor.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "webgpu/utils/SpecializationConstantProcessor.h"
+
+#include <backend/Program.h>
+
+#include <utils/CString.h>
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace filament::backend::webgpuutils {
+
+TEST(WebGPUSpecializationConstantProcessor, ReplacesConstantsById) {
+    Program::SpecializationConstantsInfo constants =
+            Program::SpecializationConstantsInfo::with_capacity(3);
+    constants.push_back(false);
+    constants.push_back(int32_t{ -7 });
+    constants.push_back(2.5f);
+
+    constexpr std::string_view source = R"(
+        @id(0) override dynamic_lighting : bool = true;
+        @id(1) override light_count : i32 = 4;
+        @id(2) override exposure : f32 = 1.0;
+    )";
+    utils::CString const specialized = specializeShaderSource(source, constants);
+    std::string_view const specializedView{ specialized };
+
+    EXPECT_NE(specializedView.find("@id(0) override dynamic_lighting : bool = false;"),
+            std::string_view::npos);
+    EXPECT_NE(specializedView.find("@id(1) override light_count : i32 = -7;"),
+            std::string_view::npos);
+    EXPECT_NE(specializedView.find("@id(2) override exposure : f32 = 2.500000;"),
+            std::string_view::npos);
+}
+
+TEST(WebGPUSpecializationConstantProcessor, AddsMissingInitializer) {
+    Program::SpecializationConstantsInfo constants =
+            Program::SpecializationConstantsInfo::with_capacity(1);
+    constants.push_back(true);
+
+    EXPECT_EQ(specializeShaderSource("@id(0) override enabled : bool;", constants),
+            "@id(0) override enabled : bool = true;");
+}
+
+TEST(WebGPUSpecializationConstantProcessor, IgnoresUnusedConstantsAndOtherAttributes) {
+    Program::SpecializationConstantsInfo constants =
+            Program::SpecializationConstantsInfo::with_capacity(2);
+    constants.push_back(false);
+    constants.push_back(true);
+
+    constexpr std::string_view source = "@id(1) @diagnostic(off, derivative_uniformity) "
+                                        "override enabled : bool = false;";
+    EXPECT_EQ(specializeShaderSource(source, constants),
+            "@id(1) @diagnostic(off, derivative_uniformity) override enabled : bool = true;");
+}
+
+TEST(WebGPUSpecializationConstantProcessor, MatchesMultiDigitIdsExactly) {
+    Program::SpecializationConstantsInfo constants =
+            Program::SpecializationConstantsInfo::with_capacity(19);
+    for (size_t i = 0; i < 19; ++i) {
+        constants.push_back(false);
+    }
+    constants[18] = true;
+
+    constexpr std::string_view source = "@id(1) override first : bool = true;\n"
+                                        "@id(18) override directional : bool = false;";
+    EXPECT_EQ(specializeShaderSource(source, constants),
+            "@id(1) override first : bool = false;\n"
+            "@id(18) override directional : bool = true;");
+}
+
+} // namespace filament::backend::webgpuutils

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -290,6 +290,9 @@ utils::io::sstream& CodeGenerator::generateCommonProlog(utils::io::sstream& out,
         // constants for UBO sizes, we must hardcode WebGPU minspec in both places.
         // With a WebGPU UBO minspec of 64 KiB (65536 bytes), height is set to 65536 / 16 = 4096.
         out << "const int CONFIG_FROXEL_RECORD_BUFFER_HEIGHT = 4096;\n";
+        // Unlike the layout constants above, other specialization constants generated below
+        // remain WGSL overrides whose defaults are specialized by WebGPUProgram before it creates
+        // the shader module.
     } else {
         generateSpecializationConstant(out, "CONFIG_MAX_INSTANCES",
                 +ReservedSpecializationConstants::CONFIG_MAX_INSTANCES, (int)CONFIG_MAX_INSTANCES);


### PR DESCRIPTION
Previously, the webgpu backend never applied specialization constant values when creating shader modules, causing shaders to always fall back to their default values. For instance, the SSR renderdiff test produced an incorrect golden image. It is because the separate gaussian blur shader defaulted to a regular 2D sampler, but SSR mipmap generation requires a 2D array sampler.

To solve this, we introduce `SpecializationConstantProcessor`, which bakes the Program specialization constant values directly into the WGSL override declarations before creating the shader module. 

This is required for the incoming DIR variant removal.

RDIFF_ACCEPT_NEW_GOLDENS