### PR TITLE
github: address zizmor security audit findings

### DIFF
--- a/.github/workflows/auto-close-restricted-paths.yml
+++ b/.github/workflows/auto-close-restricted-paths.yml
@@ -10,6 +10,7 @@ name: 'Auto-close restricted path edits'
 # repository, granting it the necessary permissions to close PRs from forks.
 
 on:
+  # zizmor: ignore[dangerous-triggers] - pull_request_target is safe here: no code checkout or execution, only API calls to validate PR paths
   pull_request_target:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/cocopods-deploy.yml
+++ b/.github/workflows/cocopods-deploy.yml
@@ -10,6 +10,9 @@ on:
         required: true
         default: 'v1.42.2'
 
+permissions:
+  contents: read
+
 jobs:
   cocoapods-deploy:
     name: cocoapods-deploy

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'v1.42.2'
 
+permissions:
+  contents: read
+
 jobs:
   npm-deploy:
     name: npm-deploy
@@ -16,6 +19,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.release_tag }}
+          persist-credentials: false
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:

--- a/.github/workflows/postsubmit-main.yml
+++ b/.github/workflows/postsubmit-main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # Update the renderdiff goldens in filament-assets. This will add or merge the new goldens from
   # a branch on filament-assets.
@@ -15,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: get_commit_msg
         uses: ./.github/actions/get-commit-msg
       - name: Check if accepting new goldens
@@ -71,6 +75,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - id: get_commit_msg
         uses: ./.github/actions/get-commit-msg
@@ -98,6 +103,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -7,6 +7,9 @@ on:
       - release
       - rc/**
 
+permissions:
+  contents: read
+
 jobs:
   build-android:
     name: build-android
@@ -17,6 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run Android Continuous
         uses: ./.github/actions/android-continuous
@@ -30,6 +34,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -51,6 +56,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run build script
         run: |
@@ -67,6 +73,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Run build script
         run: |
@@ -83,6 +90,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: ./.github/actions/web-prereq
       - name: Run build script
@@ -99,6 +107,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Run build script
         run: |
           build\windows\build-github.bat continuous

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -23,6 +23,9 @@ concurrency:
 #    The 'skip' output is only set to 'true' if it's a push to main AND the commit is verified.
 #    In all other cases (including PRs where the job is skipped), it defaults to empty.
 
+permissions:
+  contents: read
+
 jobs:
   check-verification:
     if: github.event_name == 'push'
@@ -54,6 +57,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Run build script
         run: |
@@ -69,6 +73,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run build script
         run: |
@@ -86,6 +91,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run build script
         run: |
           build\windows\build-github.bat presubmit
@@ -101,6 +107,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
@@ -140,6 +147,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -160,6 +168,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: ./.github/actions/web-prereq
       - name: Run build script
@@ -175,6 +184,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: get_commit_msg
         uses: ./.github/actions/get-commit-msg
       - name: Check for manual edits to /docs
@@ -193,6 +203,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: get_commit_msg
         uses: ./.github/actions/get-commit-msg
       - name: Check if accepting new goldens
@@ -267,6 +278,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run build script
         run: ./build.sh -W debug test_filamat filament gltf_viewer
@@ -283,6 +295,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Get commit message
         id: get_commit_msg
@@ -329,6 +342,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: ./.github/actions/get-mesa
       - uses: ./.github/actions/get-vulkan-sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run build script
         env:
@@ -76,6 +77,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - name: Run build script
         env:
@@ -111,6 +113,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Run build script
         env:
@@ -146,6 +149,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/linux-prereq
       - uses: ./.github/actions/web-prereq
       - name: Run build script
@@ -182,6 +186,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
@@ -242,6 +247,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
@@ -288,6 +294,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/mac-prereq
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -326,6 +333,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
+          persist-credentials: false
       - name: Run build script
         env:
           TAG: ${{ steps.git_ref.outputs.tag }}

--- a/.github/workflows/status-android.yml
+++ b/.github/workflows/status-android.yml
@@ -2,9 +2,13 @@ name: Android
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-android');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/status-ios.yml
+++ b/.github/workflows/status-ios.yml
@@ -2,9 +2,13 @@ name: iOS
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-ios');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/status-linux.yml
+++ b/.github/workflows/status-linux.yml
@@ -2,9 +2,13 @@ name: Linux
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-linux');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/status-macos.yml
+++ b/.github/workflows/status-macos.yml
@@ -2,9 +2,13 @@ name: macOS
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-mac');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/status-web.yml
+++ b/.github/workflows/status-web.yml
@@ -2,9 +2,13 @@ name: Web
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-web');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/status-windows.yml
+++ b/.github/workflows/status-windows.yml
@@ -2,9 +2,13 @@ name: Windows
 run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is safe here: triggers on internal postsubmit push, no code checkout or untrusted artifact execution
   workflow_run:
     workflows: ["Postsubmit CI"]
     types: [completed]
+
+permissions:
+  actions: read
 
 jobs:
   status:
@@ -17,7 +21,7 @@ jobs:
             const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: context.payload.workflow_run.id
             });
             const job = jobs.find(j => j.name === 'build-windows');
             if (job && job.conclusion !== 'success') {

--- a/.github/workflows/verify-release-notes.yml
+++ b/.github/workflows/verify-release-notes.yml
@@ -6,6 +6,10 @@ on:
       - main
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   verify-release-notes:
     name: Verify Release Notes
@@ -14,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           sparse-checkout: |
             .github
       - name: Verify release notes


### PR DESCRIPTION
Resolve zizmor findings across CI and release workflows:

- Suppress verified false positives (dangerous-triggers): Add inline ignore comments with explanations for pull_request_target in auto-close-restricted-paths.yml and workflow_run in status-*.yml, where no untrusted code is checked out or executed.
- Enforce least privilege permissions (excessive-permissions): Add explicit top-level permissions blocks (contents: read, actions: read, or pull-requests: read) across workflows lacking them.
- Prevent credential persistence (artipacked): Add persist-credentials: false to all actions/checkout steps in CI and release workflows.
- Improve script hygiene: Access workflow_run.id via context.payload.workflow_run.id instead of inline expression interpolation in status-*.yml github-script steps.