### PR TITLE
Add tvOS support (appletvos + appletvsimulator)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -184,6 +184,26 @@ The easiest way to build Filament for iOS is to use `build.sh` and the
 
 See [ios/samples/README.md](./ios/samples/README.md) for more information.
 
+## tvOS
+
+tvOS builds use the same toolchain path as iOS and are Metal-only (the OpenGL
+backend is automatically disabled). To build for Apple TV devices and the
+tvOS simulator, and bundle the results as XCFrameworks:
+
+```shell
+./build.sh -i -s -p tvos release
+```
+
+Omit `-s` to skip the simulator slice. Add `-a` to generate a
+`filament-<type>-tvos.tgz` archive. Output is installed under
+`out/tvos-<type>/filament` with one XCFramework per library
+(`tvos-arm64` and `tvos-arm64-simulator` slices).
+
+The deployment floor is tvOS 17.0. Note that the tvOS simulator advertises
+`MTLGPUFamilyApple2` (the Apple TV HD GPU), so features requiring comparison
+samplers (e.g. PCF shadows) are unavailable in the simulator while remaining
+available on all Apple TV 4K devices (`MTLGPUFamilyApple3`+).
+
 ## Windows
 
 ### Building on Windows with Visual Studio 2019 or later

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -944,7 +944,11 @@ add_subdirectory(${EXTERNAL}/cgltf/tnt)
 add_subdirectory(${EXTERNAL}/draco/tnt)
 add_subdirectory(${EXTERNAL}/jsmn/tnt)
 add_subdirectory(${EXTERNAL}/stb/tnt)
-add_subdirectory(${EXTERNAL}/perfetto/tnt)
+if (NOT APPLETV)
+    # Perfetto's subprocess support uses fork()/exec*(), which are __TVOS_PROHIBITED.
+    # The library is only consumed on Android (FILAMENT_ENABLE_PERFETTO).
+    add_subdirectory(${EXTERNAL}/perfetto/tnt)
+endif()
 add_subdirectory(${EXTERNAL}/basisu/tnt)
 
 # imageio-lite is needed for viewer

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 - backend: add Metal support for external image handles
+- build: add tvOS support (`appletvos`/`appletvsimulator`), Metal-only, via `./build.sh -p tvos`

--- a/build.sh
+++ b/build.sh
@@ -36,9 +36,9 @@ function print_help {
     echo "    -m"
     echo "        Compile with make instead of ninja."
     echo "    -p platform1,platform2,..."
-    echo "        Where platformN is [desktop|android|ios|wasm|all]."
+    echo "        Where platformN is [desktop|android|ios|tvos|wasm|all]."
     echo "        Platform(s) to build, defaults to desktop."
-    echo "        Building for iOS will automatically perform a partial desktop build."
+    echo "        Building for iOS or tvOS will automatically perform a partial desktop build."
     echo "    -q abi1,abi2,..."
     echo "        Where platformN is [armeabi-v7a|arm64-v8a|x86|x86_64|all]."
     echo "        ABIs to build when the platform is Android. Defaults to all."
@@ -176,6 +176,7 @@ ISSUE_RELEASE_BUILD=false
 # Default: build desktop only
 ISSUE_ANDROID_BUILD=false
 ISSUE_IOS_BUILD=false
+ISSUE_TVOS_BUILD=false
 ISSUE_DESKTOP_BUILD=true
 ISSUE_WASM_BUILD=false
 
@@ -758,18 +759,21 @@ function build_ios_target {
     local lc_target=$(echo "$1" | tr '[:upper:]' '[:lower:]')
     local arch=$2
     local platform=$3
+    # Output name: "ios" (default) or "tvos"; selects out/cmake-<name>-* and
+    # the out/<name>-<type>/filament install prefix.
+    local out_name=${4:-ios}
 
-    echo "Building iOS ${lc_target} (${arch}) for ${platform}..."
-    mkdir -p "out/cmake-ios-${lc_target}-${arch}-${platform}"
+    echo "Building ${out_name} ${lc_target} (${arch}) for ${platform}..."
+    mkdir -p "out/cmake-${out_name}-${lc_target}-${arch}-${platform}"
 
-    pushd "out/cmake-ios-${lc_target}-${arch}-${platform}" > /dev/null
+    pushd "out/cmake-${out_name}-${lc_target}-${arch}-${platform}" > /dev/null
 
     if [[ ! -d "CMakeFiles" ]] || [[ "${ISSUE_CMAKE_ALWAYS}" == "true" ]]; then
         cmake \
             -G "${BUILD_GENERATOR}" \
             ${IMPORT_EXECUTABLES_DIR_OPTION} \
             -DCMAKE_BUILD_TYPE="$1" \
-            -DCMAKE_INSTALL_PREFIX="../ios-${lc_target}/filament" \
+            -DCMAKE_INSTALL_PREFIX="../${out_name}-${lc_target}/filament" \
             -DIOS_ARCH="${arch}" \
             -DPLATFORM_NAME="${platform}" \
             -DIOS=1 \
@@ -782,7 +786,7 @@ function build_ios_target {
             ${EXCEPTIONS_OPTION} \
             ${MUTEX_DEBUG_OPTION} \
             ../..
-        ln -sf "out/cmake-ios-${lc_target}-${arch}/compile_commands.json" \
+        ln -sf "out/cmake-${out_name}-${lc_target}-${arch}/compile_commands.json" \
            ../../compile_commands.json
     fi
 
@@ -806,6 +810,71 @@ function archive_ios {
             tar -czvf "../filament-${lc_target}-ios.tgz" filament
             popd > /dev/null
         fi
+    fi
+}
+
+function archive_tvos {
+    local lc_target=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+    if [[ -d "out/tvos-${lc_target}/filament" ]]; then
+        if [[ "${ISSUE_ARCHIVES}" == "true" ]]; then
+            echo "Generating out/filament-${lc_target}-tvos.tgz..."
+            pushd "out/tvos-${lc_target}" > /dev/null
+            tar -czvf "../filament-${lc_target}-tvos.tgz" filament
+            popd > /dev/null
+        fi
+    fi
+}
+
+function build_tvos_type {
+    # Builds one configuration (Debug/Release) for tvOS: device + (optionally)
+    # simulator, then bundles XCFrameworks. Mirrors the iOS flow; tvOS
+    # simulators are arm64-only in practice (Apple silicon hosts).
+    local target=$1
+    local lc_target=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+    local out_dir="out/tvos-${lc_target}/filament"
+    local lib_dir="${out_dir}/lib"
+
+    build_ios_target "${target}" "arm64" "appletvos" "tvos"
+
+    if [[ "${IOS_BUILD_SIMULATOR}" == "true" ]]; then
+        build_ios_target "${target}" "arm64" "appletvsimulator" "tvos"
+    fi
+
+    if [[ ! "${INSTALL_COMMAND}" ]]; then
+        echo "Skipping tvOS XCFramework bundling: pass -i to install the libraries first."
+        return
+    fi
+
+    local xcframework_paths=("${lib_dir}/arm64-appletvos")
+    if [[ -d "${lib_dir}/arm64-appletvsimulator" ]]; then
+        xcframework_paths+=("${lib_dir}/arm64-appletvsimulator")
+    fi
+
+    build/ios/create-xc-frameworks.sh -o "${lib_dir}" "${xcframework_paths[@]}"
+
+    rm -rf \
+        "${lib_dir}/arm64-appletvos" \
+        "${lib_dir}/arm64-appletvsimulator"
+
+    archive_tvos "${target}"
+}
+
+function build_tvos {
+    # Suppress intermediate desktop tools install
+    local old_install_command=${INSTALL_COMMAND}
+    INSTALL_COMMAND=
+
+    build_desktop "${MOBILE_HOST_TOOLS}"
+
+    INSTALL_COMMAND=${old_install_command}
+
+    if [[ "${ISSUE_DEBUG_BUILD}" == "true" ]]; then
+        build_tvos_type "Debug"
+    fi
+
+    if [[ "${ISSUE_RELEASE_BUILD}" == "true" ]]; then
+        build_tvos_type "Release"
     fi
 }
 
@@ -1017,6 +1086,9 @@ while getopts ":hacCfgDimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
                     ios)
                         ISSUE_IOS_BUILD=true
                     ;;
+                    tvos)
+                        ISSUE_TVOS_BUILD=true
+                    ;;
                     wasm)
                         ISSUE_WASM_BUILD=true
                     ;;
@@ -1028,7 +1100,7 @@ while getopts ":hacCfgDimp:q:vWslwedtk:bVx:S:X:Py:ETu" opt; do
                     ;;
                     *)
                         echo "Unknown platform ${platform}"
-                        echo "Platform must be one of [desktop|android|ios|wasm|all]"
+                        echo "Platform must be one of [desktop|android|ios|tvos|wasm|all]"
                         echo ""
                         exit 1
                     ;;
@@ -1221,6 +1293,10 @@ fi
 
 if [[ "${ISSUE_IOS_BUILD}" == "true" ]]; then
     check_debug_release_build build_ios
+fi
+
+if [[ "${ISSUE_TVOS_BUILD}" == "true" ]]; then
+    check_debug_release_build build_tvos
 fi
 
 if [[ "${ISSUE_WASM_BUILD}" == "true" ]]; then

--- a/build/tvos/build.sh
+++ b/build/tvos/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source `dirname $0`/../common/ci-check.sh
+
+set -e
+set -x
+
+source `dirname $0`/../common/build-common.sh
+pushd `dirname $0`/../.. > /dev/null
+
+# If we're generating an archive for release or continuous builds, then we'll also build for the
+# simulator.
+BUILD_SIMULATOR=
+if [[ "${GENERATE_ARCHIVES}" ]]; then
+    BUILD_SIMULATOR="-s"
+fi
+
+./build.sh -i -p tvos -c $BUILD_SIMULATOR $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -64,9 +64,14 @@ void initializeSupportedGpuFamilies(MetalContext* context) {
 
         if ([device supportsFamily:MTLGPUFamilyMac2]) {
             highestSupportedFamily.mac = 2;
-        } else if ([device supportsFamily:MTLGPUFamilyMac1]) {
+        }
+#if !defined(FILAMENT_APPLETV)
+        // MTLGPUFamilyMac1 is deprecated as of the tvOS 16 SDK, and no tvOS device is a
+        // Mac1-but-not-Mac2 GPU; skip the fallback probe there.
+        else if ([device supportsFamily:MTLGPUFamilyMac1]) {
             highestSupportedFamily.mac = 1;
         }
+#endif
     } else {
 #if TARGET_OS_IOS
         using FeatureSet = std::pair<MTLFeatureSet, uint8_t>;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -1520,7 +1520,7 @@ id<MTLArgumentEncoder> MetalDescriptorSetLayout::getArgumentEncoderSlow(id<MTLDe
                 MTLArgumentDescriptor* bufferArgument = [MTLArgumentDescriptor argumentDescriptor];
                 bufferArgument.index = binding.binding * 2;
                 bufferArgument.dataType = MTLDataTypePointer;
-                bufferArgument.access = MTLArgumentAccessReadOnly;
+                bufferArgument.access = MTLBindingAccessReadOnly;
                 [arguments addObject:bufferArgument];
                 break;
             }
@@ -1558,13 +1558,13 @@ id<MTLArgumentEncoder> MetalDescriptorSetLayout::getArgumentEncoderSlow(id<MTLDe
                     textureType = textureTypes[textureIndex++];
                 }
                 textureArgument.textureType = textureType;
-                textureArgument.access = MTLArgumentAccessReadOnly;
+                textureArgument.access = MTLBindingAccessReadOnly;
                 [arguments addObject:textureArgument];
 
                 MTLArgumentDescriptor* samplerArgument = [MTLArgumentDescriptor argumentDescriptor];
                 samplerArgument.index = binding.binding * 2 + 1;
                 samplerArgument.dataType = MTLDataTypeSampler;
-                samplerArgument.access = MTLArgumentAccessReadOnly;
+                samplerArgument.access = MTLBindingAccessReadOnly;
                 [arguments addObject:samplerArgument];
                 break;
             }
@@ -1584,6 +1584,25 @@ MetalDescriptorSet::MetalDescriptorSet(MetalDescriptorSetLayout* layout) noexcep
     : layout(layout) {}
 
 void MetalDescriptorSet::finalize(MetalDriver* driver) {
+#if defined(FILAMENT_APPLETV)
+    // The tvOS floor (17.0) predates none of the stages: variants, and the stage-less
+    // useResource(s) variants are deprecated there (-Werror); always use stages:.
+    [driver->mContext->currentRenderPassEncoder useResource:driver->mContext->emptyBuffer
+                                                      usage:MTLResourceUsageRead
+                                                     stages:MTLRenderStageVertex | MTLRenderStageFragment];
+    [driver->mContext->currentRenderPassEncoder
+            useResource:getOrCreateEmptyTexture(driver->mContext)
+                  usage:MTLResourceUsageRead
+                 stages:MTLRenderStageVertex | MTLRenderStageFragment];
+    [driver->mContext->currentRenderPassEncoder useResources:vertexResources.data()
+                                                       count:vertexResources.size()
+                                                       usage:MTLResourceUsageRead
+                                                      stages:MTLRenderStageVertex];
+    [driver->mContext->currentRenderPassEncoder useResources:fragmentResources.data()
+                                                       count:fragmentResources.size()
+                                                       usage:MTLResourceUsageRead
+                                                      stages:MTLRenderStageFragment];
+#else
     [driver->mContext->currentRenderPassEncoder useResource:driver->mContext->emptyBuffer
                                                       usage:MTLResourceUsageRead];
     [driver->mContext->currentRenderPassEncoder
@@ -1607,6 +1626,7 @@ void MetalDescriptorSet::finalize(MetalDriver* driver) {
                                                            count:fragmentResources.size()
                                                            usage:MTLResourceUsageRead];
     }
+#endif
 }
 
 id<MTLBuffer> MetalDescriptorSet::finalizeAndGetBuffer(MetalDriver* driver, ShaderStage stage) {

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -156,7 +156,15 @@ id<MTLSamplerState> SamplerStateCreator::operator()(id<MTLDevice> device,
     // MTLSamplerDescriptor.
     // In practice, this means shadows are not supported when running in the simulator.
     if (samplerDescriptor.compareFunction != MTLCompareFunctionNever) {
-        if (![device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v1]) {
+#if defined(FILAMENT_APPLETV)
+        // supportsFeatureSet:/MTLFeatureSet_iOS_* are unavailable on tvOS; probe the
+        // equivalent GPU family instead (Apple TV HD is Apple2, Apple TV 4K is Apple3+).
+        const bool supportsComparison = [device supportsFamily:MTLGPUFamilyApple3];
+#else
+        const bool supportsComparison =
+                [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v1];
+#endif
+        if (!supportsComparison) {
             LOG(WARNING) << "Warning: sample comparison not supported by this GPU";
             samplerDescriptor.compareFunction = MTLCompareFunctionNever;
         }
@@ -189,7 +197,7 @@ id<MTLArgumentEncoder> ArgumentEncoderCreator::operator()(id<MTLDevice> device,
         MTLArgumentDescriptor* bufferArgument = [MTLArgumentDescriptor argumentDescriptor];
         bufferArgument.index = i++;
         bufferArgument.dataType = MTLDataTypePointer;
-        bufferArgument.access = MTLArgumentAccessReadOnly;
+        bufferArgument.access = MTLBindingAccessReadOnly;
         [arguments addObject:bufferArgument];
     }
 
@@ -198,13 +206,13 @@ id<MTLArgumentEncoder> ArgumentEncoderCreator::operator()(id<MTLDevice> device,
         textureArgument.index = i++;
         textureArgument.dataType = MTLDataTypeTexture;
         textureArgument.textureType = textureTypes[j];
-        textureArgument.access = MTLArgumentAccessReadOnly;
+        textureArgument.access = MTLBindingAccessReadOnly;
         [arguments addObject:textureArgument];
 
         MTLArgumentDescriptor* samplerArgument = [MTLArgumentDescriptor argumentDescriptor];
         samplerArgument.index = i++;
         samplerArgument.dataType = MTLDataTypeSampler;
-        samplerArgument.access = MTLArgumentAccessReadOnly;
+        samplerArgument.access = MTLBindingAccessReadOnly;
         [arguments addObject:samplerArgument];
     }
 

--- a/filament/backend/test/test_AsyncUploads.cpp
+++ b/filament/backend/test/test_AsyncUploads.cpp
@@ -222,6 +222,8 @@ TEST_F(BackendTest, BasicAsyncFlow) {
         api.draw2(0, 3, 1);
         api.endRenderPass();
 
+        // Hash recorded on the Apple silicon simulator; A-series devices
+        // rasterize this scene differently (measured 2793888331 on an A10X).
         EXPECT_IMAGE(renderTarget,
                 ScreenshotParams(kRenderTargetSize, kRenderTargetSize, "BasicAsyncFlow",
                         1079009730u));

--- a/third_party/civetweb/tnt/CMakeLists.txt
+++ b/third_party/civetweb/tnt/CMakeLists.txt
@@ -25,6 +25,11 @@ set(SRCS
 
 add_definitions(-DUSE_WEBSOCKET)
 
+if (APPLETV)
+    # fork()/exec*() are __TVOS_PROHIBITED, so CGI support cannot compile on tvOS.
+    add_definitions(-DNO_CGI)
+endif()
+
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})

--- a/third_party/clang/iOS.cmake
+++ b/third_party/clang/iOS.cmake
@@ -25,6 +25,24 @@ if(PLATFORM_NAME STREQUAL "iphonesimulator")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target ${IOS_ARCH}-apple-ios${IOS_MIN_TARGET}-simulator")
 endif()
 
+# tvOS builds reuse the iOS toolchain path: pass -DPLATFORM_NAME=appletvos or
+# -DPLATFORM_NAME=appletvsimulator. tvOS is API-wise a sibling of iOS
+# (TARGET_OS_IPHONE is 1 on both), so FILAMENT_IOS stays defined; the target
+# triple selects the tvOS SDK/availability rules.
+if(PLATFORM_NAME STREQUAL "appletvos" OR PLATFORM_NAME STREQUAL "appletvsimulator")
+    set(APPLETV TRUE)
+    add_definitions(-DFILAMENT_APPLETV)
+    set(IOS_MIN_TARGET "17.0")
+    if(PLATFORM_NAME STREQUAL "appletvsimulator")
+        add_definitions(-DFILAMENT_IOS_SIMULATOR)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target ${IOS_ARCH}-apple-tvos${IOS_MIN_TARGET}-simulator")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target ${IOS_ARCH}-apple-tvos${IOS_MIN_TARGET}-simulator")
+    else()
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target ${IOS_ARCH}-apple-tvos${IOS_MIN_TARGET}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target ${IOS_ARCH}-apple-tvos${IOS_MIN_TARGET}")
+    endif()
+endif()
+
 SET(CMAKE_SYSTEM_NAME Darwin)
 SET(CMAKE_SYSTEM_VERSION 13)
 SET(CMAKE_CXX_COMPILER_WORKS True)

--- a/third_party/clang/iOS.cmake
+++ b/third_party/clang/iOS.cmake
@@ -32,6 +32,9 @@ endif()
 if(PLATFORM_NAME STREQUAL "appletvos" OR PLATFORM_NAME STREQUAL "appletvsimulator")
     set(APPLETV TRUE)
     add_definitions(-DFILAMENT_APPLETV)
+    # tvOS is Metal-only: OpenGL ES is deprecated on Apple platforms and the
+    # CocoaTouchGL platform layer is not ported.
+    set(FILAMENT_SUPPORTS_OPENGL OFF CACHE BOOL "tvOS builds are Metal-only" FORCE)
     set(IOS_MIN_TARGET "17.0")
     if(PLATFORM_NAME STREQUAL "appletvsimulator")
         add_definitions(-DFILAMENT_IOS_SIMULATOR)

--- a/third_party/clang/usage_ios_13.cmake
+++ b/third_party/clang/usage_ios_13.cmake
@@ -1,5 +1,7 @@
 # This file is included by filamat and glslang because glslang (and thus filamat) require
 # iOS 13.0+ whereas the rest of Filament targets iOS 11.0.
-if(IOS)
+# Only ever raises the floor: tvOS builds already target 17.0, and lowering it would
+# conflict with the -target triple set by the toolchain (-Werror,-Woverriding-option).
+if(IOS AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "13.0")
     set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
 endif()


### PR DESCRIPTION
Adds tvOS (`appletvos` + `appletvsimulator`) as a build platform. Opens the discussion proposed in #10339 — since the changes turned out small (~200 lines, no new backend), a concrete diff seemed like the most useful way to have it.

## What this does

- **Toolchain**: tvOS reuses the iOS toolchain path (`third_party/clang/iOS.cmake`) — pass `-DPLATFORM_NAME=appletvos` or `appletvsimulator`. tvOS is API-wise a sibling of iOS (`TARGET_OS_IPHONE` is 1 on both), so `FILAMENT_IOS` stays defined; the target triple selects the tvOS SDK and availability rules. Builds are Metal-only (`FILAMENT_SUPPORTS_OPENGL` forced off — OpenGL ES is deprecated on Apple platforms and the CocoaTouchGL platform layer is not ported).
- **Metal backend fixes**: `MTLArgumentAccessReadOnly` → `MTLBindingAccessReadOnly` renames (the old constants' deprecation predates the tvOS floor, so they fail under `-Werror` there; the new ones are value-identical, so no behavior change on iOS/macOS), tvOS-guarded `useResource:usage:stages:` variants (the stage-less ones are deprecated on tvOS 17+), and a GPU-family probe instead of `supportsFeatureSet:` (unavailable on tvOS) for the comparison-sampler check.
- **`usage_ios_13.cmake`** now only ever *raises* the deployment floor to 13.0 instead of setting it unconditionally — on tvOS (floor 17.0) the old behavior lowered it, which conflicts with the `-target` triple under `-Werror,-Woverriding-option`. No change for iOS builds (11.0 → 13.0 as before).
- **tvOS-prohibited API exclusions**: perfetto and civetweb CGI both use `fork()`/`exec*()`, which are `__TVOS_PROHIBITED`; they're excluded/disabled on tvOS (perfetto is only consumed on Android anyway).
- **Build**: `./build.sh -p tvos` (with `-s` for the simulator slice) produces per-library XCFrameworks under `out/tvos-<type>/filament`, mirroring the iOS flow.
- **CI**: per CONTRIBUTING.md I haven't touched `.github/`, but `build/tvos/build.sh` is included and structured like the iOS wrapper, so a `build-tvos` presubmit job mirroring `build-ios` is a copy-paste for a maintainer (`cd build/tvos && printf "y" | ./build.sh presubmit`).

## Tested

A working game runs on Apple TV 4K (A10X) at 3840x2160 @ 60 fps with this branch. `backend_test` passes on the Apple TV 4K device and the Apple silicon tvOS simulator (built via the existing `INSTALL_BACKEND_TEST` opt-in from #10250; the golden hashes recorded there match on tvOS, modulo one A-series rasterization difference noted in a comment).

## Open questions for maintainers

I picked defaults for three decisions and would like your input:

1. **Deployment floor**: this PR floors tvOS at 17.0, which keeps availability guards minimal (`useResource:stages:`, `supportsFamily:` are all present). Happy to lower it if you'd rather match the iOS floor's spirit — the cost is a handful of `@available` guards.
2. **Release artifacts**: this PR deliberately does *not* add tvOS to the released XCFrameworks — it's build-from-source only. If you'd rather ship it, the `build/tvos/build.sh` wrapper is already structured like the iOS one so wiring it into the release workflow is small.
3. **CI**: should tvOS get its own presubmit job (a maintainer would need to add it, see above), be folded into the existing `build-ios` job as a device-slice build, or stay uncovered for now? The equivalent job has been running green on my fork's CI (pre-rebase branch), and this branch builds both slices clean locally with Xcode 26.5 SDKs.

---

Portions of this change were prepared with the assistance of Claude Code.
