### PR TITLE
gltfio: fix broken null-check on bufferView data in getOrCreateTexture

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -897,10 +897,10 @@ std::pair<Texture*, CacheResult> ResourceLoader::Impl::getOrCreateTexture(FFilam
     const size_t cacheIdx = any(flags & TextureProvider::TextureFlags::sRGB) ? 1 : 0;
 
     // Check if the texture slot uses BufferView data.
-    if (void** bufferViewData = bv ? &bv->buffer->data : nullptr; bufferViewData) {
+    if (bv && bv->buffer->data) {
         assert_invariant(!dataUriContent);
-        const size_t offset = bv ? bv->offset : 0;
-        const uint8_t* sourceData = offset + (const uint8_t*) *bufferViewData;
+        const size_t offset = bv->offset;
+        const uint8_t* sourceData = offset + (const uint8_t*) bv->buffer->data;
         if (auto iter = mBufferTextureCache[cacheIdx].find(sourceData);
                 iter != mBufferTextureCache[cacheIdx].end()) {
             return {iter->second, CacheResult::FOUND};


### PR DESCRIPTION
## Summary

`ResourceLoader::Impl::getOrCreateTexture` (libs/gltfio/src/ResourceLoader.cpp) intends to check whether a bufferView's underlying buffer data has actually been loaded before using it:

```cpp
if (void** bufferViewData = bv ? &bv->buffer->data : nullptr; bufferViewData) {
```

`&bv->buffer->data` takes the **address of** the `data` field, which is a valid, non-null address whenever `bv` is non-null — regardless of whether `bv->buffer->data` (the actual pointer value) is null. So this check always passes when `bv` is non-null, even when the buffer's data was never loaded (e.g. its `uri` was never resolved via `ResourceLoader::addResourceData`, a normal situation in the non-filesystem resource flow used on Android/WebGL/iOS embeddings).

## Impact

Because the guard always passes, `sourceData = offset + (const uint8_t*) *bufferViewData` computes an address from a null (or otherwise not-yet-loaded) base pointer plus an attacker-influenced `bv->offset`. That address, together with an attacker-influenced `totalSize` (`bv->size`), is passed straight to `provider->pushTexture(sourceData, totalSize, ...)`, which reaches `stb_image` / `libwebp` / basisu-ktx2 decoders that read `totalSize` bytes starting at `sourceData` — an out-of-bounds read at a near-arbitrary address, reachable from a crafted glTF asset whose image `bufferView` points at a buffer the host application hasn't (yet) supplied.

`cgltf_validate` does not catch this: it only cross-checks declared `byteOffset`/`byteLength` against the buffer's declared `size`, not whether `buffer.data` was actually populated.

## Fix

Test the pointer value itself, not its address:

```cpp
if (bv && bv->buffer->data) {
    const size_t offset = bv->offset;
    const uint8_t* sourceData = offset + (const uint8_t*) bv->buffer->data;
```

## Testing

Verified by source inspection that this is the only site using this `&x`-vs-`x` pattern for this guard; the equivalent checks elsewhere in this file (vertex/index/skin accessor paths) test the pointer value directly. No behavior change for the case this was presumably meant to guard against — this simply makes the null-check actually check for null.

I'm happy to add a regression test if maintainers can point me to the right fixture/harness for this loader path.