### PR TITLE
VK: More refactor of the external sampler flow

### DIFF
--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.cpp
@@ -356,7 +356,7 @@ void VulkanDescriptorSetCache::updateBuffer(fvkmemory::resource_ptr<VulkanDescri
 
 void VulkanDescriptorSetCache::updateSampler(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
         uint8_t binding, fvkmemory::resource_ptr<VulkanTexture> texture,
-        VkSampler sampler, VkDescriptorSetLayout externalSamplerLayout) noexcept {
+        VkSampler sampler) noexcept {
     VkDescriptorSet const vkset = set->getVkSet();
     VkImageSubresourceRange range = texture->getPrimaryViewRange();
     VkImageViewType const expectedType = texture->getViewType();

--- a/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
+++ b/filament/backend/src/vulkan/VulkanDescriptorSetCache.h
@@ -57,12 +57,7 @@ public:
             VkDeviceSize size) noexcept;
 
     void updateSampler(fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t binding,
-            fvkmemory::resource_ptr<VulkanTexture> texture, VkSampler sampler,
-            VkDescriptorSetLayout externalSamplerLayout = VK_NULL_HANDLE) noexcept;
-
-    void updateSamplerForExternalSamplerSet(fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t binding,
-            fvkmemory::resource_ptr<VulkanTexture> texture) noexcept;
-
+            fvkmemory::resource_ptr<VulkanTexture> texture, VkSampler sampler) noexcept;
 
     void updateInputAttachment(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
             VulkanAttachment const& attachment) noexcept;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -620,7 +620,7 @@ void VulkanDriver::updateDescriptorSetTexture(
     auto set = resource_ptr<VulkanDescriptorSet>::cast(&mResourceManager, dsh);
     auto texture = resource_ptr<VulkanTexture>::cast(&mResourceManager, th);
 
-    if (UTILS_UNLIKELY(mExternalImageManager.isExternallySampledTexture(texture))) {
+    if (UTILS_UNLIKELY(texture->isExternallySampled())) {
         mExternalImageManager.bindExternallySampledTexture(set, binding, texture, params);
         mAppState.hasBoundExternalImages = true;
         set->isAnExternalSamplerBound = true;
@@ -643,8 +643,6 @@ void VulkanDriver::updateDescriptorSetTexture(
         };
         VkSampler const vksampler = mSamplerCache.getSampler(cacheParams);
         mDescriptorSetCache.updateSampler(set, binding, texture, vksampler);
-        mExternalImageManager.clearTextureBinding(set, binding);
-        mStreamedImageManager.unbindStreamedTexture(set, binding);
     }
 }
 
@@ -1010,10 +1008,6 @@ void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::S
     // texture into the read layout.
     texture->transitionLayout(&commands, texture->getPrimaryViewRange(), VulkanLayout::FRAG_READ);
 
-    if (imgData.external.valid() || texture->isYUVStaging()) {
-        mExternalImageManager.addExternallySampledTexture(texture, conversion);
-    }
-
     texture.inc();
     mResourceManager.associateHandle(th.getId(), std::move(tag));
 }
@@ -1067,10 +1061,6 @@ void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
         return;
     }
     auto texture = resource_ptr<VulkanTexture>::cast(&mResourceManager, th);
-
-    // Must happen immediately on the backend thread. Removes from ExternalImageManager's tracking
-    // map. Only the dec() ref-release is deferred in the async path.
-    mExternalImageManager.removeExternallySampledTexture(texture);
 
     if (texture->asynchronous && getJobQueue()) {
         // Route the `dec()` through the queue to preserve FIFO ordering with any pending async
@@ -1712,8 +1702,6 @@ void VulkanDriver::updateStreams(CommandStream* driver) {
                             VulkanLayout::FRAG_READ);
 
                     if (imgData.external.valid()) {
-                        mExternalImageManager.addExternallySampledTexture(newTexture,
-                                conversion);
                         // Cache the AHB backed image. Acquires the image here.
                         s->pushImage(image, newTexture);
                     }
@@ -2363,7 +2351,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         if (depthStencil.texture->isTransientAttachment()) {
             discardEndVal |= TargetBufferFlags::DEPTH_AND_STENCIL;
         }
-        
+
         currentDepthStencilLayout = VulkanLayout::DEPTH_STENCIL_ATTACHMENT;
     }
 
@@ -2844,7 +2832,6 @@ void VulkanDriver::bindPipeline(PipelineState const& pipelineState) {
         if (std::any_of(layoutHandles.begin(), layoutHandles.end(), haveExternalSamplers)) {
             BindInDrawBundle bundle = {
                 .pipelineState = pipelineState,
-                .dsLayoutHandles = layoutHandles,
                 .descriptorSetMask = descriptorSetMask,
             };
             mPipelineState.bindInDraw = { true, bundle };

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -220,7 +220,6 @@ private:
 
     struct BindInDrawBundle {
         PipelineState pipelineState = {};
-        DescriptorSetLayoutHandleList dsLayoutHandles = {};
         fvkutils::DescriptorSetMask descriptorSetMask = {};
         resource_ptr<VulkanProgram> program = {};
     };

--- a/filament/backend/src/vulkan/VulkanExternalImageManager.cpp
+++ b/filament/backend/src/vulkan/VulkanExternalImageManager.cpp
@@ -38,16 +38,6 @@ void erasep(std::vector<T>& v, std::function<bool(T const&)> f) {
     v.erase(newEnd, v.end());
 }
 
-using ImageData = VulkanExternalImageManager::VulkanExternalImageManager::ImageData;
-ImageData& findImage(std::vector<ImageData>& images,
-        fvkmemory::resource_ptr<VulkanTexture> texture) {
-    auto itr = std::find_if(images.begin(), images.end(), [&](ImageData const& data) {
-        return data.image == texture;
-    });
-    assert_invariant(itr != images.end());
-    return *itr;
-}
-
 }// namespace
 
 VulkanExternalImageManager::VulkanExternalImageManager(VulkanSamplerCache* samplerCache,
@@ -62,7 +52,6 @@ VulkanExternalImageManager::~VulkanExternalImageManager() = default;
 
 void VulkanExternalImageManager::terminate() {
     mSetBindings.clear();
-    mImages.clear();
 }
 
 void VulkanExternalImageManager::updateSetAndLayout(
@@ -113,9 +102,7 @@ void VulkanExternalImageManager::updateSetAndLayout(
 
     // Update the external samplers in the set
     for (auto& [binding, sampler, image]: samplerAndBindings) {
-        // We cannot call updateSamplerForExternalSamplerSet because some samplers are non NULL
-        // (RGB) and we cannot do a combined update with a NULL sampler.
-        mDescriptorSetCache->updateSampler(set, binding, image, sampler, set->boundLayout);
+        mDescriptorSetCache->updateSampler(set, binding, image, sampler);
     }
 }
 
@@ -156,8 +143,6 @@ void VulkanExternalImageManager::removeDescriptorSet(
 void VulkanExternalImageManager::bindExternallySampledTexture(
         fvkmemory::resource_ptr<VulkanDescriptorSet> set, uint8_t bindingPoint,
         fvkmemory::resource_ptr<VulkanTexture> image, SamplerParams samplerParams) {
-    // Should we do duplicate validation here?
-    auto& imageData = findImage(mImages, image);
     // according to spec, these must match chromaFilter
     // https://registry.khronos.org/vulkan/specs/latest/man/html/VkSamplerCreateInfo.html#VUID-VkSamplerCreateInfo-minFilter-01645
     samplerParams.filterMag = SamplerMagFilter::LINEAR;
@@ -172,7 +157,7 @@ void VulkanExternalImageManager::bindExternallySampledTexture(
 
     VkSampler const sampler = mSamplerCache->getSampler({
         .sampler = samplerParams,
-        .conversion = imageData.conversion,
+        .conversion = image->getYcbcrConversion(),
     });
 
     // Do a replace if a binding+set already exists (i.e. streaming texture)
@@ -182,35 +167,11 @@ void VulkanExternalImageManager::bindExternallySampledTexture(
             });
 
     if (itr != mSetBindings.end()) {
-        itr->image = imageData.image;
+        itr->image = image;
         itr->sampler = sampler;
     } else {
-        mSetBindings.push_back({ bindingPoint, imageData.image, set, sampler });
+        mSetBindings.push_back({ bindingPoint, image, set, sampler });
     }
-}
-
-void VulkanExternalImageManager::addExternallySampledTexture(
-        fvkmemory::resource_ptr<VulkanTexture> image, VkSamplerYcbcrConversion const conversion) {
-    mImages.push_back({
-        .image = image,
-        .conversion = conversion,
-    });
-}
-
-void VulkanExternalImageManager::removeExternallySampledTexture(
-        fvkmemory::resource_ptr<VulkanTexture> image) {
-    erasep<SetBindingInfo>(mSetBindings,
-            [&](auto const& bindingInfo) { return (bindingInfo.image == image); });
-    erasep<ImageData>(mImages, [&](auto const& imageData) {
-        return imageData.image == image;
-    });
-}
-
-bool VulkanExternalImageManager::isExternallySampledTexture(
-        fvkmemory::resource_ptr<VulkanTexture> image) const {
-    return std::find_if(mImages.begin(), mImages.end(), [&](auto const& imageData) {
-        return imageData.image == image;
-    }) != mImages.end();
 }
 
 void VulkanExternalImageManager::clearTextureBinding(

--- a/filament/backend/src/vulkan/VulkanExternalImageManager.h
+++ b/filament/backend/src/vulkan/VulkanExternalImageManager.h
@@ -62,20 +62,8 @@ public:
     void clearTextureBinding(fvkmemory::resource_ptr<VulkanDescriptorSet> set,
                              uint8_t bindingPoint);
 
-    void addExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> external,
-            VkSamplerYcbcrConversion const conversion);
-
-    void removeExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> image);
-
-    bool isExternallySampledTexture(fvkmemory::resource_ptr<VulkanTexture> image) const;
-
     VkSamplerYcbcrConversion getVkSamplerYcbcrConversion(
             VulkanPlatform::ExternalImageMetadata const& metadata);
-
-    struct ImageData {
-        fvkmemory::resource_ptr<VulkanTexture> image;
-        VkSamplerYcbcrConversion conversion = VK_NULL_HANDLE;
-    };
 
     // - Update the descriptor set layout with the external samplers. This layout will be assign the
     // respective immutable samplers to the layout.
@@ -104,7 +92,6 @@ private:
 
     // Use vectors instead of hash maps because we only expect small number of entries.
     std::vector<SetBindingInfo> mSetBindings;
-    std::vector<ImageData> mImages;
 };
 
 } // filament::backend

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -271,6 +271,8 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
         return mState->mSoftwareYUVStaging.ahbuffer;
     }
 
+    bool isExternallySampled() const { return mState->mYcbcr.conversion != VK_NULL_HANDLE; }
+
     bool transitionLayout(VulkanCommandBuffer* commands, VkImageSubresourceRange const& range,
             VulkanLayout newLayout);
 
@@ -295,6 +297,8 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     // conversion per-frame. This implies that we need to invalidate the view cache when that
     // happens.
     void setYcbcrConversion(VkSamplerYcbcrConversion conversion);
+
+    VkSamplerYcbcrConversion getYcbcrConversion() const { return mState->mYcbcr.conversion; }
 
 #if FVK_ENABLED(FVK_DEBUG_TEXTURE)
     void print() const;


### PR DESCRIPTION
Query the texture directly to know if it uses an
external sampler or not. This is already known
when the texture is created.

Remove dead code related to the external sampler
flow.

Simplify the code of the VulkanExternalImageManager class.