### PR TITLE
[Vulkan] Simplify async resource creation

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -674,10 +674,7 @@ void VulkanDriver::createVertexBufferAsyncR(Handle<HwVertexBuffer> vbh, uint32_t
     // This doesn't allocate GPU memory yet, so call it synchronously on the backend thread.
     createVertexBufferCommon(vbh, vertexCount, vbih, /* asynchronous = */ true, std::move(tag));
 
-    assert_invariant(getJobQueue());
-    getJobQueue()->push([this, handler, callback, user]() {
-        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
-    });
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
@@ -726,10 +723,7 @@ void VulkanDriver::createIndexBufferAsyncR(Handle<HwIndexBuffer> ibh, ElementTyp
     createIndexBufferCommon(ibh, elementType, indexCount, /* asynchronous = */ true,
             std::move(tag));
 
-    assert_invariant(getJobQueue());
-    getJobQueue()->push([this, handler, callback, user]() {
-        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
-    });
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
@@ -778,10 +772,7 @@ void VulkanDriver::createBufferObjectAsyncR(Handle<HwBufferObject> boh, uint32_t
     createBufferObjectCommon(boh, byteCount, bindingType, usage, /* asynchronous = */ true,
             std::move(tag));
 
-    assert_invariant(getJobQueue());
-    getJobQueue()->push([this, handler, callback, user]() {
-        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
-    });
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
@@ -838,10 +829,7 @@ void VulkanDriver::createTextureAsyncR(Handle<HwTexture> th, SamplerType target,
     createTextureCommon(th, target, levels, format, samples, w, h, depth, usage,
             /* asynchronous = */ true, std::move(tag));
 
-    assert_invariant(getJobQueue());
-    getJobQueue()->push([this, handler, callback, user]() {
-        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
-    });
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::createTextureViewR(Handle<HwTexture> th, Handle<HwTexture> srch,
@@ -882,10 +870,7 @@ void VulkanDriver::createTextureViewSwizzleAsyncR(Handle<HwTexture> th, Handle<H
     // This doesn't allocate GPU memory yet, so call it synchronously on the backend thread.
     createTextureViewSwizzleCommon(th, srch, r, g, b, a, std::move(tag));
 
-    assert_invariant(getJobQueue());
-    getJobQueue()->push([this, handler, callback, user]() {
-        scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
-    });
+    scheduleAsyncCallback(handler, callback, user, AsyncCallStatus::COMPLETED);
 }
 
 void VulkanDriver::createTextureExternalImage2R(Handle<HwTexture> th, backend::SamplerType target,


### PR DESCRIPTION
The creation function don't need to send their corresponding callbacks trough the JobQueue since the work is actually synchronous.

We still guarantees that the driver receives the scheduleAsyncCallback calls from the creation, before any call from the update one.