### PR TITLE
Add Driver::purgeAll() to drain teardown callbacks

### DIFF
--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -71,6 +71,11 @@ public:
     // is where the driver can execute user callbacks.
     virtual void purge() noexcept = 0;
 
+    // Same as purge(), but keeps going until the queue stays empty, so callbacks scheduled by the
+    // callbacks being dispatched are executed too. Meant for teardown, where there is no later
+    // purge() to pick up the stragglers.
+    virtual void purgeAll() noexcept = 0;
+
     // Called from the engine thread (render-thread) to execute the `callback` via the `handler` if
     // it is available. Otherwise, if `handler` is null, the `callback` is executed on the main
     // thread via `purge()`.

--- a/filament/backend/src/Driver.cpp
+++ b/filament/backend/src/Driver.cpp
@@ -50,6 +50,15 @@ using namespace filament::math;
 
 namespace filament::backend {
 
+namespace {
+
+// Debug-only ceiling on purgeAll()'s drain rounds. Legitimate chains are a couple of hops deep
+// (e.g., countdownCallback -> user callback), so anything close to this is a callback rescheduling
+// itself.
+UTILS_UNUSED_IN_RELEASE constexpr size_t MAX_PURGE_ROUNDS = 256;
+
+} // anonymous namespace
+
 DriverBase::DriverBase(const Platform::DriverConfig& driverConfig) noexcept
     : mDriverConfig(driverConfig) {
     if constexpr (UTILS_HAS_THREADING) {
@@ -120,13 +129,35 @@ void DriverBase::scheduleCallback(CallbackHandler* handler, void* user, Callback
     }
 }
 
-void DriverBase::purge() noexcept {
+bool DriverBase::dispatchQueuedCallbacks() noexcept {
     decltype(mCallbacks) callbacks;
-    UniqueLock lock(mPurgeLock);
-    std::swap(callbacks, mCallbacks);
-    lock.unlock(); // don't remove this, it ensures callbacks are called without lock held
+    {
+        LockGuard const lock(mPurgeLock);
+        if (mCallbacks.empty()) {
+            return false;
+        }
+        std::swap(callbacks, mCallbacks);
+    }
+    // the scope above matters: it ensures callbacks are called without the lock held
     for (auto& item : callbacks) {
         item.second(item.first);
+    }
+    return true;
+}
+
+void DriverBase::purge() noexcept {
+    dispatchQueuedCallbacks();
+}
+
+void DriverBase::purgeAll() noexcept {
+    // Unlike purge(), this keeps going until the queue stays empty, because a callback is allowed
+    // to schedule another one: with no ServiceThread, CountdownCallbackHandler::countdownCallback
+    // lands here and schedules the user callback from inside this loop.
+    UTILS_UNUSED_IN_RELEASE size_t rounds = 0;
+    while (dispatchQueuedCallbacks()) {
+        // A callback that reschedules itself unconditionally would spin here forever.
+        // Assert failure here indicates a bug.
+        assert_invariant(++rounds < MAX_PURGE_ROUNDS);
     }
 }
 

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -191,6 +191,7 @@ public:
     ~DriverBase() noexcept override;
 
     void purge() noexcept final;
+    void purgeAll() noexcept final;
 
     // Helpers...
     struct CallbackData {
@@ -387,6 +388,9 @@ protected:
     void stopServiceThread() noexcept;
 
 private:
+    // Dispatches the callbacks queued so far. Returns false if there were none.
+    bool dispatchQueuedCallbacks() noexcept;
+
     const Platform::DriverConfig mDriverConfig;
 
     mutable utils::Mutex mPurgeLock;

--- a/filament/backend/test/test_AsyncCompletion.cpp
+++ b/filament/backend/test/test_AsyncCompletion.cpp
@@ -19,11 +19,17 @@
 
 #include "noop/NoopDriver.h"
 
+#include <backend/CallbackHandler.h>
 #include <backend/DriverEnums.h>
+
+#include <utils/compiler.h>
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -42,6 +48,9 @@ protected:
     // Runs the callbacks that were scheduled without a handler.
     void purge() const { mDriver->purge(); }
 
+    // Same, but keeps going until the queue stays empty.
+    void purgeAll() const { mDriver->purgeAll(); }
+
     // A completion callback that records what it was told, in order.
     using Statuses = std::vector<AsyncCallStatus>;
 
@@ -51,6 +60,75 @@ protected:
 
 private:
     std::unique_ptr<Driver> mDriver;
+};
+
+// Records every status it is told and, while it is being dispatched, schedules the next hop. This
+// is the shape CountdownCallbackHandler produces when there is no ServiceThread: its
+// countdownCallback is purged, and it schedules the user callback from there.
+struct CallbackChain {
+    DriverBase* driver;
+    int remainingHops;
+    std::vector<AsyncCallStatus> statuses;
+
+    static void hop(void* user, AsyncCallStatus const status) {
+        auto* const self = static_cast<CallbackChain*>(user);
+        self->statuses.push_back(status);
+        if (self->remainingHops > 0) {
+            --self->remainingHops;
+            DriverBase::AsyncCompletion completion(self->driver, nullptr, &CallbackChain::hop,
+                    self);
+            completion.schedule(AsyncCallStatus::COMPLETED);
+        }
+    }
+};
+
+// Schedules several callbacks from a single dispatch, so the queue grows by a whole batch rather
+// than one entry at a time. Draining has to keep up with width, not just depth.
+struct CallbackFanout {
+    DriverBase* driver;
+    int width;
+    int recorded = 0;
+
+    static void burst(void* user, AsyncCallStatus) {
+        auto* const self = static_cast<CallbackFanout*>(user);
+        for (int i = 0; i < self->width; ++i) {
+            DriverBase::AsyncCompletion completion(self->driver, nullptr, &CallbackFanout::record,
+                    self);
+            completion.schedule(AsyncCallStatus::COMPLETED);
+        }
+    }
+
+    static void record(void* user, AsyncCallStatus) {
+        ++static_cast<CallbackFanout*>(user)->recorded;
+    }
+};
+
+// Stands in for a user handler that hands its callback back to the driver's no-handler queue, which
+// is what CountdownCallbackHandler does with a null user handler. Runs on the ServiceThread, so it
+// makes that thread a producer for the queue purgeAll() drains.
+struct ServiceThreadRelay : public CallbackHandler {
+    explicit ServiceThreadRelay(DriverBase* driver)
+            : driver(driver) {}
+
+    void post(void* user, Callback callback) override {
+        driver->scheduleCallback(nullptr, user, callback);
+        relayed.store(true, std::memory_order_release);
+    }
+
+    // Returns false if the ServiceThread never got to us, rather than hanging the suite.
+    bool waitUntilRelayed() const {
+        auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!relayed.load(std::memory_order_acquire)) {
+            if (std::chrono::steady_clock::now() > deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return true;
+    }
+
+    DriverBase* driver;
+    std::atomic_bool relayed{ false };
 };
 
 } // namespace
@@ -170,5 +248,111 @@ TEST_F(AsyncCompletionTest, JobDroppedByStoppingQueueInvokesCallback) {
     purge();
     ASSERT_EQ(1u, statuses.size())
             << "a job dropped by a stopping queue must schedule its completion callback";
+    EXPECT_EQ(AsyncCallStatus::CANCELED, statuses[0]);
+}
+
+TEST_F(AsyncCompletionTest, PurgeDispatchesOnlyWhatWasQueued) {
+    // purge() is the per-frame path. It dispatches the batch that was queued when it was called and
+    // returns, leaving whatever those callbacks scheduled for the next purge -- it must not keep
+    // draining, or a frame could be held hostage by callbacks the backend thread keeps producing.
+    CallbackChain chain{ getDriver(), 2, {} };
+
+    DriverBase::AsyncCompletion completion(getDriver(), nullptr, &CallbackChain::hop, &chain);
+    completion.schedule(AsyncCallStatus::COMPLETED);
+
+    purge();
+    EXPECT_EQ(1u, chain.statuses.size());
+    purge();
+    EXPECT_EQ(2u, chain.statuses.size());
+
+    // Leave nothing behind: ~DriverBase asserts the queue is empty. One more purge() is enough
+    // because the last hop doesn't schedule anything.
+    purge();
+}
+
+TEST_F(AsyncCompletionTest, PurgeAllDrainsCallbacksScheduledFromCallbacks) {
+    // purgeAll() is the teardown path. FEngine::shutdown() purges exactly once, so a callback
+    // scheduled while the queue is being dispatched has no later purge to pick it up: it would
+    // never run, its handler would leak, and ~DriverBase's empty-queue invariant would trip.
+    CallbackChain chain{ getDriver(), 2, {} };
+
+    DriverBase::AsyncCompletion completion(getDriver(), nullptr, &CallbackChain::hop, &chain);
+    completion.schedule(AsyncCallStatus::COMPLETED);
+
+    purgeAll();
+
+    EXPECT_EQ(3u, chain.statuses.size()) << "purgeAll() stopped before the queue was drained";
+    EXPECT_EQ(0, chain.remainingHops);
+}
+
+TEST_F(AsyncCompletionTest, PurgeAllOnEmptyQueueIsANoOp) {
+    // Teardown is allowed to drain a queue nothing ever landed in, and doing so must not leave the
+    // driver unable to take callbacks afterwards.
+    purgeAll();
+    purgeAll();
+
+    Statuses statuses;
+    DriverBase::AsyncCompletion completion(getDriver(), nullptr, recordStatus, &statuses);
+    completion.schedule(AsyncCallStatus::COMPLETED);
+    purgeAll();
+
+    ASSERT_EQ(1u, statuses.size());
+    EXPECT_EQ(AsyncCallStatus::COMPLETED, statuses[0]);
+}
+
+TEST_F(AsyncCompletionTest, PurgeAllDrainsChainsOfDifferentDepths) {
+    // Several independent chains are in flight at teardown -- one per asynchronous creation still
+    // pending. Draining must follow the deepest one, not stop when the shallow ones run out.
+    CallbackChain shallow{ getDriver(), 1, {} };
+    CallbackChain deep{ getDriver(), 6, {} };
+
+    for (CallbackChain* chain: { &shallow, &deep }) {
+        DriverBase::AsyncCompletion completion(getDriver(), nullptr, &CallbackChain::hop, chain);
+        completion.schedule(AsyncCallStatus::COMPLETED);
+    }
+
+    purgeAll();
+
+    EXPECT_EQ(2u, shallow.statuses.size());
+    EXPECT_EQ(7u, deep.statuses.size()) << "purgeAll() stopped before the deepest chain was done";
+    EXPECT_EQ(0, deep.remainingHops);
+}
+
+TEST_F(AsyncCompletionTest, PurgeAllDrainsBatchesThatWidenWhileDraining) {
+    // A single dispatch can enqueue several callbacks at once: a countdown reaching zero releases
+    // everything that was waiting on it. The batch being drained grows sideways, not just deeper.
+    constexpr int width = 32;
+    CallbackFanout fanout{ getDriver(), width };
+
+    DriverBase::AsyncCompletion completion(getDriver(), nullptr, &CallbackFanout::burst, &fanout);
+    completion.schedule(AsyncCallStatus::COMPLETED);
+
+    purgeAll();
+
+    EXPECT_EQ(width, fanout.recorded) << "purgeAll() left part of the widened batch behind";
+}
+
+TEST_F(AsyncCompletionTest, PurgeAllDispatchesCallbacksHandedBackByTheServiceThread) {
+    // The threaded counterpart of the chain above: the callback goes to the ServiceThread, which
+    // hands it back to the no-handler queue (what CountdownCallbackHandler does when the user
+    // didn't supply a handler). purgeAll() is what has to pick it up at teardown.
+    if constexpr (!UTILS_HAS_THREADING) {
+        GTEST_SKIP() << "there is no ServiceThread to hand the callback back";
+    }
+
+    Statuses statuses;
+    ServiceThreadRelay relay(getDriver());
+
+    DriverBase::AsyncCompletion completion(getDriver(), &relay, recordStatus, &statuses);
+    completion.schedule(AsyncCallStatus::CANCELED);
+
+    // Wait for the producer to be done, so this asserts on draining and not on the race that
+    // purgeAll() explicitly doesn't cover.
+    ASSERT_TRUE(relay.waitUntilRelayed()) << "the ServiceThread never dispatched the callback";
+
+    purgeAll();
+
+    ASSERT_EQ(1u, statuses.size())
+            << "a callback relayed by the ServiceThread was never dispatched";
     EXPECT_EQ(AsyncCallStatus::CANCELED, statuses[0]);
 }

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -734,9 +734,10 @@ void FEngine::shutdown() {
         assert_invariant(mDeferredAsyncObjectDestruction.empty());
     }
 
-    // Finally, call user callbacks that might have been scheduled.
+    // Finally, call user callbacks that might have been scheduled. This is the last chance to run
+    // them, so it has to drain the ones that schedule other callbacks.
     // These callbacks CANNOT call driver APIs.
-    getDriver().purge();
+    getDriver().purgeAll();
 
     // and destroy the CommandStream
     std::destroy_at(std::launder(reinterpret_cast<DriverApi*>(&mDriverApiStorage)));

--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -66,6 +66,7 @@ if (FILAMENT_BUILD_TESTING)
                 test_BufferStuffingDetector.cpp
                 test_CircularQueue.cpp
                 test_compact.cpp
+                test_EngineShutdown.cpp
                 test_FenceManager.cpp
                 test_FramePacer.cpp
                 test_UboManager.cpp

--- a/filament/test/MockDriver.h
+++ b/filament/test/MockDriver.h
@@ -122,6 +122,7 @@ public:
     void debugCommandEnd(CommandStream* cmds, bool synchronous,
             const char* methodName) noexcept override {}
     void purge() noexcept override {}
+    void purgeAll() noexcept override {}
     void scheduleCallback(CallbackHandler* handler, void* user,
             CallbackHandler::Callback callback) override {}
 

--- a/filament/test/test_EngineShutdown.cpp
+++ b/filament/test/test_EngineShutdown.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CommandStreamDispatcher.h"
+#include "MockDriver.h"
+
+#include "details/AsyncHelpers.h"
+
+#include <filament/Engine.h>
+
+#include <private/backend/Driver.h>
+
+#include <backend/CallbackHandler.h>
+#include <backend/DriverEnums.h>
+#include <backend/Platform.h>
+
+#include <utils/CString.h>
+#include <utils/Mutex.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <utility>
+#include <vector>
+
+using namespace filament;
+using namespace filament::backend;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+namespace {
+
+// What the test looks at once the Engine, and the driver it owns, are both gone.
+struct ShutdownTrace {
+    std::atomic_int userCallbacksInvoked{ 0 };
+    std::atomic<AsyncCallStatus> lastStatus{ AsyncCallStatus::COMPLETED };
+    // -1 means the driver was never destroyed.
+    std::atomic_int callbacksLeftAtDestruction{ -1 };
+};
+
+using ShutdownCountdown = CountdownCallbackHandler<int>;
+
+// A driver that queues the callbacks scheduled without a handler instead of dropping them like
+// MockDriver does, with DriverBase's semantics for a build with no ServiceThread -- which is where
+// a callback scheduling another callback is reachable: purge() dispatches the batch that was queued
+// when it was called, purgeAll() keeps going until the queue stays empty.
+class QueueingDriver : public MockDriver {
+public:
+    explicit QueueingDriver(ShutdownTrace* trace)
+            : mTrace(trace) {
+        // Enough of a driver for Engine::Builder::build() to get through its validation.
+        ON_CALL(*this, getFeatureLevel()).WillByDefault(Return(FeatureLevel::FEATURE_LEVEL_1));
+        ON_CALL(*this, isTextureFormatSupported(_)).WillByDefault(Return(true));
+        ON_CALL(*this, isRenderTargetFormatSupported(_)).WillByDefault(Return(true));
+        ON_CALL(*this, isTextureFormatMipmappable(_)).WillByDefault(Return(true));
+        ON_CALL(*this, isTextureFormatFilterable(_)).WillByDefault(Return(true));
+        ON_CALL(*this, getMaxTextureSize(_)).WillByDefault(Return(2048));
+        ON_CALL(*this, isAsynchronousModeEnabled()).WillByDefault(Return(true));
+
+        // terminate() runs on the backend thread after the engine's last flush, so anything
+        // scheduled from here has only FEngine::shutdown()'s final purge left to run it. That is
+        // when a JobWorker being torn down reports its canceled asynchronous calls.
+        ON_CALL(*this, terminate())
+                .WillByDefault(Invoke(this, &QueueingDriver::reportCanceledCreation));
+    }
+
+    ~QueueingDriver() override {
+        utils::LockGuard const lock(mLock);
+        mTrace->callbacksLeftAtDestruction.store(int(mCallbacks.size()), std::memory_order_release);
+    }
+
+    // With no ServiceThread, DriverBase queues (user, callback) and invokes the callback directly
+    // at purge time, bypassing `handler`. Same here.
+    void scheduleCallback(CallbackHandler*, void* user,
+            CallbackHandler::Callback callback) override {
+        utils::LockGuard const lock(mLock);
+        mCallbacks.emplace_back(user, callback);
+    }
+
+    void purge() noexcept override {
+        dispatchQueuedCallbacks();
+    }
+
+    void purgeAll() noexcept override {
+        while (dispatchQueuedCallbacks()) {
+        }
+    }
+
+    Dispatcher getDispatcher() const noexcept override {
+        return ConcreteDispatcher<QueueingDriver>::make();
+    }
+
+private:
+    // The box DriverBase::scheduleAsyncCallback() uses to carry a status through a callback
+    // signature that doesn't have one.
+    struct StatusBox {
+        AsyncCallback callback;
+        void* user;
+        AsyncCallStatus status;
+    };
+
+    static void invokeBoxed(void* data) {
+        auto* const box = static_cast<StatusBox*>(data);
+        box->callback(box->user, box->status);
+        delete box;
+    }
+
+    // An asynchronous creation canceled by teardown, in its real shape: the countdown handler is
+    // notified from the callback queue and, reaching zero, hands the user's callback back to that
+    // same queue from inside the dispatch. Dispatching the queue once leaves the user callback
+    // behind: it never runs, and the handler it would have deleted leaks.
+    void reportCanceledCreation() {
+        auto* const countdown = ShutdownCountdown::make(
+                /* handler */ nullptr,
+                ShutdownCountdown::UserCallback(
+                        [trace = mTrace](int*, void*, AsyncCallStatus const status) {
+                            trace->lastStatus.store(status, std::memory_order_release);
+                            trace->userCallbacksInvoked.fetch_add(1, std::memory_order_acq_rel);
+                        }),
+                /* userParam1 */ nullptr, /* userParam2 */ nullptr,
+                ShutdownCountdown::CountdownCompleteCallback{}, this);
+        countdown->increaseCountdown();
+        scheduleCallback(/* handler */ countdown,
+                new StatusBox{ &ShutdownCountdown::countdownCallback, countdown,
+                    AsyncCallStatus::CANCELED },
+                &invokeBoxed);
+    }
+
+    // Dispatches what is queued so far, with no lock held. Returns false if there was nothing.
+    bool dispatchQueuedCallbacks() noexcept {
+        decltype(mCallbacks) callbacks;
+        {
+            utils::LockGuard const lock(mLock);
+            if (mCallbacks.empty()) {
+                return false;
+            }
+            std::swap(callbacks, mCallbacks);
+        }
+        for (auto& item: callbacks) {
+            item.second(item.first);
+        }
+        return true;
+    }
+
+    mutable utils::Mutex mLock;
+    std::vector<std::pair<void*, CallbackHandler::Callback>> mCallbacks UTILS_GUARDED_BY(mLock);
+    ShutdownTrace* mTrace;
+};
+
+class QueueingPlatform : public Platform {
+public:
+    explicit QueueingPlatform(ShutdownTrace* trace)
+            : mTrace(trace) {}
+
+    int getOSVersion() const noexcept override { return 0; }
+
+    utils::CString getDeviceInfo(DeviceInfoType, Driver*) const override { return {}; }
+
+    Driver* createDriver(void*, const Platform::DriverConfig&) override {
+        // The Engine takes ownership and deletes it in the FEngine destructor.
+        return new ::testing::NiceMock<QueueingDriver>(mTrace);
+    }
+
+private:
+    ShutdownTrace* mTrace;
+};
+
+} // namespace
+
+TEST(EngineShutdownTest, DrainsUserCallbacksScheduledWhileTheQueueIsBeingDispatched) {
+    // Shutting the engine down is the last chance to run the callbacks the user is still waiting
+    // on. A callback scheduled by one that is being dispatched -- the shape every canceled
+    // asynchronous creation takes, through CountdownCallbackHandler -- has no later purge to pick
+    // it up, so the final purge has to keep draining until the queue stays empty.
+    ShutdownTrace trace;
+    QueueingPlatform platform(&trace);
+
+    Engine* engine = Engine::Builder()
+            .backend(Backend::NOOP)
+            .platform(&platform)
+            .build();
+    ASSERT_NE(nullptr, engine);
+
+    Engine::destroy(&engine);
+
+    EXPECT_EQ(1, trace.userCallbacksInvoked.load(std::memory_order_acquire))
+            << "shutting down the engine must run the callbacks its own teardown schedules";
+    EXPECT_EQ(AsyncCallStatus::CANCELED, trace.lastStatus.load(std::memory_order_acquire))
+            << "a creation canceled by teardown must be reported as canceled";
+    EXPECT_EQ(0, trace.callbacksLeftAtDestruction.load(std::memory_order_acquire))
+            << "the driver was destroyed with callbacks still queued";
+}


### PR DESCRIPTION
purge() dispatches only the batch that was queued when it was called, so a callback that schedules another one leaves it behind. The current teardown process purges once, so ~DriverBase could crashes on a non-empty queue. This is reachable with no ServiceThread, where countdownCallback is purged and schedules the user callback from there.

purgeAll() is introduced to keep going until the queue stays empty, and FEngine::shutdown() uses it.