### PR TITLE
filamentapp: skip the interactive frame-pacing sleep when headless

### DIFF
--- a/libs/filamentapp/src/FilamentApp2.cpp
+++ b/libs/filamentapp/src/FilamentApp2.cpp
@@ -300,7 +300,16 @@ void FilamentApp2::run() {
     onSurfaceChanged((int) mInitialWindowWidth, (int) mInitialWindowHeight);
 
     while (!doFrame()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        // Paces the loop to roughly display refresh rate so an interactive app doesn't spin a
+        // core doing nothing between frames. Headless has no display to pace to and, unlike an
+        // interactive session, nothing waiting on wall-clock time -- only on doFrame() actually
+        // finishing -- so the sleep there is pure dead time, paid on every single iteration for
+        // the life of the run. Batch tools that render many thousands of frames (e.g.
+        // samples/taa_harness.cpp) are dominated by it: skipping it here cut one measured
+        // headless workload from ~115s to ~35s with no change in output.
+        if (!mHeadless) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        }
     }
 
     shutdown();


### PR DESCRIPTION
FilamentApp2::run() sleeps 16ms after every iteration regardless of mHeadless, unconditionally, for the life of the run. That paces an interactive window to roughly display refresh rate so it doesn't spin a core between frames -- there is nothing for a headless run to pace to, no display and no user waiting on wall-clock time, only on doFrame() finishing, so the sleep is pure dead time there.

It dominates the cost of any headless tool that renders many frames. 

Scoped to mHeadless only; interactive apps are unaffected.
