### PR TITLE
docs: update docs update linux machine dep

### DIFF
--- a/.github/actions/linux-prereq/action.yml
+++ b/.github/actions/linux-prereq/action.yml
@@ -31,7 +31,7 @@ runs:
         wget -qO- "https://github.com/Kitware/CMake/releases/download/v${GITHUB_CMAKE_VERSION}/cmake-${GITHUB_CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz" | sudo tar xz -C /usr/local --strip-components=1
 
         # For dawn
-        sudo apt-get install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libx11-xcb-dev
+        sudo apt-get install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libx11-xcb-dev libgbm-dev libdrm-dev
 
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${GITHUB_CLANG_VERSION} 100
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${GITHUB_CLANG_VERSION} 100


### PR DESCRIPTION
Building docs require buildings the webgpu backend (i.e. dawn). The new dawn update requires additional linux deps to be installed.

Here we add the deps and also force re-generation with the tag below.

DOCS_FORCE