### PR TITLE
filamentapp: support screenshot for all sample apps

### DIFF
--- a/libs/filamentapp/CMakeLists.txt
+++ b/libs/filamentapp/CMakeLists.txt
@@ -19,7 +19,9 @@ set(MATERIAL_DIR  "${GENERATION_ROOT}/generated/material")
 
 set(PUBLIC_HDRS
         include/filamentapp/AssetLoader.h
+        include/filamentapp/AssetWriter.h
         include/filamentapp/DesktopAssetLoader.h
+        include/filamentapp/DesktopAssetWriter.h
         include/filamentapp/Config.h
         include/filamentapp/Cube.h
         include/filamentapp/Grid.h
@@ -35,6 +37,7 @@ set(PUBLIC_HDRS
 set(SRCS
         src/Cube.cpp
         src/DesktopAssetLoader.cpp
+        src/DesktopAssetWriter.cpp
         src/Grid.cpp
         src/FilamentApp.cpp
         src/FilamentApp2.cpp
@@ -76,6 +79,7 @@ set(LIBS
         filament-iblprefilter
         geometry
         image
+        imageio-lite
         ktxreader
         math
         stb
@@ -89,10 +93,6 @@ if (IS_HOST_PLATFORM)
         imgui
         imageio
         sdl2
-    )
-else()
-    list(APPEND LIBS
-        imageio-lite
     )
 endif()
 

--- a/libs/filamentapp/include/filamentapp/AssetWriter.h
+++ b/libs/filamentapp/include/filamentapp/AssetWriter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENTAPP_ASSETWRITER_H
+#define TNT_FILAMENTAPP_ASSETWRITER_H
+
+#include <utils/Path.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace filament::app {
+
+class AssetWriter {
+public:
+    virtual ~AssetWriter() = default;
+
+    /**
+     * Writes raw bytes to the specified path or destination identifier.
+     *
+     * @param path Target destination path or URI.
+     * @param data Pointer to the buffer to write.
+     * @param size Size in bytes.
+     * @return true if the write completed successfully, false otherwise.
+     */
+    virtual bool write(utils::Path const& path, uint8_t const* data, size_t size) const = 0;
+
+    /**
+     * Convenience overload for vector buffers.
+     */
+    bool write(utils::Path const& path, std::vector<uint8_t> const& data) const {
+        return write(path, data.data(), data.size());
+    }
+};
+
+} // namespace filament::app
+
+#endif // TNT_FILAMENTAPP_ASSETWRITER_H

--- a/libs/filamentapp/include/filamentapp/DesktopAssetWriter.h
+++ b/libs/filamentapp/include/filamentapp/DesktopAssetWriter.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENTAPP_DESKTOPASSETWRITER_H
+#define TNT_FILAMENTAPP_DESKTOPASSETWRITER_H
+
+#include <filamentapp/AssetWriter.h>
+
+#include <utils/Path.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace filament::app {
+
+class DesktopAssetWriter : public AssetWriter {
+public:
+    ~DesktopAssetWriter() override = default;
+
+    bool write(utils::Path const& path, uint8_t const* data, size_t size) const override;
+};
+
+} // namespace filament::app
+
+#endif // TNT_FILAMENTAPP_DESKTOPASSETWRITER_H

--- a/libs/filamentapp/include/filamentapp/FilamentApp2.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp2.h
@@ -18,7 +18,6 @@
 #define TNT_FILAMENT_SAMPLE_FILAMENTAPP2_H
 
 #include "AppEvent.h"
-#include "Config.h"
 #include "Cube.h"
 #include "Grid.h"
 #include "IBL.h"
@@ -31,9 +30,11 @@
 #include <utils/Entity.h>
 #include <utils/Path.h>
 
+#include <atomic>
+#include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
-#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -64,6 +65,7 @@ class WebGPUPlatform;
 namespace filament::app {
 class DisplayManager;
 class AssetLoader;
+class AssetWriter;
 } // namespace filament::app
 
 class UTILS_PUBLIC FilamentApp2 {
@@ -85,6 +87,10 @@ public:
     using SurfaceCreatedCallback = std::function<void(filament::Engine*)>;
     using SurfaceDestroyedCallback = std::function<void(filament::Engine*)>;
 
+private:
+    static constexpr uint32_t MAX_WARMUP_FRAMES = std::numeric_limits<uint32_t>::max();
+
+public:
     class Builder {
     public:
         Builder() = default;
@@ -158,6 +164,18 @@ public:
             mAsynchronousMode = asynchronousMode;
             return *this;
         }
+        Builder& screenshotPath(utils::CString const& screenshotPath) {
+            mScreenshotPath = screenshotPath;
+            return *this;
+        }
+        Builder& warmupFrames(int warmupFrames) {
+            mWarmupFrames = warmupFrames;
+            return *this;
+        }
+        Builder& fixedTimeStep(float fixedTimeStep) {
+            mFixedTimeStep = fixedTimeStep;
+            return *this;
+        }
         /**
          * Sets a custom AssetLoader for the application.
          *
@@ -166,6 +184,17 @@ public:
          */
         Builder& assetLoader(filament::app::AssetLoader* assetLoader) {
             mAssetLoader = assetLoader;
+            return *this;
+        }
+
+        /**
+         * Sets a custom AssetWriter for the application.
+         *
+         * @param assetWriter Pointer to an AssetWriter implementation.
+         *                    If nullptr or not set, the app will use a default DesktopAssetWriter.
+         */
+        Builder& assetWriter(filament::app::AssetWriter* assetWriter) {
+            mAssetWriter = assetWriter;
             return *this;
         }
 
@@ -313,8 +342,12 @@ public:
         WebGPUBackend mForcedWebGPUBackend = WebGPUBackend::DEFAULT;
         DisplayManager mDisplayManagerConfig = DisplayManager::SDL;
         filament::backend::AsynchronousMode mAsynchronousMode = filament::backend::AsynchronousMode::NONE;
+        utils::CString mScreenshotPath;
+        uint32_t mWarmupFrames = MAX_WARMUP_FRAMES;
+        float mFixedTimeStep = 0.0f;
         filament::app::DisplayManager* mDisplayManager = nullptr;
         filament::app::AssetLoader* mAssetLoader = nullptr;
+        filament::app::AssetWriter* mAssetWriter = nullptr;
         SetupCallback mSetup;
         CleanupCallback mCleanup;
         PreRenderCallback mPreRender;
@@ -354,6 +387,7 @@ public:
 
     filament::app::DisplayManager* getDisplayManager() const noexcept { return mDisplayManager; }
     filament::app::AssetLoader* getAssetLoader() const noexcept { return mAssetLoader; }
+    filament::app::AssetWriter* getAssetWriter() const noexcept { return mAssetWriter; }
 
     void setSidebarWidth(int width) {
         mCameraParams.sidebarWidth = width;
@@ -477,12 +511,16 @@ private:
     void configureCamerasForWindow(WindowCameraParams const& camera);
     void fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const;
 
+    void captureScreenshot(utils::CString const& filepath);
+
     bool mInitialized = false;
     filament::Engine* mEngine = nullptr;
     filament::Scene* mScene = nullptr;
     std::unique_ptr<IBL> mIBL;
     filament::Texture* mDirt = nullptr;
-    bool mClosed = false;
+    // Atomic because close() can be called from asynchronous driver/readback callbacks while
+    // the main loop reads mClosed in doFrame().
+    std::atomic<bool> mClosed{ false };
     double mTime = 0;
 
     filament::Material const* mDefaultMaterial = nullptr;
@@ -508,6 +546,8 @@ private:
     filament::app::DisplayManager* const mDisplayManager;
     std::unique_ptr<filament::app::AssetLoader> mDefaultAssetLoader;
     filament::app::AssetLoader* const mAssetLoader;
+    std::unique_ptr<filament::app::AssetWriter> mDefaultAssetWriter;
+    filament::app::AssetWriter* const mAssetWriter;
 
     filament::backend::Platform* mVulkanPlatform = nullptr;
     filament::backend::Platform* mWebGPUPlatform = nullptr;
@@ -562,6 +602,13 @@ private:
     PostRenderCallback const mPostRender{};
     bool mMousePressed[3] = { false };
     bool mIsSplitView = false;
+
+    utils::CString const mScreenshotPath;
+    uint32_t mWarmupFrames = MAX_WARMUP_FRAMES;
+    float const mFixedTimeStep = 0.0f;
+    uint32_t mCurrentFrame = 0;
+    double mVirtualTime = 0.0;
+    double mLastVirtualTime = 0.0;
 
     std::unique_ptr<Cube> mCameraCube;
     std::unique_ptr<Grid> mCameraGrid;

--- a/libs/filamentapp/src/DesktopAssetWriter.cpp
+++ b/libs/filamentapp/src/DesktopAssetWriter.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filamentapp/AssetWriter.h>
+#include <filamentapp/DesktopAssetWriter.h>
+
+#include <fstream>
+
+namespace filament::app {
+
+bool DesktopAssetWriter::write(utils::Path const& path, uint8_t const* data, size_t size) const {
+    std::ofstream out(path.c_str(), std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        return false;
+    }
+    out.write(reinterpret_cast<const char*>(data), size);
+    return out.good();
+}
+
+} // namespace filament::app

--- a/libs/filamentapp/src/FilamentApp2.cpp
+++ b/libs/filamentapp/src/FilamentApp2.cpp
@@ -23,9 +23,14 @@
 
 #include "generated/resources/filamentapp.h"
 
-#include <filamentapp/AssetLoader.h>
+#include <imageio-lite/ImageEncoder.h>
+
+#include <image/ColorTransform.h>
+#include <image/LinearImage.h>
+
 #include <filamentapp/Config.h>
 #include <filamentapp/DesktopAssetLoader.h>
+#include <filamentapp/DesktopAssetWriter.h>
 #include <filamentapp/DisplayManager.h>
 #include <filamentapp/FilamentApp2.h>
 
@@ -42,6 +47,7 @@
 #include <filament/SwapChain.h>
 #include <filament/View.h>
 
+#include <backend/PixelBufferDescriptor.h>
 #include <backend/Platform.h>
 #if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
 #include <backend/platforms/VulkanPlatform.h>
@@ -59,8 +65,10 @@
 #ifdef __EXCEPTIONS
 #include <exception>
 #endif
+#include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -102,6 +110,9 @@ FilamentApp2::FilamentApp2(const Builder& builder)
                                       ? nullptr
                                       : std::make_unique<filament::app::DesktopAssetLoader>()),
           mAssetLoader(builder.mAssetLoader ? builder.mAssetLoader : mDefaultAssetLoader.get()),
+          mDefaultAssetWriter(
+                  builder.mAssetWriter ? nullptr : std::make_unique<DesktopAssetWriter>()),
+          mAssetWriter(builder.mAssetWriter ? builder.mAssetWriter : mDefaultAssetWriter.get()),
           mSetupCallback(builder.mSetup),
           mCleanupCallback(builder.mCleanup),
           mPreRender(builder.mPreRender),
@@ -112,6 +123,9 @@ FilamentApp2::FilamentApp2(const Builder& builder)
           mDropHandler(builder.mDropHandler),
           mSurfaceCreatedCallback(builder.mSurfaceCreatedCallback),
           mSurfaceDestroyedCallback(builder.mSurfaceDestroyedCallback),
+          mScreenshotPath(builder.mScreenshotPath),
+          mWarmupFrames(builder.mWarmupFrames),
+          mFixedTimeStep(builder.mFixedTimeStep),
           mWidth(builder.mWidth),
           mHeight(builder.mHeight) {}
 
@@ -365,6 +379,66 @@ void FilamentApp2::onSurfaceDestroyed() {
     }
 }
 
+void FilamentApp2::captureScreenshot(utils::CString const& filepath) {
+    if (mViews.empty() || !mViews[0] || !mRenderer) {
+        return;
+    }
+    View* view = mViews[0]->getView();
+    if (!view) {
+        return;
+    }
+    filament::Viewport const& vp = view->getViewport();
+    size_t const byteCount = size_t(vp.width) * size_t(vp.height) * 4;
+
+    struct ScreenshotState {
+        View* view = nullptr;
+        utils::CString filename;
+        FilamentApp2* app = nullptr;
+    };
+
+    backend::PixelBufferDescriptor buffer(
+            new uint8_t[byteCount], byteCount,
+            backend::PixelBufferDescriptor::PixelDataFormat::RGBA,
+            backend::PixelBufferDescriptor::PixelDataType::UBYTE,
+            [](void* buffer, size_t, void* user) {
+                std::unique_ptr<ScreenshotState> state(static_cast<ScreenshotState*>(user));
+                uint8_t* pixels = static_cast<uint8_t*>(buffer);
+                if (!state || !state->app) {
+                    delete[] pixels;
+                    return;
+                }
+
+                const filament::Viewport& vp = state->view->getViewport();
+                image::LinearImage image = image::toLinearWithAlpha<uint8_t>(
+                        vp.width, vp.height, vp.width * 4, pixels, [](uint8_t v) { return v; },
+                        image::sRGBToLinear<filament::math::float4>);
+
+                std::ostringstream ss(std::ios::binary);
+                bool const encoded = imageio_lite::ImageEncoder::encode(ss,
+                        imageio_lite::ImageEncoder::Format::TIFF, image, "", "");
+
+                if (encoded) {
+                    std::string const data = ss.str();
+                    utils::Path out(state->filename.c_str_safe());
+                    if (!state->app->getAssetWriter()->write(out,
+                                reinterpret_cast<const uint8_t*>(data.data()), data.size())) {
+                        utils::slog.e << "Failed to write screenshot output file: "
+                                      << state->filename.c_str_safe() << utils::io::endl;
+                    }
+                } else {
+                    utils::slog.e << "Failed to encode screenshot TIFF for: "
+                                  << state->filename.c_str_safe() << utils::io::endl;
+                }
+
+                delete[] pixels;
+                state->app->close();
+            },
+            new ScreenshotState{ view, filepath, this });
+
+    mRenderer->readPixels((uint32_t) vp.left, (uint32_t) vp.bottom, vp.width, vp.height,
+            std::move(buffer));
+}
+
 View* FilamentApp2::getGuiView() const noexcept { return mAppGui ? mAppGui->getView() : nullptr; }
 
 bool FilamentApp2::doFrame() {
@@ -384,10 +458,23 @@ bool FilamentApp2::doFrame() {
             mEngine->execute();
         }
 
+        float timeStep = 0.0f;
+        if (mFixedTimeStep > 0.0f) {
+            mVirtualTime += (double) mFixedTimeStep;
+            timeStep = mFixedTimeStep;
+        } else {
+            mVirtualTime = mDisplayManager ? mDisplayManager->getTime() : 0.0;
+            if (mLastVirtualTime == mVirtualTime) {
+                timeStep = 1.0f / 60.0f;
+            } else {
+                timeStep = mVirtualTime - mLastVirtualTime;
+            }
+            mLastVirtualTime = mVirtualTime;
+        }
+
         // Allow the app to animate the scene if desired.
         if (mAnimation) {
-            double time = mDisplayManager ? mDisplayManager->getTime() : 0.0;
-            mAnimation(mEngine, mMainView->getView(), time);
+            mAnimation(mEngine, mMainView->getView(), mVirtualTime);
         }
 
         // Loop over fresh events twice: first stash them and let ImGui process them, then allow
@@ -469,12 +556,6 @@ bool FilamentApp2::doFrame() {
             shutdown();
             return true;
         }
-
-        // Calculate the time step.
-        static double lastTime = 0;
-        double now = mDisplayManager ? mDisplayManager->getTime() : 0.0;
-        const float timeStep = lastTime > 0 ? (float) (now - lastTime) : (float) (1.0f / 60.0f);
-        lastTime = now;
 
         // Populate the UI scene, regardless of whether Filament wants to a skip frame. We should
         // always let ImGui generate a command list; if it skips a frame it'll destroy its widgets.
@@ -610,7 +691,16 @@ bool FilamentApp2::doFrame() {
             if (mPostRender) {
                 mPostRender(mEngine, mViews[0]->getView(), mScene, mRenderer);
             }
+
+            if (!mScreenshotPath.empty() && mCurrentFrame >= mWarmupFrames) {
+                captureScreenshot(mScreenshotPath);
+
+                // Ensures we only take one screenshot.
+                mWarmupFrames = MAX_WARMUP_FRAMES;
+            }
+
             mRenderer->endFrame();
+            mCurrentFrame++;
         } else {
             ++mSkippedFrames;
         }

--- a/samples/common/SampleConfig.h
+++ b/samples/common/SampleConfig.h
@@ -32,6 +32,9 @@ struct SampleConfig {
     DisplayManager displayManager = DisplayManager::SDL;
     filament::backend::AsynchronousMode asynchronousMode =
             filament::backend::AsynchronousMode::NONE;
+    utils::CString screenshotPath;
+    int warmupFrames = 10;
+    float fixedTimeStep = 0.0f;
     utils::FixedCapacityVector<utils::CString> positionalArgs;
     std::unordered_map<utils::CString, samples::Parameter> parameters;
 

--- a/samples/common/arguments.cpp
+++ b/samples/common/arguments.cpp
@@ -86,6 +86,13 @@ samples::SampleParameters getCommonParameters() {
                 { "opengl", "vulkan", "metal", "webgpu" }),
         samples::Parameter::makeBool("remote", 'x', "Run web server and enable remote control",
                 false),
+        samples::Parameter::makeString("screenshot", '\0', "Output screenshot image path", ""),
+        samples::Parameter::makeInt("frames", '\0', "Number of frames before capture / exit", 10,
+                1),
+        samples::Parameter::makeFloat("fixed-timestep", '\0',
+                "Fixed animation timestep in seconds (<=0 for wallclock)", 0.0f, 0.0f),
+        samples::Parameter::makeString("window-size", '\0', "Window size in WIDTHxHEIGHT format",
+                ""),
     };
 }
 
@@ -217,7 +224,7 @@ void printUsage(const char* name, const CommandLineSpecification& spec) {
 }
 
 FilamentApp2::Builder getBuilder(const SampleConfig& config, filament::app::DisplayManager* dm,
-        filament::app::AssetLoader* loader) {
+        filament::app::AssetLoader* loader, filament::app::AssetWriter* writer) {
     auto builder = FilamentApp2::Builder()
                            .title(config.title)
                            .size(config.width, config.height)
@@ -232,13 +239,19 @@ FilamentApp2::Builder getBuilder(const SampleConfig& config, filament::app::Disp
                            .stereoscopicEyeCount(config.stereoscopicEyeCount)
                            .vulkanGPUHint(config.vulkanGPUHint)
                            .forcedWebGPUBackend(config.forcedWebGPUBackend)
-                           .asynchronousMode(config.asynchronousMode);
+                           .asynchronousMode(config.asynchronousMode)
+                           .screenshotPath(config.screenshotPath)
+                           .warmupFrames(config.warmupFrames)
+                           .fixedTimeStep(config.fixedTimeStep);
 
     if (dm) {
         builder.displayManager(dm);
     }
     if (loader) {
         builder.assetLoader(loader);
+    }
+    if (writer) {
+        builder.assetWriter(writer);
     }
     return builder;
 }
@@ -398,6 +411,32 @@ int handleCommandLineArguments(int argc, char* argv[], SampleConfig* config,
             } else if (cp.name == "remote") {
                 config->displayManager = SampleConfig::DisplayManager::WEB;
                 config->headless = true;
+            } else if (cp.name == "screenshot") {
+                config->screenshotPath = arg;
+                if (!arg.empty()) {
+                    config->headless = true;
+                }
+            } else if (cp.name == "frames") {
+                try {
+                    config->warmupFrames = std::stoi(arg.c_str());
+                } catch (...) {
+                    std::cerr << "Failed to parse argument 'frames'" << std::endl;
+                }
+            } else if (cp.name == "fixed-timestep") {
+                try {
+                    config->fixedTimeStep = std::stof(arg.c_str());
+                } catch (...) {
+                    std::cerr << "Failed to parse argument 'fixed-timestep'" << std::endl;
+                }
+            } else if (cp.name == "window-size") {
+                int w = 0, h = 0;
+                if (sscanf(arg.c_str(), "%dx%d", &w, &h) == 2 && w > 0 && h > 0) {
+                    config->width = uint32_t(w);
+                    config->height = uint32_t(h);
+                } else {
+                    std::cerr << "Failed to parse argument 'window-size'. Should be of" <<
+                            "format [int]x[int]" << std::endl;
+                }
             }
         } else {
             seenSampleParams[mapping->index] = true;

--- a/samples/common/arguments.h
+++ b/samples/common/arguments.h
@@ -21,6 +21,7 @@
 #include "SampleConfig.h"
 
 #include <filamentapp/AssetLoader.h>
+#include <filamentapp/AssetWriter.h>
 #include <filamentapp/DisplayManager.h>
 #include <filamentapp/FilamentApp2.h>
 
@@ -34,7 +35,8 @@
 namespace samples {
 
 FilamentApp2::Builder getBuilder(const SampleConfig& config,
-        filament::app::DisplayManager* dm = nullptr, filament::app::AssetLoader* loader = nullptr);
+        filament::app::DisplayManager* dm = nullptr, filament::app::AssetLoader* loader = nullptr,
+        filament::app::AssetWriter* writer = nullptr);
 
 std::unique_ptr<filament::app::DisplayManager> getDisplayManager(const SampleConfig& config);
 

--- a/samples/procedural_effect.cpp
+++ b/samples/procedural_effect.cpp
@@ -60,7 +60,7 @@ struct App {
     Entity renderable;
     Entity camera;
     Camera* cam = nullptr;
-    double startTime = 0.0;
+    double startTime = -1.0;
 };
 } // namespace
 
@@ -121,7 +121,7 @@ std::unique_ptr<FilamentApp2> createSampleApp(SampleConfig config,
                             app->cam->setProjection(Camera::Projection::ORTHO, -aspect, aspect,
                                     -1.0f, 1.0f, 0.0f, 1.0f);
 
-                            if (app->startTime == 0.0) {
+                            if (app->startTime < 0.0) {
                                 app->startTime = now;
                             }
 


### PR DESCRIPTION
This can be useful for adding to the renderdiff CI test framework.

For output, we add another abstraction AssetWriter. This is to anticipate for cases where we cannot write to disk for certain platforms.

Also, fix startTime init in procedural_effect to ensure elapsed time is not off by one frame.  (Note that originally 'startTime' will be set to 'now' for two frames).