### PR TITLE
Add iridescence to the lit shading models

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -6,3 +6,4 @@
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+- materials: add `iridescence`, `iridescenceIor` and `iridescenceThickness` to the lit shading models

--- a/docs_src/src_markdeep/Materials.md.html
+++ b/docs_src/src_markdeep/Materials.md.html
@@ -118,6 +118,9 @@ in table [standardProperties].
 **secondRoughnessWeight** | Weight of the mix between the first specular lobe and the second specular lobe
 **sheenColor**            | Strength of the sheen layer
 **sheenRoughness**        | Perceived smoothness or roughness of the sheen layer
+**iridescence**           | Strength of the thin film layer, which tints the Fresnel reflectance with the interference between the film's two interfaces
+**iridescenceIor**        | Index of refraction of the thin film layer
+**iridescenceThickness**  | Thickness of the thin film layer, in nanometers
 **clearCoat**             | Strength of the clear coat layer
 **clearCoatRoughness**    | Perceived smoothness or roughness of the clear coat layer
 **normal**                | A detail normal used to perturb the surface using _bump mapping_ (_normal mapping_)
@@ -151,6 +154,9 @@ The type and range of each property is described in table [standardPropertiesTyp
 **secondRoughnessWeight** | float    |  [0..1]                  |
 **sheenColor**            | float3   |  [0..1]                  | Linear RGB
 **sheenRoughness**        | float    |  [0..1]                  |
+**iridescence**           | float    |  [0..1]                  | Optional, defaults to 0.0
+**iridescenceIor**        | float    |  [1..n]                  | Optional, defaults to 1.3
+**iridescenceThickness**  | float    |  [0..n]                  | Optional, defaults to 400.0, in nanometers
 **clearCoat**             | float    |  [0..1]                  | Should be 0 or 1
 **clearCoatRoughness**    | float    |  [0..1]                  |
 **normal**                | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
@@ -183,6 +189,9 @@ The type and range of each property is described in table [standardPropertiesTyp
 **secondRoughnessWeight** | 2
 **sheenColor**            | 1
 **sheenRoughness**        | 1
+**iridescence**           | 1
+**iridescenceIor**        | 1
+**iridescenceThickness**  | 1
 **clearCoat**             | 1
 **clearCoatRoughness**    | 1
 **normal**                | 1
@@ -442,6 +451,45 @@ The effect of `sheenRoughness` on a rough metal is shown in figure [sheenRoughne
 
 ![Figure [sheenRoughnessProperty]: `sheenRoughness` varying from 0.0
 (left) to 1.0 (right)](images/materials/sheen_roughness.png)
+
+### Iridescence
+
+The `iridescence` property adds a thin film over the base layer and controls how strongly it is
+applied, from 0 (no film at all) to 1. Light reflected off the film's two interfaces has traveled
+different distances, and the phase difference that leaves cancels some wavelengths and reinforces
+others, so the reflectance takes on a hue that varies with the viewing angle and with how thick the
+film is. This property is often used to implement the `KHR_materials_iridescence` glTF extension.
+
+The model is Belcour and Barla's, in the approximate form the glTF extension specifies: the film is
+evaluated at the viewing angle and the result is refitted to a Schlick curve, so what every lobe
+below the film sees is an ordinary Fresnel reflectance at normal incidence. The specular lobe, the
+optional second specular lobe and the image based lighting therefore all pick the film up without
+any of them knowing about it.
+
+The film sits below the clear coat layer when one is present, and above the sheen layer.
+
+!!! Note
+    Iridescence is not available with the cloth shading model. The film is refitted to a Schlick
+    curve, which requires a shading model that reads `f0` through one; cloth uses `f0` as a raw
+    reflectance.
+
+!!! Note
+    Unlike the glTF extension, the diffuse lobe is not attenuated by the film. Filament does not
+    take a Fresnel share out of the diffuse lobe for an ordinary surface either, so doing it here
+    would make the thin film the one place in the engine where that term exists.
+
+### Iridescence index of refraction
+
+The `iridescenceIor` property is the index of refraction of the thin film itself, which together
+with its thickness decides which wavelengths interfere constructively. The medium above the film is
+always assumed to be air.
+
+### Iridescence thickness
+
+The `iridescenceThickness` property is the thickness of the thin film in nanometers. Useful values
+are on the order of the wavelength of visible light, which is why the default is 400: below roughly
+100nm the film produces almost no visible tint, and past a few thousand nanometers the interference
+becomes too dense in wavelength to read as a color.
 
 ### Clear coat
 
@@ -2628,6 +2676,13 @@ struct MaterialInputs {
     // not available when the shading model is subsurface or cloth
     float3 sheenColor;          // default: float3(0.0)
     float  sheenRoughness;      // default: 0.0
+
+    // not available when the shading model is cloth
+    float  iridescence;         // default: 0.0
+    float  iridescenceIor;      // default: 1.3
+    float  iridescenceThickness;// default: 400.0, in nanometers
+
+    // not available when the shading model is subsurface or cloth
     float  clearCoat;           // default: 1.0
     float  clearCoatRoughness;  // default: 0.0
     float3 clearCoatNormal;     // default: float3(0.0, 0.0, 1.0)

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -251,7 +251,7 @@ enum class ReflectionMode : uint8_t {
 // can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t
 using AttributeBitset = utils::bitset32;
 
-static constexpr size_t MATERIAL_PROPERTIES_COUNT = 34;
+static constexpr size_t MATERIAL_PROPERTIES_COUNT = 37;
 enum class Property : uint8_t {
     BASE_COLOR,               //!< float4, all shading models
     ROUGHNESS,                //!< float,  lit shading models only
@@ -287,6 +287,9 @@ enum class Property : uint8_t {
     CLIP_SPACE_POSITION,      //!< float4, vertex shader only
     SECOND_ROUGHNESS,         //!< float,  lit shading models only, except subsurface and cloth
     SECOND_ROUGHNESS_WEIGHT,  //!< float,  lit shading models only, except subsurface and cloth
+    IRIDESCENCE,              //!< float,  lit shading models only, except cloth
+    IRIDESCENCE_IOR,          //!< float,  lit shading models only, except cloth
+    IRIDESCENCE_THICKNESS,    //!< float,  lit shading models only, except cloth
 
     // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
 };

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -56,6 +56,9 @@ std::unordered_map<std::string_view, Property> Enums::mStringToProperty = {
         { "clipSpacePosition",      Property::CLIP_SPACE_POSITION },
         { "secondRoughness",        Property::SECOND_ROUGHNESS },
         { "secondRoughnessWeight",  Property::SECOND_ROUGHNESS_WEIGHT },
+        { "iridescence",            Property::IRIDESCENCE },
+        { "iridescenceIor",         Property::IRIDESCENCE_IOR },
+        { "iridescenceThickness",   Property::IRIDESCENCE_THICKNESS },
 };
 
 template <>

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -1210,6 +1210,9 @@ char const* CodeGenerator::getConstantName(MaterialBuilder::Property property) n
         case Property::CLIP_SPACE_POSITION:         return "CLIP_SPACE_POSITION";
         case Property::SECOND_ROUGHNESS:            return "SECOND_ROUGHNESS";
         case Property::SECOND_ROUGHNESS_WEIGHT:     return "SECOND_ROUGHNESS_WEIGHT";
+        case Property::IRIDESCENCE:                 return "IRIDESCENCE";
+        case Property::IRIDESCENCE_IOR:             return "IRIDESCENCE_IOR";
+        case Property::IRIDESCENCE_THICKNESS:       return "IRIDESCENCE_THICKNESS";
     }
 }
 

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -718,6 +718,28 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSheenRoughness) {
     EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
+TEST_F(MaterialCompiler, StaticCodeAnalyzerIridescence) {
+    const std::string fragmentCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.iridescence = 1.0;
+            material.iridescenceIor = 1.3;
+            material.iridescenceThickness = 400.0;
+        }
+    )");
+
+    const std::string shaderCode = shaderWithAllProperties(ShaderStage::FRAGMENT, fragmentCode);
+
+    constexpr GLSLTools glslTools;
+    MaterialBuilder::PropertyList properties{ false };
+    glslTools.findProperties(ShaderStage::FRAGMENT, shaderCode, properties);
+    MaterialBuilder::PropertyList expected{ false };
+    expected[static_cast<size_t>(MaterialBuilder::Property::IRIDESCENCE)] = true;
+    expected[static_cast<size_t>(MaterialBuilder::Property::IRIDESCENCE_IOR)] = true;
+    expected[static_cast<size_t>(MaterialBuilder::Property::IRIDESCENCE_THICKNESS)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
 TEST_F(MaterialCompiler, StaticCodeAnalyzerNormal) {
     const std::string fragmentCode(R"(
         void material(inout MaterialInputs material) {

--- a/shaders/src/surface_brdf.fs
+++ b/shaders/src/surface_brdf.fs
@@ -157,6 +157,138 @@ float F_Schlick(float f0, float f90, float VoH) {
 }
 
 //------------------------------------------------------------------------------
+// Iridescence
+//------------------------------------------------------------------------------
+
+#if defined(MATERIAL_HAS_IRIDESCENCE)
+
+// Belcour and Barla 2017, "A Practical Extension to Microfacet Theory for the Modeling of Varying
+// Iridescence", in the approximate form KHR_materials_iridescence specifies: Schlick replaces the
+// polarized Fresnel equations, and the spectral integral is evaluated in Fourier space against
+// Gaussians fitted to the XYZ color matching functions.
+//
+// The interference math is highp: the Gaussian fits are stated in inverse meters and their
+// amplitudes are around 1e-13, neither of which mediump can represent.
+
+// Schlick with a reflectance of one at grazing incidence, which is what an interface between two
+// dielectrics has; fresnel() below substitutes a shadowing term for that.
+float F_SchlickIridescence(float f0, float cosTheta) {
+    return f0 + (1.0 - f0) * pow5(saturate(1.0 - cosTheta));
+}
+
+vec3 F_SchlickIridescence(const vec3 f0, float cosTheta) {
+    return f0 + (1.0 - f0) * pow5(saturate(1.0 - cosTheta));
+}
+
+// Spectral counterparts of iorToF0() and f0ToIor(). The latter is exact for a dielectric and an
+// approximation for a metal, whose complex index it cannot recover.
+vec3 iorToF0(const vec3 transmittedIor, float incidentIor) {
+    vec3 t = (transmittedIor - incidentIor) / (transmittedIor + incidentIor);
+    return t * t;
+}
+
+vec3 f0ToIor(const vec3 f0) {
+    vec3 r = sqrt(f0);
+    return (1.0 + r) / (1.0 - r);
+}
+
+// The XYZ sensitivity curves in Fourier space at one optical path difference and phase: four
+// Gaussians, one per curve plus the second lobe of x.
+highp vec3 evaluateIridescenceSensitivity(highp float opd, const highp vec3 shift) {
+    // the path difference arrives in nanometers and the fits are in inverse meters
+    highp float phase = 2.0 * PI * opd * 1.0e-9;
+
+    highp vec3 value    = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
+    highp vec3 position = vec3(1.6810e+06, 1.7953e+06, 2.2084e+06);
+    highp vec3 variance = vec3(4.3278e+09, 9.3046e+09, 6.6121e+09);
+
+    highp vec3 xyz = value * sqrt(2.0 * PI * variance) * cos(position * phase + shift) *
+            exp(-variance * phase * phase);
+    xyz.x += 9.7470e-14 * sqrt(2.0 * PI * 4.5282e+09) *
+            cos(2.2399e+06 * phase + shift.x) * exp(-4.5282e+09 * phase * phase);
+    xyz /= 1.0685e-7;
+
+    highp mat3 XYZ_TO_REC709 = mat3(
+         3.2404542, -0.9692660,  0.0556434,
+        -1.5371385,  1.8760108, -0.2040259,
+        -0.4985314,  0.0415560,  1.0572252);
+
+    return XYZ_TO_REC709 * xyz;
+}
+
+// Fresnel of a base surface under a film of the given IOR and thickness in nanometers. The stack is
+// air, the film and the base; the film absorbs nothing, so what leaves is the geometric series of
+// what bounces between its two interfaces, expanded to the second order as the specification does.
+vec3 F_Iridescence(float outsideIor, float filmIor, const vec3 baseF0,
+        highp float thicknessNm, float cosTheta1) {
+    // A film thin enough not to be there must behave as though it is not, or a thickness map whose
+    // minimum is zero shows an edge where the first interface appears.
+    float iridescenceIor = mix(outsideIor, filmIor, smoothstep(0.0, 0.03, thicknessNm));
+
+    // Snell's law through the film. Past the critical angle nothing enters it at all.
+    float cosTheta2Sq = 1.0 - sq(outsideIor / iridescenceIor) * (1.0 - sq(cosTheta1));
+    if (cosTheta2Sq < 0.0) {
+        return vec3(1.0);
+    }
+    float cosTheta2 = sqrt(cosTheta2Sq);
+
+    float R12 = F_SchlickIridescence(iorToF0(iridescenceIor, outsideIor), cosTheta1);
+    float T121 = 1.0 - R12;
+
+    // the clamp short of one is what keeps a white conductor's f0 from taking f0ToIor() to infinity
+    vec3 baseIor = f0ToIor(clamp(baseF0, 0.0, 0.9999));
+    vec3 R23 = F_SchlickIridescence(iorToF0(baseIor, iridescenceIor), cosTheta2);
+
+    highp float opd = 2.0 * iridescenceIor * thicknessNm * cosTheta2;
+
+    // the phase each reflection picks up, approximated as nothing entering a denser medium and half
+    // a turn entering a thinner one
+    float phi21 = PI - (iridescenceIor < outsideIor ? PI : 0.0);
+    highp vec3 phi = phi21 + vec3(
+            baseIor.x < iridescenceIor ? PI : 0.0,
+            baseIor.y < iridescenceIor ? PI : 0.0,
+            baseIor.z < iridescenceIor ? PI : 0.0);
+
+    vec3 R123 = clamp(R12 * R23, 1e-5, 0.9999);
+    vec3 r123 = sqrt(R123);
+    vec3 Rs = (T121 * T121) * R23 / (1.0 - R123);
+
+    vec3 I = R12 + Rs;
+    vec3 Cm = Rs - T121;
+
+    for (int m = 1; m <= 2; m++) {
+        Cm *= r123;
+        I += Cm * 2.0 * evaluateIridescenceSensitivity(float(m) * opd, float(m) * phi);
+    }
+
+    return max(I, vec3(0.0));
+}
+
+// Inverse of F_SchlickIridescence: the f0 whose Schlick curve passes through F at this angle.
+vec3 F_IridescenceToF0(const vec3 F, float cosTheta) {
+    // Schlick reaches one at grazing incidence whatever f0 was, so no f0 reproduces anything else
+    // there; the clamp keeps the division finite as that is approached
+    float weight = min(pow5(saturate(1.0 - cosTheta)), 0.9999);
+
+    return saturate((F - weight) / (1.0 - weight));
+}
+
+// Evaluate the film at the viewing angle and refit the result to a Schlick curve, so that what the
+// lobes below it read is an ordinary f0.
+//
+// The specification's rgb_mix() is deliberately absent: it weights the diffuse lobe by the inverse
+// of the film's strongest channel, and Filament does not take a Fresnel share out of the diffuse
+// lobe for an ordinary surface either.
+vec3 iridescentF0(const vec3 baseF0, float NoV, float iridescence, float iridescenceIor,
+        highp float thicknessNm) {
+    vec3 F = F_Iridescence(1.0, iridescenceIor, baseF0, thicknessNm, NoV);
+
+    return mix(baseF0, F_IridescenceToF0(F, NoV), iridescence);
+}
+
+#endif // MATERIAL_HAS_IRIDESCENCE
+
+//------------------------------------------------------------------------------
 // Specular BRDF dispatch
 //------------------------------------------------------------------------------
 

--- a/shaders/src/surface_material_inputs.fs
+++ b/shaders/src/surface_material_inputs.fs
@@ -46,6 +46,12 @@ struct MaterialInputs {
     float sheenRoughness;
 #endif
 
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_UNLIT)
+    float iridescence;
+    float iridescenceIor;
+    float iridescenceThickness;
+#endif
+
     float clearCoat;
     float clearCoatRoughness;
 
@@ -153,6 +159,12 @@ void initMaterial(out MaterialInputs material) {
     material.sheenColor = vec3(0.0);
     material.sheenRoughness = 0.0;
 #endif
+#endif
+
+#if defined(MATERIAL_HAS_IRIDESCENCE) && !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_UNLIT)
+    material.iridescence = 0.0;
+    material.iridescenceIor = 1.3;
+    material.iridescenceThickness = 400.0;
 #endif
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)

--- a/shaders/src/surface_shading_lit.fs
+++ b/shaders/src/surface_shading_lit.fs
@@ -164,6 +164,15 @@ void getSheenPixelParams(const MaterialInputs material, inout PixelParams pixel)
 #endif
 }
 
+// Runs after getCommonPixelParams() has settled f0 and before the clear coat remaps it to its own
+// interface, which is the order the two glTF extensions stack in.
+void getIridescencePixelParams(const MaterialInputs material, inout PixelParams pixel) {
+#if defined(MATERIAL_HAS_IRIDESCENCE) && !defined(SHADING_MODEL_CLOTH)
+    pixel.f0 = iridescentF0(pixel.f0, shading_NoV, saturate(material.iridescence),
+            max(1.0, material.iridescenceIor), max(0.0, material.iridescenceThickness));
+#endif
+}
+
 void getClearCoatPixelParams(const MaterialInputs material, inout PixelParams pixel) {
 #if defined(MATERIAL_HAS_CLEAR_COAT)
     pixel.clearCoat = material.clearCoat;
@@ -285,6 +294,7 @@ void getEnergyCompensationPixelParams(inout PixelParams pixel) {
 void getPixelParams(const MaterialInputs material, out PixelParams pixel) {
     getSpecularPixelParams(material, pixel);
     getCommonPixelParams(material, pixel);
+    getIridescencePixelParams(material, pixel);
     getSheenPixelParams(material, pixel);
     getClearCoatPixelParams(material, pixel);
     getRoughnessPixelParams(material, pixel);


### PR DESCRIPTION
Adds a thin film interference term to the lit shading models.

This is the shading model half of `KHR_materials_iridescence` support. The
`gltfio` half is a separate PR stacked on this one, since `libs/gltfio` is a
restricted path.

<img width="2009" height="925" alt="image" src="https://github.com/user-attachments/assets/855ea24f-8075-4cc9-b474-cd1776a62f5d" />

## Material model

Three new properties on the lit shading models:

| Property | Type | Range | Default |
| --- | --- | --- | --- |
| `iridescence` | float | [0..1] | 0.0 |
| `iridescenceIor` | float | [1..n] | 1.3 |
| `iridescenceThickness` | float, nanometers | [0..n] | 400.0 |

The model is Belcour and Barla 2017, *A Practical Extension to Microfacet Theory
for the Modeling of Varying Iridescence*, in the approximate form
`KHR_materials_iridescence` specifies: Schlick replaces the polarized Fresnel
equations, and the spectral integral is evaluated in Fourier space against
Gaussians fitted to the XYZ color matching functions.

The film is evaluated once, at the viewing angle, and the result is refitted to a
Schlick curve, so what it produces is an ordinary `f0`. That is the whole of the
integration — `getIridescencePixelParams()` writes `pixel.f0`, and the specular
lobe, the second specular lobe, the anisotropic lobe and the IBL all pick it up
without knowing about it. No new `PixelParams` member, no new lobe, and
`surface_shading_model_standard.fs` is untouched.

It runs after `getCommonPixelParams()` has settled `f0`, so
`KHR_materials_specular` is already folded in, and before the clear coat remaps
`f0` to its own interface — the order the two extensions stack in.

The interference math is `highp`: the Gaussian fits are stated in inverse meters
and their amplitudes are around 1e-13, neither of which mediump can represent.

## Deliberate deviation from the extension

`rgb_mix()` is not implemented. The extension weights the diffuse lobe by the
inverse of the film's strongest channel to conserve energy; Filament does not take
a Fresnel share out of the diffuse lobe for an ordinary surface either, so doing it
here would make the thin film the one place in the engine where that term exists.

Mixing the two reflectances rather than the two Fresnel values is identical
wherever `iridescence` is 0 or 1, which is what an authored material almost always
says, and it is what leaves a single `f0` for the lobes to read.

## Testing

- `matc` compiles an iridescent material for OpenGL, Vulkan and Metal, at both
  desktop and mobile precision.
- `test_filamat` passes 105/105, including a new `StaticCodeAnalyzerIridescence`
  case covering discovery of all three properties.
- With the stacked gltfio PR applied, `gltf_viewer` renders the Khronos
  iridescence sample assets correctly through both the JIT and `--ubershader`
  paths.

## For review

The new properties are at material API level 1 rather than behind
`UNSTABLE_MATERIAL_API_LEVEL`. Adding a property is additive, and every other
glTF-extension-backed property (`clearCoat`, `sheenColor`, `specularFactor`,
`dispersion`) is at level 1; putting these at level 2 would mean gltfio building
against the unstable level. Happy to move them if you would rather they landed
as level 2.
