### PR TITLE
gltf_viewer: add frame stepping

### DIFF
--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -318,6 +318,16 @@ struct ViewerOptions {
 
 struct DebugOptions {
     uint16_t skipFrames = 0;
+    //! freeze the image and advance exactly one rendered frame per step request, so
+    //! frame-to-frame effects (TAA convergence, ghosting) can be inspected one frame at a time
+    bool frameStep = false;
+    //! set by the UI (space bar, or the Step button) to request the next frame; consumed by the
+    //! application, which is responsible for clearing it
+    bool frameStepRequested = false;
+    //! how much animation time (in seconds) a single step advances; the default matches one
+    //! frame at 60Hz. Animation time is otherwise frozen while frameStep is on, so that each
+    //! step is reproducible rather than depending on how long the wall clock was paused
+    float frameStepDeltaSeconds = 1.0f / 60.0f;
 };
 
 struct Settings {

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1233,6 +1233,28 @@ void ViewerGui::updateUserInterface() {
         if (ImGui::Button("Skip 10 frames")) {
             mSettings.debug.skipFrames = 10;
         }
+
+        ImGui::Checkbox("Frame step", &mSettings.debug.frameStep);
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Freezes the image (and animation time) until stepped, so each "
+                              "frame produced by effects like TAA can be inspected on its own.");
+        }
+        if (mSettings.debug.frameStep) {
+            // While stepping, the window keeps showing the last frame that was actually
+            // rendered -- including this UI, which is why the button below stays clickable even
+            // though nothing is being redrawn. ImGui still processes input every iteration; only
+            // presentation is paused.
+            bool step = ImGui::Button("Step one frame");
+            // Space is the convenient way to do it, but must not steal the key from a text field.
+            step = step || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(ImGuiKey_Space));
+            if (step) {
+                mSettings.debug.frameStepRequested = true;
+            }
+            ImGui::SameLine();
+            ImGui::TextDisabled("(or space)");
+            ImGui::SliderFloat("Step size (seconds)",
+                    &mSettings.debug.frameStepDeltaSeconds, 0.0f, 1.0f / 15.0f, "%.4f");
+        }
     }
 
     colorGradingUI(mSettings, mRangePlot, mCurvePlot, mToneMapPlot);

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -122,6 +122,14 @@ struct App {
     bool originIsFarAway = false;
     float originDistance = 1.0f;
 
+    // Frame stepping (see Settings::debug.frameStep). frameStepTime is a virtual animation clock
+    // that only advances when a step is requested, so a step always advances by the same amount
+    // no matter how long the frame stayed paused. frameStepRenderPending carries the request from
+    // the animation callback -- which consumes it and advances the clock -- over to preRender,
+    // which is what actually lets a frame through.
+    double frameStepTime = 0.0;
+    bool frameStepRenderPending = false;
+
     struct Scene {
         Entity groundPlane;
         VertexBuffer* groundVertexBuffer;
@@ -952,6 +960,24 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
         // Gradually add renderables to the scene as their textures become ready.
         app->viewer->populateScene();
 
+        auto& debugSettings = app->viewer->getSettings().debug;
+        if (debugSettings.frameStep) {
+            // Consume a pending step here rather than in preRender: animation has to be advanced
+            // before the frame that shows it is rendered, and this callback runs first.
+            if (debugSettings.frameStepRequested) {
+                debugSettings.frameStepRequested = false;
+                app->frameStepTime += debugSettings.frameStepDeltaSeconds;
+                app->frameStepRenderPending = true;
+            }
+            // Substitute the virtual clock for the wall clock, freezing animation between steps.
+            now = app->frameStepTime;
+        } else {
+            // Keep the virtual clock aligned with the wall clock while stepping is off, so
+            // enabling it doesn't jump the animation.
+            app->frameStepTime = now;
+            app->frameStepRenderPending = false;
+        }
+
         auto const& animSettings = app->viewer->getSettings().animation;
         if (animSettings.enabled) {
             double animTime = now;
@@ -983,6 +1009,21 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
     };
 
     auto preRender = [app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
+        // Frame stepping: hold the frame by telling the renderer to skip it, which makes
+        // beginFrame() return false so nothing is rendered OR presented -- the window keeps
+        // showing the last stepped frame instead of cycling stale swap chain buffers. ImGui is
+        // still updated every iteration (it runs before this), so the UI stays interactive even
+        // while frozen; only its display is held. A step lets exactly one frame through, which
+        // is also what advances TAA's history by exactly one iteration.
+        auto const& debugSettings = app->viewer->getSettings().debug;
+        if (debugSettings.frameStep) {
+            if (app->frameStepRenderPending) {
+                app->frameStepRenderPending = false;
+            } else {
+                renderer->skipNextFrames(1);
+            }
+        }
+
         auto& rcm = engine->getRenderableManager();
         auto instance = rcm.getInstance(app->scene.groundPlane);
         const auto viewerOptions = app->automationEngine->getViewerOptions();


### PR DESCRIPTION
Add a frame step mode. While it is on, the renderer is told to skip each frame, which makes beginFrame() return false so nothing is rendered OR presented and the window keeps showing the last stepped frame rather than cycling stale swap chain buffers. A step lets exactly one frame through, which is also exactly one TAA iteration.

Animation runs off a virtual clock that only advances on a step, so a step always covers the same interval no matter how long the frame stayed paused, and the same Nth step always shows the same pose. The clock re-syncs to the wall clock when stepping is turned off, so enabling it does not jump the animation.

ImGui runs before the render gate, so input is still processed while frozen: the panel is visible in the held frame and its controls stay usable even though nothing is being redrawn.

The settings are deliberately not serialized -- persisting them would let a settings file load the viewer in a frozen state, which looks like a hang.