### PR TITLE
backend: don't silently drop jobs pushed after JobQueue::stop()

### DIFF
--- a/filament/backend/src/JobQueue.cpp
+++ b/filament/backend/src/JobQueue.cpp
@@ -18,7 +18,6 @@
 
 #include <utils/compiler.h>
 #include <utils/debug.h>
-#include <utils/Logger.h>
 #include <utils/Mutex.h>
 #include <utils/Panic.h>
 

--- a/filament/backend/src/JobQueue.cpp
+++ b/filament/backend/src/JobQueue.cpp
@@ -18,6 +18,7 @@
 
 #include <utils/compiler.h>
 #include <utils/debug.h>
+#include <utils/Logger.h>
 #include <utils/Mutex.h>
 #include <utils/Panic.h>
 
@@ -31,7 +32,12 @@ JobQueue::JobId JobQueue::push(Job job, JobId const preIssuedJobId/* = InvalidJo
     JobId jobId = preIssuedJobId;
     {
         LockGuard const lock(mQueueMutex);
-        if (mIsStopping) {
+        if (UTILS_UNLIKELY(mIsStopping)) {
+            // This queue is stopping, so any placeholder previously issued should be removed here.
+            if (jobId != InvalidJobId) {
+                mJobsMap.erase(jobId);
+            }
+            LOG(WARNING) << "JobQueue::push() called after stop(), the job is dropped";
             return InvalidJobId;
         }
 

--- a/filament/backend/src/JobQueue.cpp
+++ b/filament/backend/src/JobQueue.cpp
@@ -37,7 +37,6 @@ JobQueue::JobId JobQueue::push(Job job, JobId const preIssuedJobId/* = InvalidJo
             if (jobId != InvalidJobId) {
                 mJobsMap.erase(jobId);
             }
-            LOG(WARNING) << "JobQueue::push() called after stop(), the job is dropped";
             return InvalidJobId;
         }
 

--- a/filament/backend/src/JobQueue.h
+++ b/filament/backend/src/JobQueue.h
@@ -87,8 +87,9 @@ public:
     /**
      * Pushes a new job into queue.
      *
-     * If the queue is in the process of shutting down (via a call to `stop`), this method does
-     * nothing (a no-op) and returns an invalid job ID.
+     * If the queue is in the process of shutting down (via a call to `stop`), the job is not
+     * queued but destroyed on the calling thread. Also, this method returns `InvalidJobId`, and a
+     * placeholder for a valid `preIssuedJobId` is cleaned up internally.
      *
      * @param job The function/lambda to be executed.
      * @param preIssuedJobId The previously issued job ID where this job is assigned to.

--- a/filament/backend/test/test_AsyncCompletion.cpp
+++ b/filament/backend/test/test_AsyncCompletion.cpp
@@ -152,3 +152,23 @@ TEST_F(AsyncCompletionTest, DroppedJobInvokesCallback) {
     ASSERT_EQ(1u, statuses.size()) << "a dropped job must schedule its completion callback";
     EXPECT_EQ(AsyncCallStatus::CANCELED, statuses[0]);
 }
+
+TEST_F(AsyncCompletionTest, JobDroppedByStoppingQueueInvokesCallback) {
+    // The other way `push()` drops a job: the queue is stopping. That is the teardown path. An
+    // asynchronous call issued afterwards must be canceled.
+    JobQueue::Ptr queue = JobQueue::create();
+    Statuses statuses;
+
+    queue->stop();
+    JobQueue::JobId const pushedId = queue->push(
+            [completion = DriverBase::AsyncCompletion(getDriver(), nullptr, recordStatus,
+                     &statuses)]() mutable {
+                completion.schedule(AsyncCallStatus::COMPLETED);
+            });
+    EXPECT_EQ(JobQueue::InvalidJobId, pushedId);
+
+    purge();
+    ASSERT_EQ(1u, statuses.size())
+            << "a job dropped by a stopping queue must schedule its completion callback";
+    EXPECT_EQ(AsyncCallStatus::CANCELED, statuses[0]);
+}

--- a/filament/backend/test/test_JobQueue.cpp
+++ b/filament/backend/test/test_JobQueue.cpp
@@ -27,6 +27,19 @@
 
 using namespace filament::backend;
 
+namespace {
+
+// Mimics what a canceled or dropped job captures in practice: something whose destructor runs user
+// code that calls back into the queue (e.g. a BufferDescriptor whose release callback chains the
+// next asynchronous call). Destroying the job while the queue's lock is held deadlocks.
+struct ReentrantOnDestroy {
+    JobQueue::Ptr queue;
+    std::atomic<JobQueue::JobId>* reentrantJobId;
+    ~ReentrantOnDestroy() { reentrantJobId->store(queue->issueJobId()); }
+};
+
+} // namespace
+
 TEST(JobQueue, PushAndPop) {
     JobQueue::Ptr queue = JobQueue::create();
     int v = 0;
@@ -106,15 +119,6 @@ TEST(JobQueue, CancelInvalid) {
 TEST(JobQueue, CancelDestroysJobWithoutHoldingLock) {
     JobQueue::Ptr queue = JobQueue::create();
 
-    // Mimics what a canceled job captures in practice: something whose destructor runs user code
-    // that calls back into the queue (e.g. a BufferDescriptor whose release callback chains the
-    // next asynchronous call). Destroying the job while the queue's lock is held deadlocks.
-    struct ReentrantOnDestroy {
-        JobQueue::Ptr queue;
-        std::atomic<JobQueue::JobId>* reentrantJobId;
-        ~ReentrantOnDestroy() { reentrantJobId->store(queue->issueJobId()); }
-    };
-
     std::atomic<JobQueue::JobId> reentrantJobId = { JobQueue::InvalidJobId };
     JobQueue::JobId const idToCancel = queue->push(
             [guard = std::make_unique<ReentrantOnDestroy>(
@@ -155,6 +159,45 @@ TEST(JobQueue, Stop) {
 
     job = queue->pop(false);
     EXPECT_FALSE(job);
+}
+
+TEST(JobQueue, PushAfterStopReleasesPreIssuedJobId) {
+    JobQueue::Ptr queue = JobQueue::create();
+    JobQueue::JobId const preIssuedId = queue->issueJobId();
+    queue->stop();
+
+    EXPECT_EQ(JobQueue::InvalidJobId, queue->push([]() {}, preIssuedId));
+
+    // The reservation went with the job: there is nothing left to cancel.
+    EXPECT_FALSE(queue->cancel(preIssuedId));
+}
+
+TEST(JobQueue, PushAfterStopDestroysJobWithoutHoldingLock) {
+    JobQueue::Ptr queue = JobQueue::create();
+    queue->stop();
+
+    std::atomic<JobQueue::JobId> reentrantJobId = { JobQueue::InvalidJobId };
+
+    // Push from another thread so that a regression fails the test instead of hanging it.
+    auto pushed = std::make_shared<std::promise<JobQueue::JobId>>();
+    std::future<JobQueue::JobId> future = pushed->get_future();
+    std::thread pusher([queue, &reentrantJobId, pushed]() {
+        pushed->set_value(queue->push(
+                [guard = std::make_unique<ReentrantOnDestroy>(
+                         ReentrantOnDestroy{ queue, &reentrantJobId })]() {}));
+    });
+
+    if (future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        pusher.detach(); // the thread is stuck holding the queue's lock, it can't be joined
+        FAIL() << "push() deadlocked: the dropped job was destroyed while holding the queue's lock";
+    }
+
+    EXPECT_EQ(JobQueue::InvalidJobId, future.get());
+    pusher.join();
+
+    // The dropped job's destructor must have been able to use the queue.
+    EXPECT_NE(JobQueue::InvalidJobId, reentrantJobId.load());
+    EXPECT_TRUE(queue->cancel(reentrantJobId.load()));
 }
 
 TEST(JobQueue, PreIssuedJobId) {


### PR DESCRIPTION
`JobQueue::push()` silently refuses jobs once `stop()` has been called and it returned `InvalidJobId` and left behind the placeholder that `issueJobId()` had reserved for the job.

The job is destroyed by `push()` itself, on the calling thread, so whatever it captured runs its cleanup there.