### PR TITLE
webgpu: implement async resource upload API

### DIFF
--- a/filament/backend/src/webgpu/WebGPUBufferObject.cpp
+++ b/filament/backend/src/webgpu/WebGPUBufferObject.cpp
@@ -43,8 +43,8 @@ namespace {
 // The usage flags are determined by the binding type, and always include CopyDst to allow for
 // updating the buffer.
 WebGPUBufferObject::WebGPUBufferObject(wgpu::Device const& device,
-        const BufferObjectBinding bindingType, const uint32_t byteCount)
-    : HwBufferObject{ byteCount, false },
+        const BufferObjectBinding bindingType, const uint32_t byteCount, const bool asynchronous)
+    : HwBufferObject{ byteCount, asynchronous },
       WebGPUBufferBase{ device, wgpu::BufferUsage::CopyDst | getBufferObjectUsage(bindingType),
           byteCount, "buffer_object" } {}
 

--- a/filament/backend/src/webgpu/WebGPUBufferObject.h
+++ b/filament/backend/src/webgpu/WebGPUBufferObject.h
@@ -38,7 +38,8 @@ enum class BufferObjectBinding : uint8_t;
   */
 class WebGPUBufferObject final : public HwBufferObject, public WebGPUBufferBase {
 public:
-    WebGPUBufferObject(wgpu::Device const&, BufferObjectBinding, uint32_t byteCount);
+    WebGPUBufferObject(wgpu::Device const&, BufferObjectBinding, uint32_t byteCount,
+            bool asynchronous = false);
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUDriver.cpp
+++ b/filament/backend/src/webgpu/WebGPUDriver.cpp
@@ -128,6 +128,15 @@ WebGPUDriver::WebGPUDriver(WebGPUPlatform& platform,
                                                          .disable_heap_handle_tags
                                                : false) } {
     mDevice.GetLimits(&mDeviceLimits);
+
+    if (driverConfig.asynchronousMode != AsynchronousMode::NONE) {
+        mJobQueue = JobQueue::create();
+        // As with Vulkan, always use AmortizationWorker for now: a dedicated ThreadWorker would
+        // need its own thread-safe access to mDevice/mQueueManager, which isn't established here,
+        // and this backend also targets Emscripten, where a raw std::thread isn't available by
+        // default. Real backend-thread-offloaded uploads can follow later.
+        mJobWorker = AmortizationWorker::create(mJobQueue);
+    }
 }
 
 WebGPUDriver::~WebGPUDriver() noexcept = default;
@@ -154,10 +163,27 @@ template class ConcreteDispatcher<WebGPUDriver>;
 
 
 void WebGPUDriver::terminate() {
+    // Flush all pending asynchronous tasks. Some tasks may end up posting follow-up operations to
+    // the `ServiceThread` (e.g., via CountdownCallbackHandler or any user-provided handlers). So we
+    // early stop the ServiceThread to ensure these are processed as well. Tasks posted to the main
+    // thread (due to no user handler) during this process are handled later by `Driver::purge`
+    // within `FEngine::shutdown`.
+    if (getJobWorker()) {
+        getJobWorker()->terminate();
+    }
+    if constexpr (UTILS_HAS_THREADING) {
+        // Flush any callbacks the drained jobs posted via scheduleCallback().
+        stopServiceThread();
+    }
+
     finish();
 }
 
 void WebGPUDriver::tick(int) {
+    if (getJobWorker()) {
+        // This number is randomly/heuristically chosen, matching Vulkan's amortization worker.
+        getJobWorker()->process(5);
+    }
 #if !defined(__EMSCRIPTEN__)
     mDevice.Tick();
     mAdapter.GetInstance().ProcessEvents();
@@ -240,7 +266,16 @@ void WebGPUDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vertexBufferHandle
         return;
     }
     FWGPU_SYSTRACE_SCOPE();
-    destructHandle<WebGPUVertexBuffer>(vertexBufferHandle);
+    auto* vertexBuffer = handleCast<WebGPUVertexBuffer>(vertexBufferHandle);
+    if (vertexBuffer->asynchronous && getJobQueue()) {
+        // Route the destruction through the queue to preserve FIFO ordering with any pending
+        // async update for this handle (e.g. setVertexBufferObjectAsync).
+        getJobQueue()->push([this, vertexBufferHandle]() mutable {
+            destructHandle<WebGPUVertexBuffer>(vertexBufferHandle);
+        });
+    } else {
+        destructHandle<WebGPUVertexBuffer>(vertexBufferHandle);
+    }
 }
 
 void WebGPUDriver::destroyIndexBuffer(Handle<HwIndexBuffer> indexBufferHandle) {
@@ -248,7 +283,16 @@ void WebGPUDriver::destroyIndexBuffer(Handle<HwIndexBuffer> indexBufferHandle) {
         return;
     }
     FWGPU_SYSTRACE_SCOPE();
-    destructHandle<WebGPUIndexBuffer>(indexBufferHandle);
+    auto* indexBuffer = handleCast<WebGPUIndexBuffer>(indexBufferHandle);
+    if (indexBuffer->asynchronous && getJobQueue()) {
+        // Route the destruction through the queue to preserve FIFO ordering with any pending
+        // async update for this handle (e.g. updateIndexBufferAsync).
+        getJobQueue()->push([this, indexBufferHandle]() mutable {
+            destructHandle<WebGPUIndexBuffer>(indexBufferHandle);
+        });
+    } else {
+        destructHandle<WebGPUIndexBuffer>(indexBufferHandle);
+    }
 }
 
 void WebGPUDriver::destroyBufferObject(Handle<HwBufferObject> bufferObjectHandle) {
@@ -256,11 +300,30 @@ void WebGPUDriver::destroyBufferObject(Handle<HwBufferObject> bufferObjectHandle
         return;
     }
     FWGPU_SYSTRACE_SCOPE();
-    destructHandle<WebGPUBufferObject>(bufferObjectHandle);
+    auto* bufferObject = handleCast<WebGPUBufferObject>(bufferObjectHandle);
+    if (bufferObject->asynchronous && getJobQueue()) {
+        // Route the destruction through the queue to preserve FIFO ordering with any pending
+        // async update for this handle (e.g. updateBufferObjectAsync).
+        getJobQueue()->push([this, bufferObjectHandle]() mutable {
+            destructHandle<WebGPUBufferObject>(bufferObjectHandle);
+        });
+    } else {
+        destructHandle<WebGPUBufferObject>(bufferObjectHandle);
+    }
 }
 
 void WebGPUDriver::destroyTexture(Handle<HwTexture> textureHandle) {
-    if (textureHandle) {
+    if (!textureHandle) {
+        return;
+    }
+    auto* texture = handleCast<WebGPUTexture>(textureHandle);
+    if (texture->asynchronous && getJobQueue()) {
+        // Route the destruction through the queue to preserve FIFO ordering with any pending
+        // async update for this handle (e.g. update3DImageAsync).
+        getJobQueue()->push([this, textureHandle]() mutable {
+            destructHandle<WebGPUTexture>(textureHandle);
+        });
+    } else {
         destructHandle<WebGPUTexture>(textureHandle);
     }
 }
@@ -371,23 +434,23 @@ Handle<HwTexture> WebGPUDriver::importTextureAsyncS() noexcept {
 }
 
 AsyncCallId WebGPUDriver::update3DImageAsyncS() noexcept {
-    // TODO: implement this.
-    return InvalidAsyncCallId;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->issueJobId();
 }
 
 AsyncCallId WebGPUDriver::setVertexBufferObjectAsyncS() noexcept {
-    // TODO: implement this.
-    return InvalidAsyncCallId;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->issueJobId();
 }
 
 AsyncCallId WebGPUDriver::updateBufferObjectAsyncS() noexcept {
-    // TODO: implement this.
-    return InvalidAsyncCallId;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->issueJobId();
 }
 
 AsyncCallId WebGPUDriver::updateIndexBufferAsyncS() noexcept {
-    // TODO: implement this.
-    return InvalidAsyncCallId;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->issueJobId();
 }
 
 Handle<HwProgram> WebGPUDriver::createProgramS() noexcept {
@@ -481,8 +544,8 @@ Handle<HwTexture> WebGPUDriver::createTextureExternalImagePlaneS() noexcept {
 }
 
 AsyncCallId WebGPUDriver::queueCommandAsyncS() noexcept {
-    // TODO: implement this.
-    return InvalidAsyncCallId;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->issueJobId();
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -543,52 +606,104 @@ void WebGPUDriver::createVertexBufferInfoR(Handle<HwVertexBufferInfo> vertexBuff
     setDebugTag(vertexBufferInfoHandle.getId(), std::move(tag));
 }
 
+// Shared by every create*AsyncR: pushes a job that does nothing but fire the completion callback,
+// so it's correctly FIFO-ordered relative to other outstanding async calls (e.g. a pending
+// update*Async on the same or another handle) rather than firing immediately/out-of-band.
+void WebGPUDriver::deferCreationCompletionCallback(CallbackHandler* const handler,
+        AsyncCallback const callback, void* const user) {
+    assert_invariant(getJobQueue());
+    getJobQueue()->push([this, handler, callback, user]() {
+        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
+    });
+}
+
+void WebGPUDriver::createVertexBufferCommon(Handle<HwVertexBuffer> vertexBufferHandle,
+        const uint32_t vertexCount, Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
+        const bool asynchronous, utils::ImmutableCString&& tag) {
+    const auto vertexBufferInfo = handleCast<WebGPUVertexBufferInfo>(vertexBufferInfoHandle);
+    constructHandle<WebGPUVertexBuffer>(vertexBufferHandle, vertexCount,
+            vertexBufferInfo->bufferCount, vertexBufferInfoHandle, asynchronous);
+    setDebugTag(vertexBufferHandle.getId(), std::move(tag));
+}
+
 void WebGPUDriver::createVertexBufferR(Handle<HwVertexBuffer> vertexBufferHandle,
         const uint32_t vertexCount, Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
         utils::ImmutableCString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
-    const auto vertexBufferInfo = handleCast<WebGPUVertexBufferInfo>(vertexBufferInfoHandle);
-    constructHandle<WebGPUVertexBuffer>(vertexBufferHandle, vertexCount,
-            vertexBufferInfo->bufferCount, vertexBufferInfoHandle);
-    setDebugTag(vertexBufferHandle.getId(), std::move(tag));
+    createVertexBufferCommon(vertexBufferHandle, vertexCount, vertexBufferInfoHandle,
+            /* asynchronous = */ false, std::move(tag));
 }
 
 void WebGPUDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vertexBufferHandle,
         const uint32_t vertexCount, Handle<HwVertexBufferInfo> vertexBufferInfoHandle,
         CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
-    // TODO: implement this.
+    FWGPU_SYSTRACE_SCOPE();
+    createVertexBufferCommon(vertexBufferHandle, vertexCount, vertexBufferInfoHandle,
+            /* asynchronous = */ true, std::move(tag));
+    deferCreationCompletionCallback(handler, callback, user);
+}
+
+void WebGPUDriver::createIndexBufferCommon(Handle<HwIndexBuffer> indexBufferHandle,
+        const ElementType elementType, const uint32_t indexCount, const bool asynchronous,
+        utils::ImmutableCString&& tag) {
+    const auto elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
+    constructHandle<WebGPUIndexBuffer>(indexBufferHandle, mDevice, elementSize, indexCount,
+            asynchronous);
+    setDebugTag(indexBufferHandle.getId(), std::move(tag));
 }
 
 void WebGPUDriver::createIndexBufferR(Handle<HwIndexBuffer> indexBufferHandle,
         const ElementType elementType, const uint32_t indexCount, const BufferUsage usage,
         utils::ImmutableCString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
-    const auto elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
-    constructHandle<WebGPUIndexBuffer>(indexBufferHandle, mDevice, elementSize, indexCount);
-    setDebugTag(indexBufferHandle.getId(), std::move(tag));
+    createIndexBufferCommon(indexBufferHandle, elementType, indexCount,
+            /* asynchronous = */ false, std::move(tag));
 }
 
 void WebGPUDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> indexBufferHandle,
         const ElementType elementType, const uint32_t indexCount, const BufferUsage usage,
         CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
-    // TODO: implement this.
+    FWGPU_SYSTRACE_SCOPE();
+    createIndexBufferCommon(indexBufferHandle, elementType, indexCount,
+            /* asynchronous = */ true, std::move(tag));
+    deferCreationCompletionCallback(handler, callback, user);
+}
+
+void WebGPUDriver::createBufferObjectCommon(Handle<HwBufferObject> bufferObjectHandle,
+        const uint32_t byteCount, const BufferObjectBinding bindingType, const bool asynchronous,
+        utils::ImmutableCString&& tag) {
+    constructHandle<WebGPUBufferObject>(bufferObjectHandle, mDevice, bindingType, byteCount,
+            asynchronous);
+    setDebugTag(bufferObjectHandle.getId(), std::move(tag));
 }
 
 void WebGPUDriver::createBufferObjectR(Handle<HwBufferObject> bufferObjectHandle,
         const uint32_t byteCount, const BufferObjectBinding bindingType, const BufferUsage usage,
         utils::ImmutableCString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
-    constructHandle<WebGPUBufferObject>(bufferObjectHandle, mDevice, bindingType, byteCount);
-    setDebugTag(bufferObjectHandle.getId(), std::move(tag));
+    createBufferObjectCommon(bufferObjectHandle, byteCount, bindingType,
+            /* asynchronous = */ false, std::move(tag));
 }
 
 void WebGPUDriver::createBufferObjectAsyncR(Handle<HwBufferObject> bufferObjectHandle,
         const uint32_t byteCount, const BufferObjectBinding bindingType, const BufferUsage usage,
         CallbackHandler* handler, AsyncCallback callback, void* user,
         utils::ImmutableCString&& tag) {
-    // TODO: implement this.
+    FWGPU_SYSTRACE_SCOPE();
+    createBufferObjectCommon(bufferObjectHandle, byteCount, bindingType,
+            /* asynchronous = */ true, std::move(tag));
+    deferCreationCompletionCallback(handler, callback, user);
+}
+
+void WebGPUDriver::createTextureCommon(Handle<HwTexture> textureHandle, const SamplerType target,
+        const uint8_t levels, const TextureFormat format, const uint8_t samples,
+        const uint32_t width, const uint32_t height, const uint32_t depth,
+        const TextureUsage usage, const bool asynchronous, utils::ImmutableCString&& tag) {
+    constructHandle<WebGPUTexture>(textureHandle, target, levels, format, samples, width, height,
+            depth, usage, mDevice, asynchronous);
+    setDebugTag(textureHandle.getId(), std::move(tag));
 }
 
 void WebGPUDriver::createTextureR(Handle<HwTexture> textureHandle, const SamplerType target,
@@ -596,9 +711,8 @@ void WebGPUDriver::createTextureR(Handle<HwTexture> textureHandle, const Sampler
         const uint32_t width, const uint32_t height, const uint32_t depth,
         const TextureUsage usage, utils::ImmutableCString&& tag) {
     FWGPU_SYSTRACE_SCOPE();
-    constructHandle<WebGPUTexture>(textureHandle, target, levels, format, samples, width, height,
-            depth, usage, mDevice);
-    setDebugTag(textureHandle.getId(), std::move(tag));
+    createTextureCommon(textureHandle, target, levels, format, samples, width, height, depth,
+            usage, /* asynchronous = */ false, std::move(tag));
 }
 
 void WebGPUDriver::createTextureAsyncR(Handle<HwTexture> textureHandle, const SamplerType target,
@@ -606,8 +720,10 @@ void WebGPUDriver::createTextureAsyncR(Handle<HwTexture> textureHandle, const Sa
         const uint32_t width, const uint32_t height, const uint32_t depth,
         const TextureUsage usage, CallbackHandler* handler, AsyncCallback callback,
         void* user, utils::ImmutableCString&& tag) {
-    // TODO: implement this.
     FWGPU_SYSTRACE_SCOPE();
+    createTextureCommon(textureHandle, target, levels, format, samples, width, height, depth,
+            usage, /* asynchronous = */ true, std::move(tag));
+    deferCreationCompletionCallback(handler, callback, user);
 }
 
 void WebGPUDriver::createTextureViewR(Handle<HwTexture> textureHandle,
@@ -620,13 +736,12 @@ void WebGPUDriver::createTextureViewR(Handle<HwTexture> textureHandle,
     setDebugTag(textureHandle.getId(), std::move(tag));
 }
 
-void WebGPUDriver::createTextureViewSwizzleR(Handle<HwTexture> textureHandle,
+void WebGPUDriver::createTextureViewSwizzleCommon(Handle<HwTexture> textureHandle,
         Handle<HwTexture> sourceTextureHandle, const backend::TextureSwizzle r,
         const backend::TextureSwizzle g, const backend::TextureSwizzle b,
         const backend::TextureSwizzle a, utils::ImmutableCString&& tag) {
-
     if (!isTextureSwizzleSupported()) {
-        FWGPU_LOGW << "WebGPUDriver::createTextureViewSwizzleR called while texture swizzling is "
+        FWGPU_LOGW << "WebGPUDriver::createTextureViewSwizzle called while texture swizzling is "
                       "not supported by the device/driver";
     }
 
@@ -647,12 +762,22 @@ void WebGPUDriver::createTextureViewSwizzleR(Handle<HwTexture> textureHandle,
     setDebugTag(textureHandle.getId(), std::move(tag));
 }
 
+void WebGPUDriver::createTextureViewSwizzleR(Handle<HwTexture> textureHandle,
+        Handle<HwTexture> sourceTextureHandle, const backend::TextureSwizzle r,
+        const backend::TextureSwizzle g, const backend::TextureSwizzle b,
+        const backend::TextureSwizzle a, utils::ImmutableCString&& tag) {
+    createTextureViewSwizzleCommon(textureHandle, sourceTextureHandle, r, g, b, a,
+            std::move(tag));
+}
+
 void WebGPUDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> textureHandle,
         Handle<HwTexture> sourceTextureHandle, const backend::TextureSwizzle r,
         const backend::TextureSwizzle g, const backend::TextureSwizzle b,
         const backend::TextureSwizzle a, CallbackHandler* handler,
         AsyncCallback const callback, void* user, utils::ImmutableCString&& tag) {
-    // TODO: implement this.
+    createTextureViewSwizzleCommon(textureHandle, sourceTextureHandle, r, g, b, a,
+            std::move(tag));
+    deferCreationCompletionCallback(handler, callback, user);
 }
 
 void WebGPUDriver::createTextureExternalImage2R(Handle<HwTexture> textureHandle,
@@ -1051,7 +1176,19 @@ void WebGPUDriver::updateIndexBufferAsyncR(AsyncCallId jobId,
         Handle<HwIndexBuffer> indexBufferHandle, BufferDescriptor&& bufferDescriptor,
         const uint32_t byteOffset, CallbackHandler* handler,
         AsyncCallback const callback, void* user) {
-    // TODO: implement this.
+    assert_invariant(getJobQueue());
+    // Mark the handle as asynchronous even if it wasn't created via createIndexBufferAsync: the
+    // job below will handleCast() this handle when it eventually runs, and handleCast() has no
+    // "not already destroyed" check (unlike Vulkan's ref-counted resource_ptr::cast). If the app
+    // destroys this handle before the job runs, destroyIndexBuffer must route that destruction
+    // through this same queue instead of running it immediately, so it's correctly ordered after
+    // this pending update rather than freeing the resource out from under it.
+    handleCast<WebGPUIndexBuffer>(indexBufferHandle)->asynchronous = true;
+    getJobQueue()->push([this, indexBufferHandle, bufferDescriptor = std::move(bufferDescriptor),
+            byteOffset, completion = AsyncCompletion(this, handler, callback, user)]() mutable {
+        updateIndexBuffer(indexBufferHandle, std::move(bufferDescriptor), byteOffset);
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }, jobId);
 }
 
 void WebGPUDriver::updateBufferObject(Handle<HwBufferObject> bufferObjectHandle,
@@ -1064,7 +1201,16 @@ void WebGPUDriver::updateBufferObject(Handle<HwBufferObject> bufferObjectHandle,
 void WebGPUDriver::updateBufferObjectAsyncR(AsyncCallId jobId, Handle<HwBufferObject> bufferObjectHandle,
         BufferDescriptor&& bufferDescriptor, const uint32_t byteOffset, CallbackHandler* handler,
         AsyncCallback const callback, void* user) {
-    // TODO: implement this.
+    assert_invariant(getJobQueue());
+    // See the identical comment in updateIndexBufferAsyncR: mark this handle asynchronous so a
+    // destroy issued before this job runs gets routed through the same queue instead of freeing
+    // the resource out from under the pending update.
+    handleCast<WebGPUBufferObject>(bufferObjectHandle)->asynchronous = true;
+    getJobQueue()->push([this, bufferObjectHandle, bufferDescriptor = std::move(bufferDescriptor),
+            byteOffset, completion = AsyncCompletion(this, handler, callback, user)]() mutable {
+        updateBufferObject(bufferObjectHandle, std::move(bufferDescriptor), byteOffset);
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }, jobId);
 }
 
 void WebGPUDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> bufferObjectHandle,
@@ -1091,7 +1237,17 @@ void WebGPUDriver::setVertexBufferObjectAsyncR(AsyncCallId jobId,
         Handle<HwVertexBuffer> vertexBufferHandle, const uint32_t index,
         Handle<HwBufferObject> bufferObjectHandle, CallbackHandler* handler,
         AsyncCallback const callback, void* user) {
-    // TODO: implement this.
+    assert_invariant(getJobQueue());
+    // See the identical comment in updateIndexBufferAsyncR. The job below handleCast()s BOTH
+    // handles (via setVertexBufferObject), so both need to be marked: destroying either one
+    // before this job runs must be routed through the same queue rather than running immediately.
+    handleCast<WebGPUVertexBuffer>(vertexBufferHandle)->asynchronous = true;
+    handleCast<WebGPUBufferObject>(bufferObjectHandle)->asynchronous = true;
+    getJobQueue()->push([this, vertexBufferHandle, index, bufferObjectHandle,
+            completion = AsyncCompletion(this, handler, callback, user)]() mutable {
+        setVertexBufferObject(vertexBufferHandle, index, bufferObjectHandle);
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }, jobId);
 }
 
 // Updates a 3D texture region with pixel data from a buffer.
@@ -1244,7 +1400,18 @@ void WebGPUDriver::update3DImageAsyncR(AsyncCallId jobId,
         const uint32_t width, const uint32_t height, const uint32_t depth,
         PixelBufferDescriptor&& pixelBufferDescriptor, CallbackHandler* handler,
         AsyncCallback const callback, void* user) {
-    // TODO: implement this.
+    assert_invariant(getJobQueue());
+    // See the identical comment in updateIndexBufferAsyncR: mark this handle asynchronous so a
+    // destroy issued before this job runs gets routed through the same queue instead of freeing
+    // the resource out from under the pending update.
+    handleCast<WebGPUTexture>(textureHandle)->asynchronous = true;
+    getJobQueue()->push([this, textureHandle, level, xoffset, yoffset, zoffset, width, height,
+            depth, pixelBufferDescriptor = std::move(pixelBufferDescriptor),
+            completion = AsyncCompletion(this, handler, callback, user)]() mutable {
+        update3DImage(textureHandle, level, xoffset, yoffset, zoffset, width, height, depth,
+                std::move(pixelBufferDescriptor));
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }, jobId);
 }
 
 void WebGPUDriver::setupExternalImage(void* image) {
@@ -2392,12 +2559,19 @@ void WebGPUDriver::copyToMemoryMappedBuffer(MemoryMappedBufferHandle mmbh, size_
 
 void WebGPUDriver::queueCommandAsyncR(AsyncCallId jobId, utils::Invocable<void()>&& command,
         CallbackHandler* handler, AsyncCallback const callback, void* user) {
-    // TODO: implement this.
+    assert_invariant(getJobQueue());
+    getJobQueue()->push([command = std::move(command),
+            completion = AsyncCompletion(this, handler, callback, user)]() mutable {
+        if (command) {
+            command();
+        }
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }, jobId);
 }
 
 bool WebGPUDriver::cancelAsyncJob(AsyncCallId jobId) {
-    // TODO: implement this.
-    return false;
+    assert_invariant(getJobQueue());
+    return getJobQueue()->cancel(jobId);
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/webgpu/WebGPUDriver.h
+++ b/filament/backend/src/webgpu/WebGPUDriver.h
@@ -31,6 +31,7 @@
 #include <backend/platforms/WebGPUPlatform.h>
 
 #include "DriverBase.h"
+#include "JobQueue.h"
 #include "private/backend/Dispatcher.h"
 #include "private/backend/Driver.h"
 #include "private/backend/HandleAllocator.h"
@@ -80,6 +81,31 @@ private:
     void readTextureToBuffer(wgpu::Texture srcTexture, uint32_t level, uint32_t layer, uint32_t x,
             uint32_t y, uint32_t width, uint32_t height, PixelBufferDescriptor&& p);
 
+    JobQueue* getJobQueue() const noexcept { return mJobQueue.get(); }
+    JobWorker* getJobWorker() const noexcept { return mJobWorker.get(); }
+
+    // Shared between each create*R and create*AsyncR pair, since the two only differ in the
+    // `asynchronous` flag and whether the completion callback is deferred (see
+    // deferCreationCompletionCallback).
+    void createVertexBufferCommon(Handle<HwVertexBuffer> vertexBufferHandle, uint32_t vertexCount,
+            Handle<HwVertexBufferInfo> vertexBufferInfoHandle, bool asynchronous,
+            utils::ImmutableCString&& tag);
+    void createIndexBufferCommon(Handle<HwIndexBuffer> indexBufferHandle, ElementType elementType,
+            uint32_t indexCount, bool asynchronous, utils::ImmutableCString&& tag);
+    void createBufferObjectCommon(Handle<HwBufferObject> bufferObjectHandle, uint32_t byteCount,
+            BufferObjectBinding bindingType, bool asynchronous, utils::ImmutableCString&& tag);
+    void createTextureCommon(Handle<HwTexture> textureHandle, SamplerType target, uint8_t levels,
+            TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+            uint32_t depth, TextureUsage usage, bool asynchronous, utils::ImmutableCString&& tag);
+    void createTextureViewSwizzleCommon(Handle<HwTexture> textureHandle,
+            Handle<HwTexture> sourceTextureHandle, TextureSwizzle r, TextureSwizzle g,
+            TextureSwizzle b, TextureSwizzle a, utils::ImmutableCString&& tag);
+
+    // Shared by every create*AsyncR: pushes a job that does nothing but fire the completion
+    // callback, so it's correctly FIFO-ordered relative to other outstanding async calls.
+    void deferCreationCompletionCallback(CallbackHandler* handler, AsyncCallback callback,
+            void* user);
+
     // The platform (e.g. OS) specific aspects of the WebGPU backend are strictly only
     // handled in the WebGPUPlatform.
     WebGPUPlatform& mPlatform;
@@ -102,6 +128,8 @@ private:
     WebGPUMsaaTextureResolver mMsaaTextureResolver{};
     WebGPUBlitter mBlitter;
     webgpuutils::AsyncTaskCounter mReadPixelMapsCounter{};
+    JobQueue::Ptr mJobQueue;
+    JobWorker::Ptr mJobWorker;
 
     struct {
         // For push constant

--- a/filament/backend/src/webgpu/WebGPUIndexBuffer.cpp
+++ b/filament/backend/src/webgpu/WebGPUIndexBuffer.cpp
@@ -26,8 +26,8 @@
 namespace filament::backend {
 
 WebGPUIndexBuffer::WebGPUIndexBuffer(wgpu::Device const& device, const uint8_t elementSize,
-        const uint32_t indexCount)
-    : HwIndexBuffer{ elementSize, indexCount, false },
+        const uint32_t indexCount, const bool asynchronous)
+    : HwIndexBuffer{ elementSize, indexCount, asynchronous },
       WebGPUBufferBase{ device, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Index,
           elementSize * indexCount, "index_buffer" },
       mIndexFormat{ elementSize == 2 ? wgpu::IndexFormat::Uint16 : wgpu::IndexFormat::Uint32 } {}

--- a/filament/backend/src/webgpu/WebGPUIndexBuffer.h
+++ b/filament/backend/src/webgpu/WebGPUIndexBuffer.h
@@ -35,7 +35,8 @@ namespace filament::backend {
  */
 class WebGPUIndexBuffer final : public HwIndexBuffer, public WebGPUBufferBase {
 public:
-    WebGPUIndexBuffer(wgpu::Device const&, uint8_t elementSize, uint32_t indexCount);
+    WebGPUIndexBuffer(wgpu::Device const&, uint8_t elementSize, uint32_t indexCount,
+            bool asynchronous = false);
 
     [[nodiscard]] wgpu::IndexFormat getIndexFormat() const { return mIndexFormat; }
 

--- a/filament/backend/src/webgpu/WebGPUTexture.cpp
+++ b/filament/backend/src/webgpu/WebGPUTexture.cpp
@@ -213,8 +213,8 @@ bool isTransientUsage(wgpu::TextureUsage usage) {
 WebGPUTexture::WebGPUTexture(const SamplerType samplerType, const uint8_t levels,
         const TextureFormat format, const uint8_t samples, const uint32_t width,
         const uint32_t height, const uint32_t depth, const TextureUsage usage,
-        wgpu::Device const& device) noexcept
-    : HwTexture{ samplerType, levels, samples, width, height, depth, format, usage, false },
+        wgpu::Device const& device, const bool asynchronous) noexcept
+    : HwTexture{ samplerType, levels, samples, width, height, depth, format, usage, asynchronous },
       mViewFormat{ toWGPUTextureFormat(format) },
       mMipmapGenerationStrategy{ determineMipmapGenerationStrategy(mViewFormat, samplerType,
               samples, levels) },

--- a/filament/backend/src/webgpu/WebGPUTexture.h
+++ b/filament/backend/src/webgpu/WebGPUTexture.h
@@ -42,7 +42,8 @@ public:
      * Creates a Filament texture and a texture view
      */
     WebGPUTexture(SamplerType, uint8_t levels, TextureFormat, uint8_t samples, uint32_t width,
-            uint32_t height, uint32_t depth, TextureUsage, wgpu::Device const&) noexcept;
+            uint32_t height, uint32_t depth, TextureUsage, wgpu::Device const&,
+            bool asynchronous = false) noexcept;
 
     /**
      * Creates a "Filament Texture View", where the underlying texture is the same as the source,

--- a/filament/backend/src/webgpu/WebGPUVertexBuffer.cpp
+++ b/filament/backend/src/webgpu/WebGPUVertexBuffer.cpp
@@ -27,8 +27,8 @@
 namespace filament::backend {
 
 WebGPUVertexBuffer::WebGPUVertexBuffer(const uint32_t vertexCount, const uint32_t bufferCount,
-        Handle<HwVertexBufferInfo> vertexBufferInfoHandle)
-    : HwVertexBuffer{ vertexCount },
+        Handle<HwVertexBufferInfo> vertexBufferInfoHandle, const bool asynchronous)
+    : HwVertexBuffer{ vertexCount, asynchronous },
       mVertexBufferInfoHandle{ vertexBufferInfoHandle } {
     mBuffers.resize(bufferCount);
 }

--- a/filament/backend/src/webgpu/WebGPUVertexBuffer.h
+++ b/filament/backend/src/webgpu/WebGPUVertexBuffer.h
@@ -32,7 +32,8 @@ namespace filament::backend {
 
 class WebGPUVertexBuffer final : public HwVertexBuffer {
 public:
-    WebGPUVertexBuffer(uint32_t vertexCount, uint32_t bufferCount, Handle<HwVertexBufferInfo>);
+    WebGPUVertexBuffer(uint32_t vertexCount, uint32_t bufferCount, Handle<HwVertexBufferInfo>,
+            bool asynchronous = false);
 
     [[nodiscard]] Handle<HwVertexBufferInfo>& getVertexBufferInfoHandle() {
         return mVertexBufferInfoHandle;

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -93,7 +93,8 @@ void BackendTest::initializeDriver() {
     assert_invariant(static_cast<uint8_t>(backend) == static_cast<uint8_t>(sBackend));
     Platform::DriverConfig driverConfig;
     // Enable asynchronous mode for backends that support it.
-    if (sBackend == Backend::METAL || sBackend == Backend::OPENGL) {
+    if (sBackend == Backend::METAL || sBackend == Backend::OPENGL ||
+            sBackend == Backend::WEBGPU) {
         driverConfig.asynchronousMode = Platform::AsynchronousMode::THREAD_PREFERRED;
     }
     driver = mPlatform->createDriver(nullptr, driverConfig);

--- a/filament/backend/test/test_AsyncUploads.cpp
+++ b/filament/backend/test/test_AsyncUploads.cpp
@@ -65,7 +65,6 @@ static void recordCallback(void* user, AsyncCallStatus const status) {
 
 TEST_F(BackendTest, BasicAsyncFlow) {
     SKIP_IF(Backend::VULKAN, "Vulkan does not support asynchronous resource uploading");
-    SKIP_IF(Backend::WEBGPU, "WebGPU does not support asynchronous resource uploading");
 #if defined(FILAMENT_IOS) && !defined(FILAMENT_IOS_SIMULATOR)
     // A-series devices rasterize this scene differently from every other environment (measured
     // 2793888331 on an A10X), so there is no single hash this can be compared against.
@@ -97,6 +96,12 @@ TEST_F(BackendTest, BasicAsyncFlow) {
     auto waitFor = [&](const bool& flag) {
         int attempts = 0;
         while (!flag && attempts < 1000) {
+            // Backends whose async jobs are time-sliced on the driver thread (e.g. Vulkan and
+            // WebGPU's AmortizationWorker) only make progress when something calls tick(); a
+            // real app does this every frame via the Renderer, but this low-level test bypasses
+            // that loop entirely. Backends with a dedicated worker thread (OpenGL, Metal) don't
+            // need this, but calling it is harmless for them too.
+            api.tick();
             api.finish();
             executeCommands();
             getDriver().purge();
@@ -232,9 +237,9 @@ TEST_F(BackendTest, BasicAsyncFlow) {
 
 TEST_F(BackendTest, CanceledAsyncCallInvokesCallback) {
     // The Vulkan backend does implement asynchronous uploading, but BackendTest only enables
-    // asynchronous mode for Metal and OpenGL (BackendTest.cpp), so there is no job queue here.
+    // asynchronous mode for Metal, OpenGL and WebGPU (BackendTest.cpp), so there is no job queues
+    // here.
     SKIP_IF(Backend::VULKAN, "the test harness does not enable asynchronous mode for Vulkan");
-    SKIP_IF(Backend::WEBGPU, "WebGPU does not support asynchronous resource uploading");
 
     auto& api = getDriverApi();
     auto swapChain = addCleanup(createSwapChain());
@@ -246,6 +251,12 @@ TEST_F(BackendTest, CanceledAsyncCallInvokesCallback) {
     auto waitFor = [&](const bool& flag) {
         int attempts = 0;
         while (!flag && attempts < 1000) {
+            // Backends whose async jobs are time-sliced on the driver thread (e.g. Vulkan and
+            // WebGPU's AmortizationWorker) only make progress when something calls tick(); a
+            // real app does this every frame via the Renderer, but this low-level test bypasses
+            // that loop entirely. Backends with a dedicated worker thread (OpenGL, Metal) don't
+            // need this, but calling it is harmless for them too.
+            api.tick();
             api.finish();
             executeCommands();
             getDriver().purge();


### PR DESCRIPTION
WebGPU's *AsyncS/*AsyncR driver methods were all TODO stubs. This wires them up via the existing JobQueue/JobWorker infrastructure, using AmortizationWorker (not ThreadWorker) to mirror Vulkan's Phase 1 implementation.

Resource creation methods (e.g., createVertexBufferAsyncR) construct synchronously and only defer the completion callback, while resource update methods (e.g., updateIndexBufferAsyncR) defer the actual work itself.

WebGPUVertexBuffer/IndexBuffer/BufferObject/Texture now uses an `asynchronous` flag through to their Hw* base, matching Vulkan/OpenGL: each destroy* routes through the job queue when set, so a destroy can't run ahead of a still-pending async job on the same handle. WebGPUDriver::terminate() now also stops the ServiceThread after draining the job queue.

Two pre-existing test-harness gaps blocked verifying any of this: BackendTest never enabled AsynchronousMode for WebGPU or Vulkan, and test_AsyncUploads.cpp's waitFor() never called tick(), which AmortizationWorker-based backends need to make progress. Both fixed. BasicAsyncFlow and CanceledAsyncCallInvokesCallback now pass on WebGPU.

Resolves #10374