### PR TITLE
vk: handle surface lost gracefully wrt swapchain

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -19,6 +19,7 @@
 #include "VulkanCommands.h"
 #include "VulkanTexture.h"
 
+#include <utils/compiler.h>
 #include <utils/debug.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Panic.h>
@@ -140,7 +141,7 @@ void VulkanSwapChain::present(DriverBase& driver) {
         VkResult const result =
                 mPlatform->present(swapChain, mCurrentSwapIndex, finishedDrawing->getVkSemaphore());
         FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR ||
-                result == VK_ERROR_OUT_OF_DATE_KHR)
+                result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_ERROR_SURFACE_LOST_KHR)
                 << "Cannot present in swapchain. error=" << static_cast<int32_t>(result);
     }
 
@@ -193,14 +194,24 @@ std::pair<bool, bool> VulkanSwapChain::acquire() {
         if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
             // Following recreates the swapchain
 
-            // Calling flush multiptle times is ok, since it's no-op if not recording.
+            // Calling flush multiple times is ok, since it's no-op if not recording.
             if (mFlushAndWaitOnResize) {
                 mCommands->flush();
                 mCommands->wait();
             }
-            mPlatform->recreate(swapChain);
-            update();
-            swapchainRecreated = true;
+            if (UTILS_LIKELY(mPlatform->recreate(swapChain) == VK_SUCCESS)) {
+                update();
+                swapchainRecreated = true;
+            } else {
+                // We failed to create the swapchain. We'll wait for the swapchain to be recreated.
+                // Note that this is different from the resize case.  If we're here then probably
+                // the backing *surface* is in a bad state, and *this* handle needs to be destroyed
+                // and recreated from the client side.
+                //
+                // Break here because we shouldn't attempt to acquire if we don't even have a
+                // swapchain.
+                break;
+            }
         }
         result = mPlatform->acquire(swapChain, &imageSyncData);
     }

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.cpp
@@ -171,6 +171,10 @@ VulkanPlatformSurfaceSwapChain::~VulkanPlatformSurfaceSwapChain() {
 }
 
 VkResult VulkanPlatformSurfaceSwapChain::create() {
+    if (UTILS_VERY_UNLIKELY(mSurfaceLost)) {
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+
 #ifdef __ANDROID__
     NativeWindow::enableFrameTimestamps(static_cast<ANativeWindow*>(mNativeWindow), true);
     // on Android, disable producer throttling
@@ -204,6 +208,13 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
     // Find a suitable surface format.
     FixedCapacityVector<VkSurfaceFormatKHR> const surfaceFormats
             = fvkutils::enumerate(vkGetPhysicalDeviceSurfaceFormatsKHR, mPhysicalDevice, mSurface);
+
+    // We could get no surface formats if the we've gotten a VK_ERROR_SURFACE_LOST_KHR.
+    if (UTILS_VERY_UNLIKELY(surfaceFormats.empty())) {
+        mSurfaceLost = true;
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+
     std::array<VkFormat, 2> expectedFormats = {
         VK_FORMAT_R8G8B8A8_UNORM,
         VK_FORMAT_B8G8R8A8_UNORM,
@@ -229,6 +240,12 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
     VkPresentModeKHR const desiredPresentMode = VK_PRESENT_MODE_FIFO_KHR;
     FixedCapacityVector<VkPresentModeKHR> presentModes = fvkutils::enumerate(
             vkGetPhysicalDeviceSurfacePresentModesKHR, mPhysicalDevice, mSurface);
+
+    // We will have no present modes if the we've gotten a VK_ERROR_SURFACE_LOST_KHR.
+    if (UTILS_VERY_UNLIKELY(presentModes.empty())) {
+        mSurfaceLost = true;
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
 
     bool const foundSuitablePresentMode = std::find(presentModes.begin(), presentModes.end(),
                                             desiredPresentMode) != presentModes.end();
@@ -278,8 +295,12 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
             .oldSwapchain = mSwapchain,
     };
     VkResult result = vkCreateSwapchainKHR(mDevice, &createInfo, VKALLOC, &mSwapchain);
-    FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "vkCreateSwapchainKHR failed."
-                                                       << " error=" << static_cast<int32_t>(result);
+
+    if (UTILS_VERY_UNLIKELY(result != VK_SUCCESS)) {
+        mSurfaceLost = true;
+        LOG(ERROR) << "vkCreateSwapchainKHR failed. error=" << static_cast<int32_t>(result);
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
 
     mSwapChainBundle.colors = fvkutils::enumerate(vkGetSwapchainImagesKHR, mDevice, mSwapchain);
     mSwapChainBundle.colorFormat = surfaceFormat.format;
@@ -313,6 +334,10 @@ VkResult VulkanPlatformSurfaceSwapChain::create() {
 }
 
 VkResult VulkanPlatformSurfaceSwapChain::acquire(VulkanPlatform::ImageSyncData* outImageSyncData) {
+    if (UTILS_VERY_UNLIKELY(mSurfaceLost)) {
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+
     mCurrentImageReadyIndex = (mCurrentImageReadyIndex + 1) % IMAGE_READY_SEMAPHORE_COUNT;
     outImageSyncData->imageReadySemaphore = mImageReady[mCurrentImageReadyIndex];
     VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX,
@@ -324,10 +349,19 @@ VkResult VulkanPlatformSurfaceSwapChain::acquire(VulkanPlatform::ImageSyncData* 
         FVK_LOGW << "Vulkan Driver: Suboptimal swap chain.";
         mSuboptimal = true;
     }
+
+    if (UTILS_VERY_UNLIKELY(result == VK_ERROR_SURFACE_LOST_KHR)) {
+        mSurfaceLost = true;
+    }
+
     return result;
 }
 
 VkResult VulkanPlatformSurfaceSwapChain::present(uint32_t index, VkSemaphore finished) {
+    if (UTILS_VERY_UNLIKELY(mSurfaceLost)) {
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+
     uint32_t currentIndex = index;
     VkSemaphore finishedDrawing = finished;
 
@@ -363,12 +397,28 @@ VkResult VulkanPlatformSurfaceSwapChain::present(uint32_t index, VkSemaphore fin
         FVK_LOGW << "Vulkan Driver: Suboptimal swap chain.";
         mSuboptimal = true;
     }
+    if (UTILS_VERY_UNLIKELY(result == VK_ERROR_SURFACE_LOST_KHR)) {
+        mSurfaceLost = true;
+    }
+
     return result;
 }
 
 bool VulkanPlatformSurfaceSwapChain::hasResized() const {
+    if (UTILS_VERY_UNLIKELY(mSurfaceLost)) {
+        // We return "false" here to indicate that we're in a bad state and will not trigger the
+        // recreate path.
+        return false;
+    }
+
     VkSurfaceCapabilitiesKHR caps;
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mPhysicalDevice, mSurface, &caps);
+    VkResult result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mPhysicalDevice, mSurface, &caps);
+
+    if (UTILS_VERY_UNLIKELY(result == VK_ERROR_SURFACE_LOST_KHR)) {
+        mSurfaceLost = true;
+        return false;
+    }
+
     VkExtent2D perceivedExtent = caps.currentExtent;
     // Create the low-level swap chain.
     if (perceivedExtent.width == VULKAN_UNDEFINED_EXTENT

--- a/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
+++ b/filament/backend/src/vulkan/platform/VulkanPlatformSwapChainImpl.h
@@ -138,6 +138,7 @@ private:
 
     uint32_t mArbitraryFrameId = 0;
     int64_t mPresentationTime = 0;
+    mutable bool mSurfaceLost = false;
 
 #ifdef __ANDROID__
     AndroidSwapChainHelper mImpl{};

--- a/filament/backend/src/vulkan/utils/Helper.h
+++ b/filament/backend/src/vulkan/utils/Helper.h
@@ -25,8 +25,6 @@
 #include <utils/FixedCapacityVector.h>
 #include <utils/Panic.h>
 
-#include <utility>
-
 namespace filament::backend::fvkutils {
 
 inline bool equivalent(const VkRect2D& a, const VkRect2D& b) {
@@ -46,13 +44,19 @@ inline bool equivalent(const VkExtent2D& a, const VkExtent2D& b) {
 // considered, but because the "variadic" part of the vk methods (i.e. the inputs) are before the
 // non-variadic parts, this breaks the template type matching logic. Hence, we use a macro approach
 // here.
-#define EXPAND_ENUM(...)                                                          \
-    uint32_t size = 0;                                                            \
-    VkResult result = func(__VA_ARGS__, nullptr);                                 \
-    FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "enumerate size error"; \
-    utils::FixedCapacityVector<OutType> ret(size);                                \
-    result = func(__VA_ARGS__, ret.data());                                       \
-    FILAMENT_CHECK_POSTCONDITION(result == VK_SUCCESS) << "enumerate error";      \
+#define EXPAND_ENUM(...)                                                                           \
+    uint32_t size = 0;                                                                             \
+    VkResult result = func(__VA_ARGS__, nullptr);                                                  \
+    if (result != VK_SUCCESS) {                                                                    \
+        FVK_LOGE << "enumerate size error=" << static_cast<int32_t>(result);                       \
+        return {};                                                                                 \
+    }                                                                                              \
+    utils::FixedCapacityVector<OutType> ret(size);                                                 \
+    result = func(__VA_ARGS__, ret.data());                                                        \
+    if (result != VK_SUCCESS) {                                                                    \
+        FVK_LOGE << "enumerate error=" << static_cast<int32_t>(result);                            \
+        return {};                                                                                 \
+    }                                                                                              \
     return std::move(ret);
 
 #define EXPAND_ENUM_NO_ARGS() EXPAND_ENUM(&size)


### PR DESCRIPTION
We are currently panicking on surface lost, but there are times when it's still possible to recover from the client side (they can recreate the swapchain).

This commit adds guards in calls where surface is involved to ensure that the engine does not panic due to a surface lost.

BUGS=538238785