### PR TITLE
Fix spelling of the in DisplayHelper javadoc

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/android/DisplayHelper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/android/DisplayHelper.java
@@ -92,7 +92,7 @@ public class DisplayHelper {
      * where callbacks can execute filament code. Use this method if filament is executing
      * on another thread.
      *
-     * @param context a {@link Context} to used to retrieve teh {@link DisplayManager}
+     * @param context a {@link Context} to used to retrieve the {@link DisplayManager}
      * @param handler a {@link Handler} used to run callbacks accessing filament
      */
     public DisplayHelper(@NonNull Context context, @NonNull Handler handler) {


### PR DESCRIPTION
## Summary
- Correct `teh` → `the` in the `DisplayHelper` constructor javadoc.

## Test plan
- [x] Docs-only change; no behavior change

Happy to adjust if anything looks off.